### PR TITLE
Managed server, progress UI, project site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
+      - name: Generate coverage badge
+        run: |
+          PCT=$(node -p "require('./coverage/coverage-summary.json').total.lines.pct")
+          COLOR=$(node -p "const p=require('./coverage/coverage-summary.json').total.lines.pct; p===100?'brightgreen':p>=90?'green':p>=70?'yellow':'red'")
+          npx badge-maker --label coverage --message "${PCT}%" --color "$COLOR" > coverage/badge.svg
+      - name: Assemble site
+        run: |
+          mkdir -p _site
+          cp site/index.html _site/
+          cp -r coverage _site/coverage
+      - name: Upload Pages artifact
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+      - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+on:
+  push:
+    tags: ["v*"]
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            main.js
+            manifest.json
+            styles.css

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 main.js
 dist/
+coverage/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # lilbee for Obsidian
 
+[![CI](https://github.com/tobocop2/obsidian-lilbee/actions/workflows/ci.yml/badge.svg)](https://github.com/tobocop2/obsidian-lilbee/actions/workflows/ci.yml)
+[![Coverage](https://tobocop2.github.io/obsidian-lilbee/coverage/badge.svg)](https://tobocop2.github.io/obsidian-lilbee/coverage/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.6-blue?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Obsidian](https://img.shields.io/badge/Obsidian-Plugin-7c3aed?logo=obsidian&logoColor=white)](https://obsidian.md)
+
 > **Work in progress** — the first release is coming soon. The plugin is not usable yet.
 
 Talk to your vault. Ask questions about your notes, PDFs, code, spreadsheets, and images — and get answers grounded in what you've actually written, with source citations. Save conversations back to your vault as markdown. Everything runs locally on your machine via [Ollama](https://ollama.com), so your documents never leave your computer.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Obsidian](https://img.shields.io/badge/Obsidian-Plugin-7c3aed?logo=obsidian&logoColor=white)](https://obsidian.md)
 
-> **Work in progress** — the first release is coming soon. The plugin is not usable yet.
-
 Talk to your vault. Ask questions about your notes, PDFs, code, spreadsheets, and images — and get answers grounded in what you've actually written, with source citations. Save conversations back to your vault as markdown. Everything runs locally on your machine via [Ollama](https://ollama.com), so your documents never leave your computer.
 
 ## Demo
@@ -24,106 +22,33 @@ Attaching a scanned 1998 Star Wars: X-Wing Collector's Edition manual (PDF with 
 
 ---
 
-## What you can do
-
-- **Chat with your vault** — ask questions and get answers from your actual notes, with sources you can click through to
-- **Attach anything** — drop PDFs, code files, images, or folders into a conversation to talk about them
-- **Search by meaning** — find content by what it's about, not just keywords, with live results as you type
-- **Quick answers** — ask a one-off question and get a synthesized answer with sources
-- **Save conversations** — export any chat to your vault as markdown
-- **Scan images and PDFs** — OCR extracts text from scanned documents so you can chat about them too
-- **Stay in control** — stop generation mid-stream, cancel syncs, switch models on the fly
-- **Fully local** — everything runs on your machine. Nothing is sent to the cloud.
-
-## Prerequisites
-
-1. **[Ollama](https://ollama.com)** — local LLM runtime (embedding model auto-pulled on first sync)
-2. **[lilbee](https://github.com/tobocop2/lilbee)** — `pip install lilbee` or `uv tool install lilbee`
-
 ## Quick start
 
-1. Start Ollama (`ollama serve`)
-2. Initialize and start lilbee in your vault:
-   ```bash
-   cd /path/to/your/vault
-   lilbee init && lilbee serve
-   ```
-3. Copy `main.js`, `manifest.json`, `styles.css` into `.obsidian/plugins/lilbee/`
+1. Install [Ollama](https://ollama.com) and start it
+2. Install [BRAT](https://github.com/TfTHacker/obsidian42-brat) if you don't have it (Settings → Community plugins → Browse → search "BRAT")
+3. In Obsidian, open the command palette (`Cmd/Ctrl + P`) → **BRAT: Plugins: Add a beta plugin for testing** → paste `tobocop2/obsidian-lilbee` → Add Plugin
 4. Enable "lilbee" in Settings → Community plugins
-5. **Sync vault** from the command palette to index your documents
-6. **Open chat** and start talking to your vault
+5. **Open chat** and start attaching files to talk about them — or **Sync vault** to index everything at once
 
-## Commands
+The plugin downloads and manages the lilbee server automatically — no terminal, no pip, no manual setup.
 
-All commands available via `Ctrl/Cmd + P` → "lilbee":
+## How it works
 
-| Command | Description |
-|---------|-------------|
-| Search knowledge base | Semantic search with live results |
-| Ask a question | Single answer with source citations |
-| Open chat | Multi-turn chat sidebar |
-| Sync vault | Index new/changed files, remove deleted |
-| Add current file | Index the active file |
-| Add current folder | Index all files in the active folder |
-| Show status | Document and chunk counts |
+On first launch, the plugin downloads a pre-built [lilbee](https://github.com/tobocop2/lilbee) server binary from GitHub Releases into `.obsidian/plugins/lilbee/bin/` and runs it in the background. Syncing sends your documents to this local server, which chunks and embeds them using Ollama. When you search or chat, the server retrieves the most relevant chunks and passes them to the LLM for a grounded response.
 
-Right-click any file or folder in the file explorer to **Add to lilbee** from the context menu.
+Everything stays on your machine. The server, models, embeddings, and your documents all run and live locally.
 
-## Chat
+> **macOS users:** The binary is unsigned (Apple charges [$99/year](https://developer.apple.com/support/enrollment/) for that). The plugin clears the quarantine flag via [`xattr -cr`](https://support.apple.com/en-us/102445) automatically. See the [lilbee source](https://github.com/tobocop2/lilbee) if you want to audit the build.
 
-The chat sidebar is where most of the action happens:
+## Documentation
 
-- **Streaming responses** with full markdown rendering and expandable source citations
-- **Attach files** — drag in PDFs, code, images, or whole folders to talk about them
-- **Save to vault** — export the conversation as a markdown file in your vault
-- **Stop generation** mid-stream if the answer is going off track
-- **Model selectors** — switch chat and vision models without leaving the conversation
-- **Connection indicator** — green when connected, red when the server is unreachable
-- **Inline progress** for sync/indexing with cancel support
-
-## Settings
-
-Settings → Community plugins → lilbee:
-
-| Section | Settings |
-|---------|----------|
-| **Connection** | Server URL, Ollama URL (both with Test button) |
-| **Models** | Chat and vision model dropdowns with curated catalog, pull/delete, auto-pull with progress |
-| **General** | Results count (1–20) |
-| **Sync** | Manual or auto mode (with configurable debounce) |
-| **Advanced** | Temperature, top_p, top_k, repeat_penalty, context length, seed — defaults loaded live from the active model |
-
-## Supported formats
-
-Text extraction powered by [Kreuzberg](https://github.com/Goldziher/kreuzberg), code chunking by [tree-sitter](https://tree-sitter.github.io/tree-sitter/). This list is not exhaustive — Kreuzberg supports additional formats beyond what's listed here.
-
-| Format | Extensions |
-|--------|-----------|
-| PDF | `.pdf` (embedded text + OCR fallback for scanned pages) |
-| Office | `.docx`, `.xlsx`, `.pptx` |
-| eBook | `.epub` |
-| Images | `.png`, `.jpg`, `.jpeg`, `.tiff`, `.bmp`, `.webp` (requires vision model) |
-| Data | `.csv`, `.tsv`, `.xml`, `.json`, `.jsonl`, `.yaml`, `.yml` |
-| Text | `.md`, `.txt`, `.html`, `.rst` |
-| Code | `.py`, `.js`, `.ts`, `.go`, `.rs`, `.java`, and [150+ more](https://github.com/Goldziher/tree-sitter-language-pack) |
+See **[Usage Guide](docs/usage.md)** for the full reference — all commands, settings, chat features, supported formats, troubleshooting, and advanced configuration.
 
 ## Build your own integration
 
-lilbee is local-first, but the REST API it exposes is not tied to any specific model. The search endpoint returns relevant document chunks without calling a language model — so if you'd rather use a frontier model like ChatGPT or Claude instead of a local one, you can. Index your documents with lilbee, query the search API, and feed the results into whatever LLM you prefer.
+lilbee exposes a REST API that isn't tied to any specific model. The search endpoint returns relevant chunks without calling an LLM — so you can index locally with lilbee and feed results into a frontier model like ChatGPT or Claude if you prefer. This plugin is a full working example of a client built on that API.
 
-This plugin is a full working example of a client built on that API. Use it as a reference if you want to build your own.
-
-See the [lilbee README](https://github.com/tobocop2/lilbee) for more on the API.
-
-## Troubleshooting
-
-| Problem | Fix |
-|---------|-----|
-| Red connection dot | Start the server: `lilbee serve` in your vault directory |
-| No search results | Run **Sync vault** to index your documents |
-| Sync fails | Ensure Ollama is running — sync needs the embedding model |
-
-[Open an issue](https://github.com/tobocop2/obsidian-lilbee/issues) for bugs or feature requests.
+See the [lilbee README](https://github.com/tobocop2/lilbee) for the API docs.
 
 ## License
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,175 @@
+# Usage Guide
+
+## Installation
+
+### Prerequisites
+
+- **[Ollama](https://ollama.com)** — must be installed and running. The embedding model is pulled automatically on first sync.
+
+### Install via BRAT
+
+1. Install [BRAT](https://github.com/TfTHacker/obsidian42-brat) if you don't have it — Settings → Community plugins → Browse → search "BRAT" → Install → Enable
+2. Open the command palette (`Cmd/Ctrl + P`) → **BRAT: Plugins: Add a beta plugin for testing**
+3. Paste `tobocop2/obsidian-lilbee` and click **Add Plugin**
+4. Go to Settings → Community plugins and enable **lilbee**
+
+### What happens on first launch
+
+When you enable the plugin for the first time:
+
+1. It downloads the lilbee server binary from GitHub to `.obsidian/plugins/lilbee/bin/`
+2. On macOS, it clears the quarantine flag (`xattr -cr`) so the binary can run without Gatekeeper blocking it
+3. It starts the server on `127.0.0.1:7433` and shows progress in the status bar
+4. Once the server is ready, the status bar shows `lilbee: ready`
+
+If the download or startup fails, the status bar shows `lilbee: error`. Check that you have an internet connection (for the initial download) and that Ollama is running.
+
+---
+
+## Commands
+
+All commands are available via `Cmd/Ctrl + P` → "lilbee":
+
+| Command | What it does |
+|---------|-------------|
+| **Sync vault** | Index new/changed files, remove deleted ones |
+| **Open chat** | Open the chat sidebar |
+| **Search knowledge base** | Semantic search with live results |
+| **Ask a question** | One-off answer with source citations |
+| **Add current file** | Index just the active file |
+| **Add current folder** | Index all files in the active folder |
+| **Show status** | Show document and chunk counts |
+
+You can also right-click any file or folder in the file explorer and select **Add to lilbee**.
+
+---
+
+## Chat
+
+The chat sidebar (`lilbee: Open chat`) is the main interface:
+
+- **Streaming responses** — answers render as they arrive, with full markdown support
+- **Source citations** — expandable list of source documents with click-to-open
+- **Attach files** — use the attachment button to add PDFs, code files, images, or folders to the conversation
+- **Save to vault** — export the conversation as a markdown file
+- **Stop generation** — cancel mid-stream if the answer isn't useful
+- **Inline progress** — sync and indexing progress shows directly in the chat with cancel support
+
+---
+
+## Settings
+
+Settings → Community plugins → lilbee.
+
+### Server mode
+
+| Mode | Description |
+|------|-------------|
+| **Managed (built-in)** | The plugin downloads, starts, and stops the lilbee server automatically. This is the default. |
+| **External (manual)** | You run the lilbee server yourself. Enter the URL in the Server URL field. A "Reset to managed" button lets you switch back. |
+
+When using **managed mode**, the status bar shows `lilbee: ready`. When using **external mode**, it shows `lilbee: ready [external]` so you know you're connected to a server the plugin isn't managing.
+
+### Managed server settings
+
+| Setting | Description |
+|---------|-------------|
+| **Server status** | Shows the current state with a colored indicator (green = ready, yellow = starting, red = error) |
+| **Server port** | Port for the managed server (default: 7433) |
+| **Check for updates** | Check if a newer lilbee binary is available on GitHub |
+
+### External server settings
+
+| Setting | Description |
+|---------|-------------|
+| **Server URL** | Address of your lilbee server, with a Test button to verify connectivity |
+| **Reset to managed** | Switch back to the built-in server |
+
+### Connection
+
+| Setting | Description |
+|---------|-------------|
+| **Ollama URL** | Address of the Ollama server (default: `http://127.0.0.1:11434`), with a Test button |
+
+### Models
+
+The models section shows curated catalogs for chat and vision models. You can:
+
+- **Select a model** from the dropdown — if it's not installed, the plugin pulls it automatically with progress
+- **Pull** any model from the catalog manually
+- **Delete** installed models you no longer need
+- **Refresh** to re-fetch the catalog from the server
+
+Models installed via Ollama that aren't in the curated catalog still appear in the dropdown under "Other...".
+
+### General
+
+| Setting | Description |
+|---------|-------------|
+| **Results count** | Number of search results to return (1–20, default: 5) |
+
+### Sync
+
+| Setting | Description |
+|---------|-------------|
+| **Sync mode** | **Manual** — sync only when you run the command. **Auto** — watches for file changes and syncs after a debounce delay. |
+| **Sync debounce** | Delay in ms before auto-sync triggers after a change (default: 5000). Only shown in auto mode. |
+
+### Advanced (generation)
+
+These override the model's defaults. Leave blank to use whatever the model ships with — the placeholder shows the model's current default.
+
+| Setting | Description |
+|---------|-------------|
+| **Temperature** | Controls randomness (0.0–2.0) |
+| **Top P** | Nucleus sampling threshold (0.0–1.0) |
+| **Top K (sampling)** | Limits token choices per step |
+| **Repeat penalty** | Penalizes repeated tokens (1.0+) |
+| **Context length** | Max context window in tokens |
+| **Seed** | Fixed seed for reproducible output |
+
+---
+
+## Supported formats
+
+Text extraction powered by [Kreuzberg](https://github.com/Goldziher/kreuzberg), code chunking by [tree-sitter](https://tree-sitter.github.io/tree-sitter/). This list is not exhaustive — Kreuzberg supports additional formats beyond what's listed here.
+
+| Format | Extensions |
+|--------|-----------|
+| PDF | `.pdf` (embedded text + OCR fallback for scanned pages) |
+| Office | `.docx`, `.xlsx`, `.pptx` |
+| eBook | `.epub` |
+| Images | `.png`, `.jpg`, `.jpeg`, `.tiff`, `.bmp`, `.webp` (requires vision model) |
+| Data | `.csv`, `.tsv`, `.xml`, `.json`, `.jsonl`, `.yaml`, `.yml` |
+| Text | `.md`, `.txt`, `.html`, `.rst` |
+| Code | `.py`, `.js`, `.ts`, `.go`, `.rs`, `.java`, and [150+ more](https://github.com/Goldziher/tree-sitter-language-pack) |
+
+---
+
+## Troubleshooting
+
+### Server won't start
+
+- **macOS Gatekeeper**: The plugin runs `xattr -cr` on the binary automatically, but if macOS still blocks it, go to System Settings → Privacy & Security and click "Allow Anyway" next to the lilbee binary.
+- **Port in use**: Change the server port in settings if 7433 is already taken.
+- **No internet on first run**: The binary must be downloaded once. After that, the plugin works offline.
+
+### No search results
+
+Run **Sync vault** first. Documents need to be indexed before they're searchable.
+
+### Sync fails
+
+Make sure Ollama is running — syncing needs the embedding model. The first sync pulls the embedding model automatically, which requires Ollama to be reachable.
+
+### Red connection indicator
+
+The server isn't reachable. In managed mode, check the status bar for error details. In external mode, verify the server URL and that the server is running.
+
+### Model pull stuck
+
+Click **Cancel** on the pull progress indicator. Then try again — the download resumes from where it left off (handled by Ollama).
+
+---
+
+[Open an issue](https://github.com/tobocop2/obsidian-lilbee/issues) for bugs or feature requests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@vitest/coverage-v8": "^2.1.9",
                 "builtin-modules": "^4.0.0",
                 "esbuild": "^0.24.0",
-                "obsidian": "latest",
+                "obsidian": "^1.12.0",
                 "typescript": "^5.6.0",
                 "vitest": "^2.1.9"
             }

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>lilbee for Obsidian — talk to your vault</title>
+<style>
+  :root {
+    --bg: #1e1e2e;
+    --purple: #a78bfa;
+    --dim: #6d5daa;
+    --faint: #3b3566;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: 'JetBrains Mono', 'Fira Code', 'SF Mono', 'Courier New', monospace;
+    background: var(--bg);
+    color: var(--purple);
+    min-height: 100vh;
+    padding: 2rem;
+    font-size: 14px;
+    line-height: 1.4;
+  }
+  body::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    background: repeating-linear-gradient(
+      0deg,
+      transparent,
+      transparent 2px,
+      rgba(0, 0, 0, 0.12) 2px,
+      rgba(0, 0, 0, 0.12) 4px
+    );
+    pointer-events: none;
+    z-index: 999;
+  }
+  pre { font: inherit; white-space: pre; }
+  a { color: var(--purple); text-decoration: none; }
+  a:hover { text-shadow: 0 0 8px rgba(167, 139, 250, 0.5); }
+  .dim { color: var(--dim); }
+  .faint { color: var(--faint); }
+  .cursor {
+    display: inline-block;
+    width: 0.6em;
+    height: 1.1em;
+    background: var(--purple);
+    vertical-align: text-bottom;
+    animation: blink 1s step-end infinite;
+  }
+  @keyframes blink { 50% { opacity: 0; } }
+  h1 {
+    position: absolute;
+    width: 1px; height: 1px;
+    overflow: hidden;
+    clip: rect(0,0,0,0);
+  }
+
+  .layout {
+    display: flex;
+    gap: 3rem;
+    align-items: flex-start;
+  }
+  .main { flex: 0 1 auto; min-width: 0; }
+  .bee-art {
+    flex: 0 0 auto;
+    font-size: 7px;
+    line-height: 1.1;
+    color: var(--dim);
+    text-shadow: 0 0 4px rgba(167, 139, 250, 0.15);
+    user-select: none;
+    padding-top: 1rem;
+  }
+
+  .bee-sm { display: none; }
+  @media (max-width: 900px) {
+    .bee-art { display: none; }
+    .bee-sm { display: inline; color: var(--dim); }
+  }
+  .link-dots { }
+  .link-desc { }
+  @media (max-width: 600px) {
+    body { padding: 1rem; font-size: 11px; }
+    .link-dots, .link-desc { display: none; }
+  }
+  .main pre { overflow-x: auto; }
+</style>
+</head>
+<body>
+<h1>lilbee for Obsidian</h1>
+<div class="layout">
+<div class="main"><pre><span class="bee-sm">
+      \)  (/
+     _{    }_
+    / /o  o\ \
+    \  \__/  /
+     '-____-'
+
+</span>888 d8b 888 888
+888 Y8P 888 888
+888     888 888
+888 888 888 88888b.  .d88b.  .d88b.
+888 888 888 888 "88bd8P  Y8bd8P  Y8b
+888 888 888 888  88888888888888888888
+888 888 888 888 d88PY8b.    Y8b.
+888 888 888 88888P"  "Y8888  "Y8888
+
+<span class="dim">for Obsidian — talk to your vault</span>
+
+<span class="faint">════════════════════════════════════════════</span>
+
+ <a href="https://github.com/tobocop2/obsidian-lilbee">[1] GitHub</a><span class="link-dots"> <span class="faint">··············</span></span><span class="link-desc"> <span class="dim">source code</span></span>
+ <a href="https://github.com/tobocop2/lilbee">[2] lilbee CLI</a><span class="link-dots"> <span class="faint">··········</span></span><span class="link-desc"> <span class="dim">Python backend</span></span>
+ <a href="coverage/">[3] Coverage</a><span class="link-dots"> <span class="faint">············</span></span><span class="link-desc"> <span class="dim">100% tested</span></span>
+ <a href="https://github.com/tobocop2/obsidian-lilbee#quick-start">[4] Install via BRAT</a><span class="link-dots"> <span class="faint">····</span></span><span class="link-desc"> <span class="dim">beta install</span></span>
+
+<span class="faint">════════════════════════════════════════════</span>
+
+ <span class="dim">talk to your vault — local, private,
+ grounded in your notes</span>
+
+<span class="faint">────────────────────────────────────────────</span>
+
+ <span class="dim">&gt;</span> chat with your vault via Ollama
+ <span class="dim">&gt;</span> semantic search across notes, PDFs, code
+ <span class="dim">&gt;</span> attach anything — PDFs, images, 150+ code langs
+ <span class="dim">&gt;</span> OCR for scanned documents
+ <span class="dim">&gt;</span> inline progress with cancel support
+ <span class="dim">&gt;</span> save conversations back to your vault
+ <span class="dim">&gt;</span> runs local — nothing leaves your machine
+
+<span class="faint">──── built with lilbee ─────────────────────</span>
+
+ <a href="https://tobocop2.github.io/lilbee/">lilbee</a><span class="link-dots"> <span class="faint">···················</span></span><span class="link-desc"> <span class="dim">local knowledge base backend</span></span>
+
+<span class="faint">──── install ────────────────────────────────</span>
+
+ <span class="dim">1.</span> Install <a href="https://github.com/TfTHacker/obsidian42-brat">BRAT</a> from Community Plugins
+ <span class="dim">2.</span> BRAT → Add Beta Plugin →
+    <span class="dim">tobocop2/obsidian-lilbee</span>
+ <span class="dim">3.</span> Enable "lilbee" in Community Plugins
+ <span class="dim">4.</span> Install <a href="https://ollama.com">Ollama</a> + <a href="https://github.com/tobocop2/lilbee">lilbee CLI</a>:
+
+ <span class="faint">$</span> pip install lilbee
+ <span class="faint">$</span> cd /path/to/vault
+ <span class="faint">$</span> lilbee init && lilbee serve<span class="cursor"></span>
+
+<span class="faint">════════════════════════════════════════════</span>
+ <span class="faint"><a href="https://github.com/tobocop2/obsidian-lilbee">lilbee for Obsidian</a> — <a href="https://opensource.org/licenses/MIT">MIT License</a></span>
+</pre></div>
+<aside class="bee-art" aria-hidden="true"><pre>
+     %           %
+         %           %
+            %           %
+               %          %
+                 %          %
+                   %          %                   :::
+                    %          %                ::::::
+                 %%%%%%  %%%%%%%%%            ::::::::
+              %%%%%ZZZZ%%%%%%   %%%ZZZZ     ::::::::::         ::::::
+             %%%ZZZZZ%%%%%%%%%%%%%%ZZZZZZ  :::::::::::    :::::::::::::::::
+             ZZZ%ZZZ%%%%%%%%%%%%%%%ZZZZZZZ::::::::::***:::::::::::::::::::::
+          ZZZ%ZZZZZZ%%%%%%%%%%%%%%ZZZZZZZZZ::::::***:::::::::::::::::::::::
+        ZZZ%ZZZZZZZZZZ%%%%%%%%%%ZZZZZZ%ZZZZ:::***:::::::::::::::::::::::
+       ZZ%ZZZZZZZZZZZZZZZZZZZZZZZ%%%%% %ZZZ:**::::::::::::::::::::::
+      ZZ%ZZZZZZZZZZZZZZZZZZZZZ%%%%% | | %ZZZ *:::::::::::::::::::
+      Z%ZZZZZZZZZZZZZZZZZ%%%%%%%%%%%%%%%ZZZ::::::::::::::::::::::::::
+       ZZZZZZZZZZZ%%%%%ZZZZZZZZZZZZZZZZZZZ%%%%:::ZZZZ:::::::::::::::::
+         ZZZZ%%%%%ZZZZZZZZZZZZZZZZZZ%%%%%ZZZ%%ZZZ%ZZ%%*:::::::::::
+            ZZZZZZZZZZZZZZZZZZ%%%%%%%%%ZZZZZZZZZZ%ZZ%:::*:::::::
+            *:::%%%%%%%%%%%%%%%%%%%%%%%ZZZZZZZZZZ%%%*::::*::::
+          *:::::::%%%%%%%%%%%%%%%%%%%%%%%ZZZZZ%%      *:::Z
+         **:ZZZZ:::%%%%%%%%%%%%%%%%%%%%%%%%%%%ZZ      ZZZZZ
+        *:ZZZZZZZ       %%%%%%%%%%%%%%%%%%%%%ZZZZ    ZZZZZZZ
+       *::::ZZZZZZ         %%%%%%%%%%%%%%%ZZZZZZZ      ZZZ
+        *::ZZZZZZ           Z%%%%%%%%%%%ZZZZZZZ%%
+          ZZZZ              ZZZZZZZZZZZZZZZZ%%%%%
+                           %%%ZZZZZZZZZZZ%%%%%%%%
+                          Z%%%%%%%%%%%%%%%%%%%%%
+                          ZZ%%%%%%%%%%%%%%%%%%%
+                          %ZZZZZZZZZZZZZZZZZZZ
+                          %%ZZZZZZZZZZZZZZZZZ
+                           %%%%%%%%%%%%%%%%
+                            %%%%%%%%%%%%%
+                             %%%%%%%%%
+                              ZZZZ
+                              ZZZ
+                             ZZ
+                            Z
+</pre></aside>
+</div>
+</body>
+</html>

--- a/src/api.ts
+++ b/src/api.ts
@@ -146,6 +146,7 @@ export class LilbeeClient {
         paths: string[],
         force = false,
         visionModel?: string,
+        signal?: AbortSignal,
     ): AsyncGenerator<SSEEvent> {
         const body: Record<string, unknown> = { paths, force };
         if (visionModel) body.vision_model = visionModel;
@@ -156,12 +157,12 @@ export class LilbeeClient {
                 headers: JSON_HEADERS,
                 body: JSON.stringify(body),
             },
-            { stream: true },
+            { stream: true, signal },
         );
         yield* this.parseSSE(res);
     }
 
-    async *syncStream(forceVision = false): AsyncGenerator<SSEEvent> {
+    async *syncStream(forceVision = false, signal?: AbortSignal): AsyncGenerator<SSEEvent> {
         const res = await this.fetchWithRetry(
             `${this.baseUrl}/api/sync`,
             {
@@ -169,7 +170,7 @@ export class LilbeeClient {
                 headers: JSON_HEADERS,
                 body: JSON.stringify({ force_vision: forceVision }),
             },
-            { stream: true },
+            { stream: true, signal },
         );
         yield* this.parseSSE(res);
     }

--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -1,0 +1,126 @@
+import { execFile, spawn } from "child_process";
+import { createWriteStream, existsSync, mkdirSync, chmodSync } from "fs";
+import { join } from "path";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+/** Exported for test mocking. */
+export const node = { spawn, execFile: execFileAsync, existsSync, mkdirSync, chmodSync, createWriteStream, fetch: globalThis.fetch };
+
+const GITHUB_REPO = "tobocop2/lilbee";
+const RELEASES_API = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
+
+export function getPlatformAssetName(): string {
+    const platform = process.platform;
+    const arch = process.arch;
+    if (platform === "darwin" && arch === "arm64") return "lilbee-macos-arm64";
+    if (platform === "darwin" && arch === "x64") return "lilbee-macos-x86_64";
+    if (platform === "linux" && arch === "x64") return "lilbee-linux-x86_64";
+    if (platform === "win32" && arch === "x64") return "lilbee-windows-x86_64.exe";
+    throw new Error(`Unsupported platform: ${platform}/${arch}`);
+}
+
+interface GitHubAsset {
+    name: string;
+    browser_download_url: string;
+}
+
+interface GitHubRelease {
+    tag_name: string;
+    assets: GitHubAsset[];
+}
+
+export interface ReleaseInfo {
+    tag: string;
+    assetUrl: string;
+}
+
+export async function getLatestRelease(): Promise<ReleaseInfo> {
+    const res = await node.fetch(RELEASES_API, {
+        headers: { Accept: "application/vnd.github.v3+json" },
+    });
+    if (!res.ok) throw new Error(`GitHub API responded ${res.status}`);
+    const data = (await res.json()) as GitHubRelease;
+    const assetName = getPlatformAssetName();
+    const asset = data.assets.find((a) => a.name === assetName);
+    if (!asset) throw new Error(`No asset "${assetName}" in release ${data.tag_name}`);
+    return { tag: data.tag_name, assetUrl: asset.browser_download_url };
+}
+
+export function checkForUpdate(currentVersion: string, latestTag: string): boolean {
+    return currentVersion !== latestTag && latestTag !== "";
+}
+
+export class BinaryManager {
+    private binDir: string;
+
+    constructor(pluginDir: string) {
+        this.binDir = join(pluginDir, "bin");
+    }
+
+    get binaryPath(): string {
+        const name = process.platform === "win32" ? "lilbee.exe" : "lilbee";
+        return join(this.binDir, name);
+    }
+
+    binaryExists(): boolean {
+        return node.existsSync(this.binaryPath);
+    }
+
+    async ensureBinary(onProgress?: (msg: string) => void): Promise<string> {
+        if (this.binaryExists()) return this.binaryPath;
+        onProgress?.("Fetching latest release info...");
+        const release = await getLatestRelease();
+        await this.download(release.assetUrl, onProgress);
+        return this.binaryPath;
+    }
+
+    async download(assetUrl: string, onProgress?: (msg: string) => void): Promise<void> {
+        if (!node.existsSync(this.binDir)) {
+            node.mkdirSync(this.binDir, { recursive: true });
+        }
+
+        onProgress?.("Downloading lilbee binary...");
+        const res = await node.fetch(assetUrl);
+        if (!res.ok) throw new Error(`Download failed: ${res.status}`);
+        if (!res.body) throw new Error("Download response has no body");
+
+        const dest = this.binaryPath;
+        const fileStream = node.createWriteStream(dest);
+        const reader = res.body.getReader();
+
+        const contentLength = Number(res.headers.get("content-length") ?? 0);
+        let downloaded = 0;
+
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            fileStream.write(value);
+            downloaded += value.byteLength;
+            if (contentLength > 0) {
+                const pct = Math.round((downloaded / contentLength) * 100);
+                onProgress?.(`Downloading lilbee binary... ${pct}%`);
+            }
+        }
+        fileStream.end();
+        await new Promise<void>((resolve, reject) => {
+            fileStream.on("finish", resolve);
+            fileStream.on("error", reject);
+        });
+
+        if (process.platform !== "win32") {
+            node.chmodSync(dest, 0o755);
+        }
+
+        if (process.platform === "darwin") {
+            try {
+                await node.execFile("xattr", ["-cr", dest]);
+            } catch {
+                // xattr failure is non-fatal — user may need to allow in System Preferences
+            }
+        }
+
+        onProgress?.("Download complete.");
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,9 @@
 import { type Menu, type MenuItem, Notice, Plugin, type TAbstractFile } from "obsidian";
 import { LilbeeClient, OllamaClient } from "./api";
+import { BinaryManager } from "./binary-manager";
+import { ServerManager } from "./server-manager";
 import { LilbeeSettingTab } from "./settings";
-import { DEFAULT_SETTINGS, SSE_EVENT, type LilbeeSettings, type SSEEvent, type SyncDone } from "./types";
+import { DEFAULT_SETTINGS, SSE_EVENT, type LilbeeSettings, type ServerState, type SSEEvent, type SyncDone } from "./types";
 import { ChatView, VIEW_TYPE_CHAT } from "./views/chat-view";
 import { SearchModal } from "./views/search-modal";
 
@@ -22,16 +24,18 @@ export default class LilbeePlugin extends Plugin {
     activeVisionModel = "";
     statusBarEl: HTMLElement | null = null;
     onProgress: ((event: SSEEvent) => void) | null = null;
+    binaryManager: BinaryManager | null = null;
+    serverManager: ServerManager | null = null;
+    syncController: AbortController | null = null;
     private syncTimeout: ReturnType<typeof setTimeout> | null = null;
     private autoSyncRefs: { id: string }[] = [];
+    private previousServerMode: "managed" | "external" = "managed";
 
     async onload(): Promise<void> {
         await this.loadSettings();
-        this.api = new LilbeeClient(this.settings.serverUrl);
         this.ollama = new OllamaClient(this.settings.ollamaUrl);
 
         this.statusBarEl = this.addStatusBarItem();
-        this.setStatusReady();
         this.registerView(VIEW_TYPE_CHAT, (leaf) => new ChatView(leaf, this));
         this.addSettingTab(new LilbeeSettingTab(this.app, this));
         this.registerCommands();
@@ -46,11 +50,69 @@ export default class LilbeePlugin extends Plugin {
             }),
         );
 
-        this.fetchActiveModel();
+        if (this.settings.serverMode === "managed") {
+            await this.startManagedServer();
+        } else {
+            this.api = new LilbeeClient(this.settings.serverUrl);
+            this.setStatusReady();
+            this.fetchActiveModel();
+        }
 
         if (this.settings.syncMode === "auto") {
             this.registerAutoSync();
         }
+    }
+
+    private async startManagedServer(): Promise<void> {
+        const pluginDir = this.getPluginDir();
+        this.binaryManager = new BinaryManager(pluginDir);
+        this.updateStatusBar("lilbee: downloading...");
+
+        try {
+            const binaryPath = await this.binaryManager.ensureBinary((msg) => {
+                this.updateStatusBar(`lilbee: ${msg}`);
+            });
+
+            const dataDir = `${pluginDir}/server-data`;
+            this.serverManager = new ServerManager({
+                binaryPath,
+                dataDir,
+                port: this.settings.serverPort,
+                ollamaUrl: this.settings.ollamaUrl,
+                onStateChange: (state) => this.handleServerStateChange(state),
+            });
+
+            this.updateStatusBar("lilbee: starting...");
+            await this.serverManager.start();
+            this.api = new LilbeeClient(this.serverManager.serverUrl);
+            this.fetchActiveModel();
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : "unknown error";
+            new Notice(`lilbee: failed to start server — ${msg}`);
+            this.updateStatusBar("lilbee: error");
+        }
+    }
+
+    private handleServerStateChange(state: ServerState): void {
+        switch (state) {
+            case "ready":
+                this.setStatusReady();
+                break;
+            case "starting":
+                this.updateStatusBar("lilbee: starting...");
+                break;
+            case "error":
+                this.updateStatusBar("lilbee: error");
+                break;
+            case "stopped":
+                this.updateStatusBar("lilbee: stopped");
+                break;
+        }
+    }
+
+    private getPluginDir(): string {
+        const adapter = this.app.vault.adapter as unknown as { getBasePath(): string };
+        return `${adapter.getBasePath()}/.obsidian/plugins/lilbee`;
     }
 
     private registerCommands(): void {
@@ -121,15 +183,36 @@ export default class LilbeePlugin extends Plugin {
         if (this.syncTimeout) {
             clearTimeout(this.syncTimeout);
         }
+        void this.serverManager?.stop();
     }
 
     async loadSettings(): Promise<void> {
         this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+        this.previousServerMode = this.settings.serverMode;
     }
 
     async saveSettings(): Promise<void> {
+        const previousMode = this.previousServerMode;
+        this.previousServerMode = this.settings.serverMode;
         await this.saveData(this.settings);
-        this.api = new LilbeeClient(this.settings.serverUrl);
+
+        if (this.settings.serverMode === "managed") {
+            if (previousMode !== "managed") {
+                void this.startManagedServer();
+            } else if (this.serverManager) {
+                this.serverManager.updateOllamaUrl(this.settings.ollamaUrl);
+                this.serverManager.updatePort(this.settings.serverPort);
+                this.api = new LilbeeClient(this.serverManager.serverUrl);
+            }
+        } else {
+            if (previousMode === "managed") {
+                void this.serverManager?.stop();
+                this.serverManager = null;
+                this.binaryManager = null;
+            }
+            this.api = new LilbeeClient(this.settings.serverUrl);
+        }
+
         this.ollama = new OllamaClient(this.settings.ollamaUrl);
         this.updateAutoSync();
     }
@@ -171,13 +254,23 @@ export default class LilbeePlugin extends Plugin {
         if (this.onProgress) this.onProgress(event);
     }
 
+    cancelSync(): void {
+        this.syncController?.abort();
+        this.syncController = null;
+    }
+
     private async runAdd(paths: string[]): Promise<void> {
         this.updateStatusBar("lilbee: adding...");
+        this.syncController = new AbortController();
 
         try {
             let lastEvent: SSEEvent | null = null;
-            for await (const event of this.api.addFiles(paths, false, this.activeVisionModel || undefined)) {
+            for await (const event of this.api.addFiles(paths, false, this.activeVisionModel || undefined, this.syncController.signal)) {
                 this.emitProgress(event);
+                if (event.event === SSE_EVENT.FILE_START) {
+                    const d = event.data as { current_file: number; total_files: number };
+                    this.updateStatusBar(`lilbee: adding ${d.current_file}/${d.total_files}`);
+                }
                 lastEvent = event;
             }
 
@@ -187,12 +280,16 @@ export default class LilbeePlugin extends Plugin {
                 new Notice(summary ? `lilbee: ${summary}` : "lilbee: nothing new to add");
             }
         } catch (err) {
-            const msg = err instanceof Error ? err.message : "cannot connect to server";
-            new Notice(`lilbee: add failed — ${msg}`);
-            return;
+            if (err instanceof Error && err.name === "AbortError") {
+                new Notice("lilbee: add cancelled");
+            } else {
+                const msg = err instanceof Error ? err.message : "cannot connect to server";
+                new Notice(`lilbee: add failed — ${msg}`);
+            }
+        } finally {
+            this.syncController = null;
+            this.setStatusReady();
         }
-
-        this.setStatusReady();
     }
 
     private updateAutoSync(): void {
@@ -247,11 +344,16 @@ export default class LilbeePlugin extends Plugin {
     async triggerSync(): Promise<void> {
         if (!this.statusBarEl) return;
         this.updateStatusBar("lilbee: syncing...");
+        this.syncController = new AbortController();
 
         try {
             let lastEvent: SSEEvent | null = null;
-            for await (const event of this.api.syncStream(!!this.activeVisionModel)) {
+            for await (const event of this.api.syncStream(!!this.activeVisionModel, this.syncController.signal)) {
                 this.emitProgress(event);
+                if (event.event === SSE_EVENT.FILE_START) {
+                    const d = event.data as { current_file: number; total_files: number };
+                    this.updateStatusBar(`lilbee: syncing ${d.current_file}/${d.total_files}`);
+                }
                 lastEvent = event;
             }
 
@@ -260,11 +362,15 @@ export default class LilbeePlugin extends Plugin {
                 const summary = summarizeSyncResult(lastEvent.data as SyncDone);
                 if (summary) new Notice(`lilbee: synced — ${summary}`);
             }
-        } catch {
-            new Notice("lilbee: sync failed — cannot connect to server");
-            return;
+        } catch (err) {
+            if (err instanceof Error && err.name === "AbortError") {
+                new Notice("lilbee: sync cancelled");
+            } else {
+                new Notice("lilbee: sync failed — cannot connect to server");
+            }
+        } finally {
+            this.syncController = null;
+            this.setStatusReady();
         }
-
-        this.setStatusReady();
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { LilbeeClient, OllamaClient } from "./api";
 import { BinaryManager } from "./binary-manager";
 import { ServerManager } from "./server-manager";
 import { LilbeeSettingTab } from "./settings";
-import { DEFAULT_SETTINGS, SSE_EVENT, type LilbeeSettings, type ServerState, type SSEEvent, type SyncDone } from "./types";
+import { DEFAULT_SETTINGS, SERVER_MODE, SSE_EVENT, type LilbeeSettings, type ServerMode, type ServerState, type SSEEvent, type SyncDone } from "./types";
 import { ChatView, VIEW_TYPE_CHAT } from "./views/chat-view";
 import { SearchModal } from "./views/search-modal";
 
@@ -29,7 +29,7 @@ export default class LilbeePlugin extends Plugin {
     syncController: AbortController | null = null;
     private syncTimeout: ReturnType<typeof setTimeout> | null = null;
     private autoSyncRefs: { id: string }[] = [];
-    private previousServerMode: "managed" | "external" = "managed";
+    private previousServerMode: ServerMode = SERVER_MODE.MANAGED;
 
     async onload(): Promise<void> {
         await this.loadSettings();
@@ -50,7 +50,7 @@ export default class LilbeePlugin extends Plugin {
             }),
         );
 
-        if (this.settings.serverMode === "managed") {
+        if (this.settings.serverMode === SERVER_MODE.MANAGED) {
             await this.startManagedServer();
         } else {
             this.api = new LilbeeClient(this.settings.serverUrl);
@@ -196,8 +196,8 @@ export default class LilbeePlugin extends Plugin {
         this.previousServerMode = this.settings.serverMode;
         await this.saveData(this.settings);
 
-        if (this.settings.serverMode === "managed") {
-            if (previousMode !== "managed") {
+        if (this.settings.serverMode === SERVER_MODE.MANAGED) {
+            if (previousMode !== SERVER_MODE.MANAGED) {
                 void this.startManagedServer();
             } else if (this.serverManager) {
                 this.serverManager.updateOllamaUrl(this.settings.ollamaUrl);
@@ -205,7 +205,7 @@ export default class LilbeePlugin extends Plugin {
                 this.api = new LilbeeClient(this.serverManager.serverUrl);
             }
         } else {
-            if (previousMode === "managed") {
+            if (previousMode === SERVER_MODE.MANAGED) {
                 void this.serverManager?.stop();
                 this.serverManager = null;
                 this.binaryManager = null;
@@ -224,7 +224,8 @@ export default class LilbeePlugin extends Plugin {
     }
 
     private setStatusReady(): void {
-        this.updateStatusBar("lilbee: ready");
+        const suffix = this.settings.serverMode === SERVER_MODE.EXTERNAL ? " [external]" : "";
+        this.updateStatusBar(`lilbee: ready${suffix}`);
     }
 
     fetchActiveModel(): void {

--- a/src/server-manager.ts
+++ b/src/server-manager.ts
@@ -1,0 +1,159 @@
+import type { ChildProcess } from "child_process";
+import type { ServerState } from "./types";
+import { SERVER_STATE } from "./types";
+import { node } from "./binary-manager";
+
+const HEALTH_POLL_INTERVAL_MS = 500;
+const HEALTH_POLL_MAX_ATTEMPTS = 30;
+const STOP_GRACE_MS = 5000;
+const CRASH_RESTART_DELAY_MS = 3000;
+const MAX_CRASH_RESTARTS = 3;
+
+export interface ServerManagerOptions {
+    binaryPath: string;
+    dataDir: string;
+    port: number;
+    ollamaUrl: string;
+    onStateChange?: (state: ServerState) => void;
+}
+
+export class ServerManager {
+    private opts: ServerManagerOptions;
+    private child: ChildProcess | null = null;
+    private _state: ServerState = SERVER_STATE.STOPPED;
+    private crashCount = 0;
+    private stopping = false;
+    private restartTimer: ReturnType<typeof setTimeout> | null = null;
+
+    constructor(opts: ServerManagerOptions) {
+        this.opts = opts;
+    }
+
+    get state(): ServerState {
+        return this._state;
+    }
+
+    get serverUrl(): string {
+        return `http://127.0.0.1:${this.opts.port}`;
+    }
+
+    private setState(s: ServerState): void {
+        this._state = s;
+        this.opts.onStateChange?.(s);
+    }
+
+    async start(): Promise<void> {
+        if (this.child) return;
+        this.stopping = false;
+        this.setState(SERVER_STATE.STARTING);
+
+        const args = [
+            "serve",
+            "--host", "127.0.0.1",
+            "--port", String(this.opts.port),
+            "--data-dir", this.opts.dataDir,
+        ];
+
+        const env = { ...process.env, OLLAMA_HOST: this.opts.ollamaUrl };
+
+        this.child = node.spawn(this.opts.binaryPath, args, {
+            env,
+            stdio: "ignore",
+            detached: false,
+        });
+
+        this.child.on("exit", (_code, _signal) => {
+            this.child = null;
+            if (!this.stopping && this.crashCount < MAX_CRASH_RESTARTS) {
+                this.crashCount++;
+                this.setState(SERVER_STATE.ERROR);
+                this.restartTimer = setTimeout(() => {
+                    this.restartTimer = null;
+                    if (!this.stopping) void this.start();
+                }, CRASH_RESTART_DELAY_MS);
+            } else if (!this.stopping) {
+                this.setState(SERVER_STATE.ERROR);
+            }
+        });
+
+        this.child.on("error", () => {
+            this.child = null;
+            this.setState(SERVER_STATE.ERROR);
+        });
+
+        try {
+            await this.waitForReady();
+            this.crashCount = 0;
+            this.setState(SERVER_STATE.READY);
+        } catch {
+            this.setState(SERVER_STATE.ERROR);
+        }
+    }
+
+    private async waitForReady(): Promise<void> {
+        for (let i = 0; i < HEALTH_POLL_MAX_ATTEMPTS; i++) {
+            try {
+                const res = await node.fetch(`${this.serverUrl}/api/health`);
+                if (res.ok) return;
+            } catch {
+                // not ready yet
+            }
+            await new Promise((r) => setTimeout(r, HEALTH_POLL_INTERVAL_MS));
+        }
+        throw new Error("Server did not become ready within timeout");
+    }
+
+    async stop(): Promise<void> {
+        this.stopping = true;
+        if (this.restartTimer) {
+            clearTimeout(this.restartTimer);
+            this.restartTimer = null;
+        }
+        if (!this.child) {
+            this.setState(SERVER_STATE.STOPPED);
+            return;
+        }
+
+        const child = this.child;
+
+        if (process.platform === "win32") {
+            try {
+                await node.execFile("taskkill", ["/pid", String(child.pid), "/f", "/t"]);
+            } catch {
+                // process may already be gone
+            }
+        } else {
+            child.kill("SIGTERM");
+        }
+
+        const exited = await Promise.race([
+            new Promise<boolean>((resolve) => {
+                child.on("exit", () => resolve(true));
+            }),
+            new Promise<boolean>((resolve) => {
+                setTimeout(() => resolve(false), STOP_GRACE_MS);
+            }),
+        ]);
+
+        if (!exited && this.child) {
+            this.child.kill("SIGKILL");
+        }
+
+        this.child = null;
+        this.setState(SERVER_STATE.STOPPED);
+    }
+
+    async restart(): Promise<void> {
+        await this.stop();
+        this.crashCount = 0;
+        await this.start();
+    }
+
+    updateOllamaUrl(url: string): void {
+        this.opts.ollamaUrl = url;
+    }
+
+    updatePort(port: number): void {
+        this.opts.port = port;
+    }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,7 @@
 import { App, Notice, PluginSettingTab, setIcon, Setting } from "obsidian";
 import type LilbeePlugin from "./main";
-import type { ModelCatalog, ModelInfo, ModelsResponse, OllamaModelDefaults } from "./types";
+import { DEFAULT_SETTINGS, SERVER_MODE } from "./types";
+import type { ModelCatalog, ModelInfo, ModelsResponse, OllamaModelDefaults, ServerMode } from "./types";
 
 const CHECK_TIMEOUT_MS = 5000;
 const CLS_MODELS_CONTAINER = "lilbee-models-container";
@@ -92,17 +93,17 @@ export class LilbeeSettingTab extends PluginSettingTab {
             .setDesc("How the lilbee server is managed")
             .addDropdown((dropdown) =>
                 dropdown
-                    .addOption("managed", "Managed (built-in)")
-                    .addOption("external", "External (manual)")
+                    .addOption(SERVER_MODE.MANAGED, "Managed (built-in)")
+                    .addOption(SERVER_MODE.EXTERNAL, "External (manual)")
                     .setValue(this.plugin.settings.serverMode)
                     .onChange(async (value) => {
-                        this.plugin.settings.serverMode = value as "managed" | "external";
+                        this.plugin.settings.serverMode = value as ServerMode;
                         await this.plugin.saveSettings();
                         this.display();
                     }),
             );
 
-        if (this.plugin.settings.serverMode === "managed") {
+        if (this.plugin.settings.serverMode === SERVER_MODE.MANAGED) {
             this.renderManagedSettings(containerEl);
         } else {
             this.renderExternalSettings(containerEl);
@@ -202,6 +203,18 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 await this.checkEndpoint(`${this.plugin.settings.serverUrl}/api/health`, serverStatusEl);
             }),
         );
+
+        new Setting(containerEl)
+            .setName("Switch to managed server")
+            .setDesc("Stop using an external server and start the built-in one")
+            .addButton((btn) =>
+                btn.setButtonText("Reset to managed").onClick(async () => {
+                    this.plugin.settings.serverMode = SERVER_MODE.MANAGED;
+                    this.plugin.settings.serverUrl = DEFAULT_SETTINGS.serverUrl;
+                    await this.plugin.saveSettings();
+                    this.display();
+                }),
+            );
     }
 
     private renderModelsSection(containerEl: HTMLElement): void {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -87,27 +87,26 @@ export class LilbeeSettingTab extends PluginSettingTab {
     }
 
     private renderConnectionSettings(containerEl: HTMLElement): void {
-        const serverSetting = new Setting(containerEl)
-            .setName("Server URL")
-            .setDesc("Address of the lilbee HTTP server")
-            .addText((text) =>
-                text
-                    .setPlaceholder("http://127.0.0.1:7433")
-                    .setValue(this.plugin.settings.serverUrl)
+        new Setting(containerEl)
+            .setName("Server mode")
+            .setDesc("How the lilbee server is managed")
+            .addDropdown((dropdown) =>
+                dropdown
+                    .addOption("managed", "Managed (built-in)")
+                    .addOption("external", "External (manual)")
+                    .setValue(this.plugin.settings.serverMode)
                     .onChange(async (value) => {
-                        this.plugin.settings.serverUrl = value;
+                        this.plugin.settings.serverMode = value as "managed" | "external";
                         await this.plugin.saveSettings();
+                        this.display();
                     }),
             );
 
-        const serverStatusEl = serverSetting.settingEl.createEl("span", { cls: "lilbee-health-status" });
-        void this.checkEndpoint(`${this.plugin.settings.serverUrl}/api/health`, serverStatusEl);
-
-        serverSetting.addButton((btn) =>
-            btn.setButtonText("Test").onClick(async () => {
-                await this.checkEndpoint(`${this.plugin.settings.serverUrl}/api/health`, serverStatusEl);
-            }),
-        );
+        if (this.plugin.settings.serverMode === "managed") {
+            this.renderManagedSettings(containerEl);
+        } else {
+            this.renderExternalSettings(containerEl);
+        }
 
         const ollamaSetting = new Setting(containerEl)
             .setName("Ollama URL")
@@ -128,6 +127,79 @@ export class LilbeeSettingTab extends PluginSettingTab {
         ollamaSetting.addButton((btn) =>
             btn.setButtonText("Test").onClick(async () => {
                 await this.checkEndpoint(this.plugin.settings.ollamaUrl, ollamaStatusEl);
+            }),
+        );
+    }
+
+    private renderManagedSettings(containerEl: HTMLElement): void {
+        const statusSetting = new Setting(containerEl)
+            .setName("Server status")
+            .setDesc("Current state of the managed lilbee server");
+
+        const statusEl = statusSetting.settingEl.createDiv({ cls: "lilbee-server-status" });
+        const dot = statusEl.createDiv({ cls: "lilbee-server-dot" });
+        const stateText = statusEl.createEl("span");
+
+        const serverState = this.plugin.serverManager?.state ?? "stopped";
+        stateText.textContent = serverState;
+        dot.classList.add(`is-${serverState}`);
+
+        new Setting(containerEl)
+            .setName("Server port")
+            .setDesc("Port for the managed lilbee server")
+            .addText((text) =>
+                text
+                    .setPlaceholder("7433")
+                    .setValue(String(this.plugin.settings.serverPort))
+                    .onChange(async (value) => {
+                        const num = parseInt(value, 10);
+                        if (!isNaN(num) && num > 0 && num <= 65535) {
+                            this.plugin.settings.serverPort = num;
+                            await this.plugin.saveSettings();
+                        }
+                    }),
+            );
+
+        new Setting(containerEl)
+            .setName("Check for updates")
+            .setDesc("Check if a newer lilbee binary is available")
+            .addButton((btn) =>
+                btn.setButtonText("Check").onClick(async () => {
+                    try {
+                        const { getLatestRelease, checkForUpdate } = await import("./binary-manager");
+                        const release = await getLatestRelease();
+                        if (checkForUpdate(this.plugin.settings.lilbeeVersion, release.tag)) {
+                            new Notice(`lilbee: update available (${release.tag})`);
+                        } else {
+                            new Notice("lilbee: already up to date");
+                        }
+                    } catch {
+                        new Notice("lilbee: could not check for updates");
+                    }
+                }),
+            );
+    }
+
+    private renderExternalSettings(containerEl: HTMLElement): void {
+        const serverSetting = new Setting(containerEl)
+            .setName("Server URL")
+            .setDesc("Address of the lilbee HTTP server")
+            .addText((text) =>
+                text
+                    .setPlaceholder("http://127.0.0.1:7433")
+                    .setValue(this.plugin.settings.serverUrl)
+                    .onChange(async (value) => {
+                        this.plugin.settings.serverUrl = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        const serverStatusEl = serverSetting.settingEl.createEl("span", { cls: "lilbee-health-status" });
+        void this.checkEndpoint(`${this.plugin.settings.serverUrl}/api/health`, serverStatusEl);
+
+        serverSetting.addButton((btn) =>
+            btn.setButtonText("Test").onClick(async () => {
+                await this.checkEndpoint(`${this.plugin.settings.serverUrl}/api/health`, serverStatusEl);
             }),
         );
     }
@@ -415,18 +487,18 @@ export class LilbeeSettingTab extends PluginSettingTab {
 
         if (model.installed) {
             actionCell.createEl("span", { text: "Installed", cls: "lilbee-installed" });
-            const deleteBtn = actionCell.createEl("button", { cls: "lilbee-model-delete" });
+            const deleteBtn = actionCell.createEl("button", { cls: "lilbee-model-delete" }) as HTMLButtonElement;
             setIcon(deleteBtn, "trash-2");
             deleteBtn.setAttribute("aria-label", "Delete model");
             deleteBtn.addEventListener("click", () => this.deleteModel(deleteBtn, model, type));
         } else {
-            const btn = actionCell.createEl("button", { text: "Pull" });
+            const btn = actionCell.createEl("button", { text: "Pull" }) as HTMLButtonElement;
             btn.addEventListener("click", () => this.pullModel(btn, actionCell, model, type));
         }
     }
 
     private async pullModel(
-        btn: HTMLElement,
+        btn: HTMLButtonElement,
         actionCell: HTMLElement,
         model: ModelInfo,
         type: "chat" | "vision",
@@ -464,7 +536,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             } else {
                 new Notice(`Failed to pull ${model.name}`);
             }
-            (btn as HTMLButtonElement).disabled = false;
+            btn.disabled = false;
             btn.textContent = "Pull";
         } finally {
             progress.remove();
@@ -473,11 +545,11 @@ export class LilbeeSettingTab extends PluginSettingTab {
     }
 
     private async deleteModel(
-        btn: HTMLElement,
+        btn: HTMLButtonElement,
         model: ModelInfo,
         type: "chat" | "vision",
     ): Promise<void> {
-        (btn as HTMLButtonElement).disabled = true;
+        btn.disabled = true;
         try {
             await this.plugin.ollama.delete(model.name);
             new Notice(`Deleted ${model.name}`);
@@ -495,7 +567,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             }
         } catch {
             new Notice(`Failed to delete ${model.name}`);
-            (btn as HTMLButtonElement).disabled = false;
+            btn.disabled = false;
         }
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,6 +115,13 @@ export const SERVER_STATE: Record<string, ServerState> = {
     ERROR: "error",
 } as const;
 
+export type ServerMode = "managed" | "external";
+
+export const SERVER_MODE: Record<string, ServerMode> = {
+    MANAGED: "managed",
+    EXTERNAL: "external",
+} as const;
+
 export interface LilbeeSettings {
     serverUrl: string;
     topK: number;
@@ -127,7 +134,7 @@ export interface LilbeeSettings {
     repeat_penalty: number | null;
     num_ctx: number | null;
     seed: number | null;
-    serverMode: "managed" | "external";
+    serverMode: ServerMode;
     serverPort: number;
     lilbeeVersion: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,16 @@ export interface GenerationOptions {
     seed?: number;
 }
 
+export type ServerState = "stopped" | "downloading" | "starting" | "ready" | "error";
+
+export const SERVER_STATE: Record<string, ServerState> = {
+    STOPPED: "stopped",
+    DOWNLOADING: "downloading",
+    STARTING: "starting",
+    READY: "ready",
+    ERROR: "error",
+} as const;
+
 export interface LilbeeSettings {
     serverUrl: string;
     topK: number;
@@ -117,6 +127,9 @@ export interface LilbeeSettings {
     repeat_penalty: number | null;
     num_ctx: number | null;
     seed: number | null;
+    serverMode: "managed" | "external";
+    serverPort: number;
+    lilbeeVersion: string;
 }
 
 export const DEFAULT_SETTINGS: LilbeeSettings = {
@@ -131,6 +144,9 @@ export const DEFAULT_SETTINGS: LilbeeSettings = {
     repeat_penalty: null,
     num_ctx: null,
     seed: null,
+    serverMode: "managed",
+    serverPort: 7433,
+    lilbeeVersion: "",
 };
 
 /** SSE event type constants — shared across chat, sync, and model pull streams. */

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -25,39 +25,14 @@ export const electronDialog = {
 
 export const VIEW_TYPE_CHAT = "lilbee-chat";
 
-interface ProgressInfo {
-    label: string;
-    current: number;
-    total: number;
+export interface ProgressState {
+    fileIndex: number;
+    fileTotal: number;
+    fileName: string;
+    subLabel: string;
+    subCurrent: number;
+    subTotal: number;
 }
-
-const PROGRESS_EXTRACTORS: Record<string, (data: any) => ProgressInfo> = {
-    [SSE_EVENT.FILE_START]: (d) => ({
-        label: `Indexing ${d.current_file}/${d.total_files} — ${d.file}`,
-        current: d.current_file,
-        total: d.total_files,
-    }),
-    [SSE_EVENT.EXTRACT]: (d) => ({
-        label: `Extracting ${d.file} (page ${d.page}/${d.total_pages})`,
-        current: d.page,
-        total: d.total_pages,
-    }),
-    [SSE_EVENT.EMBED]: (d) => ({
-        label: `Embedding ${d.file} (${d.chunk}/${d.total_chunks} chunks)`,
-        current: d.chunk,
-        total: d.total_chunks,
-    }),
-    [SSE_EVENT.PROGRESS]: (d) => ({
-        label: `Indexing ${d.current}/${d.total} — ${d.file}`,
-        current: d.current,
-        total: d.total,
-    }),
-    [SSE_EVENT.PULL]: (d) => ({
-        label: `Pulling ${d.model} — ${Math.round((d.current / d.total) * 100)}%`,
-        current: d.current,
-        total: d.total,
-    }),
-};
 
 export function buildGenerationOptions(settings: {
     temperature: number | null;
@@ -94,7 +69,8 @@ export class ChatView extends ItemView {
     private pullController: AbortController | null = null;
     private progressCancelBtn: HTMLElement | null = null;
     private progressBanner: HTMLElement | null = null;
-    private progressLabel: HTMLElement | null = null;
+    private progressTopLabel: HTMLElement | null = null;
+    private progressSubLabel: HTMLElement | null = null;
     private progressBar: HTMLElement | null = null;
     private chatCatalog: ModelCatalog | null = null;
     private visionCatalog: ModelCatalog | null = null;
@@ -180,16 +156,19 @@ export class ChatView extends ItemView {
 
     private createProgressBanner(container: HTMLElement): void {
         this.progressBanner = container.createDiv({ cls: "lilbee-progress-banner" });
-        this.progressBanner.style.display = "none";
+        this.progressBanner.dataset.hidden = "";
         const row = this.progressBanner.createDiv({ cls: "lilbee-progress-row" });
-        this.progressLabel = row.createDiv({ cls: "lilbee-progress-label" });
+        this.progressTopLabel = row.createDiv({ cls: "lilbee-progress-top-label" });
         this.progressCancelBtn = row.createEl("button", { cls: "lilbee-progress-cancel" });
         setIcon(this.progressCancelBtn, "x");
         this.progressCancelBtn.setAttribute("aria-label", "Cancel");
-        this.progressCancelBtn.style.display = "none";
-        this.progressCancelBtn.addEventListener("click", () => this.pullController?.abort());
+        this.progressCancelBtn.addEventListener("click", () => {
+            this.pullController?.abort();
+            this.plugin.cancelSync();
+        });
         const barContainer = this.progressBanner.createDiv({ cls: "lilbee-progress-bar-container" });
         this.progressBar = barContainer.createDiv({ cls: "lilbee-progress-bar" });
+        this.progressSubLabel = this.progressBanner.createDiv({ cls: "lilbee-progress-sub-label" });
     }
 
     private createInputArea(container: HTMLElement): void {
@@ -306,7 +285,6 @@ export class ChatView extends ItemView {
     private autoPullAndSet(model: { name: string }, type: "chat" | "vision"): void {
         new Notice(`Pulling ${model.name}...`);
         this.pullController = new AbortController();
-        if (this.progressCancelBtn) this.progressCancelBtn.style.display = "";
         (async () => {
             try {
                 for await (const progress of this.plugin.ollama.pull(
@@ -315,7 +293,7 @@ export class ChatView extends ItemView {
                 )) {
                     if (progress.total && progress.completed !== undefined) {
                         const pct = Math.round((progress.completed / progress.total) * 100);
-                        this.showProgress(
+                        this.showPullProgress(
                             `Pulling ${model.name} — ${pct}%`,
                             progress.completed,
                             progress.total,
@@ -342,7 +320,6 @@ export class ChatView extends ItemView {
                 this.hideProgress();
             } finally {
                 this.pullController = null;
-                if (this.progressCancelBtn) this.progressCancelBtn.style.display = "none";
             }
         })();
     }
@@ -507,30 +484,69 @@ export class ChatView extends ItemView {
     }
 
     handleProgress(event: SSEEvent): void {
-        if (event.event === SSE_EVENT.DONE) {
-            this.hideProgress();
-            return;
+        const data = event.data as Record<string, unknown>;
+
+        switch (event.event) {
+            case SSE_EVENT.FILE_START: {
+                const fileIndex = Number(data.current_file ?? 0);
+                const fileTotal = Number(data.total_files ?? 0);
+                this.showFileProgress(`Syncing ${fileIndex}/${fileTotal} files`, fileIndex, fileTotal, "");
+                break;
+            }
+            case SSE_EVENT.EXTRACT: {
+                const page = Number(data.page ?? 0);
+                const totalPages = Number(data.total_pages ?? 0);
+                this.updateSubLabel(`Extracting page ${page}/${totalPages} — ${data.file ?? ""}`);
+                break;
+            }
+            case SSE_EVENT.EMBED: {
+                const chunk = Number(data.chunk ?? 0);
+                const totalChunks = Number(data.total_chunks ?? 0);
+                this.updateSubLabel(`Embedding chunk ${chunk}/${totalChunks} — ${data.file ?? ""}`);
+                break;
+            }
+            case SSE_EVENT.PROGRESS: {
+                const current = Number(data.current ?? 0);
+                const total = Number(data.total ?? 0);
+                this.showFileProgress(`Indexing ${current}/${total} — ${data.file ?? ""}`, current, total, "");
+                break;
+            }
+            case SSE_EVENT.PULL: {
+                const current = Number(data.current ?? 0);
+                const total = Number(data.total ?? 0);
+                const pct = total > 0 ? Math.round((current / total) * 100) : 0;
+                this.showFileProgress(`Pulling model — ${pct}%`, current, total, "");
+                break;
+            }
+            case SSE_EVENT.DONE:
+                this.hideProgress();
+                break;
         }
-
-        const extractor = PROGRESS_EXTRACTORS[event.event];
-        if (!extractor) return;
-
-        const info = extractor(event.data);
-        this.showProgress(info.label, info.current, info.total);
     }
 
-    showProgress(label: string, current: number, total: number): void {
-        if (!this.progressBanner || !this.progressLabel || !this.progressBar) return;
-        this.progressBanner.style.display = "";
-        this.progressLabel.textContent = label;
-        this.progressBar.style.width = `${Math.round((current / total) * 100)}%`;
+    private showFileProgress(topLabel: string, current: number, total: number, subLabel: string): void {
+        if (!this.progressBanner || !this.progressTopLabel || !this.progressBar || !this.progressSubLabel) return;
+        delete this.progressBanner.dataset.hidden;
+        this.progressTopLabel.textContent = topLabel;
+        this.progressBar.style.width = total > 0 ? `${Math.round((current / total) * 100)}%` : "0%";
+        this.progressSubLabel.textContent = subLabel;
+    }
+
+    private showPullProgress(label: string, current: number, total: number): void {
+        this.showFileProgress(label, current, total, "");
+    }
+
+    private updateSubLabel(text: string): void {
+        if (!this.progressSubLabel) return;
+        this.progressSubLabel.textContent = text;
     }
 
     hideProgress(): void {
-        if (!this.progressBanner || !this.progressBar) return;
-        this.progressBanner.style.display = "none";
+        if (!this.progressBanner || !this.progressBar || !this.progressSubLabel) return;
+        this.progressBanner.dataset.hidden = "";
         this.progressBar.style.width = "0%";
-        if (this.progressCancelBtn) this.progressCancelBtn.style.display = "none";
+        if (this.progressTopLabel) this.progressTopLabel.textContent = "";
+        this.progressSubLabel.textContent = "";
     }
 
     private async saveToVault(): Promise<void> {

--- a/styles.css
+++ b/styles.css
@@ -137,10 +137,26 @@
     background-color: var(--background-secondary);
     border-bottom: 1px solid var(--background-modifier-border);
     flex-shrink: 0;
+    transition: opacity 150ms ease;
+    opacity: 1;
 }
 
-.lilbee-progress-label {
+.lilbee-progress-banner[data-hidden] {
+    opacity: 0;
+    pointer-events: none;
+}
+
+.lilbee-progress-top-label {
     font-size: var(--font-smallest, 10px);
+    color: var(--text-normal);
+    font-weight: var(--font-medium, 500);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.lilbee-progress-sub-label {
+    font-size: 9px;
     color: var(--text-muted);
     white-space: nowrap;
     overflow: hidden;
@@ -159,7 +175,36 @@
     background-color: var(--interactive-accent);
     border-radius: 2px;
     width: 0%;
-    transition: width 0.3s ease;
+    transition: width 200ms ease-out;
+}
+
+.lilbee-server-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.lilbee-server-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: var(--text-muted);
+}
+
+.lilbee-server-dot.is-ready {
+    background-color: var(--color-green, #2d7a4f);
+}
+
+.lilbee-server-dot.is-error {
+    background-color: var(--text-error);
+}
+
+.lilbee-server-dot.is-starting {
+    background-color: var(--color-yellow, #e0a526);
+}
+
+.lilbee-server-dot.is-downloading {
+    background-color: var(--color-yellow, #e0a526);
 }
 
 .lilbee-chat-messages {
@@ -447,7 +492,7 @@
     gap: 4px;
 }
 
-.lilbee-progress-row .lilbee-progress-label {
+.lilbee-progress-row .lilbee-progress-top-label {
     flex: 1;
 }
 

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -15,6 +15,7 @@ export class MockElement {
     classList: { list: string[]; add: (...classes: string[]) => void; remove: (...classes: string[]) => void; contains: (cls: string) => boolean };
     style: Record<string, string> = {};
     attributes: Record<string, string> = {};
+    dataset: Record<string, string> = {};
     _listeners: Record<string, Function[]> = {};
     value: string = "";
     disabled: boolean = false;

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -755,6 +755,19 @@ describe("OllamaClient", () => {
             ]);
         });
 
+        it("skips blank lines between NDJSON entries", async () => {
+            fetchMock.mockResolvedValue(ndjsonResponse([
+                '{"status":"ok"}\n\n\n{"status":"done"}\n',
+            ]));
+
+            const results = await collect(ollama.pull("llama3"));
+
+            expect(results).toEqual([
+                { status: "ok" },
+                { status: "done" },
+            ]);
+        });
+
         it("handles trailing NDJSON line without newline", async () => {
             fetchMock.mockResolvedValue(ndjsonResponse([
                 '{"status":"success"}',
@@ -875,6 +888,13 @@ describe("OllamaClient", () => {
 
             const defaults = await ollama.show("llama3");
             expect(defaults.num_ctx).toBe(4096);
+        });
+
+        it("handles missing both parameters and model_info fields", async () => {
+            fetchMock.mockResolvedValue(jsonResponse({}));
+
+            const defaults = await ollama.show("llama3");
+            expect(defaults).toEqual({});
         });
     });
 });

--- a/tests/binary-manager.test.ts
+++ b/tests/binary-manager.test.ts
@@ -1,0 +1,458 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { node, getPlatformAssetName, getLatestRelease, checkForUpdate, BinaryManager } from "../src/binary-manager";
+import { EventEmitter } from "events";
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+/** Stub process.platform and process.arch, returning a restore function. */
+function stubPlatform(platform: string, arch: string) {
+    const origPlatform = Object.getOwnPropertyDescriptor(process, "platform")!;
+    const origArch = Object.getOwnPropertyDescriptor(process, "arch")!;
+    Object.defineProperty(process, "platform", { value: platform, configurable: true });
+    Object.defineProperty(process, "arch", { value: arch, configurable: true });
+    return () => {
+        Object.defineProperty(process, "platform", origPlatform);
+        Object.defineProperty(process, "arch", origArch);
+    };
+}
+
+/** Create a mock ReadableStream reader that yields the given Uint8Array chunks. */
+function mockReader(chunks: Uint8Array[]) {
+    let index = 0;
+    return {
+        read: vi.fn(async () => {
+            if (index < chunks.length) {
+                return { done: false, value: chunks[index++] };
+            }
+            return { done: true, value: undefined };
+        }),
+    };
+}
+
+/** Create a mock file stream (EventEmitter with write/end). Emits "finish" on end(). */
+function mockFileStream() {
+    const emitter = new EventEmitter();
+    const stream = Object.assign(emitter, {
+        write: vi.fn(),
+        end: vi.fn(() => {
+            // Emit finish asynchronously so the promise handler is registered first
+            queueMicrotask(() => emitter.emit("finish"));
+        }),
+    });
+    return stream;
+}
+
+/** Build a fake fetch Response for download tests. */
+function downloadResponse(chunks: Uint8Array[], contentLength?: number): Response {
+    const headers = new Headers();
+    if (contentLength !== undefined) {
+        headers.set("content-length", String(contentLength));
+    }
+    return {
+        ok: true,
+        status: 200,
+        headers,
+        body: { getReader: () => mockReader(chunks) },
+    } as unknown as Response;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Setup / Teardown                                                  */
+/* ------------------------------------------------------------------ */
+
+beforeEach(() => {
+    vi.restoreAllMocks();
+});
+
+/* ------------------------------------------------------------------ */
+/*  getPlatformAssetName                                              */
+/* ------------------------------------------------------------------ */
+
+describe("getPlatformAssetName", () => {
+    let restore: () => void;
+    afterEach(() => restore?.());
+
+    it("returns arm64 macOS asset name", () => {
+        restore = stubPlatform("darwin", "arm64");
+        expect(getPlatformAssetName()).toBe("lilbee-macos-arm64");
+    });
+
+    it("returns x64 macOS asset name", () => {
+        restore = stubPlatform("darwin", "x64");
+        expect(getPlatformAssetName()).toBe("lilbee-macos-x86_64");
+    });
+
+    it("returns linux x64 asset name", () => {
+        restore = stubPlatform("linux", "x64");
+        expect(getPlatformAssetName()).toBe("lilbee-linux-x86_64");
+    });
+
+    it("returns windows x64 asset name", () => {
+        restore = stubPlatform("win32", "x64");
+        expect(getPlatformAssetName()).toBe("lilbee-windows-x86_64.exe");
+    });
+
+    it("throws for unsupported platform", () => {
+        restore = stubPlatform("freebsd", "arm");
+        expect(() => getPlatformAssetName()).toThrow("Unsupported platform: freebsd/arm");
+    });
+});
+
+/* ------------------------------------------------------------------ */
+/*  getLatestRelease                                                  */
+/* ------------------------------------------------------------------ */
+
+describe("getLatestRelease", () => {
+    let restore: () => void;
+    afterEach(() => restore?.());
+
+    it("returns tag and assetUrl on success", async () => {
+        restore = stubPlatform("darwin", "arm64");
+        vi.spyOn(node, "fetch").mockResolvedValue({
+            ok: true,
+            json: () =>
+                Promise.resolve({
+                    tag_name: "v1.0.0",
+                    assets: [{ name: "lilbee-macos-arm64", browser_download_url: "https://example.com/download" }],
+                }),
+        } as unknown as Response);
+
+        const release = await getLatestRelease();
+        expect(release).toEqual({ tag: "v1.0.0", assetUrl: "https://example.com/download" });
+    });
+
+    it("throws when GitHub API returns non-ok response", async () => {
+        vi.spyOn(node, "fetch").mockResolvedValue({
+            ok: false,
+            status: 403,
+        } as unknown as Response);
+
+        await expect(getLatestRelease()).rejects.toThrow("GitHub API responded 403");
+    });
+
+    it("throws when asset is not found in release", async () => {
+        restore = stubPlatform("darwin", "arm64");
+        vi.spyOn(node, "fetch").mockResolvedValue({
+            ok: true,
+            json: () =>
+                Promise.resolve({
+                    tag_name: "v2.0.0",
+                    assets: [{ name: "some-other-asset", browser_download_url: "https://example.com/other" }],
+                }),
+        } as unknown as Response);
+
+        await expect(getLatestRelease()).rejects.toThrow('No asset "lilbee-macos-arm64" in release v2.0.0');
+    });
+});
+
+/* ------------------------------------------------------------------ */
+/*  checkForUpdate                                                    */
+/* ------------------------------------------------------------------ */
+
+describe("checkForUpdate", () => {
+    it("returns true when versions differ", () => {
+        expect(checkForUpdate("v1.0.0", "v2.0.0")).toBe(true);
+    });
+
+    it("returns false when versions are the same", () => {
+        expect(checkForUpdate("v1.0.0", "v1.0.0")).toBe(false);
+    });
+
+    it("returns false when latest tag is empty", () => {
+        expect(checkForUpdate("v1.0.0", "")).toBe(false);
+    });
+});
+
+/* ------------------------------------------------------------------ */
+/*  BinaryManager                                                     */
+/* ------------------------------------------------------------------ */
+
+describe("BinaryManager", () => {
+    let restore: () => void;
+    afterEach(() => restore?.());
+
+    describe("binaryPath", () => {
+        it("returns unix binary path on non-win32", () => {
+            restore = stubPlatform("darwin", "arm64");
+            const mgr = new BinaryManager("/plugins/lilbee");
+            expect(mgr.binaryPath).toContain("lilbee");
+            expect(mgr.binaryPath).not.toContain(".exe");
+            expect(mgr.binaryPath).toBe("/plugins/lilbee/bin/lilbee");
+        });
+
+        it("returns .exe binary path on win32", () => {
+            restore = stubPlatform("win32", "x64");
+            const mgr = new BinaryManager("/plugins/lilbee");
+            expect(mgr.binaryPath).toContain("lilbee.exe");
+        });
+    });
+
+    describe("binaryExists", () => {
+        it("returns true when binary file exists", () => {
+            restore = stubPlatform("darwin", "arm64");
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            const mgr = new BinaryManager("/plugins/lilbee");
+            expect(mgr.binaryExists()).toBe(true);
+        });
+
+        it("returns false when binary file does not exist", () => {
+            restore = stubPlatform("darwin", "arm64");
+            vi.spyOn(node, "existsSync").mockReturnValue(false);
+            const mgr = new BinaryManager("/plugins/lilbee");
+            expect(mgr.binaryExists()).toBe(false);
+        });
+    });
+
+    describe("ensureBinary", () => {
+        it("returns path immediately when binary already exists", async () => {
+            restore = stubPlatform("darwin", "arm64");
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            const mgr = new BinaryManager("/plugins/lilbee");
+            const path = await mgr.ensureBinary();
+            expect(path).toBe(mgr.binaryPath);
+        });
+
+        it("downloads binary when it does not exist", async () => {
+            restore = stubPlatform("darwin", "arm64");
+            const mgr = new BinaryManager("/plugins/lilbee");
+            const chunk = new Uint8Array([1, 2, 3]);
+            const fStream = mockFileStream();
+
+            // existsSync: first call (binaryExists) => false, second call (binDir check in download) => true
+            vi.spyOn(node, "existsSync").mockReturnValueOnce(false).mockReturnValueOnce(true);
+            vi.spyOn(node, "fetch")
+                .mockResolvedValueOnce({
+                    ok: true,
+                    json: () =>
+                        Promise.resolve({
+                            tag_name: "v1.0.0",
+                            assets: [{ name: "lilbee-macos-arm64", browser_download_url: "https://example.com/dl" }],
+                        }),
+                } as unknown as Response)
+                .mockResolvedValueOnce(downloadResponse([chunk]));
+            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+            vi.spyOn(node, "chmodSync").mockImplementation(() => {});
+            vi.spyOn(node, "execFile").mockResolvedValue({ stdout: "", stderr: "" });
+
+            const onProgress = vi.fn();
+            const path = await mgr.ensureBinary(onProgress);
+
+            expect(path).toBe(mgr.binaryPath);
+            expect(onProgress).toHaveBeenCalledWith("Fetching latest release info...");
+            expect(onProgress).toHaveBeenCalledWith("Downloading lilbee binary...");
+            expect(onProgress).toHaveBeenCalledWith("Download complete.");
+        });
+    });
+
+    describe("download", () => {
+        it("creates binDir when it does not exist", async () => {
+            restore = stubPlatform("linux", "x64");
+            const chunk = new Uint8Array([10, 20]);
+            const fStream = mockFileStream();
+
+            vi.spyOn(node, "existsSync").mockReturnValue(false);
+            vi.spyOn(node, "mkdirSync").mockImplementation(() => undefined as any);
+            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk]));
+            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+            vi.spyOn(node, "chmodSync").mockImplementation(() => {});
+
+            const mgr = new BinaryManager("/plugins/lilbee");
+            await mgr.download("https://example.com/dl");
+
+            expect(node.mkdirSync).toHaveBeenCalledWith(expect.stringContaining("bin"), { recursive: true });
+        });
+
+        it("skips mkdir when binDir already exists", async () => {
+            restore = stubPlatform("linux", "x64");
+            const chunk = new Uint8Array([10, 20]);
+            const fStream = mockFileStream();
+
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            vi.spyOn(node, "mkdirSync").mockImplementation(() => undefined as any);
+            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk]));
+            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+            vi.spyOn(node, "chmodSync").mockImplementation(() => {});
+
+            const mgr = new BinaryManager("/plugins/lilbee");
+            await mgr.download("https://example.com/dl");
+
+            expect(node.mkdirSync).not.toHaveBeenCalled();
+        });
+
+        it("writes stream data and calls chmod on non-win32", async () => {
+            restore = stubPlatform("linux", "x64");
+            const chunk1 = new Uint8Array([1, 2, 3]);
+            const chunk2 = new Uint8Array([4, 5, 6]);
+            const fStream = mockFileStream();
+
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk1, chunk2], 6));
+            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+            vi.spyOn(node, "chmodSync").mockImplementation(() => {});
+
+            const onProgress = vi.fn();
+            const mgr = new BinaryManager("/plugins/lilbee");
+            await mgr.download("https://example.com/dl", onProgress);
+
+            expect(fStream.write).toHaveBeenCalledTimes(2);
+            expect(fStream.write).toHaveBeenCalledWith(chunk1);
+            expect(fStream.write).toHaveBeenCalledWith(chunk2);
+            expect(fStream.end).toHaveBeenCalled();
+            expect(node.chmodSync).toHaveBeenCalledWith(mgr.binaryPath, 0o755);
+            // Progress with percentages
+            expect(onProgress).toHaveBeenCalledWith("Downloading lilbee binary... 50%");
+            expect(onProgress).toHaveBeenCalledWith("Downloading lilbee binary... 100%");
+            expect(onProgress).toHaveBeenCalledWith("Download complete.");
+        });
+
+        it("skips percentage progress when content-length is absent", async () => {
+            restore = stubPlatform("linux", "x64");
+            const chunk = new Uint8Array([1, 2, 3]);
+            const fStream = mockFileStream();
+
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            // No content-length header
+            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk]));
+            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+            vi.spyOn(node, "chmodSync").mockImplementation(() => {});
+
+            const onProgress = vi.fn();
+            const mgr = new BinaryManager("/plugins/lilbee");
+            await mgr.download("https://example.com/dl", onProgress);
+
+            // Should not have any percentage-based progress calls
+            const percentageCalls = onProgress.mock.calls.filter((c: string[]) => c[0].includes("%"));
+            expect(percentageCalls).toHaveLength(0);
+            expect(onProgress).toHaveBeenCalledWith("Downloading lilbee binary...");
+            expect(onProgress).toHaveBeenCalledWith("Download complete.");
+        });
+
+        it("calls xattr on darwin", async () => {
+            restore = stubPlatform("darwin", "arm64");
+            const chunk = new Uint8Array([1]);
+            const fStream = mockFileStream();
+
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk]));
+            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+            vi.spyOn(node, "chmodSync").mockImplementation(() => {});
+            const execSpy = vi.spyOn(node, "execFile").mockResolvedValue({ stdout: "", stderr: "" });
+
+            const mgr = new BinaryManager("/plugins/lilbee");
+            await mgr.download("https://example.com/dl");
+
+            expect(execSpy).toHaveBeenCalledWith("xattr", ["-cr", mgr.binaryPath]);
+        });
+
+        it("treats xattr failure as non-fatal on darwin", async () => {
+            restore = stubPlatform("darwin", "arm64");
+            const chunk = new Uint8Array([1]);
+            const fStream = mockFileStream();
+
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk]));
+            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+            vi.spyOn(node, "chmodSync").mockImplementation(() => {});
+            vi.spyOn(node, "execFile").mockRejectedValue(new Error("xattr not found"));
+
+            const mgr = new BinaryManager("/plugins/lilbee");
+            // Should not throw
+            await expect(mgr.download("https://example.com/dl")).resolves.toBeUndefined();
+        });
+
+        it("skips chmod on win32", async () => {
+            restore = stubPlatform("win32", "x64");
+            const chunk = new Uint8Array([1]);
+            const fStream = mockFileStream();
+
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk]));
+            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+            vi.spyOn(node, "chmodSync").mockImplementation(() => {});
+
+            const mgr = new BinaryManager("/plugins/lilbee");
+            await mgr.download("https://example.com/dl");
+
+            expect(node.chmodSync).not.toHaveBeenCalled();
+        });
+
+        it("does not call xattr on non-darwin platforms", async () => {
+            restore = stubPlatform("linux", "x64");
+            const chunk = new Uint8Array([1]);
+            const fStream = mockFileStream();
+
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk]));
+            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+            vi.spyOn(node, "chmodSync").mockImplementation(() => {});
+            const execSpy = vi.spyOn(node, "execFile").mockResolvedValue({ stdout: "", stderr: "" });
+
+            const mgr = new BinaryManager("/plugins/lilbee");
+            await mgr.download("https://example.com/dl");
+
+            expect(execSpy).not.toHaveBeenCalled();
+        });
+
+        it("throws when download response is not ok", async () => {
+            restore = stubPlatform("linux", "x64");
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            vi.spyOn(node, "fetch").mockResolvedValue({
+                ok: false,
+                status: 404,
+            } as unknown as Response);
+
+            const mgr = new BinaryManager("/plugins/lilbee");
+            await expect(mgr.download("https://example.com/dl")).rejects.toThrow("Download failed: 404");
+        });
+
+        it("throws when download response has no body", async () => {
+            restore = stubPlatform("linux", "x64");
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            vi.spyOn(node, "fetch").mockResolvedValue({
+                ok: true,
+                status: 200,
+                body: null,
+                headers: new Headers(),
+            } as unknown as Response);
+
+            const mgr = new BinaryManager("/plugins/lilbee");
+            await expect(mgr.download("https://example.com/dl")).rejects.toThrow("Download response has no body");
+        });
+
+        it("rejects when fileStream emits error", async () => {
+            restore = stubPlatform("linux", "x64");
+            const chunk = new Uint8Array([1]);
+            const emitter = new EventEmitter();
+            const fStream = Object.assign(emitter, {
+                write: vi.fn(),
+                end: vi.fn(() => {
+                    queueMicrotask(() => emitter.emit("error", new Error("disk full")));
+                }),
+            });
+
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk]));
+            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+
+            const mgr = new BinaryManager("/plugins/lilbee");
+            await expect(mgr.download("https://example.com/dl")).rejects.toThrow("disk full");
+        });
+
+        it("works without onProgress callback", async () => {
+            restore = stubPlatform("linux", "x64");
+            const chunk = new Uint8Array([1]);
+            const fStream = mockFileStream();
+
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk], 1));
+            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+            vi.spyOn(node, "chmodSync").mockImplementation(() => {});
+
+            const mgr = new BinaryManager("/plugins/lilbee");
+            // No onProgress — should not throw
+            await expect(mgr.download("https://example.com/dl")).resolves.toBeUndefined();
+        });
+    });
+});

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -33,7 +33,41 @@ vi.mock("../src/views/search-modal", () => ({
     SearchModal: vi.fn().mockImplementation(() => ({ open: vi.fn() })),
 }));
 
-async function createPlugin() {
+const mockEnsureBinary = vi.fn().mockResolvedValue("/fake/bin/lilbee");
+const mockServerStart = vi.fn().mockResolvedValue(undefined);
+const mockServerStop = vi.fn().mockResolvedValue(undefined);
+const mockUpdateOllamaUrl = vi.fn();
+const mockUpdatePort = vi.fn();
+let mockServerOpts: any = null;
+
+vi.mock("../src/binary-manager", () => ({
+    BinaryManager: vi.fn().mockImplementation(() => ({
+        ensureBinary: mockEnsureBinary,
+        binaryPath: "/fake/bin/lilbee",
+        binaryExists: vi.fn().mockReturnValue(true),
+    })),
+    getLatestRelease: vi.fn(),
+    checkForUpdate: vi.fn(),
+    node: { spawn: vi.fn(), execFile: vi.fn(), existsSync: vi.fn(), mkdirSync: vi.fn(), chmodSync: vi.fn(), createWriteStream: vi.fn(), fetch: vi.fn() },
+}));
+
+vi.mock("../src/server-manager", () => ({
+    ServerManager: vi.fn().mockImplementation((opts: any) => {
+        mockServerOpts = opts;
+        return {
+            start: mockServerStart,
+            stop: mockServerStop,
+            restart: vi.fn(),
+            updateOllamaUrl: mockUpdateOllamaUrl,
+            updatePort: mockUpdatePort,
+            get serverUrl() { return `http://127.0.0.1:${opts.port}`; },
+            get state() { return "ready"; },
+            opts,
+        };
+    }),
+}));
+
+async function createPlugin(overrideData?: Record<string, unknown>) {
     const { default: LilbeePlugin } = await import("../src/main");
     const app = new App();
     const plugin = new LilbeePlugin(app as any, {
@@ -44,6 +78,12 @@ async function createPlugin() {
         author: "test",
         description: "test",
     } as any);
+    // Default to external mode so tests don't attempt to download/spawn a binary
+    if (overrideData) {
+        plugin.loadData = vi.fn().mockResolvedValue(overrideData);
+    } else {
+        plugin.loadData = vi.fn().mockResolvedValue({ serverMode: "external" });
+    }
     return plugin;
 }
 
@@ -157,7 +197,7 @@ describe("LilbeePlugin", () => {
 
         it("with manual sync mode: registers only file-menu event (no vault events)", async () => {
             const plugin = await createPlugin();
-            plugin.loadData = vi.fn().mockResolvedValue({ syncMode: "manual" });
+            plugin.loadData = vi.fn().mockResolvedValue({ serverMode: "external", syncMode: "manual" });
             await plugin.onload();
             // 1 for file-menu
             expect(plugin.registerEvent).toHaveBeenCalledTimes(1);
@@ -165,7 +205,7 @@ describe("LilbeePlugin", () => {
 
         it("with auto sync mode: registers vault events + file-menu", async () => {
             const plugin = await createPlugin();
-            plugin.loadData = vi.fn().mockResolvedValue({ syncMode: "auto" });
+            plugin.loadData = vi.fn().mockResolvedValue({ serverMode: "external", syncMode: "auto" });
             await plugin.onload();
             // 4 vault events + 1 file-menu = 5
             expect(plugin.registerEvent).toHaveBeenCalledTimes(5);
@@ -174,7 +214,7 @@ describe("LilbeePlugin", () => {
         it("recreates API client with loaded serverUrl", async () => {
             const { LilbeeClient } = await import("../src/api");
             const plugin = await createPlugin();
-            plugin.loadData = vi.fn().mockResolvedValue({ serverUrl: "http://custom:9999" });
+            plugin.loadData = vi.fn().mockResolvedValue({ serverMode: "external", serverUrl: "http://custom:9999" });
             await plugin.onload();
             expect(LilbeeClient).toHaveBeenCalledWith("http://custom:9999");
         });
@@ -202,7 +242,7 @@ describe("LilbeePlugin", () => {
     describe("loadSettings()", () => {
         it("merges saved data over defaults", async () => {
             const plugin = await createPlugin();
-            plugin.loadData = vi.fn().mockResolvedValue({ topK: 15, syncMode: "auto" });
+            plugin.loadData = vi.fn().mockResolvedValue({ serverMode: "external", topK: 15, syncMode: "auto" });
             await plugin.loadSettings();
             expect(plugin.settings.topK).toBe(15);
             expect(plugin.settings.syncMode).toBe("auto");
@@ -210,7 +250,7 @@ describe("LilbeePlugin", () => {
         });
 
         it("uses defaults when loadData returns null/empty", async () => {
-            const plugin = await createPlugin();
+            const plugin = await createPlugin({ serverMode: "external" });
             plugin.loadData = vi.fn().mockResolvedValue(null);
             await plugin.loadSettings();
             expect(plugin.settings.topK).toBe(5);
@@ -247,7 +287,7 @@ describe("LilbeePlugin", () => {
     describe("updateAutoSync()", () => {
         it("registers vault events when switching from manual to auto", async () => {
             const plugin = await createPlugin();
-            plugin.loadData = vi.fn().mockResolvedValue({ syncMode: "manual" });
+            plugin.loadData = vi.fn().mockResolvedValue({ serverMode: "external", syncMode: "manual" });
             await plugin.onload();
 
             expect(plugin.registerEvent).toHaveBeenCalledTimes(1);
@@ -261,7 +301,7 @@ describe("LilbeePlugin", () => {
 
         it("clears autoSyncRefs when switching from auto to manual", async () => {
             const plugin = await createPlugin();
-            plugin.loadData = vi.fn().mockResolvedValue({ syncMode: "auto" });
+            plugin.loadData = vi.fn().mockResolvedValue({ serverMode: "external", syncMode: "auto" });
             await plugin.onload();
 
             expect((plugin as any).autoSyncRefs.length).toBe(4);
@@ -274,7 +314,7 @@ describe("LilbeePlugin", () => {
 
         it("does not re-register events when already in auto mode", async () => {
             const plugin = await createPlugin();
-            plugin.loadData = vi.fn().mockResolvedValue({ syncMode: "auto" });
+            plugin.loadData = vi.fn().mockResolvedValue({ serverMode: "external", syncMode: "auto" });
             await plugin.onload();
 
             const callsBefore = (plugin.registerEvent as ReturnType<typeof vi.fn>).mock.calls.length;
@@ -346,7 +386,7 @@ describe("LilbeePlugin", () => {
         it("schedules triggerSync after debounce delay", async () => {
             vi.useFakeTimers();
             const plugin = await createPlugin();
-            plugin.loadData = vi.fn().mockResolvedValue({ syncDebounceMs: 1000 });
+            plugin.loadData = vi.fn().mockResolvedValue({ serverMode: "external", syncDebounceMs: 1000 });
             await plugin.onload();
 
             const triggerSpy = vi.spyOn(plugin, "triggerSync").mockResolvedValue(undefined);
@@ -360,7 +400,7 @@ describe("LilbeePlugin", () => {
         it("cancels previous timer when called again", async () => {
             vi.useFakeTimers();
             const plugin = await createPlugin();
-            plugin.loadData = vi.fn().mockResolvedValue({ syncDebounceMs: 500 });
+            plugin.loadData = vi.fn().mockResolvedValue({ serverMode: "external", syncDebounceMs: 500 });
             await plugin.onload();
 
             const triggerSpy = vi.spyOn(plugin, "triggerSync").mockResolvedValue(undefined);
@@ -575,7 +615,7 @@ describe("LilbeePlugin", () => {
     describe("registerAutoSync()", () => {
         it("vault event callbacks call debouncedSync", async () => {
             const plugin = await createPlugin();
-            plugin.loadData = vi.fn().mockResolvedValue({ syncMode: "auto" });
+            plugin.loadData = vi.fn().mockResolvedValue({ serverMode: "external", syncMode: "auto" });
 
             const debouncedSpy = vi.spyOn(plugin as any, "debouncedSync").mockImplementation(() => {});
 
@@ -636,7 +676,7 @@ describe("LilbeePlugin", () => {
 
             await (plugin as any).addToLilbee({ path: "notes/test.md", name: "test.md" });
 
-            expect(plugin.api.addFiles).toHaveBeenCalledWith(["/test/vault/notes/test.md"], false, undefined);
+            expect(plugin.api.addFiles).toHaveBeenCalledWith(["/test/vault/notes/test.md"], false, undefined, expect.any(AbortSignal));
         });
 
         it("addToLilbee shows summary Notice on done event", async () => {
@@ -764,7 +804,7 @@ describe("LilbeePlugin", () => {
 
             await plugin.addExternalFiles(["/home/user/doc.pdf", "/tmp/notes.md"]);
 
-            expect(plugin.api.addFiles).toHaveBeenCalledWith(["/home/user/doc.pdf", "/tmp/notes.md"], false, undefined);
+            expect(plugin.api.addFiles).toHaveBeenCalledWith(["/home/user/doc.pdf", "/tmp/notes.md"], false, undefined, expect.any(AbortSignal));
         });
 
         it("passes vision model when activeVisionModel is set", async () => {
@@ -778,7 +818,7 @@ describe("LilbeePlugin", () => {
             await plugin.addExternalFiles(["/home/user/scan.pdf"]);
 
             expect(plugin.api.addFiles).toHaveBeenCalledWith(
-                ["/home/user/scan.pdf"], false, "minicpm-v:latest",
+                ["/home/user/scan.pdf"], false, "minicpm-v:latest", expect.any(AbortSignal),
             );
         });
 
@@ -818,6 +858,20 @@ describe("LilbeePlugin", () => {
             await plugin.addExternalFiles(["/home/user/doc.pdf"]);
 
             expect(Notice.instances.some((n) => n.message.includes("1 added"))).toBe(true);
+        });
+
+        it("updates status bar on FILE_START during addExternalFiles", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+
+            async function* withFileStart() {
+                yield { event: SSE_EVENT.FILE_START, data: { file: "doc.pdf", current_file: 2, total_files: 5 } };
+            }
+            plugin.api.addFiles = vi.fn().mockReturnValue(withFileStart());
+
+            await plugin.addExternalFiles(["/home/user/doc.pdf"]);
+
+            expect((plugin as any).statusBarEl?.textContent).toContain("ready");
         });
 
         it("shows error Notice on API failure", async () => {
@@ -995,6 +1049,181 @@ describe("LilbeePlugin", () => {
             expect(() => {
                 (plugin as any).updateStatusBar("test");
             }).not.toThrow();
+        });
+    });
+
+    describe("managed server mode", () => {
+        it("onload in managed mode creates binaryManager and serverManager", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+
+            expect(plugin.binaryManager).not.toBeNull();
+            expect(plugin.serverManager).not.toBeNull();
+            expect(mockEnsureBinary).toHaveBeenCalled();
+            expect(mockServerStart).toHaveBeenCalled();
+        });
+
+        it("managed mode shows error Notice when startManagedServer fails", async () => {
+            mockEnsureBinary.mockRejectedValueOnce(new Error("download failed"));
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+
+            expect(Notice.instances.some((n) => n.message.includes("failed to start server"))).toBe(true);
+            expect(Notice.instances.some((n) => n.message.includes("download failed"))).toBe(true);
+        });
+
+        it("managed mode shows error Notice with 'unknown error' for non-Error throw", async () => {
+            mockEnsureBinary.mockRejectedValueOnce("string error");
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+
+            expect(Notice.instances.some((n) => n.message.includes("unknown error"))).toBe(true);
+        });
+
+        it("handleServerStateChange updates status bar for all states", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+
+            const stateChange = mockServerOpts?.onStateChange;
+            expect(stateChange).toBeDefined();
+
+            stateChange("ready");
+            expect((plugin as any).statusBarEl?.textContent).toContain("ready");
+
+            stateChange("starting");
+            expect((plugin as any).statusBarEl?.textContent).toContain("starting");
+
+            stateChange("error");
+            expect((plugin as any).statusBarEl?.textContent).toContain("error");
+
+            stateChange("stopped");
+            expect((plugin as any).statusBarEl?.textContent).toContain("stopped");
+        });
+
+        it("ensureBinary progress callback updates status bar", async () => {
+            let progressCb: ((msg: string) => void) | undefined;
+            mockEnsureBinary.mockImplementationOnce(async (cb: any) => {
+                progressCb = cb;
+                cb?.("Downloading...");
+                return "/fake/bin/lilbee";
+            });
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+
+            expect(progressCb).toBeDefined();
+        });
+    });
+
+    describe("saveSettings mode switching", () => {
+        it("managed → external: stops server and nulls managers", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+
+            expect(plugin.serverManager).not.toBeNull();
+
+            plugin.settings.serverMode = "external";
+            await plugin.saveSettings();
+
+            expect(mockServerStop).toHaveBeenCalled();
+            expect(plugin.serverManager).toBeNull();
+            expect(plugin.binaryManager).toBeNull();
+        });
+
+        it("external → managed: starts managed server", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+
+            expect(plugin.serverManager).toBeNull();
+
+            plugin.settings.serverMode = "managed";
+            await plugin.saveSettings();
+
+            // startManagedServer is called via void (fire-and-forget)
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(plugin.binaryManager).not.toBeNull();
+        });
+
+        it("managed → managed with serverManager: updates port and ollama url", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+
+            plugin.settings.ollamaUrl = "http://custom:11434";
+            plugin.settings.serverPort = 9999;
+            await plugin.saveSettings();
+
+            expect(mockUpdateOllamaUrl).toHaveBeenCalledWith("http://custom:11434");
+            expect(mockUpdatePort).toHaveBeenCalledWith(9999);
+        });
+    });
+
+    describe("cancelSync()", () => {
+        it("aborts the sync controller and nulls it", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+
+            plugin.syncController = new AbortController();
+            const abortSpy = vi.spyOn(plugin.syncController, "abort");
+
+            plugin.cancelSync();
+
+            expect(abortSpy).toHaveBeenCalled();
+            expect(plugin.syncController).toBeNull();
+        });
+
+        it("no-ops when syncController is null", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.syncController = null;
+
+            expect(() => plugin.cancelSync()).not.toThrow();
+        });
+    });
+
+    describe("AbortError handling", () => {
+        it("runAdd shows 'add cancelled' on AbortError", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+
+            const abortError = new Error("Aborted");
+            abortError.name = "AbortError";
+            plugin.api.addFiles = vi.fn().mockImplementation(async function* () {
+                throw abortError;
+            });
+
+            await (plugin as any).addToLilbee({ path: "test.md", name: "test.md" });
+
+            expect(Notice.instances.some((n) => n.message.includes("add cancelled"))).toBe(true);
+        });
+
+        it("triggerSync shows 'sync cancelled' on AbortError", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+
+            const abortError = new Error("Aborted");
+            abortError.name = "AbortError";
+            plugin.api.syncStream = vi.fn().mockImplementation(async function* () {
+                throw abortError;
+            });
+
+            await plugin.triggerSync();
+
+            expect(Notice.instances.some((n) => n.message.includes("sync cancelled"))).toBe(true);
+        });
+    });
+
+    describe("onunload with serverManager", () => {
+        it("calls serverManager.stop on unload", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+
+            mockServerStop.mockClear();
+            plugin.onunload();
+
+            expect(mockServerStop).toHaveBeenCalled();
         });
     });
 });

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -189,10 +189,10 @@ describe("LilbeePlugin", () => {
             expect(addSpy).toHaveBeenCalledWith(folder);
         });
 
-        it("sets status bar text to 'lilbee: ready'", async () => {
+        it("sets status bar text to 'lilbee: ready [external]' in external mode", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
-            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready");
+            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready [external]");
         });
 
         it("with manual sync mode: registers only file-menu event (no vault events)", async () => {
@@ -414,7 +414,7 @@ describe("LilbeePlugin", () => {
     });
 
     describe("triggerSync()", () => {
-        it("updates status bar during sync and resets to 'ready'", async () => {
+        it("updates status bar during sync and resets to ready", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
 
@@ -423,7 +423,7 @@ describe("LilbeePlugin", () => {
 
             await plugin.triggerSync();
 
-            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready");
+            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready [external]");
         });
 
         it("emits progress events to onProgress callback", async () => {
@@ -1005,7 +1005,7 @@ describe("LilbeePlugin", () => {
             await new Promise((r) => setTimeout(r, 0));
 
             expect(plugin.activeModel).toBe("qwen3:8b");
-            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready (qwen3:8b)");
+            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready [external] (qwen3:8b)");
         });
 
         it("fetchActiveModel silently fails on API error", async () => {
@@ -1018,7 +1018,7 @@ describe("LilbeePlugin", () => {
             await new Promise((r) => setTimeout(r, 0));
 
             expect(plugin.activeModel).toBe("");
-            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready");
+            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready [external]");
         });
 
         it("status bar includes model name during sync", async () => {
@@ -1224,6 +1224,20 @@ describe("LilbeePlugin", () => {
             plugin.onunload();
 
             expect(mockServerStop).toHaveBeenCalled();
+        });
+    });
+
+    describe("external mode status bar label", () => {
+        it("shows [external] in external mode", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready [external]");
+        });
+
+        it("does not show [external] in managed mode", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            expect((plugin as any).statusBarEl?.textContent).not.toContain("[external]");
         });
     });
 });

--- a/tests/server-manager.test.ts
+++ b/tests/server-manager.test.ts
@@ -1,0 +1,474 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { node } from "../src/binary-manager";
+import { ServerManager } from "../src/server-manager";
+import type { ServerManagerOptions } from "../src/server-manager";
+
+// ── Mock child process ──────────────────────────────────────────────
+
+function mockChild() {
+    const handlers: Record<string, Function[]> = {};
+    return {
+        pid: 1234,
+        on(event: string, handler: Function) {
+            (handlers[event] ??= []).push(handler);
+        },
+        kill: vi.fn(),
+        _emit(event: string, ...args: unknown[]) {
+            for (const h of handlers[event] ?? []) h(...args);
+        },
+    };
+}
+
+type MockChild = ReturnType<typeof mockChild>;
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function defaultOpts(overrides?: Partial<ServerManagerOptions>): ServerManagerOptions {
+    return {
+        binaryPath: "/usr/local/bin/lilbee",
+        dataDir: "/tmp/data",
+        port: 7433,
+        ollamaUrl: "http://localhost:11434",
+        ...overrides,
+    };
+}
+
+/** Returns a fetch mock that succeeds (ok: true) on health checks. */
+function healthyFetch() {
+    return vi.fn().mockResolvedValue({ ok: true });
+}
+
+/** Returns a fetch mock that always rejects. */
+function failingFetch() {
+    return vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+}
+
+// ── Test suite ──────────────────────────────────────────────────────
+
+describe("ServerManager", () => {
+    let spawnSpy: ReturnType<typeof vi.spyOn>;
+    let fetchSpy: ReturnType<typeof vi.spyOn>;
+    let execFileSpy: ReturnType<typeof vi.spyOn>;
+    let child: MockChild;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        child = mockChild();
+        spawnSpy = vi.spyOn(node, "spawn").mockReturnValue(child as any);
+        fetchSpy = vi.spyOn(node, "fetch").mockResolvedValue({ ok: true } as any);
+        execFileSpy = vi.spyOn(node, "execFile").mockResolvedValue({ stdout: "", stderr: "" } as any);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    // ── Constructor / getters ───────────────────────────────────────
+
+    describe("constructor", () => {
+        it("initial state is stopped", () => {
+            const mgr = new ServerManager(defaultOpts());
+            expect(mgr.state).toBe("stopped");
+        });
+
+        it("serverUrl reflects the configured port", () => {
+            const mgr = new ServerManager(defaultOpts({ port: 9999 }));
+            expect(mgr.serverUrl).toBe("http://127.0.0.1:9999");
+        });
+    });
+
+    // ── start() ─────────────────────────────────────────────────────
+
+    describe("start()", () => {
+        it("spawns the binary with correct args and env, sets state to ready", async () => {
+            const stateChanges: string[] = [];
+            const mgr = new ServerManager(
+                defaultOpts({ onStateChange: (s) => stateChanges.push(s) }),
+            );
+
+            const startPromise = mgr.start();
+            // Health poll setTimeout — advance past it
+            await vi.advanceTimersByTimeAsync(500);
+            await startPromise;
+
+            expect(spawnSpy).toHaveBeenCalledOnce();
+            const [bin, args, opts] = spawnSpy.mock.calls[0] as any[];
+            expect(bin).toBe("/usr/local/bin/lilbee");
+            expect(args).toEqual([
+                "serve",
+                "--host", "127.0.0.1",
+                "--port", "7433",
+                "--data-dir", "/tmp/data",
+            ]);
+            expect(opts.env.OLLAMA_HOST).toBe("http://localhost:11434");
+            expect(opts.stdio).toBe("ignore");
+            expect(opts.detached).toBe(false);
+
+            expect(mgr.state).toBe("ready");
+            expect(stateChanges).toContain("starting");
+            expect(stateChanges).toContain("ready");
+        });
+
+        it("no-ops when child already exists", async () => {
+            const mgr = new ServerManager(defaultOpts());
+            const p1 = mgr.start();
+            await vi.advanceTimersByTimeAsync(500);
+            await p1;
+
+            // Second call should return immediately without spawning again
+            await mgr.start();
+            expect(spawnSpy).toHaveBeenCalledOnce();
+        });
+
+        it("sets state to error when health polling times out", async () => {
+            fetchSpy.mockRejectedValue(new Error("ECONNREFUSED"));
+            const stateChanges: string[] = [];
+            const mgr = new ServerManager(
+                defaultOpts({ onStateChange: (s) => stateChanges.push(s) }),
+            );
+
+            const startPromise = mgr.start();
+            // 30 attempts * 500ms each = 15000ms
+            await vi.advanceTimersByTimeAsync(15_000);
+            await startPromise;
+
+            expect(mgr.state).toBe("error");
+        });
+
+        it("sets state to error when health returns non-ok then eventually times out", async () => {
+            fetchSpy.mockResolvedValue({ ok: false } as any);
+            const mgr = new ServerManager(defaultOpts());
+
+            const startPromise = mgr.start();
+            await vi.advanceTimersByTimeAsync(15_000);
+            await startPromise;
+
+            expect(mgr.state).toBe("error");
+        });
+    });
+
+    // ── stop() ──────────────────────────────────────────────────────
+
+    describe("stop()", () => {
+        it("with no child, sets state to stopped immediately", async () => {
+            const stateChanges: string[] = [];
+            const mgr = new ServerManager(
+                defaultOpts({ onStateChange: (s) => stateChanges.push(s) }),
+            );
+            await mgr.stop();
+            expect(mgr.state).toBe("stopped");
+            expect(stateChanges).toContain("stopped");
+        });
+
+        it("sends SIGTERM and sets stopped after exit event (unix)", async () => {
+            const originalPlatform = process.platform;
+            Object.defineProperty(process, "platform", { value: "linux" });
+
+            const mgr = new ServerManager(defaultOpts());
+            const p1 = mgr.start();
+            await vi.advanceTimersByTimeAsync(500);
+            await p1;
+
+            // Make kill emit exit asynchronously
+            child.kill = vi.fn(() => {
+                setTimeout(() => child._emit("exit", 0, null), 10);
+            });
+
+            const stopPromise = mgr.stop();
+            await vi.advanceTimersByTimeAsync(50);
+            await stopPromise;
+
+            expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+            expect(mgr.state).toBe("stopped");
+
+            Object.defineProperty(process, "platform", { value: originalPlatform });
+        });
+
+        it("sends SIGKILL after grace period if process does not exit", async () => {
+            const mgr = new ServerManager(defaultOpts());
+            const p1 = mgr.start();
+            await vi.advanceTimersByTimeAsync(500);
+            await p1;
+
+            const stopPromise = mgr.stop();
+            // Don't emit exit — let the grace period expire
+            await vi.advanceTimersByTimeAsync(5000);
+            await stopPromise;
+
+            expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+            expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+            expect(mgr.state).toBe("stopped");
+        });
+
+        it("clears pending restart timer", async () => {
+            const mgr = new ServerManager(defaultOpts());
+            const p1 = mgr.start();
+            await vi.advanceTimersByTimeAsync(500);
+            await p1;
+
+            // Simulate crash to trigger restart timer
+            child._emit("exit", 1, null);
+            // Now a 3000ms restart timer is pending
+
+            await mgr.stop();
+            // Advance past restart delay — should NOT trigger another start
+            await vi.advanceTimersByTimeAsync(3000);
+            // spawn was called once for the original start, should not be called again
+            expect(spawnSpy).toHaveBeenCalledOnce();
+            expect(mgr.state).toBe("stopped");
+        });
+
+        it("uses taskkill on Windows", async () => {
+            const originalPlatform = process.platform;
+            Object.defineProperty(process, "platform", { value: "win32" });
+
+            const mgr = new ServerManager(defaultOpts());
+            const p1 = mgr.start();
+            await vi.advanceTimersByTimeAsync(500);
+            await p1;
+
+            // Let execFile resolve, then emit exit so stop() can finish
+            execFileSpy.mockImplementation(async () => {
+                // Schedule exit emission after taskkill "completes"
+                setTimeout(() => child._emit("exit", 0, null), 10);
+                return { stdout: "", stderr: "" };
+            });
+
+            const stopPromise = mgr.stop();
+            await vi.advanceTimersByTimeAsync(50);
+            await stopPromise;
+
+            expect(execFileSpy).toHaveBeenCalledWith(
+                "taskkill",
+                ["/pid", "1234", "/f", "/t"],
+            );
+            expect(mgr.state).toBe("stopped");
+
+            Object.defineProperty(process, "platform", { value: originalPlatform });
+        });
+
+        it("handles taskkill failure gracefully on Windows", async () => {
+            const originalPlatform = process.platform;
+            Object.defineProperty(process, "platform", { value: "win32" });
+            execFileSpy.mockImplementation(async () => {
+                setTimeout(() => child._emit("exit", 0, null), 10);
+                throw new Error("process not found");
+            });
+
+            const mgr = new ServerManager(defaultOpts());
+            const p1 = mgr.start();
+            await vi.advanceTimersByTimeAsync(500);
+            await p1;
+
+            const stopPromise = mgr.stop();
+            await vi.advanceTimersByTimeAsync(50);
+            await stopPromise;
+
+            // Should not throw — error is swallowed
+            expect(mgr.state).toBe("stopped");
+
+            Object.defineProperty(process, "platform", { value: originalPlatform });
+        });
+    });
+
+    // ── restart() ───────────────────────────────────────────────────
+
+    describe("restart()", () => {
+        it("calls stop then start and resets crash count", async () => {
+            const mgr = new ServerManager(defaultOpts());
+            const p1 = mgr.start();
+            await vi.advanceTimersByTimeAsync(500);
+            await p1;
+
+            // Simulate a crash to increment crashCount
+            child._emit("exit", 1, null);
+
+            // Prepare a fresh child for the restart
+            const child2 = mockChild();
+            spawnSpy.mockReturnValue(child2 as any);
+
+            const restartPromise = mgr.restart();
+            await vi.advanceTimersByTimeAsync(500);
+            await restartPromise;
+
+            expect(mgr.state).toBe("ready");
+            // spawn was called twice: original + restart
+            expect(spawnSpy).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    // ── Crash recovery ──────────────────────────────────────────────
+
+    describe("crash recovery", () => {
+        it("increments crashCount, sets error, and schedules restart on exit", async () => {
+            const stateChanges: string[] = [];
+            const mgr = new ServerManager(
+                defaultOpts({ onStateChange: (s) => stateChanges.push(s) }),
+            );
+
+            const p1 = mgr.start();
+            await vi.advanceTimersByTimeAsync(500);
+            await p1;
+
+            // Prepare a new child for the restart
+            const child2 = mockChild();
+            spawnSpy.mockReturnValue(child2 as any);
+
+            // Simulate crash
+            child._emit("exit", 1, null);
+            expect(mgr.state).toBe("error");
+
+            // Advance past restart delay (3000ms) + health poll (500ms)
+            await vi.advanceTimersByTimeAsync(3500);
+
+            expect(spawnSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it("stops restarting after MAX_CRASH_RESTARTS (3)", async () => {
+            const mgr = new ServerManager(defaultOpts());
+
+            const p1 = mgr.start();
+            await vi.advanceTimersByTimeAsync(500);
+            await p1;
+            // spawn call #1 done, crashCount = 0
+
+            // Make health checks fail from now on so crashCount never resets
+            fetchSpy.mockRejectedValue(new Error("ECONNREFUSED"));
+
+            for (let i = 0; i < 3; i++) {
+                const nextChild = mockChild();
+                spawnSpy.mockReturnValue(nextChild as any);
+
+                // Crash the current child
+                child._emit("exit", 1, null);
+                // crashCount is now i+1, restart timer scheduled (3000ms)
+
+                // Advance past restart delay so start() is called
+                await vi.advanceTimersByTimeAsync(3000);
+                // start() spawns nextChild and enters waitForReady (30 * 500ms = 15000ms)
+                // Advance past all health poll attempts
+                await vi.advanceTimersByTimeAsync(15_000);
+
+                child = nextChild;
+            }
+
+            // Now crashCount = 3. Crash once more — should NOT schedule restart
+            child._emit("exit", 1, null);
+            expect(mgr.state).toBe("error");
+
+            await vi.advanceTimersByTimeAsync(10_000);
+            // 1 initial + 3 restarts = 4 spawn calls total
+            expect(spawnSpy).toHaveBeenCalledTimes(4);
+        });
+
+        it("stop() during restart delay cancels the pending restart", async () => {
+            const mgr = new ServerManager(defaultOpts());
+            const p1 = mgr.start();
+            await vi.advanceTimersByTimeAsync(500);
+            await p1;
+
+            // Crash triggers restart timer
+            child._emit("exit", 1, null);
+
+            // Stop before the restart timer fires
+            await mgr.stop();
+
+            // Advance past what would have been the restart
+            await vi.advanceTimersByTimeAsync(5000);
+            expect(spawnSpy).toHaveBeenCalledOnce();
+            expect(mgr.state).toBe("stopped");
+        });
+    });
+
+    // ── error event ─────────────────────────────────────────────────
+
+    describe("error event", () => {
+        it("sets state to error and nullifies child", async () => {
+            const stateChanges: string[] = [];
+            const mgr = new ServerManager(
+                defaultOpts({ onStateChange: (s) => stateChanges.push(s) }),
+            );
+
+            const p1 = mgr.start();
+            // Fire error before health check completes
+            child._emit("error", new Error("spawn ENOENT"));
+            await vi.advanceTimersByTimeAsync(15_000);
+            await p1;
+
+            expect(stateChanges).toContain("error");
+        });
+    });
+
+    // ── updateOllamaUrl / updatePort ────────────────────────────────
+
+    describe("updateOllamaUrl", () => {
+        it("updates the Ollama URL in options", () => {
+            const mgr = new ServerManager(defaultOpts());
+            mgr.updateOllamaUrl("http://remote:11434");
+
+            // Start to verify the new URL is used
+            mgr.start();
+            const env = (spawnSpy.mock.calls[0] as any[])[2].env;
+            expect(env.OLLAMA_HOST).toBe("http://remote:11434");
+        });
+    });
+
+    describe("updatePort", () => {
+        it("updates the port in options", () => {
+            const mgr = new ServerManager(defaultOpts());
+            mgr.updatePort(8080);
+            expect(mgr.serverUrl).toBe("http://127.0.0.1:8080");
+        });
+    });
+
+    // ── onStateChange callback ──────────────────────────────────────
+
+    describe("onStateChange", () => {
+        it("fires for each state transition during start", async () => {
+            const stateChanges: string[] = [];
+            const mgr = new ServerManager(
+                defaultOpts({ onStateChange: (s) => stateChanges.push(s) }),
+            );
+
+            const p = mgr.start();
+            await vi.advanceTimersByTimeAsync(500);
+            await p;
+
+            expect(stateChanges).toEqual(["starting", "ready"]);
+        });
+
+        it("fires for state transitions during stop", async () => {
+            const stateChanges: string[] = [];
+            const mgr = new ServerManager(
+                defaultOpts({ onStateChange: (s) => stateChanges.push(s) }),
+            );
+
+            const p1 = mgr.start();
+            await vi.advanceTimersByTimeAsync(500);
+            await p1;
+
+            stateChanges.length = 0;
+
+            // Override kill to emit exit asynchronously
+            child.kill = vi.fn(() => {
+                setTimeout(() => child._emit("exit", 0, null), 10);
+            });
+
+            const stopPromise = mgr.stop();
+            await vi.advanceTimersByTimeAsync(50);
+            await stopPromise;
+
+            expect(stateChanges).toEqual(["stopped"]);
+        });
+
+        it("works when no callback is provided", async () => {
+            const mgr = new ServerManager(defaultOpts());
+            // Should not throw when setState is called without a callback
+            const p = mgr.start();
+            await vi.advanceTimersByTimeAsync(500);
+            await p;
+            expect(mgr.state).toBe("ready");
+        });
+    });
+});

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1983,4 +1983,23 @@ describe("managed mode settings", () => {
         const dot = statusEl!.find("lilbee-server-dot");
         expect(dot!.classList.contains("is-ready")).toBe(true);
     });
+
+    it("Reset to managed button resets serverMode and serverUrl", async () => {
+        const plugin = makePlugin({ serverMode: "external", serverUrl: "http://remote:9999" });
+        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        const tab = makeTab(plugin);
+
+        const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+
+        // In external mode: buttons are [Test (server), Reset to managed, Test (ollama), Refresh]
+        // Find the "Reset to managed" click — it's the one that sets serverMode back
+        const resetButton = buttonOnClicks.find((_btn, i) => i === 1);
+        expect(resetButton).toBeDefined();
+        await resetButton!();
+
+        expect(plugin.settings.serverMode).toBe("managed");
+        expect(plugin.settings.serverUrl).toBe("http://127.0.0.1:7433");
+        expect(plugin.saveSettings).toHaveBeenCalled();
+    });
+
 });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -5,6 +5,16 @@ import { LilbeeSettingTab, buildModelOptions, deduplicateLatest, SEPARATOR_KEY, 
 import type { LilbeeSettings, ModelCatalog, ModelsResponse } from "../src/types";
 import { DEFAULT_SETTINGS } from "../src/types";
 
+const mockGetLatestRelease = vi.fn();
+const mockCheckForUpdate = vi.fn();
+
+vi.mock("../src/binary-manager", () => ({
+    getLatestRelease: (...args: any[]) => mockGetLatestRelease(...args),
+    checkForUpdate: (...args: any[]) => mockCheckForUpdate(...args),
+    BinaryManager: vi.fn(),
+    node: {},
+}));
+
 function makePlugin(overrides: Partial<LilbeeSettings> = {}) {
     const settings: LilbeeSettings = { ...DEFAULT_SETTINGS, ...overrides };
     const api = {
@@ -222,7 +232,7 @@ describe("LilbeeSettingTab", () => {
 
     describe("serverUrl setting onChange", () => {
         it("updates plugin settings and calls saveSettings", async () => {
-            const plugin = makePlugin();
+            const plugin = makePlugin({ serverMode: "external" });
             (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
@@ -248,14 +258,14 @@ describe("LilbeeSettingTab", () => {
 
     describe("syncMode dropdown onChange", () => {
         it("updates syncMode, saves, and re-renders display", async () => {
-            const plugin = makePlugin({ syncMode: "manual" });
+            const plugin = makePlugin({ serverMode: "external", syncMode: "manual" });
             (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
             const tab = makeTab(plugin);
 
             const { dropdownOnChanges } = captureSettingCallbacks(() => tab.display());
             const displaySpy = vi.spyOn(tab, "display").mockImplementation(() => {});
 
-            await dropdownOnChanges[0]("auto");
+            await dropdownOnChanges[1]("auto");
 
             expect(plugin.settings.syncMode).toBe("auto");
             expect(plugin.saveSettings).toHaveBeenCalled();
@@ -1452,7 +1462,7 @@ describe("LilbeeSettingTab", () => {
 
         it("auto-checks both endpoints on display", async () => {
             globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
-            const plugin = makePlugin();
+            const plugin = makePlugin({ serverMode: "external" });
             (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
             const tab = makeTab(plugin);
 
@@ -1470,7 +1480,7 @@ describe("LilbeeSettingTab", () => {
 
         it("Test button calls checkEndpoint", async () => {
             globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
-            const plugin = makePlugin();
+            const plugin = makePlugin({ serverMode: "external" });
             (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
             const tab = makeTab(plugin);
 
@@ -1855,5 +1865,122 @@ describe("deduplicateLatest()", () => {
             "phi3:latest",
         ]);
         expect(result).toEqual(["mistral:7b", "llama3:8b", "phi3:latest"]);
+    });
+});
+
+describe("managed mode settings", () => {
+    it("server mode dropdown onChange updates serverMode and re-renders", async () => {
+        const plugin = makePlugin({ serverMode: "managed" });
+        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        const tab = makeTab(plugin);
+
+        const { dropdownOnChanges } = captureSettingCallbacks(() => tab.display());
+        const displaySpy = vi.spyOn(tab, "display").mockImplementation(() => {});
+
+        // dropdownOnChanges[0] is the server mode dropdown
+        await dropdownOnChanges[0]("external");
+
+        expect(plugin.settings.serverMode).toBe("external");
+        expect(plugin.saveSettings).toHaveBeenCalled();
+        expect(displaySpy).toHaveBeenCalled();
+    });
+
+    it("port field onChange updates serverPort", async () => {
+        const plugin = makePlugin({ serverMode: "managed" });
+        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        const tab = makeTab(plugin);
+
+        const { textOnChanges } = captureSettingCallbacks(() => tab.display());
+
+        // In managed mode: textOnChanges[0] = port, textOnChanges[1] = ollama URL, then gen settings
+        await textOnChanges[0]("9999");
+
+        expect(plugin.settings.serverPort).toBe(9999);
+        expect(plugin.saveSettings).toHaveBeenCalled();
+    });
+
+    it("port field ignores invalid values", async () => {
+        const plugin = makePlugin({ serverMode: "managed" });
+        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        const tab = makeTab(plugin);
+
+        const { textOnChanges } = captureSettingCallbacks(() => tab.display());
+
+        await textOnChanges[0]("abc");
+
+        expect(plugin.settings.serverPort).toBe(7433); // unchanged
+    });
+
+    it("check for updates button shows 'update available' when newer version exists", async () => {
+        Notice.clear();
+        mockGetLatestRelease.mockResolvedValue({ tag: "v0.2.0", assetUrl: "https://example.com" });
+        mockCheckForUpdate.mockReturnValue(true);
+
+        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.1.0" });
+        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        const tab = makeTab(plugin);
+
+        const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+
+        await buttonOnClicks[0]();
+
+        expect(Notice.instances.some((n) => n.message.includes("update available"))).toBe(true);
+    });
+
+    it("check for updates button shows 'already up to date' when no update", async () => {
+        Notice.clear();
+        mockGetLatestRelease.mockResolvedValue({ tag: "v0.1.0", assetUrl: "https://example.com" });
+        mockCheckForUpdate.mockReturnValue(false);
+
+        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.1.0" });
+        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        const tab = makeTab(plugin);
+
+        const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+
+        await buttonOnClicks[0]();
+
+        expect(Notice.instances.some((n) => n.message.includes("already up to date"))).toBe(true);
+    });
+
+    it("check for updates button shows error on failure", async () => {
+        Notice.clear();
+        mockGetLatestRelease.mockRejectedValue(new Error("network error"));
+
+        const plugin = makePlugin({ serverMode: "managed" });
+        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        const tab = makeTab(plugin);
+
+        const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+
+        await buttonOnClicks[0]();
+
+        expect(Notice.instances.some((n) => n.message.includes("could not check"))).toBe(true);
+    });
+
+    it("renders server status indicator in managed mode", () => {
+        const plugin = makePlugin({ serverMode: "managed" });
+        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        const tab = makeTab(plugin);
+        tab.display();
+
+        const statusEl = tab.containerEl.find("lilbee-server-status");
+        expect(statusEl).not.toBeNull();
+        const dot = statusEl!.find("lilbee-server-dot");
+        expect(dot).not.toBeNull();
+    });
+
+    it("renders server state from serverManager when present", () => {
+        const plugin = makePlugin({ serverMode: "managed" });
+        (plugin as any).serverManager = { state: "ready" };
+        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        const tab = makeTab(plugin);
+        tab.display();
+
+        const statusEl = tab.containerEl.find("lilbee-server-status");
+        const stateSpan = statusEl!.children.find((c) => c.tagName === "SPAN");
+        expect(stateSpan!.textContent).toBe("ready");
+        const dot = statusEl!.find("lilbee-server-dot");
+        expect(dot!.classList.contains("is-ready")).toBe(true);
     });
 });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,5 +1,5 @@
 import { vi, describe, it, expect } from "vitest";
-import { DEFAULT_SETTINGS, SSE_EVENT, JSON_HEADERS } from "../src/types";
+import { DEFAULT_SETTINGS, SSE_EVENT, JSON_HEADERS, SERVER_MODE } from "../src/types";
 import type {
     Excerpt,
     DocumentResult,
@@ -275,6 +275,13 @@ describe("SSE_EVENT constants", () => {
         expect(SSE_EVENT.EXTRACT).toBe("extract");
         expect(SSE_EVENT.EMBED).toBe("embed");
         expect(SSE_EVENT.FILE_DONE).toBe("file_done");
+    });
+});
+
+describe("SERVER_MODE constants", () => {
+    it("has MANAGED and EXTERNAL values", () => {
+        expect(SERVER_MODE.MANAGED).toBe("managed");
+        expect(SERVER_MODE.EXTERNAL).toBe("external");
     });
 });
 

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -36,7 +36,7 @@ describe("DEFAULT_SETTINGS", () => {
 
     it("is a plain object with exactly the expected keys", () => {
         const keys = Object.keys(DEFAULT_SETTINGS).sort();
-        expect(keys).toEqual(["num_ctx", "ollamaUrl", "repeat_penalty", "seed", "serverUrl", "syncDebounceMs", "syncMode", "temperature", "topK", "top_k_sampling", "top_p"].sort());
+        expect(keys).toEqual(["lilbeeVersion", "num_ctx", "ollamaUrl", "repeat_penalty", "seed", "serverMode", "serverPort", "serverUrl", "syncDebounceMs", "syncMode", "temperature", "topK", "top_k_sampling", "top_p"].sort());
     });
 });
 

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -64,6 +64,7 @@ function makePlugin(): LilbeePlugin {
         activeVisionModel: "",
         fetchActiveModel: vi.fn(),
         onProgress: null,
+        cancelSync: vi.fn(),
         app: {
             vault: {
                 getAbstractFileByPath: vi.fn().mockReturnValue(null),
@@ -162,7 +163,7 @@ describe("ChatView.onOpen — DOM structure", () => {
     it("creates a progress banner (hidden by default)", () => {
         const banner = container.find("lilbee-progress-banner");
         expect(banner).not.toBeNull();
-        expect(banner!.style.display).toBe("none");
+        expect(banner!.dataset.hidden).toBe("");
     });
 
     it("creates a messages div with class 'lilbee-chat-messages'", () => {
@@ -1068,13 +1069,12 @@ describe("ChatView — progress banner", () => {
             data: { file: "paper.pdf", current_file: 3, total_files: 10 },
         });
 
-        expect(banner.style.display).toBe("");
-        const label = container.find("lilbee-progress-label")!;
+        expect(banner.dataset.hidden).toBeUndefined();
+        const label = container.find("lilbee-progress-top-label")!;
         expect(label.textContent).toContain("3/10");
-        expect(label.textContent).toContain("paper.pdf");
     });
 
-    it("handleProgress shows banner on extract event", async () => {
+    it("handleProgress updates sub-label on extract event", async () => {
         Notice.clear();
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
@@ -1086,12 +1086,12 @@ describe("ChatView — progress banner", () => {
         });
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const label = container.find("lilbee-progress-label")!;
-        expect(label.textContent).toContain("Extracting");
-        expect(label.textContent).toContain("page 5/50");
+        const subLabel = container.find("lilbee-progress-sub-label")!;
+        expect(subLabel.textContent).toContain("Extracting");
+        expect(subLabel.textContent).toContain("page 5/50");
     });
 
-    it("handleProgress shows banner on embed event", async () => {
+    it("handleProgress updates sub-label on embed event", async () => {
         Notice.clear();
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
@@ -1103,9 +1103,9 @@ describe("ChatView — progress banner", () => {
         });
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const label = container.find("lilbee-progress-label")!;
-        expect(label.textContent).toContain("Embedding");
-        expect(label.textContent).toContain("30/100");
+        const subLabel = container.find("lilbee-progress-sub-label")!;
+        expect(subLabel.textContent).toContain("Embedding");
+        expect(subLabel.textContent).toContain("30/100");
     });
 
     it("handleProgress shows banner on progress event", async () => {
@@ -1120,7 +1120,7 @@ describe("ChatView — progress banner", () => {
         });
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const label = container.find("lilbee-progress-label")!;
+        const label = container.find("lilbee-progress-top-label")!;
         expect(label.textContent).toContain("2/5");
         expect(label.textContent).toContain("notes.md");
     });
@@ -1144,7 +1144,7 @@ describe("ChatView — progress banner", () => {
 
         const container = view.containerEl.children[1] as unknown as MockElement;
         const banner = container.find("lilbee-progress-banner")!;
-        expect(banner.style.display).toBe("none");
+        expect(banner.dataset.hidden).toBe("");
     });
 
     it("handleProgress no-ops when progressBanner is null (before onOpen)", () => {
@@ -1171,7 +1171,8 @@ describe("ChatView — progress banner", () => {
 
         view.handleProgress({ event: "unknown_event", data: {} });
 
-        expect(banner.style.display).toBe("none");
+        // Banner stays hidden (data-hidden attribute still present)
+        expect(banner.dataset.hidden).toBe("");
     });
 
     it("handleProgress shows pull-specific label on pull event", async () => {
@@ -1182,23 +1183,15 @@ describe("ChatView — progress banner", () => {
 
         const container = view.containerEl.children[1] as unknown as MockElement;
         const banner = container.find("lilbee-progress-banner")!;
-        const label = container.find("lilbee-progress-label")!;
+        const label = container.find("lilbee-progress-top-label")!;
 
         view.handleProgress({
             event: SSE_EVENT.PULL,
             data: { model: "mistral", current: 50, total: 100 },
         });
 
-        expect(banner.style.display).toBe("");
-        expect(label.textContent).toBe("Pulling mistral — 50%");
-    });
-
-    it("showProgress no-ops when progressBanner is null", () => {
-        Notice.clear();
-        const plugin = makePlugin();
-        const view = new ChatView(makeLeaf(), plugin);
-        // Before onOpen, banner elements are null
-        expect(() => view.showProgress("test", 1, 2)).not.toThrow();
+        expect(banner.dataset.hidden).toBeUndefined();
+        expect(label.textContent).toBe("Pulling model — 50%");
     });
 
     it("hideProgress no-ops when progressBanner is null", () => {
@@ -1206,6 +1199,78 @@ describe("ChatView — progress banner", () => {
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
         expect(() => view.hideProgress()).not.toThrow();
+    });
+
+    it("handleProgress with missing data fields uses fallback values", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+
+        // FILE_START with missing fields
+        view.handleProgress({ event: SSE_EVENT.FILE_START, data: {} });
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const label = container.find("lilbee-progress-top-label")!;
+        expect(label.textContent).toContain("0/0");
+
+        // EXTRACT with missing fields
+        view.handleProgress({ event: SSE_EVENT.EXTRACT, data: {} });
+        const subLabel = container.find("lilbee-progress-sub-label")!;
+        expect(subLabel.textContent).toContain("0/0");
+
+        // EMBED with missing fields
+        view.handleProgress({ event: SSE_EVENT.EMBED, data: {} });
+        expect(subLabel.textContent).toContain("0/0");
+
+        // PROGRESS with missing fields
+        view.handleProgress({ event: SSE_EVENT.PROGRESS, data: {} });
+        expect(label.textContent).toContain("0/0");
+
+        // PULL with missing fields (tests ?? fallback)
+        view.handleProgress({ event: SSE_EVENT.PULL, data: {} });
+        expect(label.textContent).toContain("0%");
+    });
+
+    it("updateSubLabel no-ops before onOpen", () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        // EXTRACT before onOpen — progressSubLabel is null
+        expect(() => {
+            view.handleProgress({ event: SSE_EVENT.EXTRACT, data: { file: "x", page: 1, total_pages: 1 } });
+        }).not.toThrow();
+    });
+
+    it("showFileProgress with total=0 sets bar width to 0%", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+
+        view.handleProgress({ event: SSE_EVENT.FILE_START, data: { current_file: 0, total_files: 0 } });
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const bar = container.find("lilbee-progress-bar")!;
+        expect(bar.style.width).toBe("0%");
+    });
+
+    it("cancel button aborts pullController when set", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+
+        // Simulate a pullController being set
+        const controller = new AbortController();
+        (view as any).pullController = controller;
+        const abortSpy = vi.spyOn(controller, "abort");
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const cancelBtn = container.find("lilbee-progress-cancel")!;
+        cancelBtn.trigger("click");
+
+        expect(abortSpy).toHaveBeenCalled();
+        expect((plugin as any).cancelSync).toHaveBeenCalled();
     });
 });
 
@@ -1240,8 +1305,10 @@ describe("ChatView — onProgress registration", () => {
         });
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const label = container.find("lilbee-progress-label")!;
+        const label = container.find("lilbee-progress-top-label")!;
         expect(label.textContent).toContain("1/2");
+        const banner = container.find("lilbee-progress-banner")!;
+        expect(banner.dataset.hidden).toBeUndefined();
     });
 });
 
@@ -1690,7 +1757,7 @@ describe("ChatView — cancel chat stream (stop button)", () => {
 });
 
 describe("ChatView — cancel model pull", () => {
-    it("progress cancel button is hidden by default", async () => {
+    it("progress cancel button exists in banner", async () => {
         Notice.clear();
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
@@ -1699,53 +1766,22 @@ describe("ChatView — cancel model pull", () => {
         const container = view.containerEl.children[1] as unknown as MockElement;
         const cancelBtn = container.find("lilbee-progress-cancel")!;
         expect(cancelBtn).not.toBeNull();
-        expect(cancelBtn.style.display).toBe("none");
+        expect(cancelBtn.tagName).toBe("BUTTON");
     });
 
-    it("cancel button becomes visible during pull and hidden after", async () => {
+    it("cancel button calls both pullController.abort and plugin.cancelSync", async () => {
         Notice.clear();
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockResolvedValue({
-            chat: {
-                active: "llama3",
-                installed: ["llama3"],
-                catalog: [
-                    { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
-                    { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
-                ],
-            },
-            vision: { active: "", installed: [], catalog: [] },
-        });
-
-        let resolveWait!: () => void;
-        const waitPromise = new Promise<void>((r) => { resolveWait = r; });
-        async function* fakePull() {
-            yield { status: "pulling", completed: 50, total: 100 };
-            await waitPromise;
-            yield { status: "success" };
-        }
-        plugin.ollama.pull = vi.fn().mockReturnValue(fakePull());
-        plugin.api.setChatModel = vi.fn().mockResolvedValue({ model: "phi3" });
-
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
-        await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
         const cancelBtn = container.find("lilbee-progress-cancel")!;
-        const select = container.find("lilbee-chat-model-select")!;
-        (select as any).value = "phi3";
-        select.trigger("change");
-        await tick();
 
-        // During pull, cancel button should be visible
-        expect(cancelBtn.style.display).toBe("");
+        // Trigger cancel click
+        cancelBtn.trigger("click");
 
-        resolveWait();
-        await new Promise((r) => setTimeout(r, 50));
-
-        // After pull completes, cancel button should be hidden
-        expect(cancelBtn.style.display).toBe("none");
+        expect((plugin as any).cancelSync).toHaveBeenCalled();
     });
 
     it("clicking cancel button during pull aborts and shows Pull cancelled Notice", async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
             provider: "v8",
             include: ["src/**/*.ts"],
             exclude: ["src/**/*.d.ts"],
-            thresholds: { lines: 100, functions: 100, branches: 99, statements: 100 },
+            reporter: ["text", "json-summary", "html"],
+            thresholds: { lines: 100, functions: 100, branches: 100, statements: 100 },
         },
         alias: {
             obsidian: new URL("./tests/__mocks__/obsidian.ts", import.meta.url).pathname,


### PR DESCRIPTION
## Summary

- **Managed server**: binary manager downloads lilbee from GitHub releases; server manager spawns/stops the process with health checks
- **Progress UI**: two-level inline progress for sync/indexing with cancel support; model pull/delete with progress in settings
- **Project site**: retro terminal page (Obsidian purple theme) deployed to GitHub Pages alongside HTML coverage report and generated badge SVG
- **CI**: coverage badge generation, Pages deployment on main push, BRAT-compatible release workflow on version tags
- **README badges**: CI status, coverage, TypeScript, MIT, Obsidian
- **Type cleanup**: proper `HTMLButtonElement` params in settings, extracted GitHub API interfaces in binary manager

520 tests, 100% coverage on all metrics.

## Test plan

- [x] `npm test` — 520/520 passing, 100% coverage
- [x] `npm run build` — succeeds
- [ ] Push to main → verify GitHub Pages deploys site + coverage
- [ ] Verify README badges render on GitHub