### PR TITLE
fix: use Obsidian requestUrl for GitHub downloads to bypass CORS

### DIFF
--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -1,12 +1,13 @@
+import { requestUrl } from "obsidian";
 import { execFile, spawn } from "child_process";
-import { createWriteStream, existsSync, mkdirSync, chmodSync } from "fs";
+import { existsSync, mkdirSync, chmodSync, writeFileSync } from "fs";
 import { join } from "path";
 import { promisify } from "util";
 
 const execFileAsync = promisify(execFile);
 
 /** Exported for test mocking. */
-export const node = { spawn, execFile: execFileAsync, existsSync, mkdirSync, chmodSync, createWriteStream, fetch: globalThis.fetch };
+export const node = { spawn, execFile: execFileAsync, existsSync, mkdirSync, chmodSync, writeFileSync, requestUrl, fetch: globalThis.fetch.bind(globalThis) };
 
 const GITHUB_REPO = "tobocop2/lilbee";
 const RELEASES_API = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
@@ -37,11 +38,12 @@ export interface ReleaseInfo {
 }
 
 export async function getLatestRelease(): Promise<ReleaseInfo> {
-    const res = await node.fetch(RELEASES_API, {
+    const res = await node.requestUrl({
+        url: RELEASES_API,
         headers: { Accept: "application/vnd.github.v3+json" },
     });
-    if (!res.ok) throw new Error(`GitHub API responded ${res.status}`);
-    const data = (await res.json()) as GitHubRelease;
+    if (res.status >= 400) throw new Error(`GitHub API responded ${res.status}`);
+    const data = res.json as GitHubRelease;
     const assetName = getPlatformAssetName();
     const asset = data.assets.find((a) => a.name === assetName);
     if (!asset) throw new Error(`No asset "${assetName}" in release ${data.tag_name}`);
@@ -82,32 +84,11 @@ export class BinaryManager {
         }
 
         onProgress?.("Downloading lilbee binary...");
-        const res = await node.fetch(assetUrl);
-        if (!res.ok) throw new Error(`Download failed: ${res.status}`);
-        if (!res.body) throw new Error("Download response has no body");
+        const res = await node.requestUrl({ url: assetUrl });
+        if (res.status >= 400) throw new Error(`Download failed: ${res.status}`);
 
         const dest = this.binaryPath;
-        const fileStream = node.createWriteStream(dest);
-        const reader = res.body.getReader();
-
-        const contentLength = Number(res.headers.get("content-length") ?? 0);
-        let downloaded = 0;
-
-        while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            fileStream.write(value);
-            downloaded += value.byteLength;
-            if (contentLength > 0) {
-                const pct = Math.round((downloaded / contentLength) * 100);
-                onProgress?.(`Downloading lilbee binary... ${pct}%`);
-            }
-        }
-        fileStream.end();
-        await new Promise<void>((resolve, reject) => {
-            fileStream.on("finish", resolve);
-            fileStream.on("error", reject);
-        });
+        node.writeFileSync(dest, Buffer.from(res.arrayBuffer));
 
         if (process.platform !== "win32") {
             node.chmodSync(dest, 0o755);

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,7 +51,7 @@ export default class LilbeePlugin extends Plugin {
         );
 
         if (this.settings.serverMode === SERVER_MODE.MANAGED) {
-            await this.startManagedServer();
+            void this.startManagedServer();
         } else {
             this.api = new LilbeeClient(this.settings.serverUrl);
             this.setStatusReady();
@@ -66,17 +66,21 @@ export default class LilbeePlugin extends Plugin {
     private async startManagedServer(): Promise<void> {
         const pluginDir = this.getPluginDir();
         this.binaryManager = new BinaryManager(pluginDir);
-        this.updateStatusBar("lilbee: downloading...");
+
+        const needsDownload = !this.binaryManager.binaryExists();
+        const downloadNotice = needsDownload
+            ? new Notice("lilbee: fetching server binary...", 0)
+            : null;
+
+        if (needsDownload) this.updateStatusBar("lilbee: downloading...");
+
+        const binaryPath = await this.downloadBinary(downloadNotice, needsDownload);
+        if (!binaryPath) return;
 
         try {
-            const binaryPath = await this.binaryManager.ensureBinary((msg) => {
-                this.updateStatusBar(`lilbee: ${msg}`);
-            });
-
-            const dataDir = `${pluginDir}/server-data`;
             this.serverManager = new ServerManager({
                 binaryPath,
-                dataDir,
+                dataDir: `${pluginDir}/server-data`,
                 port: this.settings.serverPort,
                 ollamaUrl: this.settings.ollamaUrl,
                 onStateChange: (state) => this.handleServerStateChange(state),
@@ -87,10 +91,34 @@ export default class LilbeePlugin extends Plugin {
             this.api = new LilbeeClient(this.serverManager.serverUrl);
             this.fetchActiveModel();
         } catch (err) {
-            const msg = err instanceof Error ? err.message : "unknown error";
-            new Notice(`lilbee: failed to start server — ${msg}`);
-            this.updateStatusBar("lilbee: error");
+            this.showError("failed to start server", err);
         }
+    }
+
+    private async downloadBinary(
+        downloadNotice: Notice | null,
+        needsDownload: boolean,
+    ): Promise<string | null> {
+        try {
+            const binaryPath = await this.binaryManager!.ensureBinary((msg) => {
+                this.updateStatusBar(`lilbee: ${msg}`);
+                downloadNotice?.setMessage(`lilbee: ${msg}`);
+            });
+            downloadNotice?.hide();
+            if (needsDownload) new Notice("lilbee: server binary ready");
+            return binaryPath;
+        } catch (err) {
+            downloadNotice?.hide();
+            this.showError("failed to download server", err);
+            return null;
+        }
+    }
+
+    private showError(label: string, err: unknown): void {
+        console.error(`[lilbee] ${label}:`, err);
+        const detail = err instanceof Error ? err.message : "unknown error";
+        new Notice(`lilbee: ${label} — ${detail}`);
+        this.updateStatusBar("lilbee: error");
     }
 
     private handleServerStateChange(state: ServerState): void {
@@ -284,6 +312,7 @@ export default class LilbeePlugin extends Plugin {
             if (err instanceof Error && err.name === "AbortError") {
                 new Notice("lilbee: add cancelled");
             } else {
+                console.error("[lilbee] add failed:", err);
                 const msg = err instanceof Error ? err.message : "cannot connect to server";
                 new Notice(`lilbee: add failed — ${msg}`);
             }
@@ -367,6 +396,7 @@ export default class LilbeePlugin extends Plugin {
             if (err instanceof Error && err.name === "AbortError") {
                 new Notice("lilbee: sync cancelled");
             } else {
+                console.error("[lilbee] sync failed:", err);
                 new Notice("lilbee: sync failed — cannot connect to server");
             }
         } finally {

--- a/src/server-manager.ts
+++ b/src/server-manager.ts
@@ -3,8 +3,8 @@ import type { ServerState } from "./types";
 import { SERVER_STATE } from "./types";
 import { node } from "./binary-manager";
 
-const HEALTH_POLL_INTERVAL_MS = 500;
-const HEALTH_POLL_MAX_ATTEMPTS = 30;
+const HEALTH_POLL_INTERVAL_MS = 1000;
+const HEALTH_POLL_MAX_ATTEMPTS = 60;
 const STOP_GRACE_MS = 5000;
 const CRASH_RESTART_DELAY_MS = 3000;
 const MAX_CRASH_RESTARTS = 3;

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -296,6 +296,10 @@ export const MarkdownRenderer = {
     },
 };
 
+export async function requestUrl(_req: { url: string; headers?: Record<string, string> }): Promise<{ status: number; json: unknown; arrayBuffer: ArrayBuffer; headers: Record<string, string> }> {
+    return { status: 200, json: {}, arrayBuffer: new ArrayBuffer(0), headers: {} };
+}
+
 export function setIcon(el: MockElement, icon: string): void {
     el.textContent = icon;
     el.attributes["data-icon"] = icon;
@@ -304,12 +308,15 @@ export function setIcon(el: MockElement, icon: string): void {
 export class Notice {
     message: string;
     duration: number | undefined;
+    hidden = false;
     static instances: Notice[] = [];
     constructor(message: string, duration?: number) {
         this.message = message;
         this.duration = duration;
         Notice.instances.push(this);
     }
+    setMessage(message: string): void { this.message = message; }
+    hide(): void { this.hidden = true; }
     static clear(): void { Notice.instances = []; }
 }
 

--- a/tests/binary-manager.test.ts
+++ b/tests/binary-manager.test.ts
@@ -1,6 +1,5 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { node, getPlatformAssetName, getLatestRelease, checkForUpdate, BinaryManager } from "../src/binary-manager";
-import { EventEmitter } from "events";
 
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                           */
@@ -18,44 +17,14 @@ function stubPlatform(platform: string, arch: string) {
     };
 }
 
-/** Create a mock ReadableStream reader that yields the given Uint8Array chunks. */
-function mockReader(chunks: Uint8Array[]) {
-    let index = 0;
-    return {
-        read: vi.fn(async () => {
-            if (index < chunks.length) {
-                return { done: false, value: chunks[index++] };
-            }
-            return { done: true, value: undefined };
-        }),
-    };
+/** Build a fake requestUrl response for release API calls. */
+function releaseResponse(json: unknown) {
+    return { status: 200, json, arrayBuffer: new ArrayBuffer(0), headers: {} };
 }
 
-/** Create a mock file stream (EventEmitter with write/end). Emits "finish" on end(). */
-function mockFileStream() {
-    const emitter = new EventEmitter();
-    const stream = Object.assign(emitter, {
-        write: vi.fn(),
-        end: vi.fn(() => {
-            // Emit finish asynchronously so the promise handler is registered first
-            queueMicrotask(() => emitter.emit("finish"));
-        }),
-    });
-    return stream;
-}
-
-/** Build a fake fetch Response for download tests. */
-function downloadResponse(chunks: Uint8Array[], contentLength?: number): Response {
-    const headers = new Headers();
-    if (contentLength !== undefined) {
-        headers.set("content-length", String(contentLength));
-    }
-    return {
-        ok: true,
-        status: 200,
-        headers,
-        body: { getReader: () => mockReader(chunks) },
-    } as unknown as Response;
+/** Build a fake requestUrl response for binary download. */
+function downloadResponse(data: Uint8Array) {
+    return { status: 200, json: {}, arrayBuffer: data.buffer, headers: {} };
 }
 
 /* ------------------------------------------------------------------ */
@@ -110,38 +79,29 @@ describe("getLatestRelease", () => {
 
     it("returns tag and assetUrl on success", async () => {
         restore = stubPlatform("darwin", "arm64");
-        vi.spyOn(node, "fetch").mockResolvedValue({
-            ok: true,
-            json: () =>
-                Promise.resolve({
-                    tag_name: "v1.0.0",
-                    assets: [{ name: "lilbee-macos-arm64", browser_download_url: "https://example.com/download" }],
-                }),
-        } as unknown as Response);
+        vi.spyOn(node, "requestUrl").mockResolvedValue(releaseResponse({
+            tag_name: "v1.0.0",
+            assets: [{ name: "lilbee-macos-arm64", browser_download_url: "https://example.com/download" }],
+        }));
 
         const release = await getLatestRelease();
         expect(release).toEqual({ tag: "v1.0.0", assetUrl: "https://example.com/download" });
     });
 
-    it("throws when GitHub API returns non-ok response", async () => {
-        vi.spyOn(node, "fetch").mockResolvedValue({
-            ok: false,
-            status: 403,
-        } as unknown as Response);
+    it("throws when GitHub API returns error status", async () => {
+        vi.spyOn(node, "requestUrl").mockResolvedValue({
+            status: 403, json: {}, arrayBuffer: new ArrayBuffer(0), headers: {},
+        });
 
         await expect(getLatestRelease()).rejects.toThrow("GitHub API responded 403");
     });
 
     it("throws when asset is not found in release", async () => {
         restore = stubPlatform("darwin", "arm64");
-        vi.spyOn(node, "fetch").mockResolvedValue({
-            ok: true,
-            json: () =>
-                Promise.resolve({
-                    tag_name: "v2.0.0",
-                    assets: [{ name: "some-other-asset", browser_download_url: "https://example.com/other" }],
-                }),
-        } as unknown as Response);
+        vi.spyOn(node, "requestUrl").mockResolvedValue(releaseResponse({
+            tag_name: "v2.0.0",
+            assets: [{ name: "some-other-asset", browser_download_url: "https://example.com/other" }],
+        }));
 
         await expect(getLatestRelease()).rejects.toThrow('No asset "lilbee-macos-arm64" in release v2.0.0');
     });
@@ -217,22 +177,17 @@ describe("BinaryManager", () => {
         it("downloads binary when it does not exist", async () => {
             restore = stubPlatform("darwin", "arm64");
             const mgr = new BinaryManager("/plugins/lilbee");
-            const chunk = new Uint8Array([1, 2, 3]);
-            const fStream = mockFileStream();
+            const data = new Uint8Array([1, 2, 3]);
 
             // existsSync: first call (binaryExists) => false, second call (binDir check in download) => true
             vi.spyOn(node, "existsSync").mockReturnValueOnce(false).mockReturnValueOnce(true);
-            vi.spyOn(node, "fetch")
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: () =>
-                        Promise.resolve({
-                            tag_name: "v1.0.0",
-                            assets: [{ name: "lilbee-macos-arm64", browser_download_url: "https://example.com/dl" }],
-                        }),
-                } as unknown as Response)
-                .mockResolvedValueOnce(downloadResponse([chunk]));
-            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+            vi.spyOn(node, "requestUrl")
+                .mockResolvedValueOnce(releaseResponse({
+                    tag_name: "v1.0.0",
+                    assets: [{ name: "lilbee-macos-arm64", browser_download_url: "https://example.com/dl" }],
+                }))
+                .mockResolvedValueOnce(downloadResponse(data));
+            vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
             vi.spyOn(node, "chmodSync").mockImplementation(() => {});
             vi.spyOn(node, "execFile").mockResolvedValue({ stdout: "", stderr: "" });
 
@@ -249,13 +204,12 @@ describe("BinaryManager", () => {
     describe("download", () => {
         it("creates binDir when it does not exist", async () => {
             restore = stubPlatform("linux", "x64");
-            const chunk = new Uint8Array([10, 20]);
-            const fStream = mockFileStream();
+            const data = new Uint8Array([10, 20]);
 
             vi.spyOn(node, "existsSync").mockReturnValue(false);
             vi.spyOn(node, "mkdirSync").mockImplementation(() => undefined as any);
-            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk]));
-            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+            vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(data));
+            vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
             vi.spyOn(node, "chmodSync").mockImplementation(() => {});
 
             const mgr = new BinaryManager("/plugins/lilbee");
@@ -266,13 +220,12 @@ describe("BinaryManager", () => {
 
         it("skips mkdir when binDir already exists", async () => {
             restore = stubPlatform("linux", "x64");
-            const chunk = new Uint8Array([10, 20]);
-            const fStream = mockFileStream();
+            const data = new Uint8Array([10, 20]);
 
             vi.spyOn(node, "existsSync").mockReturnValue(true);
             vi.spyOn(node, "mkdirSync").mockImplementation(() => undefined as any);
-            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk]));
-            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+            vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(data));
+            vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
             vi.spyOn(node, "chmodSync").mockImplementation(() => {});
 
             const mgr = new BinaryManager("/plugins/lilbee");
@@ -281,62 +234,34 @@ describe("BinaryManager", () => {
             expect(node.mkdirSync).not.toHaveBeenCalled();
         });
 
-        it("writes stream data and calls chmod on non-win32", async () => {
+        it("writes binary data and calls chmod on non-win32", async () => {
             restore = stubPlatform("linux", "x64");
-            const chunk1 = new Uint8Array([1, 2, 3]);
-            const chunk2 = new Uint8Array([4, 5, 6]);
-            const fStream = mockFileStream();
+            const data = new Uint8Array([1, 2, 3, 4, 5, 6]);
 
             vi.spyOn(node, "existsSync").mockReturnValue(true);
-            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk1, chunk2], 6));
-            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+            vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(data));
+            vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
             vi.spyOn(node, "chmodSync").mockImplementation(() => {});
 
             const onProgress = vi.fn();
             const mgr = new BinaryManager("/plugins/lilbee");
             await mgr.download("https://example.com/dl", onProgress);
 
-            expect(fStream.write).toHaveBeenCalledTimes(2);
-            expect(fStream.write).toHaveBeenCalledWith(chunk1);
-            expect(fStream.write).toHaveBeenCalledWith(chunk2);
-            expect(fStream.end).toHaveBeenCalled();
+            expect(node.writeFileSync).toHaveBeenCalledWith(mgr.binaryPath, expect.any(Buffer));
+            const writtenBuffer = (node.writeFileSync as ReturnType<typeof vi.fn>).mock.calls[0][1] as Buffer;
+            expect([...writtenBuffer]).toEqual([1, 2, 3, 4, 5, 6]);
             expect(node.chmodSync).toHaveBeenCalledWith(mgr.binaryPath, 0o755);
-            // Progress with percentages
-            expect(onProgress).toHaveBeenCalledWith("Downloading lilbee binary... 50%");
-            expect(onProgress).toHaveBeenCalledWith("Downloading lilbee binary... 100%");
-            expect(onProgress).toHaveBeenCalledWith("Download complete.");
-        });
-
-        it("skips percentage progress when content-length is absent", async () => {
-            restore = stubPlatform("linux", "x64");
-            const chunk = new Uint8Array([1, 2, 3]);
-            const fStream = mockFileStream();
-
-            vi.spyOn(node, "existsSync").mockReturnValue(true);
-            // No content-length header
-            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk]));
-            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
-            vi.spyOn(node, "chmodSync").mockImplementation(() => {});
-
-            const onProgress = vi.fn();
-            const mgr = new BinaryManager("/plugins/lilbee");
-            await mgr.download("https://example.com/dl", onProgress);
-
-            // Should not have any percentage-based progress calls
-            const percentageCalls = onProgress.mock.calls.filter((c: string[]) => c[0].includes("%"));
-            expect(percentageCalls).toHaveLength(0);
             expect(onProgress).toHaveBeenCalledWith("Downloading lilbee binary...");
             expect(onProgress).toHaveBeenCalledWith("Download complete.");
         });
 
         it("calls xattr on darwin", async () => {
             restore = stubPlatform("darwin", "arm64");
-            const chunk = new Uint8Array([1]);
-            const fStream = mockFileStream();
+            const data = new Uint8Array([1]);
 
             vi.spyOn(node, "existsSync").mockReturnValue(true);
-            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk]));
-            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+            vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(data));
+            vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
             vi.spyOn(node, "chmodSync").mockImplementation(() => {});
             const execSpy = vi.spyOn(node, "execFile").mockResolvedValue({ stdout: "", stderr: "" });
 
@@ -348,12 +273,11 @@ describe("BinaryManager", () => {
 
         it("treats xattr failure as non-fatal on darwin", async () => {
             restore = stubPlatform("darwin", "arm64");
-            const chunk = new Uint8Array([1]);
-            const fStream = mockFileStream();
+            const data = new Uint8Array([1]);
 
             vi.spyOn(node, "existsSync").mockReturnValue(true);
-            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk]));
-            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+            vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(data));
+            vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
             vi.spyOn(node, "chmodSync").mockImplementation(() => {});
             vi.spyOn(node, "execFile").mockRejectedValue(new Error("xattr not found"));
 
@@ -364,12 +288,11 @@ describe("BinaryManager", () => {
 
         it("skips chmod on win32", async () => {
             restore = stubPlatform("win32", "x64");
-            const chunk = new Uint8Array([1]);
-            const fStream = mockFileStream();
+            const data = new Uint8Array([1]);
 
             vi.spyOn(node, "existsSync").mockReturnValue(true);
-            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk]));
-            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+            vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(data));
+            vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
             vi.spyOn(node, "chmodSync").mockImplementation(() => {});
 
             const mgr = new BinaryManager("/plugins/lilbee");
@@ -380,12 +303,11 @@ describe("BinaryManager", () => {
 
         it("does not call xattr on non-darwin platforms", async () => {
             restore = stubPlatform("linux", "x64");
-            const chunk = new Uint8Array([1]);
-            const fStream = mockFileStream();
+            const data = new Uint8Array([1]);
 
             vi.spyOn(node, "existsSync").mockReturnValue(true);
-            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk]));
-            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+            vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(data));
+            vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
             vi.spyOn(node, "chmodSync").mockImplementation(() => {});
             const execSpy = vi.spyOn(node, "execFile").mockResolvedValue({ stdout: "", stderr: "" });
 
@@ -395,59 +317,24 @@ describe("BinaryManager", () => {
             expect(execSpy).not.toHaveBeenCalled();
         });
 
-        it("throws when download response is not ok", async () => {
+        it("throws when download response has error status", async () => {
             restore = stubPlatform("linux", "x64");
             vi.spyOn(node, "existsSync").mockReturnValue(true);
-            vi.spyOn(node, "fetch").mockResolvedValue({
-                ok: false,
-                status: 404,
-            } as unknown as Response);
+            vi.spyOn(node, "requestUrl").mockResolvedValue({
+                status: 404, json: {}, arrayBuffer: new ArrayBuffer(0), headers: {},
+            });
 
             const mgr = new BinaryManager("/plugins/lilbee");
             await expect(mgr.download("https://example.com/dl")).rejects.toThrow("Download failed: 404");
         });
 
-        it("throws when download response has no body", async () => {
-            restore = stubPlatform("linux", "x64");
-            vi.spyOn(node, "existsSync").mockReturnValue(true);
-            vi.spyOn(node, "fetch").mockResolvedValue({
-                ok: true,
-                status: 200,
-                body: null,
-                headers: new Headers(),
-            } as unknown as Response);
-
-            const mgr = new BinaryManager("/plugins/lilbee");
-            await expect(mgr.download("https://example.com/dl")).rejects.toThrow("Download response has no body");
-        });
-
-        it("rejects when fileStream emits error", async () => {
-            restore = stubPlatform("linux", "x64");
-            const chunk = new Uint8Array([1]);
-            const emitter = new EventEmitter();
-            const fStream = Object.assign(emitter, {
-                write: vi.fn(),
-                end: vi.fn(() => {
-                    queueMicrotask(() => emitter.emit("error", new Error("disk full")));
-                }),
-            });
-
-            vi.spyOn(node, "existsSync").mockReturnValue(true);
-            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk]));
-            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
-
-            const mgr = new BinaryManager("/plugins/lilbee");
-            await expect(mgr.download("https://example.com/dl")).rejects.toThrow("disk full");
-        });
-
         it("works without onProgress callback", async () => {
             restore = stubPlatform("linux", "x64");
-            const chunk = new Uint8Array([1]);
-            const fStream = mockFileStream();
+            const data = new Uint8Array([1]);
 
             vi.spyOn(node, "existsSync").mockReturnValue(true);
-            vi.spyOn(node, "fetch").mockResolvedValue(downloadResponse([chunk], 1));
-            vi.spyOn(node, "createWriteStream").mockReturnValue(fStream as any);
+            vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(data));
+            vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
             vi.spyOn(node, "chmodSync").mockImplementation(() => {});
 
             const mgr = new BinaryManager("/plugins/lilbee");

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -34,6 +34,7 @@ vi.mock("../src/views/search-modal", () => ({
 }));
 
 const mockEnsureBinary = vi.fn().mockResolvedValue("/fake/bin/lilbee");
+const mockBinaryExists = vi.fn().mockReturnValue(true);
 const mockServerStart = vi.fn().mockResolvedValue(undefined);
 const mockServerStop = vi.fn().mockResolvedValue(undefined);
 const mockUpdateOllamaUrl = vi.fn();
@@ -44,11 +45,11 @@ vi.mock("../src/binary-manager", () => ({
     BinaryManager: vi.fn().mockImplementation(() => ({
         ensureBinary: mockEnsureBinary,
         binaryPath: "/fake/bin/lilbee",
-        binaryExists: vi.fn().mockReturnValue(true),
+        binaryExists: mockBinaryExists,
     })),
     getLatestRelease: vi.fn(),
     checkForUpdate: vi.fn(),
-    node: { spawn: vi.fn(), execFile: vi.fn(), existsSync: vi.fn(), mkdirSync: vi.fn(), chmodSync: vi.fn(), createWriteStream: vi.fn(), fetch: vi.fn() },
+    node: { spawn: vi.fn(), execFile: vi.fn(), existsSync: vi.fn(), mkdirSync: vi.fn(), chmodSync: vi.fn(), writeFileSync: vi.fn(), requestUrl: vi.fn() },
 }));
 
 vi.mock("../src/server-manager", () => ({
@@ -66,6 +67,9 @@ vi.mock("../src/server-manager", () => ({
         };
     }),
 }));
+
+/** Flush the microtask queue so fire-and-forget promises settle. */
+const flush = () => new Promise((r) => setTimeout(r, 0));
 
 async function createPlugin(overrideData?: Record<string, unknown>) {
     const { default: LilbeePlugin } = await import("../src/main");
@@ -1056,6 +1060,7 @@ describe("LilbeePlugin", () => {
         it("onload in managed mode creates binaryManager and serverManager", async () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
+            await flush();
 
             expect(plugin.binaryManager).not.toBeNull();
             expect(plugin.serverManager).not.toBeNull();
@@ -1063,28 +1068,54 @@ describe("LilbeePlugin", () => {
             expect(mockServerStart).toHaveBeenCalled();
         });
 
-        it("managed mode shows error Notice when startManagedServer fails", async () => {
-            mockEnsureBinary.mockRejectedValueOnce(new Error("download failed"));
+        it("managed mode shows download error Notice when ensureBinary fails", async () => {
+            mockEnsureBinary.mockRejectedValueOnce(new Error("network timeout"));
 
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
+            await flush();
 
-            expect(Notice.instances.some((n) => n.message.includes("failed to start server"))).toBe(true);
-            expect(Notice.instances.some((n) => n.message.includes("download failed"))).toBe(true);
+            expect(Notice.instances.some((n) => n.message.includes("failed to download server"))).toBe(true);
+            expect(Notice.instances.some((n) => n.message.includes("network timeout"))).toBe(true);
         });
 
-        it("managed mode shows error Notice with 'unknown error' for non-Error throw", async () => {
+        it("managed mode shows 'unknown error' when ensureBinary throws non-Error", async () => {
             mockEnsureBinary.mockRejectedValueOnce("string error");
 
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
+            await flush();
 
+            expect(Notice.instances.some((n) => n.message.includes("failed to download server"))).toBe(true);
+            expect(Notice.instances.some((n) => n.message.includes("unknown error"))).toBe(true);
+        });
+
+        it("managed mode shows start error Notice when serverManager.start fails", async () => {
+            mockServerStart.mockRejectedValueOnce(new Error("port in use"));
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            expect(Notice.instances.some((n) => n.message.includes("failed to start server"))).toBe(true);
+            expect(Notice.instances.some((n) => n.message.includes("port in use"))).toBe(true);
+        });
+
+        it("managed mode shows 'unknown error' when serverManager.start throws non-Error", async () => {
+            mockServerStart.mockRejectedValueOnce(42);
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            expect(Notice.instances.some((n) => n.message.includes("failed to start server"))).toBe(true);
             expect(Notice.instances.some((n) => n.message.includes("unknown error"))).toBe(true);
         });
 
         it("handleServerStateChange updates status bar for all states", async () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
+            await flush();
 
             const stateChange = mockServerOpts?.onStateChange;
             expect(stateChange).toBeDefined();
@@ -1103,17 +1134,144 @@ describe("LilbeePlugin", () => {
         });
 
         it("ensureBinary progress callback updates status bar", async () => {
-            let progressCb: ((msg: string) => void) | undefined;
             mockEnsureBinary.mockImplementationOnce(async (cb: any) => {
-                progressCb = cb;
-                cb?.("Downloading...");
+                cb?.("Downloading 50%");
                 return "/fake/bin/lilbee";
             });
 
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
+            await flush();
 
-            expect(progressCb).toBeDefined();
+            expect(mockEnsureBinary).toHaveBeenCalled();
+        });
+
+        it("does not show download Notice when binary already exists", async () => {
+            mockBinaryExists.mockReturnValueOnce(true);
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const downloadNotices = Notice.instances.filter(
+                (n) => n.message.includes("fetching server binary") || n.message.includes("server binary ready"),
+            );
+            expect(downloadNotices.length).toBe(0);
+        });
+
+        it("shows persistent download Notice when binary is missing", async () => {
+            mockBinaryExists.mockReturnValueOnce(false);
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const fetchNotice = Notice.instances.find((n) => n.duration === 0);
+            expect(fetchNotice).toBeDefined();
+            expect(fetchNotice!.hidden).toBe(true); // hidden after completion
+        });
+
+        it("shows success Notice after download completes", async () => {
+            mockBinaryExists.mockReturnValueOnce(false);
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            expect(Notice.instances.some((n) => n.message.includes("server binary ready"))).toBe(true);
+        });
+
+        it("progress callback updates both status bar and download Notice", async () => {
+            mockBinaryExists.mockReturnValueOnce(false);
+            mockEnsureBinary.mockImplementationOnce(async (cb: any) => {
+                cb?.("Downloading 25%");
+                cb?.("Downloading 75%");
+                return "/fake/bin/lilbee";
+            });
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const persistentNotice = Notice.instances.find((n) => n.duration === 0);
+            expect(persistentNotice).toBeDefined();
+            expect(persistentNotice!.message).toBe("lilbee: Downloading 75%");
+        });
+
+        it("hides download Notice on ensureBinary failure", async () => {
+            mockBinaryExists.mockReturnValueOnce(false);
+            mockEnsureBinary.mockRejectedValueOnce(new Error("network error"));
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const persistentNotice = Notice.instances.find((n) => n.duration === 0);
+            expect(persistentNotice).toBeDefined();
+            expect(persistentNotice!.hidden).toBe(true);
+        });
+
+        it("sets status bar to downloading only when binary is missing", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+
+            const statusTexts: string[] = [];
+            const origSetText = (plugin as any).statusBarEl!.setText.bind((plugin as any).statusBarEl);
+            (plugin as any).statusBarEl!.setText = (text: string) => {
+                statusTexts.push(text);
+                origSetText(text);
+            };
+
+            mockBinaryExists.mockReturnValueOnce(false);
+            await (plugin as any).startManagedServer();
+
+            expect(statusTexts.some((t) => t.includes("downloading"))).toBe(true);
+        });
+
+        it("does not set status bar to downloading when binary exists", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+
+            const statusTexts: string[] = [];
+            const origSetText = (plugin as any).statusBarEl!.setText.bind((plugin as any).statusBarEl);
+            (plugin as any).statusBarEl!.setText = (text: string) => {
+                statusTexts.push(text);
+                origSetText(text);
+            };
+
+            await (plugin as any).startManagedServer();
+
+            expect(statusTexts.some((t) => t.includes("downloading"))).toBe(false);
+        });
+
+        it("does not create serverManager when ensureBinary fails", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            mockEnsureBinary.mockRejectedValueOnce(new Error("fail"));
+            await plugin.onload();
+            await flush();
+
+            expect(plugin.serverManager).toBeNull();
+            expect(mockServerStart).not.toHaveBeenCalled();
+        });
+
+        it("sets status bar to error when ensureBinary fails", async () => {
+            mockEnsureBinary.mockRejectedValueOnce(new Error("fail"));
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            expect((plugin as any).statusBarEl?.textContent).toContain("error");
+        });
+
+        it("sets status bar to error when serverManager.start fails", async () => {
+            mockServerStart.mockRejectedValueOnce(new Error("crash"));
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            expect((plugin as any).statusBarEl?.textContent).toContain("error");
         });
     });
 
@@ -1121,6 +1279,7 @@ describe("LilbeePlugin", () => {
         it("managed → external: stops server and nulls managers", async () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
+            await flush();
 
             expect(plugin.serverManager).not.toBeNull();
 
@@ -1150,6 +1309,7 @@ describe("LilbeePlugin", () => {
         it("managed → managed with serverManager: updates port and ollama url", async () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
+            await flush();
 
             plugin.settings.ollamaUrl = "http://custom:11434";
             plugin.settings.serverPort = 9999;
@@ -1219,6 +1379,7 @@ describe("LilbeePlugin", () => {
         it("calls serverManager.stop on unload", async () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
+            await flush();
 
             mockServerStop.mockClear();
             plugin.onunload();
@@ -1237,6 +1398,7 @@ describe("LilbeePlugin", () => {
         it("does not show [external] in managed mode", async () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
+            await flush();
             expect((plugin as any).statusBarEl?.textContent).not.toContain("[external]");
         });
     });

--- a/tests/server-manager.test.ts
+++ b/tests/server-manager.test.ts
@@ -89,7 +89,7 @@ describe("ServerManager", () => {
 
             const startPromise = mgr.start();
             // Health poll setTimeout — advance past it
-            await vi.advanceTimersByTimeAsync(500);
+            await vi.advanceTimersByTimeAsync(1000);
             await startPromise;
 
             expect(spawnSpy).toHaveBeenCalledOnce();
@@ -113,7 +113,7 @@ describe("ServerManager", () => {
         it("no-ops when child already exists", async () => {
             const mgr = new ServerManager(defaultOpts());
             const p1 = mgr.start();
-            await vi.advanceTimersByTimeAsync(500);
+            await vi.advanceTimersByTimeAsync(1000);
             await p1;
 
             // Second call should return immediately without spawning again
@@ -129,8 +129,8 @@ describe("ServerManager", () => {
             );
 
             const startPromise = mgr.start();
-            // 30 attempts * 500ms each = 15000ms
-            await vi.advanceTimersByTimeAsync(15_000);
+            // 60 attempts * 1000ms each = 60000ms
+            await vi.advanceTimersByTimeAsync(60_000);
             await startPromise;
 
             expect(mgr.state).toBe("error");
@@ -141,7 +141,7 @@ describe("ServerManager", () => {
             const mgr = new ServerManager(defaultOpts());
 
             const startPromise = mgr.start();
-            await vi.advanceTimersByTimeAsync(15_000);
+            await vi.advanceTimersByTimeAsync(60_000);
             await startPromise;
 
             expect(mgr.state).toBe("error");
@@ -167,7 +167,7 @@ describe("ServerManager", () => {
 
             const mgr = new ServerManager(defaultOpts());
             const p1 = mgr.start();
-            await vi.advanceTimersByTimeAsync(500);
+            await vi.advanceTimersByTimeAsync(1000);
             await p1;
 
             // Make kill emit exit asynchronously
@@ -188,7 +188,7 @@ describe("ServerManager", () => {
         it("sends SIGKILL after grace period if process does not exit", async () => {
             const mgr = new ServerManager(defaultOpts());
             const p1 = mgr.start();
-            await vi.advanceTimersByTimeAsync(500);
+            await vi.advanceTimersByTimeAsync(1000);
             await p1;
 
             const stopPromise = mgr.stop();
@@ -204,7 +204,7 @@ describe("ServerManager", () => {
         it("clears pending restart timer", async () => {
             const mgr = new ServerManager(defaultOpts());
             const p1 = mgr.start();
-            await vi.advanceTimersByTimeAsync(500);
+            await vi.advanceTimersByTimeAsync(1000);
             await p1;
 
             // Simulate crash to trigger restart timer
@@ -225,7 +225,7 @@ describe("ServerManager", () => {
 
             const mgr = new ServerManager(defaultOpts());
             const p1 = mgr.start();
-            await vi.advanceTimersByTimeAsync(500);
+            await vi.advanceTimersByTimeAsync(1000);
             await p1;
 
             // Let execFile resolve, then emit exit so stop() can finish
@@ -258,7 +258,7 @@ describe("ServerManager", () => {
 
             const mgr = new ServerManager(defaultOpts());
             const p1 = mgr.start();
-            await vi.advanceTimersByTimeAsync(500);
+            await vi.advanceTimersByTimeAsync(1000);
             await p1;
 
             const stopPromise = mgr.stop();
@@ -278,7 +278,7 @@ describe("ServerManager", () => {
         it("calls stop then start and resets crash count", async () => {
             const mgr = new ServerManager(defaultOpts());
             const p1 = mgr.start();
-            await vi.advanceTimersByTimeAsync(500);
+            await vi.advanceTimersByTimeAsync(1000);
             await p1;
 
             // Simulate a crash to increment crashCount
@@ -289,7 +289,7 @@ describe("ServerManager", () => {
             spawnSpy.mockReturnValue(child2 as any);
 
             const restartPromise = mgr.restart();
-            await vi.advanceTimersByTimeAsync(500);
+            await vi.advanceTimersByTimeAsync(1000);
             await restartPromise;
 
             expect(mgr.state).toBe("ready");
@@ -308,7 +308,7 @@ describe("ServerManager", () => {
             );
 
             const p1 = mgr.start();
-            await vi.advanceTimersByTimeAsync(500);
+            await vi.advanceTimersByTimeAsync(1000);
             await p1;
 
             // Prepare a new child for the restart
@@ -329,7 +329,7 @@ describe("ServerManager", () => {
             const mgr = new ServerManager(defaultOpts());
 
             const p1 = mgr.start();
-            await vi.advanceTimersByTimeAsync(500);
+            await vi.advanceTimersByTimeAsync(1000);
             await p1;
             // spawn call #1 done, crashCount = 0
 
@@ -365,7 +365,7 @@ describe("ServerManager", () => {
         it("stop() during restart delay cancels the pending restart", async () => {
             const mgr = new ServerManager(defaultOpts());
             const p1 = mgr.start();
-            await vi.advanceTimersByTimeAsync(500);
+            await vi.advanceTimersByTimeAsync(1000);
             await p1;
 
             // Crash triggers restart timer
@@ -432,7 +432,7 @@ describe("ServerManager", () => {
             );
 
             const p = mgr.start();
-            await vi.advanceTimersByTimeAsync(500);
+            await vi.advanceTimersByTimeAsync(1000);
             await p;
 
             expect(stateChanges).toEqual(["starting", "ready"]);
@@ -445,7 +445,7 @@ describe("ServerManager", () => {
             );
 
             const p1 = mgr.start();
-            await vi.advanceTimersByTimeAsync(500);
+            await vi.advanceTimersByTimeAsync(1000);
             await p1;
 
             stateChanges.length = 0;
@@ -466,7 +466,7 @@ describe("ServerManager", () => {
             const mgr = new ServerManager(defaultOpts());
             // Should not throw when setState is called without a callback
             const p = mgr.start();
-            await vi.advanceTimersByTimeAsync(500);
+            await vi.advanceTimersByTimeAsync(1000);
             await p;
             expect(mgr.state).toBe("ready");
         });


### PR DESCRIPTION
globalThis.fetch in Electron's renderer is blocked by CORS on
GitHub release redirects. Switch to Obsidian's requestUrl API
which uses Electron's net module and handles redirects natively.

Also fixes "Illegal invocation" when fetch lost its Window binding.
