### PR TITLE
fix: separate progress banners, file queueing, error cleanup, Obsidian colors

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,10 @@
 {
   "id": "lilbee",
   "name": "lilbee",
-  "version": "0.2.0",
+  "version": "0.1.5",
   "minAppVersion": "1.0.0",
   "description": "Search, chat, and sync your local knowledge base powered by lilbee",
   "author": "tobocop2",
-  "authorUrl": "https://github.com/tobocop2/lilbee",
+  "authorUrl": "https://tobocop2.github.io/obsidian-lilbee/",
   "isDesktopOnly": true
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -341,6 +341,7 @@ export default class LilbeePlugin extends Plugin {
             "lilbee-status-downloading",
             "lilbee-status-starting",
             "lilbee-status-ready",
+            "lilbee-status-adding",
         );
         if (cls) this.statusBarEl.classList.add(cls);
     }
@@ -393,6 +394,7 @@ export default class LilbeePlugin extends Plugin {
 
     private async runAdd(paths: string[]): Promise<void> {
         this.updateStatusBar("lilbee: adding...");
+        this.setStatusClass("lilbee-status-adding");
         this.syncController = new AbortController();
 
         try {
@@ -481,6 +483,7 @@ export default class LilbeePlugin extends Plugin {
     async triggerSync(): Promise<void> {
         if (!this.statusBarEl) return;
         this.updateStatusBar("lilbee: syncing...");
+        this.setStatusClass("lilbee-status-adding");
         this.syncController = new AbortController();
 
         try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,6 +120,7 @@ export const NOTICE = {
     PULL_CANCELLED: "lilbee: pull cancelled",
     PULL_FAILED: "lilbee: failed to pull model",
     PULL_QUEUED: "lilbee: download queued",
+    ADD_QUEUED: "lilbee: add queued",
     MODEL_ACTIVATED: "lilbee: model activated",
     ADD_FAILED: "lilbee: add failed",
     ADD_CANCELLED: "lilbee: add cancelled",

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -78,6 +78,7 @@ export class ChatView extends ItemView {
     private streamController: AbortController | null = null;
     private pullController: AbortController | null = null;
     private pullQueue = new PullQueue();
+    private addQueue = new PullQueue();
     private fileProgress: ProgressRefs | null = null;
     private pullProgress: ProgressRefs | null = null;
     private chatCatalog: ModelCatalog | null = null;
@@ -112,7 +113,6 @@ export class ChatView extends ItemView {
 
         this.createToolbar(container);
         this.fileProgress = this.createBanner(container, "lilbee-progress-banner", true, () => {
-            this.pullController?.abort();
             this.plugin.cancelSync();
         });
         this.pullProgress = this.createBanner(container, "lilbee-progress-banner-pull", false, () => {
@@ -435,9 +435,9 @@ export class ChatView extends ItemView {
                     textEl.textContent = "(stopped)";
                 }
             } else {
-                revealContent();
-                textEl.textContent = "Server unavailable — retries exhausted. Is lilbee running?";
-                textEl.addClass("lilbee-chat-error");
+                assistantBubble.remove();
+                this.history.pop();
+                new Notice("lilbee: could not reach server — is lilbee running?");
             }
         } finally {
             this.sending = false;
@@ -475,9 +475,7 @@ export class ChatView extends ItemView {
             }
             case SSE_EVENT.ERROR: {
                 const errMsg = extractString(event.data, "message");
-                revealContent();
-                textEl.textContent = errMsg;
-                textEl.addClass("lilbee-chat-error");
+                assistantBubble.remove();
                 new Notice(`lilbee: ${errMsg}`);
                 break;
             }
@@ -496,7 +494,7 @@ export class ChatView extends ItemView {
             item.setTitle("From vault")
                 .setIcon("vault")
                 .onClick(() => {
-                    new VaultFilePickerModal(this.app, this.plugin).open();
+                    new VaultFilePickerModal(this.app, (file) => this.enqueueAddFile(file)).open();
                 });
         });
         menu.addItem((item) => {
@@ -518,10 +516,23 @@ export class ChatView extends ItemView {
             : ["openFile", "multiSelections"];
         electronDialog.showOpenDialog({ properties }).then((result) => {
             if (result.canceled || result.filePaths.length === 0) return;
-            void this.plugin.addExternalFiles(result.filePaths);
+            const label = result.filePaths.length === 1
+                ? result.filePaths[0].split("/").pop()!
+                : `${result.filePaths.length} files`;
+            void this.addQueue.enqueue(
+                () => this.plugin.addExternalFiles(result.filePaths),
+                label,
+            );
         }).catch(() => {
             new Notice("lilbee: could not open file picker");
         });
+    }
+
+    private enqueueAddFile(file: TFile): void {
+        void this.addQueue.enqueue(
+            () => this.plugin.addToLilbee(file),
+            file.name,
+        );
     }
 
     handleProgress(event: SSEEvent): void {
@@ -644,11 +655,11 @@ export class ChatView extends ItemView {
 }
 
 export class VaultFilePickerModal extends FuzzySuggestModal<TFile> {
-    private plugin: LilbeePlugin;
+    private onChoose: (file: TFile) => void;
 
-    constructor(app: import("obsidian").App, plugin: LilbeePlugin) {
+    constructor(app: import("obsidian").App, onChoose: (file: TFile) => void) {
         super(app);
-        this.plugin = plugin;
+        this.onChoose = onChoose;
         this.setPlaceholder("Pick a vault file to add to lilbee...");
     }
 
@@ -661,6 +672,6 @@ export class VaultFilePickerModal extends FuzzySuggestModal<TFile> {
     }
 
     onChooseItem(item: TFile): void {
-        void this.plugin.addToLilbee(item);
+        this.onChoose(item);
     }
 }

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -36,6 +36,14 @@ export interface ProgressState {
     subTotal: number;
 }
 
+export interface ProgressRefs {
+    banner: HTMLElement;
+    topLabel: HTMLElement;
+    bar: HTMLElement;
+    cancelBtn: HTMLElement;
+    subLabel: HTMLElement | null;
+}
+
 export function buildGenerationOptions(settings: {
     temperature: number | null;
     top_p: number | null;
@@ -70,11 +78,8 @@ export class ChatView extends ItemView {
     private streamController: AbortController | null = null;
     private pullController: AbortController | null = null;
     private pullQueue = new PullQueue();
-    private progressCancelBtn: HTMLElement | null = null;
-    private progressBanner: HTMLElement | null = null;
-    private progressTopLabel: HTMLElement | null = null;
-    private progressSubLabel: HTMLElement | null = null;
-    private progressBar: HTMLElement | null = null;
+    private fileProgress: ProgressRefs | null = null;
+    private pullProgress: ProgressRefs | null = null;
     private chatCatalog: ModelCatalog | null = null;
     private visionCatalog: ModelCatalog | null = null;
     private chatSelectEl: HTMLSelectElement | null = null;
@@ -106,7 +111,13 @@ export class ChatView extends ItemView {
         container.addClass("lilbee-chat-container");
 
         this.createToolbar(container);
-        this.createProgressBanner(container);
+        this.fileProgress = this.createBanner(container, "lilbee-progress-banner", true, () => {
+            this.pullController?.abort();
+            this.plugin.cancelSync();
+        });
+        this.pullProgress = this.createBanner(container, "lilbee-progress-banner-pull", false, () => {
+            this.pullController?.abort();
+        });
         this.messagesEl = container.createDiv({ cls: "lilbee-chat-messages" });
         this.createInputArea(container);
 
@@ -162,21 +173,26 @@ export class ChatView extends ItemView {
         clearBtn.addEventListener("click", () => this.clearChat());
     }
 
-    private createProgressBanner(container: HTMLElement): void {
-        this.progressBanner = container.createDiv({ cls: "lilbee-progress-banner" });
-        this.progressBanner.dataset.hidden = "";
-        const row = this.progressBanner.createDiv({ cls: "lilbee-progress-row" });
-        this.progressTopLabel = row.createDiv({ cls: "lilbee-progress-top-label" });
-        this.progressCancelBtn = row.createEl("button", { cls: "lilbee-progress-cancel" });
-        setIcon(this.progressCancelBtn, "x");
-        this.progressCancelBtn.setAttribute("aria-label", "Cancel");
-        this.progressCancelBtn.addEventListener("click", () => {
-            this.pullController?.abort();
-            this.plugin.cancelSync();
-        });
-        const barContainer = this.progressBanner.createDiv({ cls: "lilbee-progress-bar-container" });
-        this.progressBar = barContainer.createDiv({ cls: "lilbee-progress-bar" });
-        this.progressSubLabel = this.progressBanner.createDiv({ cls: "lilbee-progress-sub-label" });
+    private createBanner(
+        container: HTMLElement,
+        className: string,
+        withSubLabel: boolean,
+        onCancel: () => void,
+    ): ProgressRefs {
+        const banner = container.createDiv({ cls: className });
+        banner.dataset.hidden = "";
+        const row = banner.createDiv({ cls: "lilbee-progress-row" });
+        const topLabel = row.createDiv({ cls: "lilbee-progress-top-label" });
+        const cancelBtn = row.createEl("button", { cls: "lilbee-progress-cancel" });
+        setIcon(cancelBtn, "x");
+        cancelBtn.setAttribute("aria-label", "Cancel");
+        cancelBtn.addEventListener("click", onCancel);
+        const barContainer = banner.createDiv({ cls: "lilbee-progress-bar-container" });
+        const bar = barContainer.createDiv({ cls: "lilbee-progress-bar" });
+        const subLabel = withSubLabel
+            ? banner.createDiv({ cls: "lilbee-progress-sub-label" })
+            : null;
+        return { banner, topLabel, bar, cancelBtn, subLabel };
     }
 
     private createInputArea(container: HTMLElement): void {
@@ -326,7 +342,7 @@ export class ChatView extends ItemView {
                     );
                 }
             }
-            this.hideProgress();
+            this.hidePullProgress();
             if (type === MODEL_TYPE.CHAT) {
                 await this.plugin.api.setChatModel(model.name);
                 this.plugin.activeModel = model.name;
@@ -343,7 +359,7 @@ export class ChatView extends ItemView {
             } else {
                 new Notice(`lilbee: failed to pull ${model.name}`);
             }
-            this.hideProgress();
+            this.hidePullProgress();
         } finally {
             this.pullController = null;
         }
@@ -540,7 +556,7 @@ export class ChatView extends ItemView {
                 const current = Number(data.current ?? 0);
                 const total = Number(data.total ?? 0);
                 const pct = total > 0 ? Math.round((current / total) * 100) : 0;
-                this.showFileProgress(`Pulling model — ${pct}%`, current, total, "");
+                this.showPullProgress(`Pulling model — ${pct}%`, current, total);
                 break;
             }
             case SSE_EVENT.DONE:
@@ -550,28 +566,38 @@ export class ChatView extends ItemView {
     }
 
     private showFileProgress(topLabel: string, current: number, total: number, subLabel: string): void {
-        if (!this.progressBanner || !this.progressTopLabel || !this.progressBar || !this.progressSubLabel) return;
-        delete this.progressBanner.dataset.hidden;
-        this.progressTopLabel.textContent = topLabel;
-        this.progressBar.style.width = total > 0 ? `${Math.round((current / total) * 100)}%` : "0%";
-        this.progressSubLabel.textContent = subLabel;
+        if (!this.fileProgress) return;
+        delete this.fileProgress.banner.dataset.hidden;
+        this.fileProgress.topLabel.textContent = topLabel;
+        this.fileProgress.bar.style.width = total > 0 ? `${Math.round((current / total) * 100)}%` : "0%";
+        if (this.fileProgress.subLabel) this.fileProgress.subLabel.textContent = subLabel;
     }
 
     private showPullProgress(label: string, current: number, total: number): void {
-        this.showFileProgress(label, current, total, "");
+        if (!this.pullProgress) return;
+        delete this.pullProgress.banner.dataset.hidden;
+        this.pullProgress.topLabel.textContent = label;
+        this.pullProgress.bar.style.width = total > 0 ? `${Math.round((current / total) * 100)}%` : "0%";
     }
 
     private updateSubLabel(text: string): void {
-        if (!this.progressSubLabel) return;
-        this.progressSubLabel.textContent = text;
+        if (!this.fileProgress?.subLabel) return;
+        this.fileProgress.subLabel.textContent = text;
     }
 
     hideProgress(): void {
-        if (!this.progressBanner || !this.progressBar || !this.progressSubLabel) return;
-        this.progressBanner.dataset.hidden = "";
-        this.progressBar.style.width = "0%";
-        if (this.progressTopLabel) this.progressTopLabel.textContent = "";
-        this.progressSubLabel.textContent = "";
+        if (!this.fileProgress) return;
+        this.fileProgress.banner.dataset.hidden = "";
+        this.fileProgress.bar.style.width = "0%";
+        this.fileProgress.topLabel.textContent = "";
+        if (this.fileProgress.subLabel) this.fileProgress.subLabel.textContent = "";
+    }
+
+    private hidePullProgress(): void {
+        if (!this.pullProgress) return;
+        this.pullProgress.banner.dataset.hidden = "";
+        this.pullProgress.bar.style.width = "0%";
+        this.pullProgress.topLabel.textContent = "";
     }
 
     private async saveToVault(): Promise<void> {

--- a/styles.css
+++ b/styles.css
@@ -129,7 +129,8 @@
     flex: 1;
 }
 
-.lilbee-progress-banner {
+.lilbee-progress-banner,
+.lilbee-progress-banner-pull {
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -141,7 +142,8 @@
     opacity: 1;
 }
 
-.lilbee-progress-banner[data-hidden] {
+.lilbee-progress-banner[data-hidden],
+.lilbee-progress-banner-pull[data-hidden] {
     opacity: 0;
     pointer-events: none;
 }

--- a/styles.css
+++ b/styles.css
@@ -194,7 +194,7 @@
 }
 
 .lilbee-server-dot.is-ready {
-    background-color: var(--color-green, #2d7a4f);
+    background-color: var(--text-success);
 }
 
 .lilbee-server-dot.is-error {
@@ -202,11 +202,11 @@
 }
 
 .lilbee-server-dot.is-starting {
-    background-color: var(--color-yellow, #e0a526);
+    background-color: var(--text-warning);
 }
 
 .lilbee-server-dot.is-downloading {
-    background-color: var(--color-yellow, #e0a526);
+    background-color: var(--text-warning);
 }
 
 .lilbee-chat-messages {
@@ -342,11 +342,6 @@
     cursor: not-allowed;
 }
 
-.lilbee-chat-error {
-    color: var(--text-error);
-    font-style: italic;
-}
-
 .lilbee-modal {
     padding: var(--size-4-3, 12px);
 }
@@ -474,8 +469,8 @@
     display: inline-block;
     padding: 1px var(--size-4-2, 8px);
     border-radius: 999px;
-    background-color: var(--color-green, #2d7a4f);
-    color: var(--text-on-accent, #fff);
+    background-color: var(--text-success);
+    color: var(--text-on-accent);
     font-size: var(--font-smallest, 10px);
     font-weight: var(--font-medium, 500);
 }
@@ -619,7 +614,7 @@
     background: linear-gradient(
         90deg,
         transparent,
-        rgba(255, 255, 255, 0.35),
+        rgba(255, 255, 255, 0.15),
         transparent
     );
     animation: lilbee-knight 1.4s ease-in-out infinite;
@@ -642,7 +637,7 @@
 }
 
 .lilbee-health-dot.is-ok {
-    background-color: var(--color-green, #2d7a4f);
+    background-color: var(--text-success);
 }
 
 .lilbee-health-dot.is-error {
@@ -651,7 +646,7 @@
 
 .lilbee-status-starting {
     color: var(--text-on-accent) !important;
-    background-color: var(--color-yellow, #e0a526);
+    background-color: var(--text-warning);
     border-radius: var(--radius-s, 4px);
     padding: 0 var(--size-4-2, 8px);
     position: relative;
@@ -668,15 +663,40 @@
     background: linear-gradient(
         90deg,
         transparent,
-        rgba(255, 255, 255, 0.35),
+        rgba(255, 255, 255, 0.15),
         transparent
     );
     animation: lilbee-knight 1.4s ease-in-out infinite;
 }
 
 .lilbee-status-ready {
-    color: var(--text-on-accent, #fff) !important;
-    background-color: var(--color-green, #2d7a4f);
+    color: var(--text-on-accent) !important;
+    background-color: var(--text-success);
     border-radius: var(--radius-s, 4px);
     padding: 0 var(--size-4-2, 8px);
+}
+
+.lilbee-status-adding {
+    color: var(--text-on-accent) !important;
+    background-color: var(--interactive-accent);
+    border-radius: var(--radius-s, 4px);
+    padding: 0 var(--size-4-2, 8px);
+    position: relative;
+    overflow: hidden;
+}
+
+.lilbee-status-adding::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: -40%;
+    width: 40%;
+    height: 100%;
+    background: linear-gradient(
+        90deg,
+        transparent,
+        rgba(255, 255, 255, 0.15),
+        transparent
+    );
+    animation: lilbee-knight 1.4s ease-in-out infinite;
 }

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -529,7 +529,7 @@ describe("ChatView.sendMessage — sources", () => {
 });
 
 describe("ChatView.sendMessage — error event", () => {
-    it("shows a Notice and renders error inline when error event is received", async () => {
+    it("shows a Notice and removes assistant bubble when error event is received", async () => {
         Notice.clear();
         const plugin = makePlugin();
         const { mockFn, done } = makeStream([
@@ -548,15 +548,37 @@ describe("ChatView.sendMessage — error event", () => {
         await tick();
 
         expect(Notice.instances[0].message).toBe("lilbee: something went wrong");
-        const assistantBubble = messagesEl.children[1];
-        const textEl = assistantBubble.find("lilbee-chat-content");
-        expect(textEl!.textContent).toBe("something went wrong");
-        expect(textEl!.classList.contains("lilbee-chat-error")).toBe(true);
+        // Assistant bubble should be removed — only user bubble remains
+        expect(messagesEl.children.length).toBe(1);
+        expect(messagesEl.children[0].classList.contains("user")).toBe(true);
+    });
+
+    it("does not add error message to chat history", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const { mockFn, done } = makeStream([
+            { event: SSE_EVENT.ERROR, data: "model not found" },
+        ]);
+        plugin.api.chatStream = mockFn;
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const textarea = container.find("lilbee-chat-textarea")!;
+        textarea.value = "test question";
+
+        container.find("lilbee-chat-send")!.trigger("click");
+        await done;
+        await tick();
+
+        // History should only have the user message, not the error
+        const history = (view as any).history;
+        expect(history.length).toBe(1);
+        expect(history[0].role).toBe("user");
     });
 });
 
 describe("ChatView.sendMessage — API throws", () => {
-    it("sets assistant text to unavailable message and adds error class when chatStream throws", async () => {
+    it("removes assistant bubble, pops history, and shows Notice when chatStream throws", async () => {
         Notice.clear();
         const plugin = makePlugin();
         let resolveThrown!: () => void;
@@ -578,10 +600,13 @@ describe("ChatView.sendMessage — API throws", () => {
         await thrown;
         await tick();
 
-        const assistantBubble = messagesEl.children[1];
-        const textEl = assistantBubble.find("lilbee-chat-content");
-        expect(textEl!.textContent).toBe("Server unavailable — retries exhausted. Is lilbee running?");
-        expect(textEl!.classList.contains("lilbee-chat-error")).toBe(true);
+        // Assistant bubble removed — only user bubble remains
+        expect(messagesEl.children.length).toBe(1);
+        expect(messagesEl.children[0].classList.contains("user")).toBe(true);
+        // Notice shown
+        expect(Notice.instances.some((n) => n.message === "lilbee: could not reach server — is lilbee running?")).toBe(true);
+        // History popped — no user message either
+        expect((view as any).history.length).toBe(0);
     });
 });
 
@@ -989,28 +1014,27 @@ describe("ChatView.sendMessage — loading indicator", () => {
 
 describe("VaultFilePickerModal", () => {
     it("getItems returns vault files", () => {
-        const plugin = makePlugin();
+        const onChoose = vi.fn();
         const files = [{ path: "a.md", name: "a.md" }, { path: "b.md", name: "b.md" }];
         const leaf = makeLeaf();
         (leaf.app.vault as any).getFiles = vi.fn().mockReturnValue(files);
-        const modal = new VaultFilePickerModal(leaf.app as any, plugin);
+        const modal = new VaultFilePickerModal(leaf.app as any, onChoose);
         expect(modal.getItems()).toEqual(files);
     });
 
     it("getItemText returns file path", () => {
-        const plugin = makePlugin();
-        const modal = new VaultFilePickerModal(makeLeaf().app as any, plugin);
+        const onChoose = vi.fn();
+        const modal = new VaultFilePickerModal(makeLeaf().app as any, onChoose);
         const file = { path: "notes/test.md", name: "test.md" } as any;
         expect(modal.getItemText(file)).toBe("notes/test.md");
     });
 
-    it("onChooseItem calls plugin.addToLilbee", () => {
-        const plugin = makePlugin();
-        (plugin as any).addToLilbee = vi.fn().mockResolvedValue(undefined);
-        const modal = new VaultFilePickerModal(makeLeaf().app as any, plugin);
+    it("onChooseItem calls the provided callback", () => {
+        const onChoose = vi.fn();
+        const modal = new VaultFilePickerModal(makeLeaf().app as any, onChoose);
         const file = { path: "test.md", name: "test.md" } as any;
         modal.onChooseItem(file, undefined);
-        expect((plugin as any).addToLilbee).toHaveBeenCalledWith(file);
+        expect(onChoose).toHaveBeenCalledWith(file);
     });
 });
 
@@ -1275,13 +1299,12 @@ describe("ChatView — progress banner", () => {
         expect(bar.style.width).toBe("0%");
     });
 
-    it("cancel button aborts pullController when set", async () => {
+    it("file cancel button does not abort pullController", async () => {
         Notice.clear();
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
 
-        // Simulate a pullController being set
         const controller = new AbortController();
         (view as any).pullController = controller;
         const abortSpy = vi.spyOn(controller, "abort");
@@ -1290,7 +1313,7 @@ describe("ChatView — progress banner", () => {
         const cancelBtn = container.find("lilbee-progress-cancel")!;
         cancelBtn.trigger("click");
 
-        expect(abortSpy).toHaveBeenCalled();
+        expect(abortSpy).not.toHaveBeenCalled();
         expect((plugin as any).cancelSync).toHaveBeenCalled();
     });
 
@@ -1508,6 +1531,7 @@ describe("ChatView.onOpen — add file button opens menu", () => {
         const container = view.containerEl.children[1] as unknown as MockElement;
         const addBtn = container.find("lilbee-chat-add-file")!;
         addBtn.trigger("click", { clientX: 0, clientY: 0 } as MouseEvent);
+        await tick();
         await tick();
 
         expect((plugin as any).addExternalFiles).toHaveBeenCalledWith(["/home/user/doc.pdf", "/tmp/notes.md"]);
@@ -1939,19 +1963,22 @@ describe("ChatView — cancel model pull", () => {
         expect(cancelBtn.tagName).toBe("BUTTON");
     });
 
-    it("cancel button calls both pullController.abort and plugin.cancelSync", async () => {
+    it("cancel button calls plugin.cancelSync (not pullController.abort)", async () => {
         Notice.clear();
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
 
+        const controller = new AbortController();
+        (view as any).pullController = controller;
+        const abortSpy = vi.spyOn(controller, "abort");
+
         const container = view.containerEl.children[1] as unknown as MockElement;
         const cancelBtn = container.find("lilbee-progress-cancel")!;
-
-        // Trigger cancel click
         cancelBtn.trigger("click");
 
         expect((plugin as any).cancelSync).toHaveBeenCalled();
+        expect(abortSpy).not.toHaveBeenCalled();
     });
 
     it("clicking cancel button during pull aborts and shows Pull cancelled Notice", async () => {
@@ -2023,6 +2050,140 @@ describe("ChatView — pull queue", () => {
         resolveSlow();
         await p2;
         // Second should have run via runNextPull
+        expect(secondRun).toHaveBeenCalled();
+    });
+
+    it("cancel running pull → next queued pull runs", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+
+        let resolveFirst!: () => void;
+        let rejectFirst!: (err: Error) => void;
+        const firstRun = vi.fn(() => new Promise<void>((res, rej) => {
+            resolveFirst = res;
+            rejectFirst = rej;
+        }));
+        const secondRun = vi.fn().mockResolvedValue(undefined);
+
+        // Start first, queue second
+        const p1 = (view as any).pullQueue.enqueue(firstRun, "first");
+        (view as any).pullQueue.enqueue(secondRun, "second");
+        expect(firstRun).toHaveBeenCalled();
+        expect(secondRun).not.toHaveBeenCalled();
+
+        // Cancel the first (reject with AbortError)
+        const abortErr = new Error("aborted");
+        abortErr.name = "AbortError";
+        rejectFirst(abortErr);
+        await p1.catch(() => { /* queue rejections are unhandled */ });
+        await tick();
+
+        // Second should have run
+        expect(secondRun).toHaveBeenCalled();
+    });
+});
+
+describe("ChatView — add queue", () => {
+    it("file adds are routed through addQueue", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        (plugin as any).addExternalFiles = vi.fn().mockResolvedValue(undefined);
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+
+        const addSpy = vi.spyOn((view as any).addQueue, "enqueue");
+
+        const firstRun = vi.fn().mockResolvedValue(undefined);
+        const secondRun = vi.fn().mockResolvedValue(undefined);
+
+        // Enqueue two adds
+        await (view as any).addQueue.enqueue(firstRun, "file1.md");
+        expect(firstRun).toHaveBeenCalled();
+
+        // Start a slow add, then queue a second
+        let resolveSlow!: () => void;
+        const slowRun = () => new Promise<void>((r) => { resolveSlow = r; });
+        const p = (view as any).addQueue.enqueue(slowRun, "slow.md");
+        (view as any).addQueue.enqueue(secondRun, "file2.md");
+        expect(secondRun).not.toHaveBeenCalled();
+
+        resolveSlow();
+        await p;
+        expect(secondRun).toHaveBeenCalled();
+    });
+
+    it("vault file picker routes through addQueue", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        (plugin as any).addToLilbee = vi.fn().mockResolvedValue(undefined);
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+
+        // Directly test the queue behavior by simulating what the modal callback does
+        const queueSpy = vi.spyOn((view as any).addQueue, "enqueue");
+        const file = { path: "test.md", name: "test.md" } as any;
+
+        void (view as any).addQueue.enqueue(
+            () => (plugin as any).addToLilbee(file),
+            file.name,
+        );
+        await tick();
+
+        expect(queueSpy).toHaveBeenCalled();
+        expect((plugin as any).addToLilbee).toHaveBeenCalledWith(file);
+    });
+
+    it("addQueue and pullQueue are independent", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+
+        expect((view as any).addQueue).not.toBe((view as any).pullQueue);
+    });
+
+    it("enqueueAddFile routes through addQueue", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        (plugin as any).addToLilbee = vi.fn().mockResolvedValue(undefined);
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+
+        const file = { path: "test.md", name: "test.md" } as any;
+        (view as any).enqueueAddFile(file);
+        await tick();
+
+        expect((plugin as any).addToLilbee).toHaveBeenCalledWith(file);
+    });
+
+    it("cancel running add → next queued add runs", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+
+        let rejectFirst!: (err: Error) => void;
+        const firstRun = vi.fn(() => new Promise<void>((_res, rej) => {
+            rejectFirst = rej;
+        }));
+        const secondRun = vi.fn().mockResolvedValue(undefined);
+
+        // Start first, queue second
+        const p1 = (view as any).addQueue.enqueue(firstRun, "first");
+        (view as any).addQueue.enqueue(secondRun, "second");
+        expect(firstRun).toHaveBeenCalled();
+        expect(secondRun).not.toHaveBeenCalled();
+
+        // Cancel the first
+        const abortErr = new Error("aborted");
+        abortErr.name = "AbortError";
+        rejectFirst(abortErr);
+        await p1.catch(() => { /* queue rejection */ });
+        await tick();
+
+        // Second should have run
         expect(secondRun).toHaveBeenCalled();
     });
 });

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -175,6 +175,12 @@ describe("ChatView.onOpen — DOM structure", () => {
         expect(banner!.dataset.hidden).toBe("");
     });
 
+    it("creates a pull progress banner (hidden by default)", () => {
+        const banner = container.find("lilbee-progress-banner-pull");
+        expect(banner).not.toBeNull();
+        expect(banner!.dataset.hidden).toBe("");
+    });
+
     it("creates a messages div with class 'lilbee-chat-messages'", () => {
         expect(container.find("lilbee-chat-messages")).not.toBeNull();
     });
@@ -1195,8 +1201,8 @@ describe("ChatView — progress banner", () => {
         await view.onOpen();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const banner = container.find("lilbee-progress-banner")!;
-        const label = container.find("lilbee-progress-top-label")!;
+        const banner = container.find("lilbee-progress-banner-pull")!;
+        const label = banner.find("lilbee-progress-top-label")!;
 
         view.handleProgress({
             event: SSE_EVENT.PULL,
@@ -1241,7 +1247,9 @@ describe("ChatView — progress banner", () => {
 
         // PULL with missing fields (tests ?? fallback)
         view.handleProgress({ event: SSE_EVENT.PULL, data: {} });
-        expect(label.textContent).toContain("0%");
+        const pullBanner = container.find("lilbee-progress-banner-pull")!;
+        const pullLabel = pullBanner.find("lilbee-progress-top-label")!;
+        expect(pullLabel.textContent).toContain("0%");
     });
 
     it("updateSubLabel no-ops before onOpen", () => {
@@ -1284,6 +1292,155 @@ describe("ChatView — progress banner", () => {
 
         expect(abortSpy).toHaveBeenCalled();
         expect((plugin as any).cancelSync).toHaveBeenCalled();
+    });
+
+    it("pull cancel button only aborts pullController, not cancelSync", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+
+        const controller = new AbortController();
+        (view as any).pullController = controller;
+        const abortSpy = vi.spyOn(controller, "abort");
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const pullBanner = container.find("lilbee-progress-banner-pull")!;
+        const pullCancelBtn = pullBanner.find("lilbee-progress-cancel")!;
+        pullCancelBtn.trigger("click");
+
+        expect(abortSpy).toHaveBeenCalled();
+        expect((plugin as any).cancelSync).not.toHaveBeenCalled();
+    });
+
+    it("both banners can show simultaneously without interference", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+
+        // Show file progress
+        view.handleProgress({
+            event: SSE_EVENT.FILE_START,
+            data: { current_file: 1, total_files: 3 },
+        });
+
+        // Show pull progress
+        view.handleProgress({
+            event: SSE_EVENT.PULL,
+            data: { current: 50, total: 100 },
+        });
+
+        const fileBanner = container.find("lilbee-progress-banner")!;
+        const pullBanner = container.find("lilbee-progress-banner-pull")!;
+
+        // Both banners visible
+        expect(fileBanner.dataset.hidden).toBeUndefined();
+        expect(pullBanner.dataset.hidden).toBeUndefined();
+
+        // Each banner has its own label
+        const fileLabel = fileBanner.find("lilbee-progress-top-label")!;
+        expect(fileLabel.textContent).toContain("1/3");
+
+        const pullLabel = pullBanner.find("lilbee-progress-top-label")!;
+        expect(pullLabel.textContent).toContain("50%");
+    });
+
+    it("hideProgress hides file banner but not pull banner", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+
+        // Show both banners
+        view.handleProgress({ event: SSE_EVENT.FILE_START, data: { current_file: 1, total_files: 1 } });
+        view.handleProgress({ event: SSE_EVENT.PULL, data: { current: 50, total: 100 } });
+
+        // Hide file banner via DONE
+        view.handleProgress({ event: SSE_EVENT.DONE, data: {} });
+
+        const fileBanner = container.find("lilbee-progress-banner")!;
+        const pullBanner = container.find("lilbee-progress-banner-pull")!;
+
+        expect(fileBanner.dataset.hidden).toBe("");
+        expect(pullBanner.dataset.hidden).toBeUndefined();
+    });
+
+    it("hidePullProgress is called after pull completes, not hideProgress", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        plugin.api.listModels = vi.fn().mockResolvedValue({
+            chat: {
+                active: "llama3",
+                installed: ["llama3"],
+                catalog: [
+                    { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
+                    { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
+                ],
+            },
+            vision: { active: "", installed: [], catalog: [] },
+        });
+
+        async function* pullGen() {
+            yield { status: "pulling", completed: 100, total: 100 };
+        }
+        plugin.ollama.pull = vi.fn().mockReturnValue(pullGen());
+
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+
+        // Start a file operation
+        view.handleProgress({ event: SSE_EVENT.FILE_START, data: { current_file: 1, total_files: 2 } });
+
+        // Trigger pull via model selector
+        const select = container.find("lilbee-chat-model-select")!;
+        (select as any).value = "phi3";
+        select.trigger("change");
+        await tick();
+        await new Promise((r) => setTimeout(r, 50));
+
+        // File banner should still be visible (not hidden by pull completion)
+        const fileBanner = container.find("lilbee-progress-banner")!;
+        expect(fileBanner.dataset.hidden).toBeUndefined();
+    });
+
+    it("pull banner no-ops when pullProgress is null (before onOpen)", () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+
+        // showPullProgress before onOpen — should not throw
+        expect(() => {
+            (view as any).showPullProgress("test", 50, 100);
+        }).not.toThrow();
+    });
+
+    it("hidePullProgress no-ops when pullProgress is null", () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        expect(() => (view as any).hidePullProgress()).not.toThrow();
+    });
+
+    it("pull banner bar width is 0% when total is 0", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+
+        view.handleProgress({ event: SSE_EVENT.PULL, data: { current: 0, total: 0 } });
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const pullBanner = container.find("lilbee-progress-banner-pull")!;
+        const bar = pullBanner.find("lilbee-progress-bar")!;
+        expect(bar.style.width).toBe("0%");
     });
 });
 


### PR DESCRIPTION
## What

- **Separate progress banners** — file adds and model pulls each get their own banner. No more overlap.
- **File add queue** — adds go through `addQueue`, independent from `pullQueue`. Queued adds surface after the current one finishes or is cancelled.
- **Cancel isolation** — file banner cancel only cancels sync, no longer kills running model pull. Pull banner cancel only aborts pull.
- **Error messages** — "model not found" and "server unavailable" show as temporary Notices instead of permanent chat bubbles. Failed messages are cleaned up so retries work with fresh context.
- **Obsidian colors** — green/yellow replaced with `--text-success`/`--text-warning`. Adding and syncing status shows a shimmer animation.

## Files

- `src/views/chat-view.ts` — split banners, add queue, cancel handlers, error cleanup
- `src/main.ts` — adding status class, queue constants
- `src/types.ts` — `ProgressRefs` interface, `ADD_QUEUED` notice
- `styles.css` — semantic color vars, shimmer animation, new status class
- `tests/views/chat-view.test.ts` — concurrency, cancel isolation, queue tests

613 tests, 100% coverage.