### PR TITLE
feat: setup wizard for first-time users

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { ChatView, VIEW_TYPE_CHAT } from "./views/chat-view";
 import { CrawlModal } from "./views/crawl-modal";
 import { DocumentsModal } from "./views/documents-modal";
 import { SearchModal } from "./views/search-modal";
+import { SetupWizard } from "./views/setup-wizard";
 
 
 function summarizeSyncResult(done: SyncDone): string {
@@ -61,6 +62,10 @@ export default class LilbeePlugin extends Plugin {
             this.api = new LilbeeClient(this.settings.serverUrl);
             this.setStatusReady();
             this.fetchActiveModel();
+        }
+
+        if (!this.settings.setupCompleted) {
+            new SetupWizard(this.app, this).open();
         }
 
         if (this.settings.syncMode === "auto") {
@@ -294,6 +299,12 @@ export default class LilbeePlugin extends Plugin {
         });
 
         this.addCommand({
+            id: "lilbee:setup",
+            name: "Run setup wizard",
+            callback: () => new SetupWizard(this.app, this).open(),
+        });
+
+        this.addCommand({
             id: "lilbee:status",
             name: "Show status",
             callback: async () => {
@@ -459,7 +470,7 @@ export default class LilbeePlugin extends Plugin {
         this.autoSyncRefs = [];
     }
 
-    private async activateChatView(): Promise<void> {
+    async activateChatView(): Promise<void> {
         const existing = this.app.workspace.getLeavesOfType(VIEW_TYPE_CHAT);
         if (existing.length > 0) {
             this.app.workspace.revealLeaf(existing[0]);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,6 +7,7 @@ import { PullQueue } from "./pull-queue";
 import { CatalogModal } from "./views/catalog-modal";
 import { ConfirmModal } from "./views/confirm-modal";
 import { ConfirmPullModal } from "./views/confirm-pull-modal";
+import { SetupWizard } from "./views/setup-wizard";
 
 const CHECK_TIMEOUT_MS = 5000;
 const CLS_MODELS_CONTAINER = "lilbee-models-container";
@@ -111,6 +112,15 @@ export class LilbeeSettingTab extends PluginSettingTab {
                         await this.plugin.saveSettings();
                         this.display();
                     }),
+            );
+
+        new Setting(containerEl)
+            .setName("Setup wizard")
+            .setDesc("Walk through initial setup again")
+            .addButton((btn) =>
+                btn.setButtonText("Run setup wizard").onClick(() => {
+                    new SetupWizard(this.app, this.plugin).open();
+                }),
             );
 
         if (this.plugin.settings.serverMode === SERVER_MODE.MANAGED) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,6 +132,7 @@ export interface LilbeeSettings {
     serverPort: number | null;
     lilbeeVersion: string;
     systemPrompt: string;
+    setupCompleted: boolean;
 }
 
 export const DEFAULT_SETTINGS: LilbeeSettings = {
@@ -149,6 +150,7 @@ export const DEFAULT_SETTINGS: LilbeeSettings = {
     serverPort: null,
     lilbeeVersion: "",
     systemPrompt: "",
+    setupCompleted: false,
 };
 
 /** SSE event type constants — shared across chat, sync, and model pull streams. */

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -1,0 +1,510 @@
+import { App, Modal, Notice } from "obsidian";
+import type LilbeePlugin from "../main";
+import type { CatalogModel, SSEEvent, SyncDone } from "../types";
+import { SERVER_MODE, SSE_EVENT } from "../types";
+import { CatalogModal } from "./catalog-modal";
+
+interface FeaturedModel {
+    name: string;
+    size_gb: number;
+    min_ram_gb: number;
+    description: string;
+    source: "native" | "litellm";
+}
+
+export function getSystemMemoryGB(): number | null {
+    try {
+        const os = require("os") as { totalmem(): number };
+        return Math.round(os.totalmem() / (1024 * 1024 * 1024));
+    /* v8 ignore next 3 */
+    } catch {
+        return null;
+    }
+}
+
+export function recommendedIndex(models: FeaturedModel[], memGB: number | null): number {
+    if (memGB === null || models.length === 0) return 0;
+    let best = 0;
+    let bestRam = 0;
+    for (let i = 0; i < models.length; i++) {
+        if (models[i].min_ram_gb <= memGB && models[i].min_ram_gb >= bestRam) {
+            best = i;
+            bestRam = models[i].min_ram_gb;
+        }
+    }
+    return best;
+}
+
+export class SetupWizard extends Modal {
+    private plugin: LilbeePlugin;
+    private step = 0;
+    private selectedModel: FeaturedModel | null = null;
+    private featuredModels: FeaturedModel[] = [];
+    private pullController: AbortController | null = null;
+    private syncController: AbortController | null = null;
+    private syncResult: SyncDone | null = null;
+    private pulledModelName = "";
+
+    constructor(app: App, plugin: LilbeePlugin) {
+        super(app);
+        this.plugin = plugin;
+    }
+
+    onOpen(): void {
+        const { contentEl } = this;
+        contentEl.empty();
+        contentEl.addClass("lilbee-wizard");
+        this.renderStep();
+    }
+
+    onClose(): void {
+        this.pullController?.abort();
+        this.syncController?.abort();
+    }
+
+    private renderStep(): void {
+        const { contentEl } = this;
+        contentEl.empty();
+
+        switch (this.step) {
+            case 0: this.renderWelcome(); break;
+            case 1: this.renderServerMode(); break;
+            case 2: this.renderModelPicker(); break;
+            case 3: this.renderSync(); break;
+            case 4: this.renderDone(); break;
+        }
+    }
+
+    private renderWelcome(): void {
+        const { contentEl } = this;
+        const step = contentEl.createDiv({ cls: "lilbee-wizard-step" });
+
+        step.createEl("h2", { text: "Welcome to lilbee" });
+        step.createEl("p", {
+            text: "lilbee turns your Obsidian vault into a searchable knowledge base powered by AI running on your machine.",
+        });
+
+        step.createEl("p", { text: "This wizard will help you:" });
+        const ul = step.createEl("ul");
+        ul.createEl("li", { text: "Choose an AI model that fits your computer" });
+        ul.createEl("li", { text: "Index your vault so you can search and chat" });
+
+        step.createEl("p", {
+            text: "Everything runs locally \u2014 your notes never leave your machine.",
+        });
+
+        const actions = step.createDiv({ cls: "lilbee-wizard-actions" });
+        const skipBtn = actions.createEl("button", { text: "Skip setup" });
+        skipBtn.addEventListener("click", () => this.skip());
+
+        const startBtn = actions.createEl("button", { text: "Get started", cls: "mod-cta" });
+        startBtn.addEventListener("click", () => this.next());
+    }
+
+    private renderServerMode(): void {
+        const { contentEl } = this;
+        const step = contentEl.createDiv({ cls: "lilbee-wizard-step" });
+
+        step.createEl("h2", { text: "How do you want to run lilbee?" });
+
+        let mode: "managed" | "external" = this.plugin.settings.serverMode === SERVER_MODE.EXTERNAL
+            ? "external"
+            : "managed";
+
+        const managedOption = step.createDiv({ cls: `lilbee-wizard-model-option${mode === "managed" ? " selected" : ""}` });
+        managedOption.createEl("strong", { text: "Managed (recommended)" });
+        managedOption.createEl("p", {
+            text: "lilbee starts and stops automatically with Obsidian. No terminal needed.",
+        });
+
+        const externalOption = step.createDiv({ cls: `lilbee-wizard-model-option${mode === "external" ? " selected" : ""}` });
+        externalOption.createEl("strong", { text: "External" });
+        externalOption.createEl("p", {
+            text: "You run the lilbee server yourself. For advanced users or shared setups.",
+        });
+
+        const urlInput = step.createEl("input", {
+            cls: "lilbee-wizard-url-input",
+            placeholder: "http://127.0.0.1:7433",
+            attr: { type: "text" },
+        });
+        urlInput.value = this.plugin.settings.serverUrl;
+        urlInput.style.display = mode === "external" ? "" : "none";
+
+        const statusEl = step.createDiv({ cls: "lilbee-wizard-status" });
+
+        managedOption.addEventListener("click", () => {
+            mode = "managed";
+            managedOption.classList.add("selected");
+            externalOption.classList.remove("selected");
+            urlInput.style.display = "none";
+            statusEl.textContent = "";
+        });
+
+        externalOption.addEventListener("click", () => {
+            mode = "external";
+            externalOption.classList.add("selected");
+            managedOption.classList.remove("selected");
+            urlInput.style.display = "";
+        });
+
+        const actions = step.createDiv({ cls: "lilbee-wizard-actions" });
+        const backBtn = actions.createEl("button", { text: "Back" });
+        backBtn.addEventListener("click", () => this.back());
+        const skipBtn = actions.createEl("button", { text: "Skip setup" });
+        skipBtn.addEventListener("click", () => this.skip());
+
+        const nextBtn = actions.createEl("button", { text: "Next", cls: "mod-cta" });
+        nextBtn.addEventListener("click", () => {
+            if (mode === "managed") {
+                this.plugin.settings.serverMode = SERVER_MODE.MANAGED;
+                statusEl.textContent = "Starting server...";
+                statusEl.classList.add("lilbee-loading");
+                nextBtn.disabled = true;
+                void this.startManagedAndAdvance(statusEl, nextBtn);
+            } else {
+                this.plugin.settings.serverUrl = String(urlInput.value || "").trim() || "http://127.0.0.1:7433";
+                this.plugin.settings.serverMode = SERVER_MODE.EXTERNAL;
+                statusEl.textContent = "Checking connection...";
+                nextBtn.disabled = true;
+                void this.checkExternalAndAdvance(statusEl, nextBtn);
+            }
+        });
+    }
+
+    private async startManagedAndAdvance(statusEl: HTMLElement, nextBtn: HTMLElement): Promise<void> {
+        try {
+            await this.plugin.saveSettings();
+            if (!this.plugin.serverManager) {
+                await this.plugin.startManagedServer();
+            }
+            statusEl.textContent = "";
+            statusEl.classList.remove("lilbee-loading");
+            this.step = 2;
+            this.renderStep();
+        } catch {
+            statusEl.textContent = "Failed to start server. Check the settings tab for details.";
+            statusEl.classList.remove("lilbee-loading");
+            (nextBtn as HTMLButtonElement).disabled = false;
+        }
+    }
+
+    private async checkExternalAndAdvance(statusEl: HTMLElement, nextBtn: HTMLElement): Promise<void> {
+        try {
+            await this.plugin.saveSettings();
+            await this.plugin.api.health();
+            statusEl.textContent = "";
+            this.step = 2;
+            this.renderStep();
+        } catch {
+            statusEl.textContent = "Could not connect. Check the URL and make sure the server is running.";
+            (nextBtn as HTMLButtonElement).disabled = false;
+        }
+    }
+
+    private renderModelPicker(): void {
+        const { contentEl } = this;
+        const step = contentEl.createDiv({ cls: "lilbee-wizard-step" });
+
+        step.createEl("h2", { text: "Pick a chat model" });
+        step.createEl("p", {
+            text: "This is the AI that answers your questions about your notes. Bigger models are smarter but need more RAM and disk space.",
+        });
+
+        const memGB = getSystemMemoryGB();
+        if (memGB !== null) {
+            step.createEl("p", {
+                text: `Your system: ${memGB} GB RAM`,
+                cls: "lilbee-wizard-system-info",
+            });
+        }
+
+        const modelsContainer = step.createDiv({ cls: "lilbee-wizard-models" });
+        const statusEl = step.createDiv({ cls: "lilbee-wizard-status" });
+        const progressEl = step.createDiv({ cls: "lilbee-wizard-progress" });
+        progressEl.style.display = "none";
+        const progressBar = progressEl.createDiv({ cls: "lilbee-progress-bar-container" });
+        const progressFill = progressBar.createDiv({ cls: "lilbee-progress-bar" });
+        const progressLabel = progressEl.createDiv({ cls: "lilbee-wizard-progress-label" });
+
+        const actions = step.createDiv({ cls: "lilbee-wizard-actions" });
+        const backBtn = actions.createEl("button", { text: "Back" });
+        backBtn.addEventListener("click", () => {
+            this.pullController?.abort();
+            this.back();
+        });
+        const skipBtn = actions.createEl("button", { text: "Skip setup" });
+        skipBtn.addEventListener("click", () => {
+            this.pullController?.abort();
+            this.skip();
+        });
+
+        const catalogBtn = actions.createEl("button", { text: "Browse full catalog" });
+        catalogBtn.addEventListener("click", () => {
+            new CatalogModal(this.app, this.plugin).open();
+        });
+
+        const downloadBtn = actions.createEl("button", { text: "Download & continue", cls: "mod-cta" });
+        downloadBtn.addEventListener("click", () => {
+            if (!this.selectedModel) {
+                statusEl.textContent = "Please select a model first.";
+                return;
+            }
+            downloadBtn.disabled = true;
+            statusEl.textContent = "";
+            void this.pullSelectedModel(downloadBtn, progressEl, progressFill, progressLabel, statusEl);
+        });
+
+        void this.loadFeaturedModels(modelsContainer, memGB, statusEl);
+    }
+
+    private async loadFeaturedModels(
+        container: HTMLElement,
+        memGB: number | null,
+        statusEl: HTMLElement,
+    ): Promise<void> {
+        try {
+            const response = await this.plugin.api.catalog({
+                task: "chat",
+                featured: true,
+                sort: "featured",
+                limit: 4,
+            });
+            this.featuredModels = response.models.map((m: CatalogModel) => ({
+                name: m.name,
+                size_gb: m.size_gb,
+                min_ram_gb: m.min_ram_gb,
+                description: m.description,
+                source: m.source,
+            }));
+        } catch {
+            this.featuredModels = [];
+            statusEl.textContent = "Could not load models from server.";
+            return;
+        }
+
+        const recommended = recommendedIndex(this.featuredModels, memGB);
+        this.selectedModel = this.featuredModels[recommended] ?? null;
+
+        for (let i = 0; i < this.featuredModels.length; i++) {
+            const model = this.featuredModels[i];
+            const option = container.createDiv({
+                cls: `lilbee-wizard-model-option${i === recommended ? " selected" : ""}`,
+            });
+
+            const header = option.createDiv({ cls: "lilbee-wizard-model-header" });
+            if (i === recommended) {
+                header.createEl("span", { text: "Recommended", cls: "lilbee-wizard-recommended" });
+            }
+            header.createEl("strong", { text: model.name });
+            header.createEl("span", { text: `${model.size_gb} GB` });
+            option.createEl("p", { text: model.description });
+            option.createEl("p", { text: `Minimum ${model.min_ram_gb} GB RAM`, cls: "lilbee-wizard-model-ram" });
+
+            option.addEventListener("click", () => {
+                this.selectedModel = model;
+                for (const child of container.children) {
+                    child.classList.remove("selected");
+                }
+                option.classList.add("selected");
+            });
+        }
+    }
+
+    private async pullSelectedModel(
+        downloadBtn: HTMLElement,
+        progressEl: HTMLElement,
+        progressFill: HTMLElement,
+        progressLabel: HTMLElement,
+        statusEl: HTMLElement,
+    ): Promise<void> {
+        if (!this.selectedModel) return;
+        const model = this.selectedModel;
+        progressEl.style.display = "";
+        progressLabel.textContent = `Downloading ${model.name}...`;
+        this.pullController = new AbortController();
+
+        try {
+            for await (const event of this.plugin.api.pullModel(
+                model.name,
+                model.source,
+                this.pullController.signal,
+            )) {
+                if (event.event === SSE_EVENT.PROGRESS) {
+                    const d = event.data as { current?: number; total?: number };
+                    if (d.total && d.current !== undefined) {
+                        const pct = Math.round((d.current / d.total) * 100);
+                        progressFill.style.width = `${pct}%`;
+                        progressLabel.textContent = `Downloading ${model.name}... ${pct}%`;
+                    }
+                }
+            }
+
+            await this.plugin.api.setChatModel(model.name);
+            this.plugin.activeModel = model.name;
+            this.plugin.fetchActiveModel();
+            this.pulledModelName = model.name;
+            this.step = 3;
+            this.renderStep();
+        } catch (err) {
+            if (err instanceof Error && err.name === "AbortError") {
+                new Notice("lilbee: download cancelled");
+            } else {
+                statusEl.textContent = "Download failed. Please try again or pick a different model.";
+            }
+            progressEl.style.display = "none";
+            (downloadBtn as HTMLButtonElement).disabled = false;
+        } finally {
+            this.pullController = null;
+        }
+    }
+
+    private renderSync(): void {
+        const { contentEl } = this;
+        const step = contentEl.createDiv({ cls: "lilbee-wizard-step" });
+
+        step.createEl("h2", { text: "Index your vault" });
+        step.createEl("p", {
+            text: "lilbee needs to read your notes once to make them searchable. This happens locally on your machine.",
+        });
+
+        const progressEl = step.createDiv({ cls: "lilbee-wizard-progress" });
+        const progressBar = progressEl.createDiv({ cls: "lilbee-progress-bar-container" });
+        const progressFill = progressBar.createDiv({ cls: "lilbee-progress-bar" });
+        const progressLabel = progressEl.createDiv({ cls: "lilbee-wizard-progress-label" });
+        progressLabel.textContent = "Starting...";
+
+        step.createEl("p", {
+            text: "After this, new and changed files are indexed automatically (or manually, your choice).",
+            cls: "lilbee-wizard-hint",
+        });
+
+        const actions = step.createDiv({ cls: "lilbee-wizard-actions" });
+        const backBtn = actions.createEl("button", { text: "Back" });
+        backBtn.addEventListener("click", () => {
+            this.syncController?.abort();
+            this.back();
+        });
+        const skipBtn = actions.createEl("button", { text: "Skip setup" });
+        skipBtn.addEventListener("click", () => {
+            this.syncController?.abort();
+            this.skip();
+        });
+
+        void this.runSync(progressFill, progressLabel);
+    }
+
+    private async runSync(
+        progressFill: HTMLElement,
+        progressLabel: HTMLElement,
+    ): Promise<void> {
+        this.syncController = new AbortController();
+        try {
+            let lastEvent: SSEEvent | null = null;
+            for await (const event of this.plugin.api.syncStream(
+                !!this.plugin.activeVisionModel,
+                this.syncController.signal,
+            )) {
+                if (event.event === SSE_EVENT.FILE_START) {
+                    const d = event.data as { current_file: number; total_files: number; file?: string };
+                    const pct = d.total_files > 0 ? Math.round((d.current_file / d.total_files) * 100) : 0;
+                    progressFill.style.width = `${pct}%`;
+                    progressLabel.textContent = `Processing ${d.current_file}/${d.total_files} files`;
+                }
+                if (event.event === SSE_EVENT.EMBED) {
+                    const d = event.data as { file?: string };
+                    if (d.file) {
+                        progressLabel.textContent = `Indexing: ${d.file}`;
+                    }
+                }
+                lastEvent = event;
+            }
+
+            if (lastEvent?.event === SSE_EVENT.DONE) {
+                this.syncResult = lastEvent.data as SyncDone;
+            }
+            progressFill.style.width = "100%";
+            progressLabel.textContent = "Done!";
+            this.step = 4;
+            this.renderStep();
+        } catch (err) {
+            if (err instanceof Error && err.name === "AbortError") {
+                new Notice("lilbee: indexing cancelled");
+            } else {
+                progressLabel.textContent = "Indexing failed. You can retry from the settings tab.";
+            }
+        } finally {
+            this.syncController = null;
+        }
+    }
+
+    private renderDone(): void {
+        const { contentEl } = this;
+        const step = contentEl.createDiv({ cls: "lilbee-wizard-step" });
+
+        step.createEl("h2", { text: "You're all set!" });
+
+        const summary = step.createDiv({ cls: "lilbee-wizard-summary" });
+        if (this.pulledModelName) {
+            summary.createEl("p", { text: `Chat model: ${this.pulledModelName}` });
+        }
+        if (this.syncResult) {
+            const total = this.syncResult.added.length +
+                this.syncResult.updated.length +
+                this.syncResult.unchanged;
+            const chunks = this.syncResult.added.length + this.syncResult.updated.length;
+            summary.createEl("p", { text: `${total} files indexed` });
+            if (chunks > 0) {
+                summary.createEl("p", { text: `${chunks} files processed` });
+            }
+        }
+
+        const tips = step.createDiv({ cls: "lilbee-wizard-tips" });
+        tips.createEl("p", { text: "Try it out:" });
+        const ul = tips.createEl("ul");
+        ul.createEl("li", { text: "Open the chat panel to ask questions about your notes" });
+        ul.createEl("li", { text: "Use the search command to find specific content" });
+        ul.createEl("li", { text: "Drag files into the chat to add context" });
+
+        step.createEl("p", {
+            text: "You can change models and settings anytime in the lilbee settings tab.",
+        });
+
+        const actions = step.createDiv({ cls: "lilbee-wizard-actions" });
+        const openChatBtn = actions.createEl("button", { text: "Open chat", cls: "mod-cta" });
+        openChatBtn.addEventListener("click", () => this.complete());
+    }
+
+    next(): void {
+        if (this.step === 0) {
+            const serverReady = this.plugin.serverManager?.state === "ready" ||
+                this.plugin.settings.serverMode === SERVER_MODE.EXTERNAL;
+            this.step = serverReady ? 2 : 1;
+        } else {
+            this.step++;
+        }
+        this.renderStep();
+    }
+
+    back(): void {
+        if (this.step === 2) {
+            const serverReady = this.plugin.serverManager?.state === "ready" ||
+                this.plugin.settings.serverMode === SERVER_MODE.EXTERNAL;
+            this.step = serverReady ? 0 : 1;
+        } else {
+            this.step = Math.max(0, this.step - 1);
+        }
+        this.renderStep();
+    }
+
+    skip(): void {
+        this.close();
+    }
+
+    async complete(): Promise<void> {
+        this.plugin.settings.setupCompleted = true;
+        await this.plugin.saveSettings();
+        this.close();
+        void this.plugin.activateChatView();
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -1003,3 +1003,138 @@
     padding: var(--size-4-2, 8px) 0;
     color: var(--text-normal);
 }
+
+/* Setup Wizard */
+
+.lilbee-wizard {
+    max-width: 540px;
+}
+
+.lilbee-wizard-step {
+    padding: var(--size-4-4, 16px) var(--size-4-3, 12px);
+}
+
+.lilbee-wizard-step h2 {
+    margin: 0 0 var(--size-4-3, 12px);
+}
+
+.lilbee-wizard-step p {
+    margin: 0 0 var(--size-4-2, 8px);
+    color: var(--text-normal);
+    line-height: var(--line-height-normal, 1.5);
+}
+
+.lilbee-wizard-step ul {
+    margin: 0 0 var(--size-4-2, 8px);
+    padding-left: var(--size-4-6, 24px);
+}
+
+.lilbee-wizard-model-option {
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-m, 6px);
+    padding: var(--size-4-3, 12px);
+    margin-bottom: var(--size-4-2, 8px);
+    cursor: pointer;
+    transition: border-color 150ms ease;
+}
+
+.lilbee-wizard-model-option:hover {
+    border-color: var(--interactive-accent);
+}
+
+.lilbee-wizard-model-option.selected {
+    border-color: var(--interactive-accent);
+    background-color: var(--background-secondary);
+}
+
+.lilbee-wizard-model-option strong {
+    display: block;
+    margin-bottom: var(--size-4-1, 4px);
+}
+
+.lilbee-wizard-model-option p {
+    margin: 0;
+    font-size: var(--font-small, 13px);
+    color: var(--text-muted);
+}
+
+.lilbee-wizard-model-header {
+    display: flex;
+    align-items: center;
+    gap: var(--size-4-2, 8px);
+    margin-bottom: var(--size-4-1, 4px);
+}
+
+.lilbee-wizard-model-ram {
+    font-size: var(--font-smallest, 10px) !important;
+    color: var(--text-faint) !important;
+}
+
+.lilbee-wizard-recommended {
+    display: inline-block;
+    padding: 1px var(--size-4-2, 8px);
+    border-radius: 999px;
+    background-color: var(--interactive-accent);
+    color: var(--text-on-accent);
+    font-size: var(--font-smallest, 10px);
+    font-weight: var(--font-medium, 500);
+}
+
+.lilbee-wizard-system-info {
+    font-size: var(--font-small, 13px);
+    color: var(--text-muted) !important;
+}
+
+.lilbee-wizard-progress {
+    margin: var(--size-4-3, 12px) 0;
+}
+
+.lilbee-wizard-progress-label {
+    font-size: var(--font-small, 13px);
+    color: var(--text-muted);
+    margin-top: var(--size-4-1, 4px);
+}
+
+.lilbee-wizard-actions {
+    display: flex;
+    gap: var(--size-4-2, 8px);
+    justify-content: flex-end;
+    margin-top: var(--size-4-4, 16px);
+}
+
+.lilbee-wizard-summary p {
+    font-weight: var(--font-medium, 500);
+}
+
+.lilbee-wizard-tips {
+    margin-top: var(--size-4-2, 8px);
+}
+
+.lilbee-wizard-hint {
+    font-size: var(--font-small, 13px);
+    color: var(--text-muted) !important;
+}
+
+.lilbee-wizard-status {
+    font-size: var(--font-small, 13px);
+    color: var(--text-muted);
+    min-height: 1.5em;
+    margin: var(--size-4-2, 8px) 0;
+}
+
+.lilbee-wizard-url-input {
+    width: 100%;
+    padding: var(--size-4-2, 8px) var(--size-4-3, 12px);
+    margin: var(--size-4-2, 8px) 0;
+    background-color: var(--background-secondary);
+    color: var(--text-normal);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-m, 6px);
+    font-size: var(--font-text-size, 15px);
+    outline: none;
+    box-sizing: border-box;
+}
+
+.lilbee-wizard-url-input:focus {
+    border-color: var(--interactive-accent);
+}

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -41,6 +41,10 @@ vi.mock("../src/views/documents-modal", () => ({
     DocumentsModal: vi.fn().mockImplementation(() => ({ open: vi.fn() })),
 }));
 
+vi.mock("../src/views/setup-wizard", () => ({
+    SetupWizard: vi.fn().mockImplementation(() => ({ open: vi.fn(), close: vi.fn() })),
+}));
+
 const mockEnsureBinary = vi.fn().mockResolvedValue("/fake/bin/lilbee");
 const mockBinaryExists = vi.fn().mockReturnValue(true);
 const mockDownload = vi.fn().mockResolvedValue(undefined);
@@ -122,11 +126,11 @@ describe("LilbeePlugin", () => {
             expect(plugin.registerView).toHaveBeenCalled();
         });
 
-        it("adds all ten commands", async () => {
+        it("adds all eleven commands", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
 
-            expect(plugin.addCommand).toHaveBeenCalledTimes(10);
+            expect(plugin.addCommand).toHaveBeenCalledTimes(11);
             const ids = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.map(
                 (c: any[]) => c[0].id,
             );
@@ -139,6 +143,7 @@ describe("LilbeePlugin", () => {
             expect(ids).toContain("lilbee:catalog");
             expect(ids).toContain("lilbee:crawl");
             expect(ids).toContain("lilbee:documents");
+            expect(ids).toContain("lilbee:setup");
             expect(ids).toContain("lilbee:status");
         });
 
@@ -235,6 +240,33 @@ describe("LilbeePlugin", () => {
             plugin.loadData = vi.fn().mockResolvedValue({ serverMode: "external", serverUrl: "http://custom:9999" });
             await plugin.onload();
             expect(LilbeeClient).toHaveBeenCalledWith("http://custom:9999");
+        });
+
+        it("auto-opens setup wizard when setupCompleted is false", async () => {
+            const { SetupWizard } = await import("../src/views/setup-wizard");
+            const plugin = await createPlugin({ serverMode: "external", setupCompleted: false });
+            await plugin.onload();
+            expect(SetupWizard).toHaveBeenCalled();
+        });
+
+        it("does not auto-open setup wizard when setupCompleted is true", async () => {
+            const { SetupWizard } = await import("../src/views/setup-wizard");
+            (SetupWizard as ReturnType<typeof vi.fn>).mockClear();
+            const plugin = await createPlugin({ serverMode: "external", setupCompleted: true });
+            await plugin.onload();
+            expect(SetupWizard).not.toHaveBeenCalled();
+        });
+
+        it("setup command opens SetupWizard", async () => {
+            const plugin = await createPlugin({ serverMode: "external", setupCompleted: true });
+            await plugin.onload();
+            const cmd = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.find(
+                (c: any[]) => c[0].id === "lilbee:setup",
+            )![0];
+            expect(cmd.name).toBe("Run setup wizard");
+            cmd.callback();
+            const { SetupWizard } = await import("../src/views/setup-wizard");
+            expect(SetupWizard).toHaveBeenCalled();
         });
     });
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -31,6 +31,13 @@ vi.mock("../src/views/catalog-modal", () => ({
     })),
 }));
 
+vi.mock("../src/views/setup-wizard", () => ({
+    SetupWizard: vi.fn().mockImplementation(() => ({
+        open: vi.fn(),
+        close: vi.fn(),
+    })),
+}));
+
 let mockGenericConfirmResult = true;
 vi.mock("../src/views/confirm-modal", () => ({
     ConfirmModal: vi.fn().mockImplementation(() => ({
@@ -532,10 +539,25 @@ describe("LilbeeSettingTab", () => {
             const tab = makeTab(plugin);
             const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
-            // Start + Check for updates + Refresh + Browse Catalog = 4
-            expect(buttonOnClicks.length).toBe(4);
-            // Refresh is the third button (index 2)
-            await expect(buttonOnClicks[2]()).resolves.not.toThrow();
+            // Setup wizard + Start + Check for updates + Refresh + Browse Catalog = 5
+            expect(buttonOnClicks.length).toBe(5);
+            // Refresh is the fourth button (index 3)
+            await expect(buttonOnClicks[3]()).resolves.not.toThrow();
+        });
+    });
+
+    describe("Setup wizard button in settings", () => {
+        it("onClick opens SetupWizard", async () => {
+            const { SetupWizard } = await import("../src/views/setup-wizard");
+            const plugin = makePlugin();
+            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            const tab = makeTab(plugin);
+            const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+
+            // Setup wizard is the first button (index 0)
+            buttonOnClicks[0]();
+
+            expect(SetupWizard).toHaveBeenCalled();
         });
     });
 
@@ -547,8 +569,8 @@ describe("LilbeeSettingTab", () => {
             const tab = makeTab(plugin);
             const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
-            // Browse Catalog is the fourth button (index 3)
-            buttonOnClicks[3]();
+            // Browse Catalog is the fifth button (index 4)
+            buttonOnClicks[4]();
 
             expect(CatalogModal).toHaveBeenCalled();
         });
@@ -1617,8 +1639,8 @@ describe("LilbeeSettingTab", () => {
             await new Promise((r) => setTimeout(r, 0));
             (globalThis.fetch as ReturnType<typeof vi.fn>).mockClear();
 
-            // buttonOnClicks[0] = server Test
-            await buttonOnClicks[0]();
+            // buttonOnClicks[0] = Setup wizard, [1] = server Test
+            await buttonOnClicks[1]();
 
             expect(globalThis.fetch).toHaveBeenCalledTimes(1);
             expect(globalThis.fetch).toHaveBeenCalledWith(
@@ -2063,8 +2085,8 @@ describe("managed mode settings", () => {
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
-        // buttonOnClicks[0] = Start (server controls), [1] = Check for updates
-        await buttonOnClicks[1]();
+        // buttonOnClicks[0] = Setup wizard, [1] = Start (server controls), [2] = Check for updates
+        await buttonOnClicks[2]();
 
         // No notice on check — button transforms to "Update to vX.Y.Z" instead
         expect(Notice.instances.some((n) => n.message.includes("update available"))).toBe(false);
@@ -2080,8 +2102,8 @@ describe("managed mode settings", () => {
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
-        // buttonOnClicks[0] = Start, [1] = Check for updates
-        await buttonOnClicks[1]();
+        // buttonOnClicks[0] = Setup wizard, [1] = Start, [2] = Check for updates
+        await buttonOnClicks[2]();
 
         expect(Notice.instances.some((n) => n.message.includes("already up to date"))).toBe(true);
     });
@@ -2100,9 +2122,9 @@ describe("managed mode settings", () => {
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
         // First click: check for updates (sets pendingRelease)
-        await buttonOnClicks[1]();
+        await buttonOnClicks[2]();
         // Same handler clicked again: now triggers update via pendingRelease
-        await buttonOnClicks[1]();
+        await buttonOnClicks[2]();
 
         expect((plugin as any).updateServer).toHaveBeenCalled();
         expect(Notice.instances.some((n) => n.message.includes("updated to v0.2.0"))).toBe(true);
@@ -2120,7 +2142,7 @@ describe("managed mode settings", () => {
         const countBefore = buttonOnClicks.length;
 
         // Click check for updates — should NOT add a new handler
-        await buttonOnClicks[1]();
+        await buttonOnClicks[2]();
 
         expect(buttonOnClicks.length).toBe(countBefore);
     });
@@ -2137,8 +2159,8 @@ describe("managed mode settings", () => {
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
         // First click: check (sets pendingRelease); second click: update (fails)
-        await buttonOnClicks[1]();
-        await buttonOnClicks[1]();
+        await buttonOnClicks[2]();
+        await buttonOnClicks[2]();
 
         expect(Notice.instances.some((n) => n.message.includes("update failed"))).toBe(true);
     });
@@ -2153,8 +2175,8 @@ describe("managed mode settings", () => {
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
-        // buttonOnClicks[0] = Start, [1] = Check for updates
-        await buttonOnClicks[1]();
+        // buttonOnClicks[0] = Setup wizard, [1] = Start, [2] = Check for updates
+        await buttonOnClicks[2]();
 
         expect(Notice.instances.some((n) => n.message.includes("could not check"))).toBe(true);
     });
@@ -2192,9 +2214,9 @@ describe("managed mode settings", () => {
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
-        // In external mode: buttons are [Test (server), Reset to managed, Test (litellm), Refresh]
+        // In external mode: buttons are [Setup wizard, Test (server), Reset to managed, Refresh, Browse Catalog]
         // Find the "Reset to managed" click — it's the one that sets serverMode back
-        const resetButton = buttonOnClicks.find((_btn, i) => i === 1);
+        const resetButton = buttonOnClicks.find((_btn, i) => i === 2);
         expect(resetButton).toBeDefined();
         await resetButton!();
 
@@ -2226,8 +2248,8 @@ describe("managed mode settings", () => {
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
         const displaySpy = vi.spyOn(tab, "display").mockImplementation(() => {});
-        // First button in managed stopped mode is Start
-        await buttonOnClicks[0]();
+        // buttonOnClicks[0] = Setup wizard, [1] = Start
+        await buttonOnClicks[1]();
 
         expect(mockStart).toHaveBeenCalled();
         expect(displaySpy).toHaveBeenCalled();
@@ -2242,8 +2264,8 @@ describe("managed mode settings", () => {
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
         const displaySpy = vi.spyOn(tab, "display").mockImplementation(() => {});
-        // In ready state: buttons are Stop, Restart, Check for updates, Test (litellm), Refresh
-        await buttonOnClicks[0]();
+        // buttonOnClicks[0] = Setup wizard, [1] = Stop, [2] = Restart, [3] = Check for updates
+        await buttonOnClicks[1]();
 
         expect(mockStop).toHaveBeenCalled();
         expect(displaySpy).toHaveBeenCalled();
@@ -2258,8 +2280,8 @@ describe("managed mode settings", () => {
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
         const displaySpy = vi.spyOn(tab, "display").mockImplementation(() => {});
-        // In ready state: buttons are Stop, Restart, Check for updates, Test (litellm), Refresh
-        await buttonOnClicks[1]();
+        // buttonOnClicks[0] = Setup wizard, [1] = Stop, [2] = Restart
+        await buttonOnClicks[2]();
 
         expect(mockRestart).toHaveBeenCalled();
         expect(displaySpy).toHaveBeenCalled();

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -43,7 +43,7 @@ describe("DEFAULT_SETTINGS", () => {
 
     it("is a plain object with exactly the expected keys", () => {
         const keys = Object.keys(DEFAULT_SETTINGS).sort();
-        expect(keys).toEqual(["lilbeeVersion", "num_ctx", "repeat_penalty", "seed", "serverMode", "serverPort", "serverUrl", "syncDebounceMs", "syncMode", "systemPrompt", "temperature", "topK", "top_k_sampling", "top_p"].sort());
+        expect(keys).toEqual(["lilbeeVersion", "num_ctx", "repeat_penalty", "seed", "serverMode", "serverPort", "serverUrl", "setupCompleted", "syncDebounceMs", "syncMode", "systemPrompt", "temperature", "topK", "top_k_sampling", "top_p"].sort());
     });
 });
 
@@ -243,6 +243,7 @@ describe("LilbeeSettings interface", () => {
             serverPort: null,
             lilbeeVersion: "",
             systemPrompt: "",
+            setupCompleted: false,
         };
         expect(s.syncMode).toBe("manual");
     });
@@ -263,6 +264,7 @@ describe("LilbeeSettings interface", () => {
             serverPort: null,
             lilbeeVersion: "",
             systemPrompt: "",
+            setupCompleted: true,
         };
         expect(s.syncMode).toBe("auto");
     });

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -318,6 +318,28 @@ describe("CatalogModal", () => {
         expect(plugin.api.setChatModel).toHaveBeenCalledWith("phi3");
     });
 
+    it("Pull passes non-native source to pullModel", async () => {
+        vi.useRealTimers();
+        const models = [makeCatalogModel({ name: "gpt-4o-mini", installed: false, source: "litellm" })];
+        const plugin = makePlugin({ activeModel: "llama3" });
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(models));
+        plugin.api.pullModel.mockReturnValue((async function* () {
+            yield { event: SSE_EVENT.PROGRESS, data: { current: 100, total: 100 } };
+        })());
+        const app = new App();
+        const modal = new CatalogModal(app as any, plugin as any);
+        modal.open();
+        await tick();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const pullBtn = el.findAll("lilbee-catalog-pull")[0];
+        pullBtn.trigger("click");
+        await tick();
+        await tick();
+
+        expect(plugin.api.pullModel).toHaveBeenCalledWith("gpt-4o-mini", "litellm");
+    });
+
     it("Pull cancelled by confirm modal does not pull", async () => {
         vi.useRealTimers();
         mockConfirmResult = false;

--- a/tests/views/crawl-modal.test.ts
+++ b/tests/views/crawl-modal.test.ts
@@ -294,6 +294,43 @@ describe("CrawlModal", () => {
         expect(Notice.instances.some(n => n.message.includes("unknown error"))).toBe(true);
     });
 
+    it("aborts crawl controller when modal is closed during crawl", async () => {
+        const app = new App();
+        const plugin = makePlugin();
+        let resolveStream: (() => void) | null = null;
+        const streamPromise = new Promise<void>((r) => { resolveStream = r; });
+        plugin.api.crawl.mockReturnValue((async function* () {
+            yield { event: SSE_EVENT.CRAWL_START, data: {} };
+            // Block until we resolve externally — simulates an in-progress crawl
+            await streamPromise;
+            yield { event: SSE_EVENT.CRAWL_DONE, data: { pages_crawled: 1 } };
+        })());
+        const modal = new CrawlModal(app as any, plugin as any);
+        modal.onOpen();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const urlInput = el.find("lilbee-crawl-url")!;
+        (urlInput as any).value = "https://example.com";
+        const crawlBtn = findButtons(el).find(b => b.textContent === "Crawl")!;
+        crawlBtn.trigger("click");
+        await tick();
+
+        // crawlController is now set — grab the signal before closing
+        const signal = plugin.api.crawl.mock.calls[0][3] as AbortSignal;
+        expect(signal.aborted).toBe(false);
+
+        // Close the modal while the crawl is in-progress
+        modal.onClose();
+        expect(signal.aborted).toBe(true);
+
+        // Unblock stream so the async generator can finish
+        resolveStream!();
+        await tick();
+
+        const result = await modal.result;
+        expect(result).toBe(false);
+    });
+
     it("CRAWL_PAGE with missing url uses empty string fallback", async () => {
         const app = new App();
         const plugin = makePlugin();

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -1,0 +1,1142 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { App, Notice } from "obsidian";
+import { MockElement } from "../__mocks__/obsidian";
+import { SetupWizard, getSystemMemoryGB, recommendedIndex } from "../../src/views/setup-wizard";
+import { SSE_EVENT } from "../../src/types";
+import type { CatalogModel, CatalogResponse } from "../../src/types";
+
+vi.mock("../../src/views/catalog-modal", () => ({
+    CatalogModal: vi.fn().mockImplementation(() => ({
+        open: vi.fn(),
+        close: vi.fn(),
+    })),
+}));
+
+function makeCatalogModel(overrides: Partial<CatalogModel> = {}): CatalogModel {
+    return {
+        name: "qwen3:0.6b",
+        size_gb: 0.5,
+        min_ram_gb: 4,
+        description: "Runs on anything",
+        installed: false,
+        source: "native",
+        ...overrides,
+    };
+}
+
+function makeCatalogResponse(models: CatalogModel[] = []): CatalogResponse {
+    return {
+        total: models.length,
+        limit: 4,
+        offset: 0,
+        models,
+    };
+}
+
+function makePlugin(overrides: Record<string, unknown> = {}) {
+    return {
+        app: new App(),
+        settings: {
+            serverUrl: "http://127.0.0.1:7433",
+            serverMode: "managed",
+            setupCompleted: false,
+            syncMode: "manual",
+            ...((overrides.settings as Record<string, unknown>) || {}),
+        },
+        api: {
+            catalog: vi.fn().mockResolvedValue(makeCatalogResponse()),
+            pullModel: vi.fn(),
+            setChatModel: vi.fn().mockResolvedValue({ model: "" }),
+            setVisionModel: vi.fn().mockResolvedValue({ model: "" }),
+            health: vi.fn().mockResolvedValue({ status: "ok", version: "1.0.0" }),
+            syncStream: vi.fn(),
+            listModels: vi.fn().mockResolvedValue({
+                chat: { active: "", catalog: [], installed: [] },
+                vision: { active: "", catalog: [], installed: [] },
+            }),
+        },
+        activeModel: "",
+        activeVisionModel: "",
+        fetchActiveModel: vi.fn(),
+        serverManager: overrides.serverManager ?? null,
+        startManagedServer: vi.fn().mockResolvedValue(undefined),
+        saveSettings: vi.fn().mockResolvedValue(undefined),
+        activateChatView: vi.fn().mockResolvedValue(undefined),
+        ...overrides,
+    };
+}
+
+function collectTexts(el: MockElement): string[] {
+    const texts: string[] = [];
+    if (el.textContent) texts.push(el.textContent);
+    for (const child of el.children) {
+        texts.push(...collectTexts(child));
+    }
+    return texts;
+}
+
+function findButtons(el: MockElement): MockElement[] {
+    const buttons: MockElement[] = [];
+    if (el.tagName === "BUTTON") buttons.push(el);
+    for (const child of el.children) {
+        buttons.push(...findButtons(child));
+    }
+    return buttons;
+}
+
+function findByText(el: MockElement, text: string): MockElement | null {
+    if (el.textContent === text) return el;
+    for (const child of el.children) {
+        const found = findByText(child, text);
+        if (found) return found;
+    }
+    return null;
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+describe("SetupWizard", () => {
+    beforeEach(() => {
+        Notice.clear();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe("Step 0: Welcome", () => {
+        it("renders welcome screen on open", () => {
+            const plugin = makePlugin();
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("Welcome to lilbee"))).toBe(true);
+            expect(texts.some(t => t.includes("knowledge base"))).toBe(true);
+            expect(texts.some(t => t.includes("never leave your machine"))).toBe(true);
+        });
+
+        it("has Skip setup and Get started buttons", () => {
+            const plugin = makePlugin();
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const buttons = findButtons(el);
+            expect(buttons.some(b => b.textContent === "Skip setup")).toBe(true);
+            expect(buttons.some(b => b.textContent === "Get started")).toBe(true);
+        });
+
+        it("Skip setup closes the wizard", () => {
+            const plugin = makePlugin();
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            const closeSpy = vi.spyOn(wizard, "close");
+            wizard.open();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const skipBtn = findButtons(el).find(b => b.textContent === "Skip setup")!;
+            skipBtn.trigger("click");
+            expect(closeSpy).toHaveBeenCalled();
+        });
+
+        it("Get started advances to model picker when server is ready (external mode)", () => {
+            const plugin = makePlugin({
+                settings: { serverMode: "external" },
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const startBtn = findButtons(el).find(b => b.textContent === "Get started")!;
+            startBtn.trigger("click");
+
+            // Should be on step 2 (model picker) since server is "ready" in external mode
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Pick a chat model"))).toBe(true);
+        });
+
+        it("Get started advances to server mode when server is not ready", () => {
+            const plugin = makePlugin({
+                settings: { serverMode: "managed" },
+                serverManager: null,
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const startBtn = findButtons(el).find(b => b.textContent === "Get started")!;
+            startBtn.trigger("click");
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("How do you want to run lilbee?"))).toBe(true);
+        });
+
+        it("Get started skips server step when managed server is ready", () => {
+            const plugin = makePlugin({
+                settings: { serverMode: "managed" },
+                serverManager: { state: "ready" },
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const startBtn = findButtons(el).find(b => b.textContent === "Get started")!;
+            startBtn.trigger("click");
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Pick a chat model"))).toBe(true);
+        });
+    });
+
+    describe("Step 1: Server Mode", () => {
+        it("renders managed and external options", () => {
+            const plugin = makePlugin({ serverManager: null });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("Managed (recommended)"))).toBe(true);
+            expect(texts.some(t => t.includes("External"))).toBe(true);
+        });
+
+        it("clicking managed option selects it", () => {
+            const plugin = makePlugin({ serverManager: null });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const options = el.findAll("lilbee-wizard-model-option");
+            // Click managed (first option)
+            options[0].trigger("click");
+            expect(options[0].classList.contains("selected")).toBe(true);
+            expect(options[1].classList.contains("selected")).toBe(false);
+        });
+
+        it("clicking managed option hides URL input and clears status", () => {
+            const plugin = makePlugin({ serverManager: null, settings: { serverMode: "managed" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const options = el.findAll("lilbee-wizard-model-option");
+            // First click external to show URL input
+            options[1].trigger("click");
+            // Then click managed to hide it
+            options[0].trigger("click");
+            expect(options[0].classList.contains("selected")).toBe(true);
+            const status = el.find("lilbee-wizard-status");
+            expect(status?.textContent).toBe("");
+        });
+
+        it("pre-selects external when settings have external mode", () => {
+            const plugin = makePlugin({ serverManager: null, settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 1;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const options = el.findAll("lilbee-wizard-model-option");
+            // External option (index 1) should be selected
+            expect(options[1].classList.contains("selected")).toBe(true);
+            expect(options[0].classList.contains("selected")).toBe(false);
+        });
+
+        it("clicking external option selects it and shows URL input", () => {
+            const plugin = makePlugin({ serverManager: null });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const options = el.findAll("lilbee-wizard-model-option");
+            // Click external (second option)
+            options[1].trigger("click");
+            expect(options[1].classList.contains("selected")).toBe(true);
+            expect(options[0].classList.contains("selected")).toBe(false);
+        });
+
+        it("managed mode: Next starts server and advances", async () => {
+            const plugin = makePlugin({ serverManager: null });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const nextBtn = findButtons(el).find(b => b.textContent === "Next")!;
+            nextBtn.trigger("click");
+            await tick();
+            await tick();
+
+            expect(plugin.saveSettings).toHaveBeenCalled();
+            expect(plugin.startManagedServer).toHaveBeenCalled();
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Pick a chat model"))).toBe(true);
+        });
+
+        it("managed mode: handles server start failure", async () => {
+            const plugin = makePlugin({ serverManager: null });
+            plugin.startManagedServer = vi.fn().mockRejectedValue(new Error("fail"));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const nextBtn = findButtons(el).find(b => b.textContent === "Next")!;
+            nextBtn.trigger("click");
+            await tick();
+            await tick();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Failed to start server"))).toBe(true);
+        });
+
+        it("external mode: Next checks health and advances", async () => {
+            const plugin = makePlugin({
+                serverManager: null,
+                settings: { serverMode: "managed" },
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next(); // goes to step 1 since no server manager
+
+            const el = wizard.contentEl as unknown as MockElement;
+            // Click external option (second one)
+            const options = el.findAll("lilbee-wizard-model-option");
+            options[1].trigger("click");
+
+            const nextBtn = findButtons(el).find(b => b.textContent === "Next")!;
+            nextBtn.trigger("click");
+            await tick();
+            await tick();
+
+            expect(plugin.api.health).toHaveBeenCalled();
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Pick a chat model"))).toBe(true);
+        });
+
+        it("external mode: handles health check failure", async () => {
+            const plugin = makePlugin({
+                serverManager: null,
+                settings: { serverMode: "managed" },
+            });
+            plugin.api.health = vi.fn().mockRejectedValue(new Error("connection refused"));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const options = el.findAll("lilbee-wizard-model-option");
+            options[1].trigger("click");
+
+            const nextBtn = findButtons(el).find(b => b.textContent === "Next")!;
+            nextBtn.trigger("click");
+            await tick();
+            await tick();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Could not connect"))).toBe(true);
+        });
+
+        it("Back returns to welcome", () => {
+            const plugin = makePlugin({ serverManager: null });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const backBtn = findButtons(el).find(b => b.textContent === "Back")!;
+            backBtn.trigger("click");
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Welcome to lilbee"))).toBe(true);
+        });
+
+        it("managed mode with existing serverManager advances to model picker", async () => {
+            const plugin = makePlugin({
+                serverManager: { state: "ready" },
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            // Force to step 1
+            (wizard as any).step = 1;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const nextBtn = findButtons(el).find(b => b.textContent === "Next")!;
+            nextBtn.trigger("click");
+            await tick();
+            await tick();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Pick a chat model"))).toBe(true);
+        });
+
+        it("Skip setup button closes the wizard", () => {
+            const plugin = makePlugin({ serverManager: null });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            const closeSpy = vi.spyOn(wizard, "close");
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const skipBtn = findButtons(el).find(b => b.textContent === "Skip setup")!;
+            skipBtn.trigger("click");
+            expect(closeSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe("Step 2: Model Picker", () => {
+        it("renders model picker with featured models", async () => {
+            const models = [
+                makeCatalogModel({ name: "qwen3:0.6b", size_gb: 0.5, min_ram_gb: 4 }),
+                makeCatalogModel({ name: "qwen3:4b", size_gb: 2.5, min_ram_gb: 8 }),
+            ];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("Pick a chat model"))).toBe(true);
+            expect(texts.some(t => t.includes("qwen3:0.6b"))).toBe(true);
+            expect(texts.some(t => t.includes("qwen3:4b"))).toBe(true);
+        });
+
+        it("pre-selects recommended model based on first in list when no memory detection", async () => {
+            const models = [
+                makeCatalogModel({ name: "qwen3:0.6b", size_gb: 0.5, min_ram_gb: 4 }),
+                makeCatalogModel({ name: "qwen3:4b", size_gb: 2.5, min_ram_gb: 8 }),
+            ];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const options = el.findAll("lilbee-wizard-model-option");
+            // At least one should be selected
+            expect(options.some(o => o.classList.contains("selected"))).toBe(true);
+        });
+
+        it("clicking a model option selects it", async () => {
+            const models = [
+                makeCatalogModel({ name: "qwen3:0.6b", size_gb: 0.5, min_ram_gb: 4 }),
+                makeCatalogModel({ name: "qwen3:4b", size_gb: 2.5, min_ram_gb: 8 }),
+            ];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const options = el.findAll("lilbee-wizard-model-option");
+            options[1].trigger("click");
+            expect(options[1].classList.contains("selected")).toBe(true);
+            expect(options[0].classList.contains("selected")).toBe(false);
+        });
+
+        it("shows error when catalog fetch fails", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockRejectedValue(new Error("fail"));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("Could not load models"))).toBe(true);
+        });
+
+        it("Download & continue requires model selection", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse([]));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const downloadBtn = findButtons(el).find(b => b.textContent === "Download & continue")!;
+            downloadBtn.trigger("click");
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Please select a model first"))).toBe(true);
+        });
+
+        it("Download & continue pulls model and advances to sync step", async () => {
+            const models = [makeCatalogModel({ name: "qwen3:0.6b" })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            plugin.api.pullModel = vi.fn().mockReturnValue((async function* () {
+                yield { event: SSE_EVENT.PROGRESS, data: { current: 50, total: 100 } };
+                yield { event: SSE_EVENT.PROGRESS, data: { current: 100, total: 100 } };
+            })());
+            // syncStream will be called when step 3 auto-starts
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                yield { event: SSE_EVENT.FILE_START, data: { current_file: 1, total_files: 1 } };
+                yield { event: SSE_EVENT.DONE, data: { added: [], updated: [], removed: [], unchanged: 0, failed: [] } };
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const downloadBtn = findButtons(el).find(b => b.textContent === "Download & continue")!;
+            downloadBtn.trigger("click");
+            await tick();
+            await tick();
+
+            expect(plugin.api.pullModel).toHaveBeenCalledWith("qwen3:0.6b", "native", expect.any(AbortSignal));
+            expect(plugin.api.setChatModel).toHaveBeenCalledWith("qwen3:0.6b");
+            // After pull completes, it goes to step 3 (sync), which auto-starts and finishes, going to step 4 (done)
+            await tick();
+            await tick();
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            // Could be on sync step or done step depending on timing
+            expect(texts.some(t => t.includes("Index your vault") || t.includes("You're all set!"))).toBe(true);
+        });
+
+        it("handles pull failure", async () => {
+            const models = [makeCatalogModel({ name: "qwen3:0.6b" })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            plugin.api.pullModel = vi.fn().mockReturnValue((async function* () {
+                throw new Error("network error");
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const downloadBtn = findButtons(el).find(b => b.textContent === "Download & continue")!;
+            downloadBtn.trigger("click");
+            await tick();
+            await tick();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Download failed"))).toBe(true);
+        });
+
+        it("handles pull abort", async () => {
+            const models = [makeCatalogModel({ name: "qwen3:0.6b" })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            const abortErr = new Error("aborted");
+            abortErr.name = "AbortError";
+            plugin.api.pullModel = vi.fn().mockReturnValue((async function* () {
+                throw abortErr;
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const downloadBtn = findButtons(el).find(b => b.textContent === "Download & continue")!;
+            downloadBtn.trigger("click");
+            await tick();
+            await tick();
+
+            expect(Notice.instances.some(n => n.message.includes("download cancelled"))).toBe(true);
+        });
+
+        it("Back from model picker returns to welcome (external mode)", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse([]));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const backBtn = findButtons(el).find(b => b.textContent === "Back")!;
+            backBtn.trigger("click");
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Welcome to lilbee"))).toBe(true);
+        });
+
+        it("Back from model picker returns to server mode when no server manager", async () => {
+            const plugin = makePlugin({ serverManager: null, settings: { serverMode: "managed" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse([]));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            // Force to step 2
+            (wizard as any).step = 2;
+            (wizard as any).renderStep();
+            await tick();
+
+            wizard.back();
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("How do you want to run lilbee?"))).toBe(true);
+        });
+
+        it("Browse full catalog button opens CatalogModal", async () => {
+            const { CatalogModal } = await import("../../src/views/catalog-modal");
+            const models = [makeCatalogModel()];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const catalogBtn = findButtons(el).find(b => b.textContent === "Browse full catalog")!;
+            catalogBtn.trigger("click");
+
+            expect(CatalogModal).toHaveBeenCalled();
+        });
+
+        it("Back cancels ongoing pull", async () => {
+            const models = [makeCatalogModel({ name: "qwen3:0.6b" })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            let abortSignal: AbortSignal | null = null;
+            plugin.api.pullModel = vi.fn().mockImplementation((_name: string, _source: string, signal?: AbortSignal) => {
+                abortSignal = signal ?? null;
+                return (async function* () {
+                    yield { event: SSE_EVENT.PROGRESS, data: { current: 50, total: 100 } };
+                    // Wait forever
+                    await new Promise(() => {});
+                })();
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const downloadBtn = findButtons(el).find(b => b.textContent === "Download & continue")!;
+            downloadBtn.trigger("click");
+            await tick();
+
+            // Now click back, which should abort
+            const backBtn = findButtons(wizard.contentEl as unknown as MockElement).find(b => b.textContent === "Back")!;
+            backBtn.trigger("click");
+
+            expect(abortSignal?.aborted).toBe(true);
+        });
+
+        it("Skip setup aborts active pull and closes wizard", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue({
+                models: [makeCatalogModel({ name: "qwen3:0.6b", size_gb: 0.5, min_ram_gb: 4 })],
+                total: 1, limit: 20, offset: 0,
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            const closeSpy = vi.spyOn(wizard, "close");
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            // Simulate an in-progress pull
+            const controller = new AbortController();
+            (wizard as any).pullController = controller;
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const skipBtn = findButtons(el).find(b => b.textContent === "Skip setup")!;
+            skipBtn.trigger("click");
+            expect(controller.signal.aborted).toBe(true);
+            expect(closeSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe("Step 3: Sync", () => {
+        it("renders sync screen and starts syncing", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                yield { event: SSE_EVENT.FILE_START, data: { current_file: 1, total_files: 10 } };
+                yield { event: SSE_EVENT.EMBED, data: { file: "test.md" } };
+                yield { event: SSE_EVENT.DONE, data: { added: ["a.md"], updated: [], removed: [], unchanged: 5, failed: [] } };
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 3;
+            (wizard as any).renderStep();
+            await tick();
+            await tick();
+
+            // Should have advanced to done
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("You're all set!"))).toBe(true);
+        });
+
+        it("sync abort shows notice", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const abortErr = new Error("aborted");
+            abortErr.name = "AbortError";
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                throw abortErr;
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 3;
+            (wizard as any).renderStep();
+            await tick();
+            await tick();
+
+            expect(Notice.instances.some(n => n.message.includes("indexing cancelled"))).toBe(true);
+        });
+
+        it("sync failure shows error message", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                throw new Error("network");
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 3;
+            (wizard as any).renderStep();
+            await tick();
+            await tick();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Indexing failed"))).toBe(true);
+        });
+
+        it("Back from sync cancels and returns to model picker", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            let abortSignal: AbortSignal | null = null;
+            plugin.api.syncStream = vi.fn().mockImplementation((_force: boolean, signal?: AbortSignal) => {
+                abortSignal = signal ?? null;
+                return (async function* () {
+                    yield { event: SSE_EVENT.FILE_START, data: { current_file: 1, total_files: 100 } };
+                    await new Promise(() => {});
+                })();
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 3;
+            (wizard as any).renderStep();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const backBtn = findButtons(el).find(b => b.textContent === "Back")!;
+            backBtn.trigger("click");
+
+            expect(abortSignal?.aborted).toBe(true);
+        });
+
+        it("Skip setup aborts sync and closes wizard", async () => {
+            let abortSignal: AbortSignal | null = null;
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.syncStream = vi.fn().mockImplementation((_opts: any, signal?: AbortSignal) => {
+                abortSignal = signal ?? null;
+                return (async function* () {
+                    yield { event: SSE_EVENT.FILE_START, data: { current_file: 1, total_files: 100 } };
+                    await new Promise(() => {});
+                })();
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            const closeSpy = vi.spyOn(wizard, "close");
+            wizard.open();
+            (wizard as any).step = 3;
+            (wizard as any).renderStep();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const skipBtn = findButtons(el).find(b => b.textContent === "Skip setup")!;
+            skipBtn.trigger("click");
+            expect(closeSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe("Step 4: Done", () => {
+        it("renders done screen with summary", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).pulledModelName = "qwen3:8b";
+            (wizard as any).syncResult = { added: ["a.md", "b.md"], updated: [], removed: [], unchanged: 8, failed: [] };
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("You're all set!"))).toBe(true);
+            expect(texts.some(t => t.includes("qwen3:8b"))).toBe(true);
+            expect(texts.some(t => t.includes("10 files indexed"))).toBe(true);
+            expect(texts.some(t => t.includes("Open chat"))).toBe(true);
+        });
+
+        it("renders done screen without model/sync info if skipped", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("You're all set!"))).toBe(true);
+        });
+
+        it("Open chat marks setup complete and opens chat view", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            const closeSpy = vi.spyOn(wizard, "close");
+            wizard.open();
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const openChatBtn = findButtons(el).find(b => b.textContent === "Open chat")!;
+            openChatBtn.trigger("click");
+            await tick();
+
+            expect(plugin.settings.setupCompleted).toBe(true);
+            expect(plugin.saveSettings).toHaveBeenCalled();
+            expect(plugin.activateChatView).toHaveBeenCalled();
+            expect(closeSpy).toHaveBeenCalled();
+        });
+
+        it("shows tips about what to try", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("chat panel"))).toBe(true);
+            expect(texts.some(t => t.includes("search command"))).toBe(true);
+        });
+    });
+
+    describe("Navigation", () => {
+        it("next() from non-zero step increments step", () => {
+            const plugin = makePlugin({ serverManager: null });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse([]));
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                await new Promise(() => {});
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            // Set step to 1 and call next()
+            (wizard as any).step = 1;
+            wizard.next();
+            // Should go to step 2
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Pick a chat model"))).toBe(true);
+        });
+
+        it("back() at step 0 stays at step 0", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.back();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Welcome to lilbee"))).toBe(true);
+        });
+
+        it("back() at step 3 goes to step 2", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse([]));
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                await new Promise(() => {});
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 3;
+            wizard.back();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            // step 2 goes back to step 0 in external mode (since server is ready)
+            // So from step 3, back() goes to step 2 (model picker)
+            expect(texts.some(t => t.includes("Pick a chat model"))).toBe(true);
+        });
+
+        it("back() at step 4 goes to step 3", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                await new Promise(() => {});
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 4;
+            wizard.back();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Index your vault"))).toBe(true);
+        });
+    });
+
+    describe("onClose cleanup", () => {
+        it("aborts pull controller on close", async () => {
+            const models = [makeCatalogModel({ name: "qwen3:0.6b" })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            plugin.api.pullModel = vi.fn().mockReturnValue((async function* () {
+                yield { event: SSE_EVENT.PROGRESS, data: { current: 50, total: 100 } };
+                await new Promise(() => {});
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            // Start pull
+            const el = wizard.contentEl as unknown as MockElement;
+            const downloadBtn = findButtons(el).find(b => b.textContent === "Download & continue")!;
+            downloadBtn.trigger("click");
+            await tick();
+
+            // Close should abort
+            wizard.close();
+        });
+
+        it("aborts sync controller on close", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                yield { event: SSE_EVENT.FILE_START, data: { current_file: 1, total_files: 100 } };
+                await new Promise(() => {});
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 3;
+            (wizard as any).renderStep();
+            await tick();
+
+            wizard.close();
+        });
+
+        it("clears server check timer on close", () => {
+            const plugin = makePlugin();
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            (wizard as any).serverCheckTimer = setTimeout(() => {}, 10000);
+            wizard.close();
+            // Should not throw
+        });
+    });
+
+    describe("System memory detection", () => {
+        it("handles missing os module gracefully", async () => {
+            const models = [
+                makeCatalogModel({ name: "qwen3:0.6b", min_ram_gb: 4 }),
+                makeCatalogModel({ name: "qwen3:4b", min_ram_gb: 8 }),
+            ];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            // Should still render without crashing
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("Pick a chat model"))).toBe(true);
+        });
+    });
+
+    describe("Full flow integration", () => {
+        it("complete flow: welcome -> model -> sync -> done", async () => {
+            const models = [makeCatalogModel({ name: "qwen3:0.6b" })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            plugin.api.pullModel = vi.fn().mockReturnValue((async function* () {
+                yield { event: SSE_EVENT.PROGRESS, data: { current: 100, total: 100 } };
+            })());
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                yield { event: SSE_EVENT.FILE_START, data: { current_file: 1, total_files: 5 } };
+                yield { event: SSE_EVENT.DONE, data: { added: ["a.md"], updated: [], removed: [], unchanged: 4, failed: [] } };
+            })());
+
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+
+            // Step 0: Welcome -> Get started
+            let el = wizard.contentEl as unknown as MockElement;
+            findButtons(el).find(b => b.textContent === "Get started")!.trigger("click");
+            await tick();
+
+            // Step 2: Model picker -> Download
+            el = wizard.contentEl as unknown as MockElement;
+            expect(collectTexts(el).some(t => t.includes("Pick a chat model"))).toBe(true);
+            findButtons(el).find(b => b.textContent === "Download & continue")!.trigger("click");
+            await tick();
+            await tick();
+
+            // Step 3: Sync (auto-starts, should auto-advance)
+            await tick();
+            await tick();
+
+            // Step 4: Done -> Open chat
+            el = wizard.contentEl as unknown as MockElement;
+            expect(collectTexts(el).some(t => t.includes("You're all set!"))).toBe(true);
+
+            findButtons(el).find(b => b.textContent === "Open chat")!.trigger("click");
+            await tick();
+
+            expect(plugin.settings.setupCompleted).toBe(true);
+            expect(plugin.activateChatView).toHaveBeenCalled();
+        });
+    });
+
+    describe("recommendedIndex", () => {
+        it("returns 0 when memGB is null", () => {
+            const models = [
+                { name: "small", size_gb: 0.5, min_ram_gb: 4, description: "", source: "native" as const },
+                { name: "large", size_gb: 5, min_ram_gb: 16, description: "", source: "native" as const },
+            ];
+            expect(recommendedIndex(models, null)).toBe(0);
+        });
+
+        it("returns 0 when models is empty", () => {
+            expect(recommendedIndex([], 16)).toBe(0);
+        });
+
+        it("selects largest model that fits in memory", () => {
+            const models = [
+                { name: "small", size_gb: 0.5, min_ram_gb: 4, description: "", source: "native" as const },
+                { name: "medium", size_gb: 2.5, min_ram_gb: 8, description: "", source: "native" as const },
+                { name: "large", size_gb: 5, min_ram_gb: 16, description: "", source: "native" as const },
+            ];
+            expect(recommendedIndex(models, 10)).toBe(1);
+            expect(recommendedIndex(models, 16)).toBe(2);
+            expect(recommendedIndex(models, 3)).toBe(0);
+        });
+    });
+
+    describe("getSystemMemoryGB", () => {
+        it("returns a number in Node.js environment", () => {
+            const result = getSystemMemoryGB();
+            // In Node.js test environment, os module is available
+            expect(typeof result).toBe("number");
+            expect(result).toBeGreaterThan(0);
+        });
+    });
+
+    describe("sync with zero total_files", () => {
+        it("handles FILE_START with total_files=0 without division error", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                yield { event: SSE_EVENT.FILE_START, data: { current_file: 0, total_files: 0 } };
+                yield { event: SSE_EVENT.DONE, data: { added: [], updated: [], removed: [], unchanged: 0, failed: [] } };
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 3;
+            (wizard as any).renderStep();
+            await tick();
+            await tick();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("You're all set!"))).toBe(true);
+        });
+    });
+
+    describe("pullSelectedModel early return", () => {
+        it("returns early when selectedModel is null", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            // Call pullSelectedModel directly with no selected model
+            (wizard as any).selectedModel = null;
+            const el = new MockElement("div");
+            await (wizard as any).pullSelectedModel(el, el, el, el, el);
+            // Should return without calling pullModel
+            expect(plugin.api.pullModel).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("back from step 2 with ready server manager", () => {
+        it("goes to step 0 when serverManager is ready", () => {
+            const plugin = makePlugin({
+                settings: { serverMode: "managed" },
+                serverManager: { state: "ready" },
+            });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse([]));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 2;
+            wizard.back();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Welcome to lilbee"))).toBe(true);
+        });
+    });
+
+    describe("sync with FILE_START progress update", () => {
+        it("updates progress bar during sync", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                yield { event: SSE_EVENT.FILE_START, data: { current_file: 3, total_files: 10 } };
+                yield { event: SSE_EVENT.FILE_START, data: { current_file: 7, total_files: 10 } };
+                yield { event: SSE_EVENT.DONE, data: { added: [], updated: [], removed: [], unchanged: 10, failed: [] } };
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 3;
+            (wizard as any).renderStep();
+            await tick();
+            await tick();
+
+            // Should reach done
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("You're all set!"))).toBe(true);
+        });
+    });
+
+    describe("done screen with processed files count", () => {
+        it("shows files processed when sync result has additions", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).pulledModelName = "test-model";
+            (wizard as any).syncResult = {
+                added: ["a.md", "b.md", "c.md"],
+                updated: ["d.md"],
+                removed: [],
+                unchanged: 6,
+                failed: [],
+            };
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("10 files indexed"))).toBe(true);
+            expect(texts.some(t => t.includes("4 files processed"))).toBe(true);
+        });
+
+        it("does not show files processed when no additions or updates", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).syncResult = {
+                added: [],
+                updated: [],
+                removed: [],
+                unchanged: 10,
+                failed: [],
+            };
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("10 files indexed"))).toBe(true);
+            expect(texts.some(t => t.includes("files processed"))).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
Optional 5-step guided setup for users who may have never used local AI before.

**Steps:** Welcome → Server Mode (skipped if server ready) → Model Picker (featured models from catalog with RAM-based recommendation) → Vault Indexing (SSE progress) → Done summary with Open Chat.

Every step has a Skip button. No auto-pull — user explicitly picks and downloads their model. Auto-opens on first load when setupCompleted is false. Re-accessible via lilbee:setup command and a button in settings.

783 tests, 100% coverage.