### PR TITLE
fix: file sync and model pull progress bars no longer overlap

### DIFF
--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -36,6 +36,14 @@ export interface ProgressState {
     subTotal: number;
 }
 
+export interface ProgressRefs {
+    banner: HTMLElement;
+    topLabel: HTMLElement;
+    bar: HTMLElement;
+    cancelBtn: HTMLElement;
+    subLabel: HTMLElement | null;
+}
+
 export function buildGenerationOptions(settings: {
     temperature: number | null;
     top_p: number | null;
@@ -70,11 +78,8 @@ export class ChatView extends ItemView {
     private streamController: AbortController | null = null;
     private pullController: AbortController | null = null;
     private pullQueue = new PullQueue();
-    private progressCancelBtn: HTMLElement | null = null;
-    private progressBanner: HTMLElement | null = null;
-    private progressTopLabel: HTMLElement | null = null;
-    private progressSubLabel: HTMLElement | null = null;
-    private progressBar: HTMLElement | null = null;
+    private fileProgress: ProgressRefs | null = null;
+    private pullProgress: ProgressRefs | null = null;
     private chatCatalog: ModelCatalog | null = null;
     private visionCatalog: ModelCatalog | null = null;
     private chatSelectEl: HTMLSelectElement | null = null;
@@ -106,7 +111,13 @@ export class ChatView extends ItemView {
         container.addClass("lilbee-chat-container");
 
         this.createToolbar(container);
-        this.createProgressBanner(container);
+        this.fileProgress = this.createBanner(container, "lilbee-progress-banner", true, () => {
+            this.pullController?.abort();
+            this.plugin.cancelSync();
+        });
+        this.pullProgress = this.createBanner(container, "lilbee-progress-banner-pull", false, () => {
+            this.pullController?.abort();
+        });
         this.messagesEl = container.createDiv({ cls: "lilbee-chat-messages" });
         this.createInputArea(container);
 
@@ -162,21 +173,26 @@ export class ChatView extends ItemView {
         clearBtn.addEventListener("click", () => this.clearChat());
     }
 
-    private createProgressBanner(container: HTMLElement): void {
-        this.progressBanner = container.createDiv({ cls: "lilbee-progress-banner" });
-        this.progressBanner.dataset.hidden = "";
-        const row = this.progressBanner.createDiv({ cls: "lilbee-progress-row" });
-        this.progressTopLabel = row.createDiv({ cls: "lilbee-progress-top-label" });
-        this.progressCancelBtn = row.createEl("button", { cls: "lilbee-progress-cancel" });
-        setIcon(this.progressCancelBtn, "x");
-        this.progressCancelBtn.setAttribute("aria-label", "Cancel");
-        this.progressCancelBtn.addEventListener("click", () => {
-            this.pullController?.abort();
-            this.plugin.cancelSync();
-        });
-        const barContainer = this.progressBanner.createDiv({ cls: "lilbee-progress-bar-container" });
-        this.progressBar = barContainer.createDiv({ cls: "lilbee-progress-bar" });
-        this.progressSubLabel = this.progressBanner.createDiv({ cls: "lilbee-progress-sub-label" });
+    private createBanner(
+        container: HTMLElement,
+        className: string,
+        withSubLabel: boolean,
+        onCancel: () => void,
+    ): ProgressRefs {
+        const banner = container.createDiv({ cls: className });
+        banner.dataset.hidden = "";
+        const row = banner.createDiv({ cls: "lilbee-progress-row" });
+        const topLabel = row.createDiv({ cls: "lilbee-progress-top-label" });
+        const cancelBtn = row.createEl("button", { cls: "lilbee-progress-cancel" });
+        setIcon(cancelBtn, "x");
+        cancelBtn.setAttribute("aria-label", "Cancel");
+        cancelBtn.addEventListener("click", onCancel);
+        const barContainer = banner.createDiv({ cls: "lilbee-progress-bar-container" });
+        const bar = barContainer.createDiv({ cls: "lilbee-progress-bar" });
+        const subLabel = withSubLabel
+            ? banner.createDiv({ cls: "lilbee-progress-sub-label" })
+            : null;
+        return { banner, topLabel, bar, cancelBtn, subLabel };
     }
 
     private createInputArea(container: HTMLElement): void {
@@ -326,7 +342,7 @@ export class ChatView extends ItemView {
                     );
                 }
             }
-            this.hideProgress();
+            this.hidePullProgress();
             if (type === MODEL_TYPE.CHAT) {
                 await this.plugin.api.setChatModel(model.name);
                 this.plugin.activeModel = model.name;
@@ -343,7 +359,7 @@ export class ChatView extends ItemView {
             } else {
                 new Notice(`lilbee: failed to pull ${model.name}`);
             }
-            this.hideProgress();
+            this.hidePullProgress();
         } finally {
             this.pullController = null;
         }
@@ -540,7 +556,7 @@ export class ChatView extends ItemView {
                 const current = Number(data.current ?? 0);
                 const total = Number(data.total ?? 0);
                 const pct = total > 0 ? Math.round((current / total) * 100) : 0;
-                this.showFileProgress(`Pulling model — ${pct}%`, current, total, "");
+                this.showPullProgress(`Pulling model — ${pct}%`, current, total);
                 break;
             }
             case SSE_EVENT.DONE:
@@ -550,28 +566,38 @@ export class ChatView extends ItemView {
     }
 
     private showFileProgress(topLabel: string, current: number, total: number, subLabel: string): void {
-        if (!this.progressBanner || !this.progressTopLabel || !this.progressBar || !this.progressSubLabel) return;
-        delete this.progressBanner.dataset.hidden;
-        this.progressTopLabel.textContent = topLabel;
-        this.progressBar.style.width = total > 0 ? `${Math.round((current / total) * 100)}%` : "0%";
-        this.progressSubLabel.textContent = subLabel;
+        if (!this.fileProgress) return;
+        delete this.fileProgress.banner.dataset.hidden;
+        this.fileProgress.topLabel.textContent = topLabel;
+        this.fileProgress.bar.style.width = total > 0 ? `${Math.round((current / total) * 100)}%` : "0%";
+        if (this.fileProgress.subLabel) this.fileProgress.subLabel.textContent = subLabel;
     }
 
     private showPullProgress(label: string, current: number, total: number): void {
-        this.showFileProgress(label, current, total, "");
+        if (!this.pullProgress) return;
+        delete this.pullProgress.banner.dataset.hidden;
+        this.pullProgress.topLabel.textContent = label;
+        this.pullProgress.bar.style.width = total > 0 ? `${Math.round((current / total) * 100)}%` : "0%";
     }
 
     private updateSubLabel(text: string): void {
-        if (!this.progressSubLabel) return;
-        this.progressSubLabel.textContent = text;
+        if (!this.fileProgress?.subLabel) return;
+        this.fileProgress.subLabel.textContent = text;
     }
 
     hideProgress(): void {
-        if (!this.progressBanner || !this.progressBar || !this.progressSubLabel) return;
-        this.progressBanner.dataset.hidden = "";
-        this.progressBar.style.width = "0%";
-        if (this.progressTopLabel) this.progressTopLabel.textContent = "";
-        this.progressSubLabel.textContent = "";
+        if (!this.fileProgress) return;
+        this.fileProgress.banner.dataset.hidden = "";
+        this.fileProgress.bar.style.width = "0%";
+        this.fileProgress.topLabel.textContent = "";
+        if (this.fileProgress.subLabel) this.fileProgress.subLabel.textContent = "";
+    }
+
+    private hidePullProgress(): void {
+        if (!this.pullProgress) return;
+        this.pullProgress.banner.dataset.hidden = "";
+        this.pullProgress.bar.style.width = "0%";
+        this.pullProgress.topLabel.textContent = "";
     }
 
     private async saveToVault(): Promise<void> {

--- a/styles.css
+++ b/styles.css
@@ -129,7 +129,8 @@
     flex: 1;
 }
 
-.lilbee-progress-banner {
+.lilbee-progress-banner,
+.lilbee-progress-banner-pull {
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -141,7 +142,8 @@
     opacity: 1;
 }
 
-.lilbee-progress-banner[data-hidden] {
+.lilbee-progress-banner[data-hidden],
+.lilbee-progress-banner-pull[data-hidden] {
     opacity: 0;
     pointer-events: none;
 }

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -175,6 +175,12 @@ describe("ChatView.onOpen — DOM structure", () => {
         expect(banner!.dataset.hidden).toBe("");
     });
 
+    it("creates a pull progress banner (hidden by default)", () => {
+        const banner = container.find("lilbee-progress-banner-pull");
+        expect(banner).not.toBeNull();
+        expect(banner!.dataset.hidden).toBe("");
+    });
+
     it("creates a messages div with class 'lilbee-chat-messages'", () => {
         expect(container.find("lilbee-chat-messages")).not.toBeNull();
     });
@@ -1195,8 +1201,8 @@ describe("ChatView — progress banner", () => {
         await view.onOpen();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const banner = container.find("lilbee-progress-banner")!;
-        const label = container.find("lilbee-progress-top-label")!;
+        const banner = container.find("lilbee-progress-banner-pull")!;
+        const label = banner.find("lilbee-progress-top-label")!;
 
         view.handleProgress({
             event: SSE_EVENT.PULL,
@@ -1241,7 +1247,9 @@ describe("ChatView — progress banner", () => {
 
         // PULL with missing fields (tests ?? fallback)
         view.handleProgress({ event: SSE_EVENT.PULL, data: {} });
-        expect(label.textContent).toContain("0%");
+        const pullBanner = container.find("lilbee-progress-banner-pull")!;
+        const pullLabel = pullBanner.find("lilbee-progress-top-label")!;
+        expect(pullLabel.textContent).toContain("0%");
     });
 
     it("updateSubLabel no-ops before onOpen", () => {
@@ -1284,6 +1292,155 @@ describe("ChatView — progress banner", () => {
 
         expect(abortSpy).toHaveBeenCalled();
         expect((plugin as any).cancelSync).toHaveBeenCalled();
+    });
+
+    it("pull cancel button only aborts pullController, not cancelSync", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+
+        const controller = new AbortController();
+        (view as any).pullController = controller;
+        const abortSpy = vi.spyOn(controller, "abort");
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const pullBanner = container.find("lilbee-progress-banner-pull")!;
+        const pullCancelBtn = pullBanner.find("lilbee-progress-cancel")!;
+        pullCancelBtn.trigger("click");
+
+        expect(abortSpy).toHaveBeenCalled();
+        expect((plugin as any).cancelSync).not.toHaveBeenCalled();
+    });
+
+    it("both banners can show simultaneously without interference", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+
+        // Show file progress
+        view.handleProgress({
+            event: SSE_EVENT.FILE_START,
+            data: { current_file: 1, total_files: 3 },
+        });
+
+        // Show pull progress
+        view.handleProgress({
+            event: SSE_EVENT.PULL,
+            data: { current: 50, total: 100 },
+        });
+
+        const fileBanner = container.find("lilbee-progress-banner")!;
+        const pullBanner = container.find("lilbee-progress-banner-pull")!;
+
+        // Both banners visible
+        expect(fileBanner.dataset.hidden).toBeUndefined();
+        expect(pullBanner.dataset.hidden).toBeUndefined();
+
+        // Each banner has its own label
+        const fileLabel = fileBanner.find("lilbee-progress-top-label")!;
+        expect(fileLabel.textContent).toContain("1/3");
+
+        const pullLabel = pullBanner.find("lilbee-progress-top-label")!;
+        expect(pullLabel.textContent).toContain("50%");
+    });
+
+    it("hideProgress hides file banner but not pull banner", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+
+        // Show both banners
+        view.handleProgress({ event: SSE_EVENT.FILE_START, data: { current_file: 1, total_files: 1 } });
+        view.handleProgress({ event: SSE_EVENT.PULL, data: { current: 50, total: 100 } });
+
+        // Hide file banner via DONE
+        view.handleProgress({ event: SSE_EVENT.DONE, data: {} });
+
+        const fileBanner = container.find("lilbee-progress-banner")!;
+        const pullBanner = container.find("lilbee-progress-banner-pull")!;
+
+        expect(fileBanner.dataset.hidden).toBe("");
+        expect(pullBanner.dataset.hidden).toBeUndefined();
+    });
+
+    it("hidePullProgress is called after pull completes, not hideProgress", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        plugin.api.listModels = vi.fn().mockResolvedValue({
+            chat: {
+                active: "llama3",
+                installed: ["llama3"],
+                catalog: [
+                    { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
+                    { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
+                ],
+            },
+            vision: { active: "", installed: [], catalog: [] },
+        });
+
+        async function* pullGen() {
+            yield { status: "pulling", completed: 100, total: 100 };
+        }
+        plugin.ollama.pull = vi.fn().mockReturnValue(pullGen());
+
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+
+        // Start a file operation
+        view.handleProgress({ event: SSE_EVENT.FILE_START, data: { current_file: 1, total_files: 2 } });
+
+        // Trigger pull via model selector
+        const select = container.find("lilbee-chat-model-select")!;
+        (select as any).value = "phi3";
+        select.trigger("change");
+        await tick();
+        await new Promise((r) => setTimeout(r, 50));
+
+        // File banner should still be visible (not hidden by pull completion)
+        const fileBanner = container.find("lilbee-progress-banner")!;
+        expect(fileBanner.dataset.hidden).toBeUndefined();
+    });
+
+    it("pull banner no-ops when pullProgress is null (before onOpen)", () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+
+        // showPullProgress before onOpen — should not throw
+        expect(() => {
+            (view as any).showPullProgress("test", 50, 100);
+        }).not.toThrow();
+    });
+
+    it("hidePullProgress no-ops when pullProgress is null", () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        expect(() => (view as any).hidePullProgress()).not.toThrow();
+    });
+
+    it("pull banner bar width is 0% when total is 0", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+
+        view.handleProgress({ event: SSE_EVENT.PULL, data: { current: 0, total: 0 } });
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const pullBanner = container.find("lilbee-progress-banner-pull")!;
+        const bar = pullBanner.find("lilbee-progress-bar")!;
+        expect(bar.style.width).toBe("0%");
     });
 });
 


### PR DESCRIPTION
## Problem
The chat view used a single progress banner for both file adding and model pulling. When both ran concurrently (e.g. adding files while a model is downloading), they'd overwrite each other's label and bar width.

## Solution
Split into two independent banners stacked vertically:
- **File banner** (`lilbee-progress-banner`) — shows sync/indexing/extract progress with sub-label
- **Pull banner** (`lilbee-progress-banner-pull`) — shows model download percentage

Each has its own DOM refs, show/hide logic, and cancel behavior:
- File cancel → aborts pull + cancels sync
- Pull cancel → aborts pull only

## Changes
- `src/views/chat-view.ts` — new `ProgressRefs` interface, `createBanner()` helper (DRY), split `showFileProgress`/`showPullProgress`, added `hidePullProgress()`
- `styles.css` — pull banner reuses all existing styles via comma-separated selectors (~6 new selector lines)
- `tests/views/chat-view.test.ts` — 8 new tests for concurrency, independence, cancel split, null guards

## Verification
- 606 tests pass, 100% coverage
- Build succeeds