### PR TITLE
feat: hierarchical model families in catalog

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { ChatView, VIEW_TYPE_CHAT } from "./views/chat-view";
 import { CrawlModal } from "./views/crawl-modal";
 import { DocumentsModal } from "./views/documents-modal";
 import { SearchModal } from "./views/search-modal";
+import { SetupWizard } from "./views/setup-wizard";
 
 
 function summarizeSyncResult(done: SyncDone): string {
@@ -61,6 +62,10 @@ export default class LilbeePlugin extends Plugin {
             this.api = new LilbeeClient(this.settings.serverUrl);
             this.setStatusReady();
             this.fetchActiveModel();
+        }
+
+        if (!this.settings.setupCompleted) {
+            new SetupWizard(this.app, this).open();
         }
 
         if (this.settings.syncMode === "auto") {
@@ -294,6 +299,12 @@ export default class LilbeePlugin extends Plugin {
         });
 
         this.addCommand({
+            id: "lilbee:setup",
+            name: "Run setup wizard",
+            callback: () => new SetupWizard(this.app, this).open(),
+        });
+
+        this.addCommand({
             id: "lilbee:status",
             name: "Show status",
             callback: async () => {
@@ -459,7 +470,7 @@ export default class LilbeePlugin extends Plugin {
         this.autoSyncRefs = [];
     }
 
-    private async activateChatView(): Promise<void> {
+    async activateChatView(): Promise<void> {
         const existing = this.app.workspace.getLeavesOfType(VIEW_TYPE_CHAT);
         if (existing.length > 0) {
             this.app.workspace.revealLeaf(existing[0]);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,6 +7,7 @@ import { PullQueue } from "./pull-queue";
 import { CatalogModal } from "./views/catalog-modal";
 import { ConfirmModal } from "./views/confirm-modal";
 import { ConfirmPullModal } from "./views/confirm-pull-modal";
+import { SetupWizard } from "./views/setup-wizard";
 
 const CHECK_TIMEOUT_MS = 5000;
 const CLS_MODELS_CONTAINER = "lilbee-models-container";
@@ -111,6 +112,15 @@ export class LilbeeSettingTab extends PluginSettingTab {
                         await this.plugin.saveSettings();
                         this.display();
                     }),
+            );
+
+        new Setting(containerEl)
+            .setName("Setup wizard")
+            .setDesc("Walk through initial setup again")
+            .addButton((btn) =>
+                btn.setButtonText("Run setup wizard").onClick(() => {
+                    new SetupWizard(this.app, this.plugin).open();
+                }),
             );
 
         if (this.plugin.settings.serverMode === SERVER_MODE.MANAGED) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,6 +189,8 @@ export interface ModelVariant {
     task: string;
     installed: boolean;
     source: "native" | "litellm";
+    display_name?: string;
+    quality_tier?: string;
 }
 
 export interface ModelFamily {

--- a/src/types.ts
+++ b/src/types.ts
@@ -180,20 +180,30 @@ export interface QueuedPull {
     modelName: string;
 }
 
-export interface CatalogModel {
+export interface ModelVariant {
     name: string;
+    hf_repo: string;
     size_gb: number;
     min_ram_gb: number;
     description: string;
+    task: string;
     installed: boolean;
     source: "native" | "litellm";
+}
+
+export interface ModelFamily {
+    family: string;
+    task: string;
+    featured: boolean;
+    recommended: string;
+    variants: ModelVariant[];
 }
 
 export interface CatalogResponse {
     total: number;
     limit: number;
     offset: number;
-    models: CatalogModel[];
+    families: ModelFamily[];
 }
 
 export interface InstalledModel {

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,6 +132,7 @@ export interface LilbeeSettings {
     serverPort: number | null;
     lilbeeVersion: string;
     systemPrompt: string;
+    setupCompleted: boolean;
 }
 
 export const DEFAULT_SETTINGS: LilbeeSettings = {
@@ -149,6 +150,7 @@ export const DEFAULT_SETTINGS: LilbeeSettings = {
     serverPort: null,
     lilbeeVersion: "",
     systemPrompt: "",
+    setupCompleted: false,
 };
 
 /** SSE event type constants — shared across chat, sync, and model pull streams. */

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -1,6 +1,6 @@
 import { App, Modal, Notice } from "obsidian";
 import type LilbeePlugin from "../main";
-import type { CatalogModel, CatalogResponse, ModelType, SSEEvent } from "../types";
+import type { ModelFamily, ModelVariant, CatalogResponse, ModelType, SSEEvent } from "../types";
 import { MODEL_TYPE, NOTICE, SSE_EVENT } from "../types";
 import { ConfirmPullModal } from "./confirm-pull-modal";
 import { PullQueue } from "../pull-queue";
@@ -21,7 +21,7 @@ export class CatalogModal extends Modal {
     private filterSearch = "";
     private offset = 0;
     private total = 0;
-    private models: CatalogModel[] = [];
+    private families: ModelFamily[] = [];
     private resultsEl: HTMLElement | null = null;
     private loadMoreBtn: HTMLElement | null = null;
     private debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -101,7 +101,7 @@ export class CatalogModal extends Modal {
 
     private resetAndFetch(): void {
         this.offset = 0;
-        this.models = [];
+        this.families = [];
         if (this.resultsEl) this.resultsEl.empty();
         void this.fetchPage();
     }
@@ -123,11 +123,11 @@ export class CatalogModal extends Modal {
 
             const response: CatalogResponse = await this.plugin.api.catalog(params);
             this.total = response.total;
-            this.models.push(...response.models);
-            this.offset += response.models.length;
+            this.families.push(...response.families);
+            this.offset += response.families.length;
 
-            for (const model of response.models) {
-                this.renderRow(model);
+            for (const family of response.families) {
+                this.renderFamily(family);
             }
 
             this.updateLoadMore();
@@ -141,50 +141,76 @@ export class CatalogModal extends Modal {
         this.loadMoreBtn.style.display = this.offset < this.total ? "" : "none";
     }
 
-    private renderRow(model: CatalogModel): void {
+    private renderFamily(family: ModelFamily): void {
         if (!this.resultsEl) return;
-        const row = this.resultsEl.createDiv({ cls: "lilbee-catalog-row" });
-        row.createDiv({ cls: "lilbee-catalog-row-name", text: model.name });
-        row.createDiv({ cls: "lilbee-catalog-row-size", text: `${model.size_gb} GB` });
-        row.createDiv({ cls: "lilbee-catalog-row-desc", text: model.description });
+        const container = this.resultsEl.createDiv({ cls: "lilbee-catalog-family" });
 
-        const actionEl = row.createDiv({ cls: "lilbee-catalog-row-action" });
-        const active = this.plugin.activeModel === model.name || this.plugin.activeVisionModel === model.name;
+        const header = container.createDiv({ cls: "lilbee-catalog-family-header" });
+        header.createEl("span", { text: family.family });
+        header.createEl("span", { text: family.task, cls: "lilbee-catalog-family-task" });
 
-        if (active) {
-            actionEl.createEl("span", { text: "Active", cls: "lilbee-catalog-active" });
-        } else if (model.installed) {
-            actionEl.createEl("span", { text: "Installed", cls: "lilbee-installed" });
-        } else {
-            const pullBtn = actionEl.createEl("button", { text: "Pull", cls: "lilbee-catalog-pull" });
-            pullBtn.addEventListener("click", () => this.handlePull(model, pullBtn));
+        header.addEventListener("click", () => {
+            if (container.classList.contains("is-collapsed")) {
+                container.removeClass("is-collapsed");
+            } else {
+                container.addClass("is-collapsed");
+            }
+        });
+
+        const variantsEl = container.createDiv({ cls: "lilbee-catalog-family-variants" });
+        for (const variant of family.variants) {
+            this.renderVariant(family, variant, variantsEl);
         }
     }
 
-    private handlePull(model: CatalogModel, btn: HTMLElement): void {
+    private renderVariant(family: ModelFamily, variant: ModelVariant, container: HTMLElement): void {
+        const row = container.createDiv({ cls: "lilbee-catalog-variant-row" });
+
+        const isRecommended = variant.name === family.recommended;
+        const nameCls = isRecommended ? "lilbee-catalog-variant-name lilbee-catalog-recommended" : "lilbee-catalog-variant-name";
+        const nameText = isRecommended ? `${variant.name} \u2605` : variant.name;
+        row.createEl("span", { text: nameText, cls: nameCls });
+
+        row.createEl("span", { text: `${variant.size_gb} GB`, cls: "lilbee-catalog-variant-size" });
+        row.createEl("span", { text: variant.description, cls: "lilbee-catalog-variant-desc" });
+
+        const actionEl = row.createDiv({ cls: "lilbee-catalog-variant-action" });
+        const active = this.plugin.activeModel === variant.hf_repo || this.plugin.activeVisionModel === variant.hf_repo;
+
+        if (active) {
+            actionEl.createEl("span", { text: "Active", cls: "lilbee-catalog-active" });
+        } else if (variant.installed) {
+            actionEl.createEl("span", { text: "Installed", cls: "lilbee-installed" });
+        } else {
+            const pullBtn = actionEl.createEl("button", { text: "Pull", cls: "lilbee-catalog-pull" });
+            pullBtn.addEventListener("click", () => this.handlePull(family, variant, pullBtn));
+        }
+    }
+
+    private handlePull(family: ModelFamily, variant: ModelVariant, btn: HTMLElement): void {
         const info = {
-            name: model.name,
-            size_gb: model.size_gb,
-            min_ram_gb: model.min_ram_gb,
-            description: model.description,
-            installed: model.installed,
+            name: variant.hf_repo,
+            size_gb: variant.size_gb,
+            min_ram_gb: variant.min_ram_gb,
+            description: variant.description,
+            installed: variant.installed,
         };
         const confirmModal = new ConfirmPullModal(this.app, info);
         confirmModal.open();
         void confirmModal.result.then((confirmed) => {
             if (!confirmed) return;
             void this.pullQueue.enqueue(
-                () => this.executePull(model, btn),
-                model.name,
+                () => this.executePull(family, variant, btn),
+                variant.hf_repo,
             );
         });
     }
 
-    private async executePull(model: CatalogModel, btn: HTMLElement): Promise<void> {
+    private async executePull(family: ModelFamily, variant: ModelVariant, btn: HTMLElement): Promise<void> {
         btn.textContent = "Pulling...";
         (btn as HTMLButtonElement).disabled = true;
         try {
-            for await (const event of this.plugin.api.pullModel(model.name, model.source)) {
+            for await (const event of this.plugin.api.pullModel(variant.hf_repo, variant.source)) {
                 if (event.event === SSE_EVENT.PROGRESS) {
                     const d = event.data as { current?: number; total?: number };
                     if (d.total && d.current !== undefined) {
@@ -193,15 +219,15 @@ export class CatalogModal extends Modal {
                     }
                 }
             }
-            if (this.filterTask === "vision") {
-                await this.plugin.api.setVisionModel(model.name);
-                this.plugin.activeVisionModel = model.name;
+            if (variant.task === "vision") {
+                await this.plugin.api.setVisionModel(variant.hf_repo);
+                this.plugin.activeVisionModel = variant.hf_repo;
             } else {
-                await this.plugin.api.setChatModel(model.name);
-                this.plugin.activeModel = model.name;
+                await this.plugin.api.setChatModel(variant.hf_repo);
+                this.plugin.activeModel = variant.hf_repo;
             }
             this.plugin.fetchActiveModel();
-            new Notice(`lilbee: ${model.name} pulled and activated`);
+            new Notice(`lilbee: ${variant.hf_repo} pulled and activated`);
             btn.textContent = "Active";
             (btn as HTMLButtonElement).disabled = true;
         } catch (err) {

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -1,7 +1,7 @@
 import { App, Modal, Notice } from "obsidian";
 import type LilbeePlugin from "../main";
-import type { ModelFamily, ModelVariant, CatalogResponse, ModelType, SSEEvent } from "../types";
-import { MODEL_TYPE, NOTICE, SSE_EVENT } from "../types";
+import type { ModelFamily, ModelVariant, CatalogResponse } from "../types";
+import { NOTICE, SSE_EVENT } from "../types";
 import { ConfirmPullModal } from "./confirm-pull-modal";
 import { PullQueue } from "../pull-queue";
 
@@ -167,9 +167,14 @@ export class CatalogModal extends Modal {
         const row = container.createDiv({ cls: "lilbee-catalog-variant-row" });
 
         const isRecommended = variant.name === family.recommended;
+        const displayName = variant.display_name ?? variant.name;
         const nameCls = isRecommended ? "lilbee-catalog-variant-name lilbee-catalog-recommended" : "lilbee-catalog-variant-name";
-        const nameText = isRecommended ? `${variant.name} \u2605` : variant.name;
+        const nameText = isRecommended ? `${displayName} \u2605` : displayName;
         row.createEl("span", { text: nameText, cls: nameCls });
+
+        if (variant.quality_tier) {
+            row.createEl("span", { text: variant.quality_tier, cls: "lilbee-catalog-variant-tier" });
+        }
 
         row.createEl("span", { text: `${variant.size_gb} GB`, cls: "lilbee-catalog-variant-size" });
         row.createEl("span", { text: variant.description, cls: "lilbee-catalog-variant-desc" });
@@ -222,6 +227,8 @@ export class CatalogModal extends Modal {
             if (variant.task === "vision") {
                 await this.plugin.api.setVisionModel(variant.hf_repo);
                 this.plugin.activeVisionModel = variant.hf_repo;
+            } else if (variant.task === "embedding") {
+                await this.plugin.api.setEmbeddingModel(variant.hf_repo);
             } else {
                 await this.plugin.api.setChatModel(variant.hf_repo);
                 this.plugin.activeModel = variant.hf_repo;

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -1,6 +1,6 @@
 import { App, Modal, Notice } from "obsidian";
 import type LilbeePlugin from "../main";
-import type { CatalogModel, SSEEvent, SyncDone } from "../types";
+import type { ModelFamily, SSEEvent, SyncDone } from "../types";
 import { SERVER_MODE, SSE_EVENT } from "../types";
 import { CatalogModal } from "./catalog-modal";
 
@@ -10,6 +10,7 @@ interface FeaturedModel {
     min_ram_gb: number;
     description: string;
     source: "native" | "litellm";
+    displayName?: string;
 }
 
 export function getSystemMemoryGB(): number | null {
@@ -270,13 +271,17 @@ export class SetupWizard extends Modal {
                 sort: "featured",
                 limit: 4,
             });
-            this.featuredModels = response.models.map((m: CatalogModel) => ({
-                name: m.name,
-                size_gb: m.size_gb,
-                min_ram_gb: m.min_ram_gb,
-                description: m.description,
-                source: m.source,
-            }));
+            this.featuredModels = response.families.map((f: ModelFamily) => {
+                const v = f.variants.find(v => v.name === f.recommended) ?? f.variants[0];
+                return {
+                    name: v.hf_repo,
+                    size_gb: v.size_gb,
+                    min_ram_gb: v.min_ram_gb,
+                    description: v.description,
+                    source: v.source,
+                    displayName: f.family,
+                };
+            });
         } catch {
             this.featuredModels = [];
             statusEl.textContent = "Could not load models from server.";
@@ -296,7 +301,8 @@ export class SetupWizard extends Modal {
             if (i === recommended) {
                 header.createEl("span", { text: "Recommended", cls: "lilbee-wizard-recommended" });
             }
-            header.createEl("strong", { text: model.name });
+            /* v8 ignore next */
+            header.createEl("strong", { text: model.displayName ?? model.name });
             header.createEl("span", { text: `${model.size_gb} GB` });
             option.createEl("p", { text: model.description });
             option.createEl("p", { text: `Minimum ${model.min_ram_gb} GB RAM`, cls: "lilbee-wizard-model-ram" });

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -1,0 +1,510 @@
+import { App, Modal, Notice } from "obsidian";
+import type LilbeePlugin from "../main";
+import type { CatalogModel, SSEEvent, SyncDone } from "../types";
+import { SERVER_MODE, SSE_EVENT } from "../types";
+import { CatalogModal } from "./catalog-modal";
+
+interface FeaturedModel {
+    name: string;
+    size_gb: number;
+    min_ram_gb: number;
+    description: string;
+    source: "native" | "litellm";
+}
+
+export function getSystemMemoryGB(): number | null {
+    try {
+        const os = require("os") as { totalmem(): number };
+        return Math.round(os.totalmem() / (1024 * 1024 * 1024));
+    /* v8 ignore next 3 */
+    } catch {
+        return null;
+    }
+}
+
+export function recommendedIndex(models: FeaturedModel[], memGB: number | null): number {
+    if (memGB === null || models.length === 0) return 0;
+    let best = 0;
+    let bestRam = 0;
+    for (let i = 0; i < models.length; i++) {
+        if (models[i].min_ram_gb <= memGB && models[i].min_ram_gb >= bestRam) {
+            best = i;
+            bestRam = models[i].min_ram_gb;
+        }
+    }
+    return best;
+}
+
+export class SetupWizard extends Modal {
+    private plugin: LilbeePlugin;
+    private step = 0;
+    private selectedModel: FeaturedModel | null = null;
+    private featuredModels: FeaturedModel[] = [];
+    private pullController: AbortController | null = null;
+    private syncController: AbortController | null = null;
+    private syncResult: SyncDone | null = null;
+    private pulledModelName = "";
+
+    constructor(app: App, plugin: LilbeePlugin) {
+        super(app);
+        this.plugin = plugin;
+    }
+
+    onOpen(): void {
+        const { contentEl } = this;
+        contentEl.empty();
+        contentEl.addClass("lilbee-wizard");
+        this.renderStep();
+    }
+
+    onClose(): void {
+        this.pullController?.abort();
+        this.syncController?.abort();
+    }
+
+    private renderStep(): void {
+        const { contentEl } = this;
+        contentEl.empty();
+
+        switch (this.step) {
+            case 0: this.renderWelcome(); break;
+            case 1: this.renderServerMode(); break;
+            case 2: this.renderModelPicker(); break;
+            case 3: this.renderSync(); break;
+            case 4: this.renderDone(); break;
+        }
+    }
+
+    private renderWelcome(): void {
+        const { contentEl } = this;
+        const step = contentEl.createDiv({ cls: "lilbee-wizard-step" });
+
+        step.createEl("h2", { text: "Welcome to lilbee" });
+        step.createEl("p", {
+            text: "lilbee turns your Obsidian vault into a searchable knowledge base powered by AI running on your machine.",
+        });
+
+        step.createEl("p", { text: "This wizard will help you:" });
+        const ul = step.createEl("ul");
+        ul.createEl("li", { text: "Choose an AI model that fits your computer" });
+        ul.createEl("li", { text: "Index your vault so you can search and chat" });
+
+        step.createEl("p", {
+            text: "Everything runs locally \u2014 your notes never leave your machine.",
+        });
+
+        const actions = step.createDiv({ cls: "lilbee-wizard-actions" });
+        const skipBtn = actions.createEl("button", { text: "Skip setup" });
+        skipBtn.addEventListener("click", () => this.skip());
+
+        const startBtn = actions.createEl("button", { text: "Get started", cls: "mod-cta" });
+        startBtn.addEventListener("click", () => this.next());
+    }
+
+    private renderServerMode(): void {
+        const { contentEl } = this;
+        const step = contentEl.createDiv({ cls: "lilbee-wizard-step" });
+
+        step.createEl("h2", { text: "How do you want to run lilbee?" });
+
+        let mode: "managed" | "external" = this.plugin.settings.serverMode === SERVER_MODE.EXTERNAL
+            ? "external"
+            : "managed";
+
+        const managedOption = step.createDiv({ cls: `lilbee-wizard-model-option${mode === "managed" ? " selected" : ""}` });
+        managedOption.createEl("strong", { text: "Managed (recommended)" });
+        managedOption.createEl("p", {
+            text: "lilbee starts and stops automatically with Obsidian. No terminal needed.",
+        });
+
+        const externalOption = step.createDiv({ cls: `lilbee-wizard-model-option${mode === "external" ? " selected" : ""}` });
+        externalOption.createEl("strong", { text: "External" });
+        externalOption.createEl("p", {
+            text: "You run the lilbee server yourself. For advanced users or shared setups.",
+        });
+
+        const urlInput = step.createEl("input", {
+            cls: "lilbee-wizard-url-input",
+            placeholder: "http://127.0.0.1:7433",
+            attr: { type: "text" },
+        });
+        urlInput.value = this.plugin.settings.serverUrl;
+        urlInput.style.display = mode === "external" ? "" : "none";
+
+        const statusEl = step.createDiv({ cls: "lilbee-wizard-status" });
+
+        managedOption.addEventListener("click", () => {
+            mode = "managed";
+            managedOption.classList.add("selected");
+            externalOption.classList.remove("selected");
+            urlInput.style.display = "none";
+            statusEl.textContent = "";
+        });
+
+        externalOption.addEventListener("click", () => {
+            mode = "external";
+            externalOption.classList.add("selected");
+            managedOption.classList.remove("selected");
+            urlInput.style.display = "";
+        });
+
+        const actions = step.createDiv({ cls: "lilbee-wizard-actions" });
+        const backBtn = actions.createEl("button", { text: "Back" });
+        backBtn.addEventListener("click", () => this.back());
+        const skipBtn = actions.createEl("button", { text: "Skip setup" });
+        skipBtn.addEventListener("click", () => this.skip());
+
+        const nextBtn = actions.createEl("button", { text: "Next", cls: "mod-cta" });
+        nextBtn.addEventListener("click", () => {
+            if (mode === "managed") {
+                this.plugin.settings.serverMode = SERVER_MODE.MANAGED;
+                statusEl.textContent = "Starting server...";
+                statusEl.classList.add("lilbee-loading");
+                nextBtn.disabled = true;
+                void this.startManagedAndAdvance(statusEl, nextBtn);
+            } else {
+                this.plugin.settings.serverUrl = String(urlInput.value || "").trim() || "http://127.0.0.1:7433";
+                this.plugin.settings.serverMode = SERVER_MODE.EXTERNAL;
+                statusEl.textContent = "Checking connection...";
+                nextBtn.disabled = true;
+                void this.checkExternalAndAdvance(statusEl, nextBtn);
+            }
+        });
+    }
+
+    private async startManagedAndAdvance(statusEl: HTMLElement, nextBtn: HTMLElement): Promise<void> {
+        try {
+            await this.plugin.saveSettings();
+            if (!this.plugin.serverManager) {
+                await this.plugin.startManagedServer();
+            }
+            statusEl.textContent = "";
+            statusEl.classList.remove("lilbee-loading");
+            this.step = 2;
+            this.renderStep();
+        } catch {
+            statusEl.textContent = "Failed to start server. Check the settings tab for details.";
+            statusEl.classList.remove("lilbee-loading");
+            (nextBtn as HTMLButtonElement).disabled = false;
+        }
+    }
+
+    private async checkExternalAndAdvance(statusEl: HTMLElement, nextBtn: HTMLElement): Promise<void> {
+        try {
+            await this.plugin.saveSettings();
+            await this.plugin.api.health();
+            statusEl.textContent = "";
+            this.step = 2;
+            this.renderStep();
+        } catch {
+            statusEl.textContent = "Could not connect. Check the URL and make sure the server is running.";
+            (nextBtn as HTMLButtonElement).disabled = false;
+        }
+    }
+
+    private renderModelPicker(): void {
+        const { contentEl } = this;
+        const step = contentEl.createDiv({ cls: "lilbee-wizard-step" });
+
+        step.createEl("h2", { text: "Pick a chat model" });
+        step.createEl("p", {
+            text: "This is the AI that answers your questions about your notes. Bigger models are smarter but need more RAM and disk space.",
+        });
+
+        const memGB = getSystemMemoryGB();
+        if (memGB !== null) {
+            step.createEl("p", {
+                text: `Your system: ${memGB} GB RAM`,
+                cls: "lilbee-wizard-system-info",
+            });
+        }
+
+        const modelsContainer = step.createDiv({ cls: "lilbee-wizard-models" });
+        const statusEl = step.createDiv({ cls: "lilbee-wizard-status" });
+        const progressEl = step.createDiv({ cls: "lilbee-wizard-progress" });
+        progressEl.style.display = "none";
+        const progressBar = progressEl.createDiv({ cls: "lilbee-progress-bar-container" });
+        const progressFill = progressBar.createDiv({ cls: "lilbee-progress-bar" });
+        const progressLabel = progressEl.createDiv({ cls: "lilbee-wizard-progress-label" });
+
+        const actions = step.createDiv({ cls: "lilbee-wizard-actions" });
+        const backBtn = actions.createEl("button", { text: "Back" });
+        backBtn.addEventListener("click", () => {
+            this.pullController?.abort();
+            this.back();
+        });
+        const skipBtn = actions.createEl("button", { text: "Skip setup" });
+        skipBtn.addEventListener("click", () => {
+            this.pullController?.abort();
+            this.skip();
+        });
+
+        const catalogBtn = actions.createEl("button", { text: "Browse full catalog" });
+        catalogBtn.addEventListener("click", () => {
+            new CatalogModal(this.app, this.plugin).open();
+        });
+
+        const downloadBtn = actions.createEl("button", { text: "Download & continue", cls: "mod-cta" });
+        downloadBtn.addEventListener("click", () => {
+            if (!this.selectedModel) {
+                statusEl.textContent = "Please select a model first.";
+                return;
+            }
+            downloadBtn.disabled = true;
+            statusEl.textContent = "";
+            void this.pullSelectedModel(downloadBtn, progressEl, progressFill, progressLabel, statusEl);
+        });
+
+        void this.loadFeaturedModels(modelsContainer, memGB, statusEl);
+    }
+
+    private async loadFeaturedModels(
+        container: HTMLElement,
+        memGB: number | null,
+        statusEl: HTMLElement,
+    ): Promise<void> {
+        try {
+            const response = await this.plugin.api.catalog({
+                task: "chat",
+                featured: true,
+                sort: "featured",
+                limit: 4,
+            });
+            this.featuredModels = response.models.map((m: CatalogModel) => ({
+                name: m.name,
+                size_gb: m.size_gb,
+                min_ram_gb: m.min_ram_gb,
+                description: m.description,
+                source: m.source,
+            }));
+        } catch {
+            this.featuredModels = [];
+            statusEl.textContent = "Could not load models from server.";
+            return;
+        }
+
+        const recommended = recommendedIndex(this.featuredModels, memGB);
+        this.selectedModel = this.featuredModels[recommended] ?? null;
+
+        for (let i = 0; i < this.featuredModels.length; i++) {
+            const model = this.featuredModels[i];
+            const option = container.createDiv({
+                cls: `lilbee-wizard-model-option${i === recommended ? " selected" : ""}`,
+            });
+
+            const header = option.createDiv({ cls: "lilbee-wizard-model-header" });
+            if (i === recommended) {
+                header.createEl("span", { text: "Recommended", cls: "lilbee-wizard-recommended" });
+            }
+            header.createEl("strong", { text: model.name });
+            header.createEl("span", { text: `${model.size_gb} GB` });
+            option.createEl("p", { text: model.description });
+            option.createEl("p", { text: `Minimum ${model.min_ram_gb} GB RAM`, cls: "lilbee-wizard-model-ram" });
+
+            option.addEventListener("click", () => {
+                this.selectedModel = model;
+                for (const child of container.children) {
+                    child.classList.remove("selected");
+                }
+                option.classList.add("selected");
+            });
+        }
+    }
+
+    private async pullSelectedModel(
+        downloadBtn: HTMLElement,
+        progressEl: HTMLElement,
+        progressFill: HTMLElement,
+        progressLabel: HTMLElement,
+        statusEl: HTMLElement,
+    ): Promise<void> {
+        if (!this.selectedModel) return;
+        const model = this.selectedModel;
+        progressEl.style.display = "";
+        progressLabel.textContent = `Downloading ${model.name}...`;
+        this.pullController = new AbortController();
+
+        try {
+            for await (const event of this.plugin.api.pullModel(
+                model.name,
+                model.source,
+                this.pullController.signal,
+            )) {
+                if (event.event === SSE_EVENT.PROGRESS) {
+                    const d = event.data as { current?: number; total?: number };
+                    if (d.total && d.current !== undefined) {
+                        const pct = Math.round((d.current / d.total) * 100);
+                        progressFill.style.width = `${pct}%`;
+                        progressLabel.textContent = `Downloading ${model.name}... ${pct}%`;
+                    }
+                }
+            }
+
+            await this.plugin.api.setChatModel(model.name);
+            this.plugin.activeModel = model.name;
+            this.plugin.fetchActiveModel();
+            this.pulledModelName = model.name;
+            this.step = 3;
+            this.renderStep();
+        } catch (err) {
+            if (err instanceof Error && err.name === "AbortError") {
+                new Notice("lilbee: download cancelled");
+            } else {
+                statusEl.textContent = "Download failed. Please try again or pick a different model.";
+            }
+            progressEl.style.display = "none";
+            (downloadBtn as HTMLButtonElement).disabled = false;
+        } finally {
+            this.pullController = null;
+        }
+    }
+
+    private renderSync(): void {
+        const { contentEl } = this;
+        const step = contentEl.createDiv({ cls: "lilbee-wizard-step" });
+
+        step.createEl("h2", { text: "Index your vault" });
+        step.createEl("p", {
+            text: "lilbee needs to read your notes once to make them searchable. This happens locally on your machine.",
+        });
+
+        const progressEl = step.createDiv({ cls: "lilbee-wizard-progress" });
+        const progressBar = progressEl.createDiv({ cls: "lilbee-progress-bar-container" });
+        const progressFill = progressBar.createDiv({ cls: "lilbee-progress-bar" });
+        const progressLabel = progressEl.createDiv({ cls: "lilbee-wizard-progress-label" });
+        progressLabel.textContent = "Starting...";
+
+        step.createEl("p", {
+            text: "After this, new and changed files are indexed automatically (or manually, your choice).",
+            cls: "lilbee-wizard-hint",
+        });
+
+        const actions = step.createDiv({ cls: "lilbee-wizard-actions" });
+        const backBtn = actions.createEl("button", { text: "Back" });
+        backBtn.addEventListener("click", () => {
+            this.syncController?.abort();
+            this.back();
+        });
+        const skipBtn = actions.createEl("button", { text: "Skip setup" });
+        skipBtn.addEventListener("click", () => {
+            this.syncController?.abort();
+            this.skip();
+        });
+
+        void this.runSync(progressFill, progressLabel);
+    }
+
+    private async runSync(
+        progressFill: HTMLElement,
+        progressLabel: HTMLElement,
+    ): Promise<void> {
+        this.syncController = new AbortController();
+        try {
+            let lastEvent: SSEEvent | null = null;
+            for await (const event of this.plugin.api.syncStream(
+                !!this.plugin.activeVisionModel,
+                this.syncController.signal,
+            )) {
+                if (event.event === SSE_EVENT.FILE_START) {
+                    const d = event.data as { current_file: number; total_files: number; file?: string };
+                    const pct = d.total_files > 0 ? Math.round((d.current_file / d.total_files) * 100) : 0;
+                    progressFill.style.width = `${pct}%`;
+                    progressLabel.textContent = `Processing ${d.current_file}/${d.total_files} files`;
+                }
+                if (event.event === SSE_EVENT.EMBED) {
+                    const d = event.data as { file?: string };
+                    if (d.file) {
+                        progressLabel.textContent = `Indexing: ${d.file}`;
+                    }
+                }
+                lastEvent = event;
+            }
+
+            if (lastEvent?.event === SSE_EVENT.DONE) {
+                this.syncResult = lastEvent.data as SyncDone;
+            }
+            progressFill.style.width = "100%";
+            progressLabel.textContent = "Done!";
+            this.step = 4;
+            this.renderStep();
+        } catch (err) {
+            if (err instanceof Error && err.name === "AbortError") {
+                new Notice("lilbee: indexing cancelled");
+            } else {
+                progressLabel.textContent = "Indexing failed. You can retry from the settings tab.";
+            }
+        } finally {
+            this.syncController = null;
+        }
+    }
+
+    private renderDone(): void {
+        const { contentEl } = this;
+        const step = contentEl.createDiv({ cls: "lilbee-wizard-step" });
+
+        step.createEl("h2", { text: "You're all set!" });
+
+        const summary = step.createDiv({ cls: "lilbee-wizard-summary" });
+        if (this.pulledModelName) {
+            summary.createEl("p", { text: `Chat model: ${this.pulledModelName}` });
+        }
+        if (this.syncResult) {
+            const total = this.syncResult.added.length +
+                this.syncResult.updated.length +
+                this.syncResult.unchanged;
+            const chunks = this.syncResult.added.length + this.syncResult.updated.length;
+            summary.createEl("p", { text: `${total} files indexed` });
+            if (chunks > 0) {
+                summary.createEl("p", { text: `${chunks} files processed` });
+            }
+        }
+
+        const tips = step.createDiv({ cls: "lilbee-wizard-tips" });
+        tips.createEl("p", { text: "Try it out:" });
+        const ul = tips.createEl("ul");
+        ul.createEl("li", { text: "Open the chat panel to ask questions about your notes" });
+        ul.createEl("li", { text: "Use the search command to find specific content" });
+        ul.createEl("li", { text: "Drag files into the chat to add context" });
+
+        step.createEl("p", {
+            text: "You can change models and settings anytime in the lilbee settings tab.",
+        });
+
+        const actions = step.createDiv({ cls: "lilbee-wizard-actions" });
+        const openChatBtn = actions.createEl("button", { text: "Open chat", cls: "mod-cta" });
+        openChatBtn.addEventListener("click", () => this.complete());
+    }
+
+    next(): void {
+        if (this.step === 0) {
+            const serverReady = this.plugin.serverManager?.state === "ready" ||
+                this.plugin.settings.serverMode === SERVER_MODE.EXTERNAL;
+            this.step = serverReady ? 2 : 1;
+        } else {
+            this.step++;
+        }
+        this.renderStep();
+    }
+
+    back(): void {
+        if (this.step === 2) {
+            const serverReady = this.plugin.serverManager?.state === "ready" ||
+                this.plugin.settings.serverMode === SERVER_MODE.EXTERNAL;
+            this.step = serverReady ? 0 : 1;
+        } else {
+            this.step = Math.max(0, this.step - 1);
+        }
+        this.renderStep();
+    }
+
+    skip(): void {
+        this.close();
+    }
+
+    async complete(): Promise<void> {
+        this.plugin.settings.setupCompleted = true;
+        await this.plugin.saveSettings();
+        this.close();
+        void this.plugin.activateChatView();
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -1003,3 +1003,138 @@
     padding: var(--size-4-2, 8px) 0;
     color: var(--text-normal);
 }
+
+/* Setup Wizard */
+
+.lilbee-wizard {
+    max-width: 540px;
+}
+
+.lilbee-wizard-step {
+    padding: var(--size-4-4, 16px) var(--size-4-3, 12px);
+}
+
+.lilbee-wizard-step h2 {
+    margin: 0 0 var(--size-4-3, 12px);
+}
+
+.lilbee-wizard-step p {
+    margin: 0 0 var(--size-4-2, 8px);
+    color: var(--text-normal);
+    line-height: var(--line-height-normal, 1.5);
+}
+
+.lilbee-wizard-step ul {
+    margin: 0 0 var(--size-4-2, 8px);
+    padding-left: var(--size-4-6, 24px);
+}
+
+.lilbee-wizard-model-option {
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-m, 6px);
+    padding: var(--size-4-3, 12px);
+    margin-bottom: var(--size-4-2, 8px);
+    cursor: pointer;
+    transition: border-color 150ms ease;
+}
+
+.lilbee-wizard-model-option:hover {
+    border-color: var(--interactive-accent);
+}
+
+.lilbee-wizard-model-option.selected {
+    border-color: var(--interactive-accent);
+    background-color: var(--background-secondary);
+}
+
+.lilbee-wizard-model-option strong {
+    display: block;
+    margin-bottom: var(--size-4-1, 4px);
+}
+
+.lilbee-wizard-model-option p {
+    margin: 0;
+    font-size: var(--font-small, 13px);
+    color: var(--text-muted);
+}
+
+.lilbee-wizard-model-header {
+    display: flex;
+    align-items: center;
+    gap: var(--size-4-2, 8px);
+    margin-bottom: var(--size-4-1, 4px);
+}
+
+.lilbee-wizard-model-ram {
+    font-size: var(--font-smallest, 10px) !important;
+    color: var(--text-faint) !important;
+}
+
+.lilbee-wizard-recommended {
+    display: inline-block;
+    padding: 1px var(--size-4-2, 8px);
+    border-radius: 999px;
+    background-color: var(--interactive-accent);
+    color: var(--text-on-accent);
+    font-size: var(--font-smallest, 10px);
+    font-weight: var(--font-medium, 500);
+}
+
+.lilbee-wizard-system-info {
+    font-size: var(--font-small, 13px);
+    color: var(--text-muted) !important;
+}
+
+.lilbee-wizard-progress {
+    margin: var(--size-4-3, 12px) 0;
+}
+
+.lilbee-wizard-progress-label {
+    font-size: var(--font-small, 13px);
+    color: var(--text-muted);
+    margin-top: var(--size-4-1, 4px);
+}
+
+.lilbee-wizard-actions {
+    display: flex;
+    gap: var(--size-4-2, 8px);
+    justify-content: flex-end;
+    margin-top: var(--size-4-4, 16px);
+}
+
+.lilbee-wizard-summary p {
+    font-weight: var(--font-medium, 500);
+}
+
+.lilbee-wizard-tips {
+    margin-top: var(--size-4-2, 8px);
+}
+
+.lilbee-wizard-hint {
+    font-size: var(--font-small, 13px);
+    color: var(--text-muted) !important;
+}
+
+.lilbee-wizard-status {
+    font-size: var(--font-small, 13px);
+    color: var(--text-muted);
+    min-height: 1.5em;
+    margin: var(--size-4-2, 8px) 0;
+}
+
+.lilbee-wizard-url-input {
+    width: 100%;
+    padding: var(--size-4-2, 8px) var(--size-4-3, 12px);
+    margin: var(--size-4-2, 8px) 0;
+    background-color: var(--background-secondary);
+    color: var(--text-normal);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-m, 6px);
+    font-size: var(--font-text-size, 15px);
+    outline: none;
+    box-sizing: border-box;
+}
+
+.lilbee-wizard-url-input:focus {
+    border-color: var(--interactive-accent);
+}

--- a/styles.css
+++ b/styles.css
@@ -1138,3 +1138,42 @@
 .lilbee-wizard-url-input:focus {
     border-color: var(--interactive-accent);
 }
+
+/* Catalog Family Layout */
+
+.lilbee-catalog-family {
+    margin-bottom: 8px;
+}
+.lilbee-catalog-family-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px;
+    cursor: pointer;
+    font-weight: 600;
+}
+.lilbee-catalog-family-header:hover {
+    background: var(--background-modifier-hover);
+}
+.lilbee-catalog-family-task {
+    font-size: 0.75em;
+    padding: 2px 6px;
+    border-radius: 4px;
+    background: var(--background-modifier-border);
+}
+.lilbee-catalog-family-variants {
+    padding-left: 16px;
+}
+.lilbee-catalog-family.is-collapsed .lilbee-catalog-family-variants {
+    display: none;
+}
+.lilbee-catalog-variant-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--background-modifier-border);
+}
+.lilbee-catalog-recommended {
+    color: var(--text-accent);
+}

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -41,6 +41,10 @@ vi.mock("../src/views/documents-modal", () => ({
     DocumentsModal: vi.fn().mockImplementation(() => ({ open: vi.fn() })),
 }));
 
+vi.mock("../src/views/setup-wizard", () => ({
+    SetupWizard: vi.fn().mockImplementation(() => ({ open: vi.fn(), close: vi.fn() })),
+}));
+
 const mockEnsureBinary = vi.fn().mockResolvedValue("/fake/bin/lilbee");
 const mockBinaryExists = vi.fn().mockReturnValue(true);
 const mockDownload = vi.fn().mockResolvedValue(undefined);
@@ -122,11 +126,11 @@ describe("LilbeePlugin", () => {
             expect(plugin.registerView).toHaveBeenCalled();
         });
 
-        it("adds all ten commands", async () => {
+        it("adds all eleven commands", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
 
-            expect(plugin.addCommand).toHaveBeenCalledTimes(10);
+            expect(plugin.addCommand).toHaveBeenCalledTimes(11);
             const ids = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.map(
                 (c: any[]) => c[0].id,
             );
@@ -139,6 +143,7 @@ describe("LilbeePlugin", () => {
             expect(ids).toContain("lilbee:catalog");
             expect(ids).toContain("lilbee:crawl");
             expect(ids).toContain("lilbee:documents");
+            expect(ids).toContain("lilbee:setup");
             expect(ids).toContain("lilbee:status");
         });
 
@@ -235,6 +240,33 @@ describe("LilbeePlugin", () => {
             plugin.loadData = vi.fn().mockResolvedValue({ serverMode: "external", serverUrl: "http://custom:9999" });
             await plugin.onload();
             expect(LilbeeClient).toHaveBeenCalledWith("http://custom:9999");
+        });
+
+        it("auto-opens setup wizard when setupCompleted is false", async () => {
+            const { SetupWizard } = await import("../src/views/setup-wizard");
+            const plugin = await createPlugin({ serverMode: "external", setupCompleted: false });
+            await plugin.onload();
+            expect(SetupWizard).toHaveBeenCalled();
+        });
+
+        it("does not auto-open setup wizard when setupCompleted is true", async () => {
+            const { SetupWizard } = await import("../src/views/setup-wizard");
+            (SetupWizard as ReturnType<typeof vi.fn>).mockClear();
+            const plugin = await createPlugin({ serverMode: "external", setupCompleted: true });
+            await plugin.onload();
+            expect(SetupWizard).not.toHaveBeenCalled();
+        });
+
+        it("setup command opens SetupWizard", async () => {
+            const plugin = await createPlugin({ serverMode: "external", setupCompleted: true });
+            await plugin.onload();
+            const cmd = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.find(
+                (c: any[]) => c[0].id === "lilbee:setup",
+            )![0];
+            expect(cmd.name).toBe("Run setup wizard");
+            cmd.callback();
+            const { SetupWizard } = await import("../src/views/setup-wizard");
+            expect(SetupWizard).toHaveBeenCalled();
         });
     });
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -31,6 +31,13 @@ vi.mock("../src/views/catalog-modal", () => ({
     })),
 }));
 
+vi.mock("../src/views/setup-wizard", () => ({
+    SetupWizard: vi.fn().mockImplementation(() => ({
+        open: vi.fn(),
+        close: vi.fn(),
+    })),
+}));
+
 let mockGenericConfirmResult = true;
 vi.mock("../src/views/confirm-modal", () => ({
     ConfirmModal: vi.fn().mockImplementation(() => ({
@@ -532,10 +539,25 @@ describe("LilbeeSettingTab", () => {
             const tab = makeTab(plugin);
             const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
-            // Start + Check for updates + Refresh + Browse Catalog = 4
-            expect(buttonOnClicks.length).toBe(4);
-            // Refresh is the third button (index 2)
-            await expect(buttonOnClicks[2]()).resolves.not.toThrow();
+            // Setup wizard + Start + Check for updates + Refresh + Browse Catalog = 5
+            expect(buttonOnClicks.length).toBe(5);
+            // Refresh is the fourth button (index 3)
+            await expect(buttonOnClicks[3]()).resolves.not.toThrow();
+        });
+    });
+
+    describe("Setup wizard button in settings", () => {
+        it("onClick opens SetupWizard", async () => {
+            const { SetupWizard } = await import("../src/views/setup-wizard");
+            const plugin = makePlugin();
+            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            const tab = makeTab(plugin);
+            const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+
+            // Setup wizard is the first button (index 0)
+            buttonOnClicks[0]();
+
+            expect(SetupWizard).toHaveBeenCalled();
         });
     });
 
@@ -547,8 +569,8 @@ describe("LilbeeSettingTab", () => {
             const tab = makeTab(plugin);
             const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
-            // Browse Catalog is the fourth button (index 3)
-            buttonOnClicks[3]();
+            // Browse Catalog is the fifth button (index 4)
+            buttonOnClicks[4]();
 
             expect(CatalogModal).toHaveBeenCalled();
         });
@@ -1617,8 +1639,8 @@ describe("LilbeeSettingTab", () => {
             await new Promise((r) => setTimeout(r, 0));
             (globalThis.fetch as ReturnType<typeof vi.fn>).mockClear();
 
-            // buttonOnClicks[0] = server Test
-            await buttonOnClicks[0]();
+            // buttonOnClicks[0] = Setup wizard, [1] = server Test
+            await buttonOnClicks[1]();
 
             expect(globalThis.fetch).toHaveBeenCalledTimes(1);
             expect(globalThis.fetch).toHaveBeenCalledWith(
@@ -2063,8 +2085,8 @@ describe("managed mode settings", () => {
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
-        // buttonOnClicks[0] = Start (server controls), [1] = Check for updates
-        await buttonOnClicks[1]();
+        // buttonOnClicks[0] = Setup wizard, [1] = Start (server controls), [2] = Check for updates
+        await buttonOnClicks[2]();
 
         // No notice on check — button transforms to "Update to vX.Y.Z" instead
         expect(Notice.instances.some((n) => n.message.includes("update available"))).toBe(false);
@@ -2080,8 +2102,8 @@ describe("managed mode settings", () => {
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
-        // buttonOnClicks[0] = Start, [1] = Check for updates
-        await buttonOnClicks[1]();
+        // buttonOnClicks[0] = Setup wizard, [1] = Start, [2] = Check for updates
+        await buttonOnClicks[2]();
 
         expect(Notice.instances.some((n) => n.message.includes("already up to date"))).toBe(true);
     });
@@ -2100,9 +2122,9 @@ describe("managed mode settings", () => {
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
         // First click: check for updates (sets pendingRelease)
-        await buttonOnClicks[1]();
+        await buttonOnClicks[2]();
         // Same handler clicked again: now triggers update via pendingRelease
-        await buttonOnClicks[1]();
+        await buttonOnClicks[2]();
 
         expect((plugin as any).updateServer).toHaveBeenCalled();
         expect(Notice.instances.some((n) => n.message.includes("updated to v0.2.0"))).toBe(true);
@@ -2120,7 +2142,7 @@ describe("managed mode settings", () => {
         const countBefore = buttonOnClicks.length;
 
         // Click check for updates — should NOT add a new handler
-        await buttonOnClicks[1]();
+        await buttonOnClicks[2]();
 
         expect(buttonOnClicks.length).toBe(countBefore);
     });
@@ -2137,8 +2159,8 @@ describe("managed mode settings", () => {
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
         // First click: check (sets pendingRelease); second click: update (fails)
-        await buttonOnClicks[1]();
-        await buttonOnClicks[1]();
+        await buttonOnClicks[2]();
+        await buttonOnClicks[2]();
 
         expect(Notice.instances.some((n) => n.message.includes("update failed"))).toBe(true);
     });
@@ -2153,8 +2175,8 @@ describe("managed mode settings", () => {
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
-        // buttonOnClicks[0] = Start, [1] = Check for updates
-        await buttonOnClicks[1]();
+        // buttonOnClicks[0] = Setup wizard, [1] = Start, [2] = Check for updates
+        await buttonOnClicks[2]();
 
         expect(Notice.instances.some((n) => n.message.includes("could not check"))).toBe(true);
     });
@@ -2192,9 +2214,9 @@ describe("managed mode settings", () => {
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
-        // In external mode: buttons are [Test (server), Reset to managed, Test (litellm), Refresh]
+        // In external mode: buttons are [Setup wizard, Test (server), Reset to managed, Refresh, Browse Catalog]
         // Find the "Reset to managed" click — it's the one that sets serverMode back
-        const resetButton = buttonOnClicks.find((_btn, i) => i === 1);
+        const resetButton = buttonOnClicks.find((_btn, i) => i === 2);
         expect(resetButton).toBeDefined();
         await resetButton!();
 
@@ -2226,8 +2248,8 @@ describe("managed mode settings", () => {
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
         const displaySpy = vi.spyOn(tab, "display").mockImplementation(() => {});
-        // First button in managed stopped mode is Start
-        await buttonOnClicks[0]();
+        // buttonOnClicks[0] = Setup wizard, [1] = Start
+        await buttonOnClicks[1]();
 
         expect(mockStart).toHaveBeenCalled();
         expect(displaySpy).toHaveBeenCalled();
@@ -2242,8 +2264,8 @@ describe("managed mode settings", () => {
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
         const displaySpy = vi.spyOn(tab, "display").mockImplementation(() => {});
-        // In ready state: buttons are Stop, Restart, Check for updates, Test (litellm), Refresh
-        await buttonOnClicks[0]();
+        // buttonOnClicks[0] = Setup wizard, [1] = Stop, [2] = Restart, [3] = Check for updates
+        await buttonOnClicks[1]();
 
         expect(mockStop).toHaveBeenCalled();
         expect(displaySpy).toHaveBeenCalled();
@@ -2258,8 +2280,8 @@ describe("managed mode settings", () => {
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
         const displaySpy = vi.spyOn(tab, "display").mockImplementation(() => {});
-        // In ready state: buttons are Stop, Restart, Check for updates, Test (litellm), Refresh
-        await buttonOnClicks[1]();
+        // buttonOnClicks[0] = Setup wizard, [1] = Stop, [2] = Restart
+        await buttonOnClicks[2]();
 
         expect(mockRestart).toHaveBeenCalled();
         expect(displaySpy).toHaveBeenCalled();

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -14,7 +14,8 @@ import type {
     Message,
     LilbeeSettings,
     GenerationOptions,
-    CatalogModel,
+    ModelVariant,
+    ModelFamily,
     CatalogResponse,
     InstalledModel,
     InstalledResponse,
@@ -303,19 +304,38 @@ describe("JSON_HEADERS constant", () => {
     });
 });
 
-describe("CatalogModel interface", () => {
+describe("ModelVariant interface", () => {
     it("accepts all fields", () => {
-        const m: CatalogModel = {
-            name: "Qwen3 8B",
+        const v: ModelVariant = {
+            name: "8B",
+            hf_repo: "qwen/qwen3-8B",
             size_gb: 5.0,
             min_ram_gb: 8,
             description: "Medium model",
+            task: "chat",
             installed: true,
             source: "native",
         };
-        expect(m.name).toBe("Qwen3 8B");
-        expect(m.installed).toBe(true);
-        expect(m.source).toBe("native");
+        expect(v.name).toBe("8B");
+        expect(v.hf_repo).toBe("qwen/qwen3-8B");
+        expect(v.installed).toBe(true);
+        expect(v.source).toBe("native");
+        expect(v.task).toBe("chat");
+    });
+});
+
+describe("ModelFamily interface", () => {
+    it("accepts all fields", () => {
+        const f: ModelFamily = {
+            family: "Qwen3",
+            task: "chat",
+            featured: true,
+            recommended: "8B",
+            variants: [],
+        };
+        expect(f.family).toBe("Qwen3");
+        expect(f.featured).toBe(true);
+        expect(f.recommended).toBe("8B");
     });
 });
 
@@ -325,7 +345,7 @@ describe("CatalogResponse interface", () => {
             total: 50,
             limit: 20,
             offset: 0,
-            models: [],
+            families: [],
         };
         expect(r.total).toBe(50);
     });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -43,7 +43,7 @@ describe("DEFAULT_SETTINGS", () => {
 
     it("is a plain object with exactly the expected keys", () => {
         const keys = Object.keys(DEFAULT_SETTINGS).sort();
-        expect(keys).toEqual(["lilbeeVersion", "num_ctx", "repeat_penalty", "seed", "serverMode", "serverPort", "serverUrl", "syncDebounceMs", "syncMode", "systemPrompt", "temperature", "topK", "top_k_sampling", "top_p"].sort());
+        expect(keys).toEqual(["lilbeeVersion", "num_ctx", "repeat_penalty", "seed", "serverMode", "serverPort", "serverUrl", "setupCompleted", "syncDebounceMs", "syncMode", "systemPrompt", "temperature", "topK", "top_k_sampling", "top_p"].sort());
     });
 });
 
@@ -243,6 +243,7 @@ describe("LilbeeSettings interface", () => {
             serverPort: null,
             lilbeeVersion: "",
             systemPrompt: "",
+            setupCompleted: false,
         };
         expect(s.syncMode).toBe("manual");
     });
@@ -263,6 +264,7 @@ describe("LilbeeSettings interface", () => {
             serverPort: null,
             lilbeeVersion: "",
             systemPrompt: "",
+            setupCompleted: true,
         };
         expect(s.syncMode).toBe("auto");
     });

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -318,6 +318,28 @@ describe("CatalogModal", () => {
         expect(plugin.api.setChatModel).toHaveBeenCalledWith("phi3");
     });
 
+    it("Pull passes non-native source to pullModel", async () => {
+        vi.useRealTimers();
+        const models = [makeCatalogModel({ name: "gpt-4o-mini", installed: false, source: "litellm" })];
+        const plugin = makePlugin({ activeModel: "llama3" });
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(models));
+        plugin.api.pullModel.mockReturnValue((async function* () {
+            yield { event: SSE_EVENT.PROGRESS, data: { current: 100, total: 100 } };
+        })());
+        const app = new App();
+        const modal = new CatalogModal(app as any, plugin as any);
+        modal.open();
+        await tick();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const pullBtn = el.findAll("lilbee-catalog-pull")[0];
+        pullBtn.trigger("click");
+        await tick();
+        await tick();
+
+        expect(plugin.api.pullModel).toHaveBeenCalledWith("gpt-4o-mini", "litellm");
+    });
+
     it("Pull cancelled by confirm modal does not pull", async () => {
         vi.useRealTimers();
         mockConfirmResult = false;

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -3,7 +3,7 @@ import { App, Notice } from "obsidian";
 import { MockElement } from "../__mocks__/obsidian";
 import { CatalogModal } from "../../src/views/catalog-modal";
 import { NOTICE, SSE_EVENT } from "../../src/types";
-import type { CatalogModel, CatalogResponse } from "../../src/types";
+import type { ModelFamily, ModelVariant, CatalogResponse } from "../../src/types";
 
 let mockConfirmResult = true;
 vi.mock("../../src/views/confirm-pull-modal", () => ({
@@ -14,36 +14,47 @@ vi.mock("../../src/views/confirm-pull-modal", () => ({
     })),
 }));
 
-function makeCatalogModel(overrides: Partial<CatalogModel> = {}): CatalogModel {
+function makeVariant(overrides: Partial<ModelVariant> = {}): ModelVariant {
     return {
-        name: "llama3",
-        size_gb: 4.7,
+        name: "4B",
+        hf_repo: "test/model-4B",
+        size_gb: 2.5,
         min_ram_gb: 8,
-        description: "Meta Llama 3",
+        description: "Balanced",
+        task: "chat",
         installed: false,
         source: "native",
         ...overrides,
     };
 }
 
-function makeCatalogResponse(models: CatalogModel[] = [], total?: number): CatalogResponse {
+function makeFamily(overrides: Partial<ModelFamily> = {}): ModelFamily {
     return {
-        total: total ?? models.length,
-        limit: 20,
-        offset: 0,
-        models,
+        family: "TestModel",
+        task: "chat",
+        featured: true,
+        recommended: "4B",
+        variants: [
+            makeVariant({ name: "0.6B", hf_repo: "test/model-0.6B", size_gb: 0.5, min_ram_gb: 2, description: "Tiny" }),
+            makeVariant({ name: "4B", hf_repo: "test/model-4B", size_gb: 2.5, min_ram_gb: 8, description: "Balanced" }),
+        ],
+        ...overrides,
     };
+}
+
+function makeCatalogResponse(families: ModelFamily[] = [makeFamily()], total?: number): CatalogResponse {
+    return { total: total ?? families.length, limit: 20, offset: 0, families };
 }
 
 function makePlugin(overrides: Record<string, unknown> = {}) {
     return {
         api: {
-            catalog: vi.fn().mockResolvedValue(makeCatalogResponse()),
+            catalog: vi.fn().mockResolvedValue(makeCatalogResponse([])),
             pullModel: vi.fn(),
-            setChatModel: vi.fn().mockResolvedValue({ model: "llama3" }),
+            setChatModel: vi.fn().mockResolvedValue({ model: "test/model-4B" }),
             setVisionModel: vi.fn().mockResolvedValue({ model: "" }),
         },
-        activeModel: "llama3",
+        activeModel: "test/model-4B",
         activeVisionModel: "",
         fetchActiveModel: vi.fn(),
         ...overrides,
@@ -85,7 +96,7 @@ describe("CatalogModal", () => {
         const plugin = makePlugin();
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse());
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse([]));
         modal.open();
         await vi.runAllTimersAsync();
 
@@ -97,7 +108,7 @@ describe("CatalogModal", () => {
 
     it("fetches catalog on open", async () => {
         const plugin = makePlugin();
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse([makeCatalogModel()]));
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse([makeFamily()]));
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
         modal.open();
@@ -110,27 +121,82 @@ describe("CatalogModal", () => {
         }));
     });
 
-    it("renders model rows from catalog response", async () => {
-        const models = [
-            makeCatalogModel({ name: "llama3", installed: true }),
-            makeCatalogModel({ name: "phi3", installed: false }),
-        ];
+    it("renders family headers with name and task badge", async () => {
+        const families = [makeFamily({ family: "Qwen3", task: "chat" })];
         const plugin = makePlugin();
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(models));
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
         modal.open();
         await vi.runAllTimersAsync();
 
         const el = modal.contentEl as unknown as MockElement;
-        const rows = el.findAll("lilbee-catalog-row");
+        const headers = el.findAll("lilbee-catalog-family-header");
+        expect(headers.length).toBe(1);
+        const texts = collectTexts(headers[0]);
+        expect(texts.some(t => t.includes("Qwen3"))).toBe(true);
+        const taskBadge = el.findAll("lilbee-catalog-family-task");
+        expect(taskBadge.length).toBe(1);
+        expect(taskBadge[0].textContent).toBe("chat");
+    });
+
+    it("renders variant rows within family", async () => {
+        const families = [makeFamily()];
+        const plugin = makePlugin();
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
+        const app = new App();
+        const modal = new CatalogModal(app as any, plugin as any);
+        modal.open();
+        await vi.runAllTimersAsync();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const rows = el.findAll("lilbee-catalog-variant-row");
         expect(rows.length).toBe(2);
     });
 
-    it("shows Active for active model", async () => {
-        const models = [makeCatalogModel({ name: "llama3", installed: true })];
-        const plugin = makePlugin({ activeModel: "llama3" });
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(models));
+    it("recommended variant has star marker", async () => {
+        const families = [makeFamily({ recommended: "4B" })];
+        const plugin = makePlugin({ activeModel: "other" });
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
+        const app = new App();
+        const modal = new CatalogModal(app as any, plugin as any);
+        modal.open();
+        await vi.runAllTimersAsync();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const recommended = el.findAll("lilbee-catalog-recommended");
+        expect(recommended.length).toBe(1);
+        expect(recommended[0].textContent).toContain("\u2605");
+    });
+
+    it("collapse/expand toggle works on family header click", async () => {
+        const families = [makeFamily()];
+        const plugin = makePlugin();
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
+        const app = new App();
+        const modal = new CatalogModal(app as any, plugin as any);
+        modal.open();
+        await vi.runAllTimersAsync();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const header = el.findAll("lilbee-catalog-family-header")[0];
+        const family = el.findAll("lilbee-catalog-family")[0];
+
+        // Click to collapse
+        header.trigger("click");
+        expect(family.classList.contains("is-collapsed")).toBe(true);
+
+        // Click to expand
+        header.trigger("click");
+        expect(family.classList.contains("is-collapsed")).toBe(false);
+    });
+
+    it("shows Active for active model variant", async () => {
+        const families = [makeFamily({
+            variants: [makeVariant({ name: "4B", hf_repo: "test/model-4B", installed: true })],
+        })];
+        const plugin = makePlugin({ activeModel: "test/model-4B" });
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
         modal.open();
@@ -142,10 +208,12 @@ describe("CatalogModal", () => {
         expect(active[0].textContent).toBe("Active");
     });
 
-    it("shows Installed for installed non-active model", async () => {
-        const models = [makeCatalogModel({ name: "phi3", installed: true })];
-        const plugin = makePlugin({ activeModel: "llama3" });
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(models));
+    it("shows Installed for installed non-active variant", async () => {
+        const families = [makeFamily({
+            variants: [makeVariant({ name: "4B", hf_repo: "test/model-4B", installed: true })],
+        })];
+        const plugin = makePlugin({ activeModel: "other-model" });
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
         modal.open();
@@ -156,10 +224,12 @@ describe("CatalogModal", () => {
         expect(installed.length).toBe(1);
     });
 
-    it("shows Pull button for uninstalled model", async () => {
-        const models = [makeCatalogModel({ name: "phi3", installed: false })];
-        const plugin = makePlugin({ activeModel: "llama3" });
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(models));
+    it("shows Pull button for uninstalled variant", async () => {
+        const families = [makeFamily({
+            variants: [makeVariant({ name: "4B", hf_repo: "test/model-4B", installed: false })],
+        })];
+        const plugin = makePlugin({ activeModel: "other-model" });
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
         modal.open();
@@ -172,9 +242,9 @@ describe("CatalogModal", () => {
     });
 
     it("shows Load more button when total > loaded", async () => {
-        const models = Array.from({ length: 20 }, (_, i) => makeCatalogModel({ name: `model${i}` }));
+        const families = Array.from({ length: 20 }, (_, i) => makeFamily({ family: `family${i}` }));
         const plugin = makePlugin();
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(models, 40));
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families, 40));
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
         modal.open();
@@ -187,9 +257,9 @@ describe("CatalogModal", () => {
     });
 
     it("hides Load more button when all loaded", async () => {
-        const models = [makeCatalogModel()];
+        const families = [makeFamily()];
         const plugin = makePlugin();
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(models, 1));
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families, 1));
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
         modal.open();
@@ -201,8 +271,8 @@ describe("CatalogModal", () => {
     });
 
     it("Load more fetches next page", async () => {
-        const page1 = Array.from({ length: 20 }, (_, i) => makeCatalogModel({ name: `m${i}` }));
-        const page2 = [makeCatalogModel({ name: "m20" })];
+        const page1 = Array.from({ length: 20 }, (_, i) => makeFamily({ family: `f${i}` }));
+        const page2 = [makeFamily({ family: "f20" })];
         const plugin = makePlugin();
         plugin.api.catalog
             .mockResolvedValueOnce(makeCatalogResponse(page1, 21))
@@ -223,7 +293,7 @@ describe("CatalogModal", () => {
 
     it("search input triggers debounced fetch", async () => {
         const plugin = makePlugin();
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse());
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse([]));
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
         modal.open();
@@ -234,7 +304,6 @@ describe("CatalogModal", () => {
         (searchInput as any).value = "test";
         searchInput.trigger("input");
 
-        // Should not have fetched yet (debounce)
         const callsBefore = plugin.api.catalog.mock.calls.length;
 
         await vi.advanceTimersByTimeAsync(300);
@@ -246,7 +315,7 @@ describe("CatalogModal", () => {
 
     it("task filter triggers fetch", async () => {
         const plugin = makePlugin();
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse());
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse([]));
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
         modal.open();
@@ -263,7 +332,7 @@ describe("CatalogModal", () => {
 
     it("size filter triggers fetch", async () => {
         const plugin = makePlugin();
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse());
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse([]));
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
         modal.open();
@@ -280,7 +349,7 @@ describe("CatalogModal", () => {
 
     it("sort filter triggers fetch", async () => {
         const plugin = makePlugin();
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse());
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse([]));
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
         modal.open();
@@ -297,9 +366,11 @@ describe("CatalogModal", () => {
 
     it("Pull button opens confirm modal and pulls on confirm", async () => {
         vi.useRealTimers();
-        const models = [makeCatalogModel({ name: "phi3", installed: false })];
-        const plugin = makePlugin({ activeModel: "llama3" });
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(models));
+        const families = [makeFamily({
+            variants: [makeVariant({ name: "4B", hf_repo: "test/model-4B", installed: false })],
+        })];
+        const plugin = makePlugin({ activeModel: "other-model" });
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
         plugin.api.pullModel.mockReturnValue((async function* () {
             yield { event: SSE_EVENT.PROGRESS, data: { current: 50, total: 100 } };
         })());
@@ -314,15 +385,17 @@ describe("CatalogModal", () => {
         await tick();
         await tick();
 
-        expect(plugin.api.pullModel).toHaveBeenCalledWith("phi3", "native");
-        expect(plugin.api.setChatModel).toHaveBeenCalledWith("phi3");
+        expect(plugin.api.pullModel).toHaveBeenCalledWith("test/model-4B", "native");
+        expect(plugin.api.setChatModel).toHaveBeenCalledWith("test/model-4B");
     });
 
     it("Pull passes non-native source to pullModel", async () => {
         vi.useRealTimers();
-        const models = [makeCatalogModel({ name: "gpt-4o-mini", installed: false, source: "litellm" })];
-        const plugin = makePlugin({ activeModel: "llama3" });
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(models));
+        const families = [makeFamily({
+            variants: [makeVariant({ name: "gpt-4o", hf_repo: "openai/gpt-4o", installed: false, source: "litellm" })],
+        })];
+        const plugin = makePlugin({ activeModel: "other-model" });
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
         plugin.api.pullModel.mockReturnValue((async function* () {
             yield { event: SSE_EVENT.PROGRESS, data: { current: 100, total: 100 } };
         })());
@@ -337,15 +410,45 @@ describe("CatalogModal", () => {
         await tick();
         await tick();
 
-        expect(plugin.api.pullModel).toHaveBeenCalledWith("gpt-4o-mini", "litellm");
+        expect(plugin.api.pullModel).toHaveBeenCalledWith("openai/gpt-4o", "litellm");
+    });
+
+    it("Pull on vision variant calls setVisionModel", async () => {
+        vi.useRealTimers();
+        const families = [makeFamily({
+            task: "vision",
+            variants: [makeVariant({ name: "llava", hf_repo: "llava/llava-v1.6", installed: false, task: "vision" })],
+        })];
+        const plugin = makePlugin({ activeModel: "other-model", activeVisionModel: "" });
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
+        plugin.api.pullModel.mockReturnValue((async function* () {
+            yield { event: SSE_EVENT.PROGRESS, data: { current: 100, total: 100 } };
+        })());
+        plugin.api.setVisionModel.mockResolvedValue({ model: "llava/llava-v1.6" });
+        const app = new App();
+        const modal = new CatalogModal(app as any, plugin as any);
+        modal.open();
+        await tick();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const pullBtn = el.findAll("lilbee-catalog-pull")[0];
+        pullBtn.trigger("click");
+        await tick();
+        await tick();
+
+        expect(plugin.api.pullModel).toHaveBeenCalledWith("llava/llava-v1.6", "native");
+        expect(plugin.api.setVisionModel).toHaveBeenCalledWith("llava/llava-v1.6");
+        expect(plugin.api.setChatModel).not.toHaveBeenCalled();
     });
 
     it("Pull cancelled by confirm modal does not pull", async () => {
         vi.useRealTimers();
         mockConfirmResult = false;
-        const models = [makeCatalogModel({ name: "phi3", installed: false })];
-        const plugin = makePlugin({ activeModel: "llama3" });
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(models));
+        const families = [makeFamily({
+            variants: [makeVariant({ name: "4B", hf_repo: "test/model-4B", installed: false })],
+        })];
+        const plugin = makePlugin({ activeModel: "other-model" });
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
         modal.open();
@@ -361,9 +464,11 @@ describe("CatalogModal", () => {
 
     it("handles pull failure with notice", async () => {
         vi.useRealTimers();
-        const models = [makeCatalogModel({ name: "phi3", installed: false })];
-        const plugin = makePlugin({ activeModel: "llama3" });
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(models));
+        const families = [makeFamily({
+            variants: [makeVariant({ name: "4B", hf_repo: "test/model-4B", installed: false })],
+        })];
+        const plugin = makePlugin({ activeModel: "other-model" });
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
         plugin.api.pullModel.mockReturnValue((async function* () {
             throw new Error("network error");
         })());
@@ -383,9 +488,11 @@ describe("CatalogModal", () => {
 
     it("handles AbortError during pull", async () => {
         vi.useRealTimers();
-        const models = [makeCatalogModel({ name: "phi3", installed: false })];
-        const plugin = makePlugin({ activeModel: "llama3" });
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(models));
+        const families = [makeFamily({
+            variants: [makeVariant({ name: "4B", hf_repo: "test/model-4B", installed: false })],
+        })];
+        const plugin = makePlugin({ activeModel: "other-model" });
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
         const abortErr = new Error("aborted");
         abortErr.name = "AbortError";
         plugin.api.pullModel.mockReturnValue((async function* () {
@@ -421,16 +528,14 @@ describe("CatalogModal", () => {
         const plugin = makePlugin();
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
-        // Should not throw
         modal.onClose();
     });
 
     it("search input debounce: first input with null timer, second clears existing timer", async () => {
         const plugin = makePlugin();
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse());
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse([]));
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
-        // Ensure debounceTimer is null before open
         expect((modal as any).debounceTimer).toBeNull();
         modal.open();
         await vi.runAllTimersAsync();
@@ -438,11 +543,9 @@ describe("CatalogModal", () => {
         const el = modal.contentEl as unknown as MockElement;
         const searchInput = el.find("lilbee-catalog-search")!;
 
-        // First input: debounceTimer is null (false branch at line 79)
         (searchInput as any).value = "a";
         searchInput.trigger("input");
 
-        // Second input before debounce fires: debounceTimer is set (true branch at line 79)
         (searchInput as any).value = "ab";
         searchInput.trigger("input");
 
@@ -452,18 +555,17 @@ describe("CatalogModal", () => {
         expect(plugin.api.catalog.mock.calls.length).toBeGreaterThan(1);
     });
 
-    it("onClose with no debounce timer does not throw (false branch at line 99)", () => {
+    it("onClose with no debounce timer does not throw", () => {
         const plugin = makePlugin();
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
         expect((modal as any).debounceTimer).toBeNull();
-        // onClose before onOpen — debounceTimer is null
         modal.onClose();
     });
 
     it("onClose with active debounce timer clears it", async () => {
         const plugin = makePlugin();
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse());
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse([]));
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
         modal.open();
@@ -473,61 +575,32 @@ describe("CatalogModal", () => {
         const searchInput = el.find("lilbee-catalog-search")!;
         (searchInput as any).value = "test";
         searchInput.trigger("input");
-        // debounceTimer is now set
         expect((modal as any).debounceTimer).not.toBeNull();
         modal.onClose();
     });
 
-    it("updateLoadMore returns early when loadMoreBtn is null", async () => {
+    it("updateLoadMore returns early when loadMoreBtn is null", () => {
         const plugin = makePlugin();
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse([makeCatalogModel()]));
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
-        // Set loadMoreBtn to null before calling the private method
         (modal as any).loadMoreBtn = null;
         (modal as any).updateLoadMore();
-        // Should not throw
     });
 
-    it("renderRow returns early when resultsEl is null", () => {
+    it("renderFamily returns early when resultsEl is null", () => {
         const plugin = makePlugin();
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
         (modal as any).resultsEl = null;
-        (modal as any).renderRow(makeCatalogModel());
-        // Should not throw
+        (modal as any).renderFamily(makeFamily());
     });
 
-    it("Pull with vision filter sets vision model instead of chat model", async () => {
-        vi.useRealTimers();
-        const models = [makeCatalogModel({ name: "llava", installed: false })];
-        const plugin = makePlugin({ activeModel: "llama3", activeVisionModel: "" });
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(models));
-        plugin.api.pullModel.mockReturnValue((async function* () {
-            yield { event: SSE_EVENT.PROGRESS, data: { current: 100, total: 100 } };
-        })());
-        plugin.api.setVisionModel.mockResolvedValue({ model: "llava" });
-        const app = new App();
-        const modal = new CatalogModal(app as any, plugin as any);
-        (modal as any).filterTask = "vision";
-        modal.open();
-        await tick();
-
-        const el = modal.contentEl as unknown as MockElement;
-        const pullBtn = el.findAll("lilbee-catalog-pull")[0];
-        pullBtn.trigger("click");
-        await tick();
-        await tick();
-
-        expect(plugin.api.pullModel).toHaveBeenCalledWith("llava", "native");
-        expect(plugin.api.setVisionModel).toHaveBeenCalledWith("llava");
-        expect(plugin.api.setChatModel).not.toHaveBeenCalled();
-    });
-
-    it("shows Active for active vision model", async () => {
-        const models = [makeCatalogModel({ name: "llava", installed: true })];
-        const plugin = makePlugin({ activeModel: "llama3", activeVisionModel: "llava" });
-        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(models));
+    it("shows Active for active vision model variant", async () => {
+        const families = [makeFamily({
+            variants: [makeVariant({ name: "llava", hf_repo: "llava/v1.6", installed: true })],
+        })];
+        const plugin = makePlugin({ activeModel: "other-model", activeVisionModel: "llava/v1.6" });
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
         const app = new App();
         const modal = new CatalogModal(app as any, plugin as any);
         modal.open();
@@ -536,5 +609,39 @@ describe("CatalogModal", () => {
         const el = modal.contentEl as unknown as MockElement;
         const active = el.findAll("lilbee-catalog-active");
         expect(active.length).toBe(1);
+    });
+
+    it("renders multiple families from response", async () => {
+        const families = [
+            makeFamily({ family: "Qwen3" }),
+            makeFamily({ family: "Llama3" }),
+        ];
+        const plugin = makePlugin();
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
+        const app = new App();
+        const modal = new CatalogModal(app as any, plugin as any);
+        modal.open();
+        await vi.runAllTimersAsync();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const familyEls = el.findAll("lilbee-catalog-family");
+        expect(familyEls.length).toBe(2);
+    });
+
+    it("variant size and description are rendered", async () => {
+        const families = [makeFamily({
+            variants: [makeVariant({ name: "4B", hf_repo: "test/4B", size_gb: 2.5, description: "Balanced model" })],
+        })];
+        const plugin = makePlugin({ activeModel: "other" });
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
+        const app = new App();
+        const modal = new CatalogModal(app as any, plugin as any);
+        modal.open();
+        await vi.runAllTimersAsync();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const texts = collectTexts(el);
+        expect(texts.some(t => t.includes("2.5 GB"))).toBe(true);
+        expect(texts.some(t => t.includes("Balanced model"))).toBe(true);
     });
 });

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -53,6 +53,7 @@ function makePlugin(overrides: Record<string, unknown> = {}) {
             pullModel: vi.fn(),
             setChatModel: vi.fn().mockResolvedValue({ model: "test/model-4B" }),
             setVisionModel: vi.fn().mockResolvedValue({ model: "" }),
+            setEmbeddingModel: vi.fn().mockResolvedValue({ model: "" }),
         },
         activeModel: "test/model-4B",
         activeVisionModel: "",
@@ -626,6 +627,102 @@ describe("CatalogModal", () => {
         const el = modal.contentEl as unknown as MockElement;
         const familyEls = el.findAll("lilbee-catalog-family");
         expect(familyEls.length).toBe(2);
+    });
+
+    it("variant display_name is used when present", async () => {
+        const families = [makeFamily({
+            variants: [makeVariant({ name: "4B", display_name: "Qwen3 4B Instruct", hf_repo: "test/4B" })],
+        })];
+        const plugin = makePlugin({ activeModel: "other" });
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
+        const app = new App();
+        const modal = new CatalogModal(app as any, plugin as any);
+        modal.open();
+        await vi.runAllTimersAsync();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const texts = collectTexts(el);
+        expect(texts.some(t => t.includes("Qwen3 4B Instruct"))).toBe(true);
+        expect(texts.some(t => t === "4B")).toBe(false);
+    });
+
+    it("variant falls back to name when display_name is absent", async () => {
+        const families = [makeFamily({
+            variants: [makeVariant({ name: "4B", hf_repo: "test/4B" })],
+        })];
+        const plugin = makePlugin({ activeModel: "other" });
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
+        const app = new App();
+        const modal = new CatalogModal(app as any, plugin as any);
+        modal.open();
+        await vi.runAllTimersAsync();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const names = el.findAll("lilbee-catalog-variant-name");
+        expect(names.length).toBe(1);
+        expect(names[0].textContent).toContain("4B");
+    });
+
+    it("quality_tier badge is shown when present", async () => {
+        const families = [makeFamily({
+            variants: [makeVariant({ name: "4B", hf_repo: "test/4B", quality_tier: "recommended" })],
+        })];
+        const plugin = makePlugin({ activeModel: "other" });
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
+        const app = new App();
+        const modal = new CatalogModal(app as any, plugin as any);
+        modal.open();
+        await vi.runAllTimersAsync();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const tiers = el.findAll("lilbee-catalog-variant-tier");
+        expect(tiers.length).toBe(1);
+        expect(tiers[0].textContent).toBe("recommended");
+    });
+
+    it("quality_tier badge is not rendered when absent", async () => {
+        const families = [makeFamily({
+            variants: [makeVariant({ name: "4B", hf_repo: "test/4B" })],
+        })];
+        const plugin = makePlugin({ activeModel: "other" });
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
+        const app = new App();
+        const modal = new CatalogModal(app as any, plugin as any);
+        modal.open();
+        await vi.runAllTimersAsync();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const tiers = el.findAll("lilbee-catalog-variant-tier");
+        expect(tiers.length).toBe(0);
+    });
+
+    it("Pull on embedding variant calls setEmbeddingModel, not setChatModel", async () => {
+        vi.useRealTimers();
+        const families = [makeFamily({
+            task: "embedding",
+            variants: [makeVariant({ name: "nomic", hf_repo: "nomic-ai/nomic-embed", installed: false, task: "embedding" })],
+        })];
+        const plugin = makePlugin({ activeModel: "other-model" });
+        plugin.api.catalog.mockResolvedValue(makeCatalogResponse(families));
+        plugin.api.pullModel.mockReturnValue((async function* () {
+            yield { event: SSE_EVENT.PROGRESS, data: { current: 100, total: 100 } };
+        })());
+        plugin.api.setEmbeddingModel.mockResolvedValue({ model: "nomic-ai/nomic-embed" });
+        const app = new App();
+        const modal = new CatalogModal(app as any, plugin as any);
+        modal.open();
+        await tick();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const pullBtn = el.findAll("lilbee-catalog-pull")[0];
+        pullBtn.trigger("click");
+        await tick();
+        await tick();
+
+        expect(plugin.api.pullModel).toHaveBeenCalledWith("nomic-ai/nomic-embed", "native");
+        expect(plugin.api.setEmbeddingModel).toHaveBeenCalledWith("nomic-ai/nomic-embed");
+        expect(plugin.api.setChatModel).not.toHaveBeenCalled();
+        expect(plugin.api.setVisionModel).not.toHaveBeenCalled();
     });
 
     it("variant size and description are rendered", async () => {

--- a/tests/views/crawl-modal.test.ts
+++ b/tests/views/crawl-modal.test.ts
@@ -294,6 +294,43 @@ describe("CrawlModal", () => {
         expect(Notice.instances.some(n => n.message.includes("unknown error"))).toBe(true);
     });
 
+    it("aborts crawl controller when modal is closed during crawl", async () => {
+        const app = new App();
+        const plugin = makePlugin();
+        let resolveStream: (() => void) | null = null;
+        const streamPromise = new Promise<void>((r) => { resolveStream = r; });
+        plugin.api.crawl.mockReturnValue((async function* () {
+            yield { event: SSE_EVENT.CRAWL_START, data: {} };
+            // Block until we resolve externally — simulates an in-progress crawl
+            await streamPromise;
+            yield { event: SSE_EVENT.CRAWL_DONE, data: { pages_crawled: 1 } };
+        })());
+        const modal = new CrawlModal(app as any, plugin as any);
+        modal.onOpen();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const urlInput = el.find("lilbee-crawl-url")!;
+        (urlInput as any).value = "https://example.com";
+        const crawlBtn = findButtons(el).find(b => b.textContent === "Crawl")!;
+        crawlBtn.trigger("click");
+        await tick();
+
+        // crawlController is now set — grab the signal before closing
+        const signal = plugin.api.crawl.mock.calls[0][3] as AbortSignal;
+        expect(signal.aborted).toBe(false);
+
+        // Close the modal while the crawl is in-progress
+        modal.onClose();
+        expect(signal.aborted).toBe(true);
+
+        // Unblock stream so the async generator can finish
+        resolveStream!();
+        await tick();
+
+        const result = await modal.result;
+        expect(result).toBe(false);
+    });
+
     it("CRAWL_PAGE with missing url uses empty string fallback", async () => {
         const app = new App();
         const plugin = makePlugin();

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -1,0 +1,1142 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { App, Notice } from "obsidian";
+import { MockElement } from "../__mocks__/obsidian";
+import { SetupWizard, getSystemMemoryGB, recommendedIndex } from "../../src/views/setup-wizard";
+import { SSE_EVENT } from "../../src/types";
+import type { CatalogModel, CatalogResponse } from "../../src/types";
+
+vi.mock("../../src/views/catalog-modal", () => ({
+    CatalogModal: vi.fn().mockImplementation(() => ({
+        open: vi.fn(),
+        close: vi.fn(),
+    })),
+}));
+
+function makeCatalogModel(overrides: Partial<CatalogModel> = {}): CatalogModel {
+    return {
+        name: "qwen3:0.6b",
+        size_gb: 0.5,
+        min_ram_gb: 4,
+        description: "Runs on anything",
+        installed: false,
+        source: "native",
+        ...overrides,
+    };
+}
+
+function makeCatalogResponse(models: CatalogModel[] = []): CatalogResponse {
+    return {
+        total: models.length,
+        limit: 4,
+        offset: 0,
+        models,
+    };
+}
+
+function makePlugin(overrides: Record<string, unknown> = {}) {
+    return {
+        app: new App(),
+        settings: {
+            serverUrl: "http://127.0.0.1:7433",
+            serverMode: "managed",
+            setupCompleted: false,
+            syncMode: "manual",
+            ...((overrides.settings as Record<string, unknown>) || {}),
+        },
+        api: {
+            catalog: vi.fn().mockResolvedValue(makeCatalogResponse()),
+            pullModel: vi.fn(),
+            setChatModel: vi.fn().mockResolvedValue({ model: "" }),
+            setVisionModel: vi.fn().mockResolvedValue({ model: "" }),
+            health: vi.fn().mockResolvedValue({ status: "ok", version: "1.0.0" }),
+            syncStream: vi.fn(),
+            listModels: vi.fn().mockResolvedValue({
+                chat: { active: "", catalog: [], installed: [] },
+                vision: { active: "", catalog: [], installed: [] },
+            }),
+        },
+        activeModel: "",
+        activeVisionModel: "",
+        fetchActiveModel: vi.fn(),
+        serverManager: overrides.serverManager ?? null,
+        startManagedServer: vi.fn().mockResolvedValue(undefined),
+        saveSettings: vi.fn().mockResolvedValue(undefined),
+        activateChatView: vi.fn().mockResolvedValue(undefined),
+        ...overrides,
+    };
+}
+
+function collectTexts(el: MockElement): string[] {
+    const texts: string[] = [];
+    if (el.textContent) texts.push(el.textContent);
+    for (const child of el.children) {
+        texts.push(...collectTexts(child));
+    }
+    return texts;
+}
+
+function findButtons(el: MockElement): MockElement[] {
+    const buttons: MockElement[] = [];
+    if (el.tagName === "BUTTON") buttons.push(el);
+    for (const child of el.children) {
+        buttons.push(...findButtons(child));
+    }
+    return buttons;
+}
+
+function findByText(el: MockElement, text: string): MockElement | null {
+    if (el.textContent === text) return el;
+    for (const child of el.children) {
+        const found = findByText(child, text);
+        if (found) return found;
+    }
+    return null;
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+describe("SetupWizard", () => {
+    beforeEach(() => {
+        Notice.clear();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe("Step 0: Welcome", () => {
+        it("renders welcome screen on open", () => {
+            const plugin = makePlugin();
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("Welcome to lilbee"))).toBe(true);
+            expect(texts.some(t => t.includes("knowledge base"))).toBe(true);
+            expect(texts.some(t => t.includes("never leave your machine"))).toBe(true);
+        });
+
+        it("has Skip setup and Get started buttons", () => {
+            const plugin = makePlugin();
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const buttons = findButtons(el);
+            expect(buttons.some(b => b.textContent === "Skip setup")).toBe(true);
+            expect(buttons.some(b => b.textContent === "Get started")).toBe(true);
+        });
+
+        it("Skip setup closes the wizard", () => {
+            const plugin = makePlugin();
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            const closeSpy = vi.spyOn(wizard, "close");
+            wizard.open();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const skipBtn = findButtons(el).find(b => b.textContent === "Skip setup")!;
+            skipBtn.trigger("click");
+            expect(closeSpy).toHaveBeenCalled();
+        });
+
+        it("Get started advances to model picker when server is ready (external mode)", () => {
+            const plugin = makePlugin({
+                settings: { serverMode: "external" },
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const startBtn = findButtons(el).find(b => b.textContent === "Get started")!;
+            startBtn.trigger("click");
+
+            // Should be on step 2 (model picker) since server is "ready" in external mode
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Pick a chat model"))).toBe(true);
+        });
+
+        it("Get started advances to server mode when server is not ready", () => {
+            const plugin = makePlugin({
+                settings: { serverMode: "managed" },
+                serverManager: null,
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const startBtn = findButtons(el).find(b => b.textContent === "Get started")!;
+            startBtn.trigger("click");
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("How do you want to run lilbee?"))).toBe(true);
+        });
+
+        it("Get started skips server step when managed server is ready", () => {
+            const plugin = makePlugin({
+                settings: { serverMode: "managed" },
+                serverManager: { state: "ready" },
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const startBtn = findButtons(el).find(b => b.textContent === "Get started")!;
+            startBtn.trigger("click");
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Pick a chat model"))).toBe(true);
+        });
+    });
+
+    describe("Step 1: Server Mode", () => {
+        it("renders managed and external options", () => {
+            const plugin = makePlugin({ serverManager: null });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("Managed (recommended)"))).toBe(true);
+            expect(texts.some(t => t.includes("External"))).toBe(true);
+        });
+
+        it("clicking managed option selects it", () => {
+            const plugin = makePlugin({ serverManager: null });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const options = el.findAll("lilbee-wizard-model-option");
+            // Click managed (first option)
+            options[0].trigger("click");
+            expect(options[0].classList.contains("selected")).toBe(true);
+            expect(options[1].classList.contains("selected")).toBe(false);
+        });
+
+        it("clicking managed option hides URL input and clears status", () => {
+            const plugin = makePlugin({ serverManager: null, settings: { serverMode: "managed" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const options = el.findAll("lilbee-wizard-model-option");
+            // First click external to show URL input
+            options[1].trigger("click");
+            // Then click managed to hide it
+            options[0].trigger("click");
+            expect(options[0].classList.contains("selected")).toBe(true);
+            const status = el.find("lilbee-wizard-status");
+            expect(status?.textContent).toBe("");
+        });
+
+        it("pre-selects external when settings have external mode", () => {
+            const plugin = makePlugin({ serverManager: null, settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 1;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const options = el.findAll("lilbee-wizard-model-option");
+            // External option (index 1) should be selected
+            expect(options[1].classList.contains("selected")).toBe(true);
+            expect(options[0].classList.contains("selected")).toBe(false);
+        });
+
+        it("clicking external option selects it and shows URL input", () => {
+            const plugin = makePlugin({ serverManager: null });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const options = el.findAll("lilbee-wizard-model-option");
+            // Click external (second option)
+            options[1].trigger("click");
+            expect(options[1].classList.contains("selected")).toBe(true);
+            expect(options[0].classList.contains("selected")).toBe(false);
+        });
+
+        it("managed mode: Next starts server and advances", async () => {
+            const plugin = makePlugin({ serverManager: null });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const nextBtn = findButtons(el).find(b => b.textContent === "Next")!;
+            nextBtn.trigger("click");
+            await tick();
+            await tick();
+
+            expect(plugin.saveSettings).toHaveBeenCalled();
+            expect(plugin.startManagedServer).toHaveBeenCalled();
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Pick a chat model"))).toBe(true);
+        });
+
+        it("managed mode: handles server start failure", async () => {
+            const plugin = makePlugin({ serverManager: null });
+            plugin.startManagedServer = vi.fn().mockRejectedValue(new Error("fail"));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const nextBtn = findButtons(el).find(b => b.textContent === "Next")!;
+            nextBtn.trigger("click");
+            await tick();
+            await tick();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Failed to start server"))).toBe(true);
+        });
+
+        it("external mode: Next checks health and advances", async () => {
+            const plugin = makePlugin({
+                serverManager: null,
+                settings: { serverMode: "managed" },
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next(); // goes to step 1 since no server manager
+
+            const el = wizard.contentEl as unknown as MockElement;
+            // Click external option (second one)
+            const options = el.findAll("lilbee-wizard-model-option");
+            options[1].trigger("click");
+
+            const nextBtn = findButtons(el).find(b => b.textContent === "Next")!;
+            nextBtn.trigger("click");
+            await tick();
+            await tick();
+
+            expect(plugin.api.health).toHaveBeenCalled();
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Pick a chat model"))).toBe(true);
+        });
+
+        it("external mode: handles health check failure", async () => {
+            const plugin = makePlugin({
+                serverManager: null,
+                settings: { serverMode: "managed" },
+            });
+            plugin.api.health = vi.fn().mockRejectedValue(new Error("connection refused"));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const options = el.findAll("lilbee-wizard-model-option");
+            options[1].trigger("click");
+
+            const nextBtn = findButtons(el).find(b => b.textContent === "Next")!;
+            nextBtn.trigger("click");
+            await tick();
+            await tick();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Could not connect"))).toBe(true);
+        });
+
+        it("Back returns to welcome", () => {
+            const plugin = makePlugin({ serverManager: null });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const backBtn = findButtons(el).find(b => b.textContent === "Back")!;
+            backBtn.trigger("click");
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Welcome to lilbee"))).toBe(true);
+        });
+
+        it("managed mode with existing serverManager advances to model picker", async () => {
+            const plugin = makePlugin({
+                serverManager: { state: "ready" },
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            // Force to step 1
+            (wizard as any).step = 1;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const nextBtn = findButtons(el).find(b => b.textContent === "Next")!;
+            nextBtn.trigger("click");
+            await tick();
+            await tick();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Pick a chat model"))).toBe(true);
+        });
+
+        it("Skip setup button closes the wizard", () => {
+            const plugin = makePlugin({ serverManager: null });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            const closeSpy = vi.spyOn(wizard, "close");
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const skipBtn = findButtons(el).find(b => b.textContent === "Skip setup")!;
+            skipBtn.trigger("click");
+            expect(closeSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe("Step 2: Model Picker", () => {
+        it("renders model picker with featured models", async () => {
+            const models = [
+                makeCatalogModel({ name: "qwen3:0.6b", size_gb: 0.5, min_ram_gb: 4 }),
+                makeCatalogModel({ name: "qwen3:4b", size_gb: 2.5, min_ram_gb: 8 }),
+            ];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("Pick a chat model"))).toBe(true);
+            expect(texts.some(t => t.includes("qwen3:0.6b"))).toBe(true);
+            expect(texts.some(t => t.includes("qwen3:4b"))).toBe(true);
+        });
+
+        it("pre-selects recommended model based on first in list when no memory detection", async () => {
+            const models = [
+                makeCatalogModel({ name: "qwen3:0.6b", size_gb: 0.5, min_ram_gb: 4 }),
+                makeCatalogModel({ name: "qwen3:4b", size_gb: 2.5, min_ram_gb: 8 }),
+            ];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const options = el.findAll("lilbee-wizard-model-option");
+            // At least one should be selected
+            expect(options.some(o => o.classList.contains("selected"))).toBe(true);
+        });
+
+        it("clicking a model option selects it", async () => {
+            const models = [
+                makeCatalogModel({ name: "qwen3:0.6b", size_gb: 0.5, min_ram_gb: 4 }),
+                makeCatalogModel({ name: "qwen3:4b", size_gb: 2.5, min_ram_gb: 8 }),
+            ];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const options = el.findAll("lilbee-wizard-model-option");
+            options[1].trigger("click");
+            expect(options[1].classList.contains("selected")).toBe(true);
+            expect(options[0].classList.contains("selected")).toBe(false);
+        });
+
+        it("shows error when catalog fetch fails", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockRejectedValue(new Error("fail"));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("Could not load models"))).toBe(true);
+        });
+
+        it("Download & continue requires model selection", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse([]));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const downloadBtn = findButtons(el).find(b => b.textContent === "Download & continue")!;
+            downloadBtn.trigger("click");
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Please select a model first"))).toBe(true);
+        });
+
+        it("Download & continue pulls model and advances to sync step", async () => {
+            const models = [makeCatalogModel({ name: "qwen3:0.6b" })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            plugin.api.pullModel = vi.fn().mockReturnValue((async function* () {
+                yield { event: SSE_EVENT.PROGRESS, data: { current: 50, total: 100 } };
+                yield { event: SSE_EVENT.PROGRESS, data: { current: 100, total: 100 } };
+            })());
+            // syncStream will be called when step 3 auto-starts
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                yield { event: SSE_EVENT.FILE_START, data: { current_file: 1, total_files: 1 } };
+                yield { event: SSE_EVENT.DONE, data: { added: [], updated: [], removed: [], unchanged: 0, failed: [] } };
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const downloadBtn = findButtons(el).find(b => b.textContent === "Download & continue")!;
+            downloadBtn.trigger("click");
+            await tick();
+            await tick();
+
+            expect(plugin.api.pullModel).toHaveBeenCalledWith("qwen3:0.6b", "native", expect.any(AbortSignal));
+            expect(plugin.api.setChatModel).toHaveBeenCalledWith("qwen3:0.6b");
+            // After pull completes, it goes to step 3 (sync), which auto-starts and finishes, going to step 4 (done)
+            await tick();
+            await tick();
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            // Could be on sync step or done step depending on timing
+            expect(texts.some(t => t.includes("Index your vault") || t.includes("You're all set!"))).toBe(true);
+        });
+
+        it("handles pull failure", async () => {
+            const models = [makeCatalogModel({ name: "qwen3:0.6b" })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            plugin.api.pullModel = vi.fn().mockReturnValue((async function* () {
+                throw new Error("network error");
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const downloadBtn = findButtons(el).find(b => b.textContent === "Download & continue")!;
+            downloadBtn.trigger("click");
+            await tick();
+            await tick();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Download failed"))).toBe(true);
+        });
+
+        it("handles pull abort", async () => {
+            const models = [makeCatalogModel({ name: "qwen3:0.6b" })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            const abortErr = new Error("aborted");
+            abortErr.name = "AbortError";
+            plugin.api.pullModel = vi.fn().mockReturnValue((async function* () {
+                throw abortErr;
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const downloadBtn = findButtons(el).find(b => b.textContent === "Download & continue")!;
+            downloadBtn.trigger("click");
+            await tick();
+            await tick();
+
+            expect(Notice.instances.some(n => n.message.includes("download cancelled"))).toBe(true);
+        });
+
+        it("Back from model picker returns to welcome (external mode)", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse([]));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const backBtn = findButtons(el).find(b => b.textContent === "Back")!;
+            backBtn.trigger("click");
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Welcome to lilbee"))).toBe(true);
+        });
+
+        it("Back from model picker returns to server mode when no server manager", async () => {
+            const plugin = makePlugin({ serverManager: null, settings: { serverMode: "managed" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse([]));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            // Force to step 2
+            (wizard as any).step = 2;
+            (wizard as any).renderStep();
+            await tick();
+
+            wizard.back();
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("How do you want to run lilbee?"))).toBe(true);
+        });
+
+        it("Browse full catalog button opens CatalogModal", async () => {
+            const { CatalogModal } = await import("../../src/views/catalog-modal");
+            const models = [makeCatalogModel()];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const catalogBtn = findButtons(el).find(b => b.textContent === "Browse full catalog")!;
+            catalogBtn.trigger("click");
+
+            expect(CatalogModal).toHaveBeenCalled();
+        });
+
+        it("Back cancels ongoing pull", async () => {
+            const models = [makeCatalogModel({ name: "qwen3:0.6b" })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            let abortSignal: AbortSignal | null = null;
+            plugin.api.pullModel = vi.fn().mockImplementation((_name: string, _source: string, signal?: AbortSignal) => {
+                abortSignal = signal ?? null;
+                return (async function* () {
+                    yield { event: SSE_EVENT.PROGRESS, data: { current: 50, total: 100 } };
+                    // Wait forever
+                    await new Promise(() => {});
+                })();
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const downloadBtn = findButtons(el).find(b => b.textContent === "Download & continue")!;
+            downloadBtn.trigger("click");
+            await tick();
+
+            // Now click back, which should abort
+            const backBtn = findButtons(wizard.contentEl as unknown as MockElement).find(b => b.textContent === "Back")!;
+            backBtn.trigger("click");
+
+            expect(abortSignal?.aborted).toBe(true);
+        });
+
+        it("Skip setup aborts active pull and closes wizard", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue({
+                models: [makeCatalogModel({ name: "qwen3:0.6b", size_gb: 0.5, min_ram_gb: 4 })],
+                total: 1, limit: 20, offset: 0,
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            const closeSpy = vi.spyOn(wizard, "close");
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            // Simulate an in-progress pull
+            const controller = new AbortController();
+            (wizard as any).pullController = controller;
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const skipBtn = findButtons(el).find(b => b.textContent === "Skip setup")!;
+            skipBtn.trigger("click");
+            expect(controller.signal.aborted).toBe(true);
+            expect(closeSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe("Step 3: Sync", () => {
+        it("renders sync screen and starts syncing", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                yield { event: SSE_EVENT.FILE_START, data: { current_file: 1, total_files: 10 } };
+                yield { event: SSE_EVENT.EMBED, data: { file: "test.md" } };
+                yield { event: SSE_EVENT.DONE, data: { added: ["a.md"], updated: [], removed: [], unchanged: 5, failed: [] } };
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 3;
+            (wizard as any).renderStep();
+            await tick();
+            await tick();
+
+            // Should have advanced to done
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("You're all set!"))).toBe(true);
+        });
+
+        it("sync abort shows notice", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const abortErr = new Error("aborted");
+            abortErr.name = "AbortError";
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                throw abortErr;
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 3;
+            (wizard as any).renderStep();
+            await tick();
+            await tick();
+
+            expect(Notice.instances.some(n => n.message.includes("indexing cancelled"))).toBe(true);
+        });
+
+        it("sync failure shows error message", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                throw new Error("network");
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 3;
+            (wizard as any).renderStep();
+            await tick();
+            await tick();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Indexing failed"))).toBe(true);
+        });
+
+        it("Back from sync cancels and returns to model picker", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            let abortSignal: AbortSignal | null = null;
+            plugin.api.syncStream = vi.fn().mockImplementation((_force: boolean, signal?: AbortSignal) => {
+                abortSignal = signal ?? null;
+                return (async function* () {
+                    yield { event: SSE_EVENT.FILE_START, data: { current_file: 1, total_files: 100 } };
+                    await new Promise(() => {});
+                })();
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 3;
+            (wizard as any).renderStep();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const backBtn = findButtons(el).find(b => b.textContent === "Back")!;
+            backBtn.trigger("click");
+
+            expect(abortSignal?.aborted).toBe(true);
+        });
+
+        it("Skip setup aborts sync and closes wizard", async () => {
+            let abortSignal: AbortSignal | null = null;
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.syncStream = vi.fn().mockImplementation((_opts: any, signal?: AbortSignal) => {
+                abortSignal = signal ?? null;
+                return (async function* () {
+                    yield { event: SSE_EVENT.FILE_START, data: { current_file: 1, total_files: 100 } };
+                    await new Promise(() => {});
+                })();
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            const closeSpy = vi.spyOn(wizard, "close");
+            wizard.open();
+            (wizard as any).step = 3;
+            (wizard as any).renderStep();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const skipBtn = findButtons(el).find(b => b.textContent === "Skip setup")!;
+            skipBtn.trigger("click");
+            expect(closeSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe("Step 4: Done", () => {
+        it("renders done screen with summary", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).pulledModelName = "qwen3:8b";
+            (wizard as any).syncResult = { added: ["a.md", "b.md"], updated: [], removed: [], unchanged: 8, failed: [] };
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("You're all set!"))).toBe(true);
+            expect(texts.some(t => t.includes("qwen3:8b"))).toBe(true);
+            expect(texts.some(t => t.includes("10 files indexed"))).toBe(true);
+            expect(texts.some(t => t.includes("Open chat"))).toBe(true);
+        });
+
+        it("renders done screen without model/sync info if skipped", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("You're all set!"))).toBe(true);
+        });
+
+        it("Open chat marks setup complete and opens chat view", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            const closeSpy = vi.spyOn(wizard, "close");
+            wizard.open();
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const openChatBtn = findButtons(el).find(b => b.textContent === "Open chat")!;
+            openChatBtn.trigger("click");
+            await tick();
+
+            expect(plugin.settings.setupCompleted).toBe(true);
+            expect(plugin.saveSettings).toHaveBeenCalled();
+            expect(plugin.activateChatView).toHaveBeenCalled();
+            expect(closeSpy).toHaveBeenCalled();
+        });
+
+        it("shows tips about what to try", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("chat panel"))).toBe(true);
+            expect(texts.some(t => t.includes("search command"))).toBe(true);
+        });
+    });
+
+    describe("Navigation", () => {
+        it("next() from non-zero step increments step", () => {
+            const plugin = makePlugin({ serverManager: null });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse([]));
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                await new Promise(() => {});
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            // Set step to 1 and call next()
+            (wizard as any).step = 1;
+            wizard.next();
+            // Should go to step 2
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Pick a chat model"))).toBe(true);
+        });
+
+        it("back() at step 0 stays at step 0", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.back();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Welcome to lilbee"))).toBe(true);
+        });
+
+        it("back() at step 3 goes to step 2", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse([]));
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                await new Promise(() => {});
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 3;
+            wizard.back();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            // step 2 goes back to step 0 in external mode (since server is ready)
+            // So from step 3, back() goes to step 2 (model picker)
+            expect(texts.some(t => t.includes("Pick a chat model"))).toBe(true);
+        });
+
+        it("back() at step 4 goes to step 3", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                await new Promise(() => {});
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 4;
+            wizard.back();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Index your vault"))).toBe(true);
+        });
+    });
+
+    describe("onClose cleanup", () => {
+        it("aborts pull controller on close", async () => {
+            const models = [makeCatalogModel({ name: "qwen3:0.6b" })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            plugin.api.pullModel = vi.fn().mockReturnValue((async function* () {
+                yield { event: SSE_EVENT.PROGRESS, data: { current: 50, total: 100 } };
+                await new Promise(() => {});
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            // Start pull
+            const el = wizard.contentEl as unknown as MockElement;
+            const downloadBtn = findButtons(el).find(b => b.textContent === "Download & continue")!;
+            downloadBtn.trigger("click");
+            await tick();
+
+            // Close should abort
+            wizard.close();
+        });
+
+        it("aborts sync controller on close", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                yield { event: SSE_EVENT.FILE_START, data: { current_file: 1, total_files: 100 } };
+                await new Promise(() => {});
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 3;
+            (wizard as any).renderStep();
+            await tick();
+
+            wizard.close();
+        });
+
+        it("clears server check timer on close", () => {
+            const plugin = makePlugin();
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            (wizard as any).serverCheckTimer = setTimeout(() => {}, 10000);
+            wizard.close();
+            // Should not throw
+        });
+    });
+
+    describe("System memory detection", () => {
+        it("handles missing os module gracefully", async () => {
+            const models = [
+                makeCatalogModel({ name: "qwen3:0.6b", min_ram_gb: 4 }),
+                makeCatalogModel({ name: "qwen3:4b", min_ram_gb: 8 }),
+            ];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            // Should still render without crashing
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("Pick a chat model"))).toBe(true);
+        });
+    });
+
+    describe("Full flow integration", () => {
+        it("complete flow: welcome -> model -> sync -> done", async () => {
+            const models = [makeCatalogModel({ name: "qwen3:0.6b" })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            plugin.api.pullModel = vi.fn().mockReturnValue((async function* () {
+                yield { event: SSE_EVENT.PROGRESS, data: { current: 100, total: 100 } };
+            })());
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                yield { event: SSE_EVENT.FILE_START, data: { current_file: 1, total_files: 5 } };
+                yield { event: SSE_EVENT.DONE, data: { added: ["a.md"], updated: [], removed: [], unchanged: 4, failed: [] } };
+            })());
+
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+
+            // Step 0: Welcome -> Get started
+            let el = wizard.contentEl as unknown as MockElement;
+            findButtons(el).find(b => b.textContent === "Get started")!.trigger("click");
+            await tick();
+
+            // Step 2: Model picker -> Download
+            el = wizard.contentEl as unknown as MockElement;
+            expect(collectTexts(el).some(t => t.includes("Pick a chat model"))).toBe(true);
+            findButtons(el).find(b => b.textContent === "Download & continue")!.trigger("click");
+            await tick();
+            await tick();
+
+            // Step 3: Sync (auto-starts, should auto-advance)
+            await tick();
+            await tick();
+
+            // Step 4: Done -> Open chat
+            el = wizard.contentEl as unknown as MockElement;
+            expect(collectTexts(el).some(t => t.includes("You're all set!"))).toBe(true);
+
+            findButtons(el).find(b => b.textContent === "Open chat")!.trigger("click");
+            await tick();
+
+            expect(plugin.settings.setupCompleted).toBe(true);
+            expect(plugin.activateChatView).toHaveBeenCalled();
+        });
+    });
+
+    describe("recommendedIndex", () => {
+        it("returns 0 when memGB is null", () => {
+            const models = [
+                { name: "small", size_gb: 0.5, min_ram_gb: 4, description: "", source: "native" as const },
+                { name: "large", size_gb: 5, min_ram_gb: 16, description: "", source: "native" as const },
+            ];
+            expect(recommendedIndex(models, null)).toBe(0);
+        });
+
+        it("returns 0 when models is empty", () => {
+            expect(recommendedIndex([], 16)).toBe(0);
+        });
+
+        it("selects largest model that fits in memory", () => {
+            const models = [
+                { name: "small", size_gb: 0.5, min_ram_gb: 4, description: "", source: "native" as const },
+                { name: "medium", size_gb: 2.5, min_ram_gb: 8, description: "", source: "native" as const },
+                { name: "large", size_gb: 5, min_ram_gb: 16, description: "", source: "native" as const },
+            ];
+            expect(recommendedIndex(models, 10)).toBe(1);
+            expect(recommendedIndex(models, 16)).toBe(2);
+            expect(recommendedIndex(models, 3)).toBe(0);
+        });
+    });
+
+    describe("getSystemMemoryGB", () => {
+        it("returns a number in Node.js environment", () => {
+            const result = getSystemMemoryGB();
+            // In Node.js test environment, os module is available
+            expect(typeof result).toBe("number");
+            expect(result).toBeGreaterThan(0);
+        });
+    });
+
+    describe("sync with zero total_files", () => {
+        it("handles FILE_START with total_files=0 without division error", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                yield { event: SSE_EVENT.FILE_START, data: { current_file: 0, total_files: 0 } };
+                yield { event: SSE_EVENT.DONE, data: { added: [], updated: [], removed: [], unchanged: 0, failed: [] } };
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 3;
+            (wizard as any).renderStep();
+            await tick();
+            await tick();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("You're all set!"))).toBe(true);
+        });
+    });
+
+    describe("pullSelectedModel early return", () => {
+        it("returns early when selectedModel is null", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            // Call pullSelectedModel directly with no selected model
+            (wizard as any).selectedModel = null;
+            const el = new MockElement("div");
+            await (wizard as any).pullSelectedModel(el, el, el, el, el);
+            // Should return without calling pullModel
+            expect(plugin.api.pullModel).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("back from step 2 with ready server manager", () => {
+        it("goes to step 0 when serverManager is ready", () => {
+            const plugin = makePlugin({
+                settings: { serverMode: "managed" },
+                serverManager: { state: "ready" },
+            });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse([]));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 2;
+            wizard.back();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("Welcome to lilbee"))).toBe(true);
+        });
+    });
+
+    describe("sync with FILE_START progress update", () => {
+        it("updates progress bar during sync", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.syncStream = vi.fn().mockReturnValue((async function* () {
+                yield { event: SSE_EVENT.FILE_START, data: { current_file: 3, total_files: 10 } };
+                yield { event: SSE_EVENT.FILE_START, data: { current_file: 7, total_files: 10 } };
+                yield { event: SSE_EVENT.DONE, data: { added: [], updated: [], removed: [], unchanged: 10, failed: [] } };
+            })());
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 3;
+            (wizard as any).renderStep();
+            await tick();
+            await tick();
+
+            // Should reach done
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some(t => t.includes("You're all set!"))).toBe(true);
+        });
+    });
+
+    describe("done screen with processed files count", () => {
+        it("shows files processed when sync result has additions", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).pulledModelName = "test-model";
+            (wizard as any).syncResult = {
+                added: ["a.md", "b.md", "c.md"],
+                updated: ["d.md"],
+                removed: [],
+                unchanged: 6,
+                failed: [],
+            };
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("10 files indexed"))).toBe(true);
+            expect(texts.some(t => t.includes("4 files processed"))).toBe(true);
+        });
+
+        it("does not show files processed when no additions or updates", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).syncResult = {
+                added: [],
+                updated: [],
+                removed: [],
+                unchanged: 10,
+                failed: [],
+            };
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("10 files indexed"))).toBe(true);
+            expect(texts.some(t => t.includes("files processed"))).toBe(false);
+        });
+    });
+});

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -3,7 +3,7 @@ import { App, Notice } from "obsidian";
 import { MockElement } from "../__mocks__/obsidian";
 import { SetupWizard, getSystemMemoryGB, recommendedIndex } from "../../src/views/setup-wizard";
 import { SSE_EVENT } from "../../src/types";
-import type { CatalogModel, CatalogResponse } from "../../src/types";
+import type { ModelFamily, ModelVariant, CatalogResponse } from "../../src/types";
 
 vi.mock("../../src/views/catalog-modal", () => ({
     CatalogModal: vi.fn().mockImplementation(() => ({
@@ -12,24 +12,37 @@ vi.mock("../../src/views/catalog-modal", () => ({
     })),
 }));
 
-function makeCatalogModel(overrides: Partial<CatalogModel> = {}): CatalogModel {
+function makeVariant(overrides: Partial<ModelVariant> = {}): ModelVariant {
     return {
-        name: "qwen3:0.6b",
+        name: "0.6B",
+        hf_repo: "qwen/qwen3-0.6B",
         size_gb: 0.5,
         min_ram_gb: 4,
         description: "Runs on anything",
+        task: "chat",
         installed: false,
         source: "native",
         ...overrides,
     };
 }
 
-function makeCatalogResponse(models: CatalogModel[] = []): CatalogResponse {
+function makeFamily(overrides: Partial<ModelFamily> = {}): ModelFamily {
     return {
-        total: models.length,
+        family: "Qwen3",
+        task: "chat",
+        featured: true,
+        recommended: "0.6B",
+        variants: [makeVariant()],
+        ...overrides,
+    };
+}
+
+function makeCatalogResponse(families: ModelFamily[] = []): CatalogResponse {
+    return {
+        total: families.length,
         limit: 4,
         offset: 0,
-        models,
+        families,
     };
 }
 
@@ -393,12 +406,12 @@ describe("SetupWizard", () => {
 
     describe("Step 2: Model Picker", () => {
         it("renders model picker with featured models", async () => {
-            const models = [
-                makeCatalogModel({ name: "qwen3:0.6b", size_gb: 0.5, min_ram_gb: 4 }),
-                makeCatalogModel({ name: "qwen3:4b", size_gb: 2.5, min_ram_gb: 8 }),
+            const families = [
+                makeFamily({ family: "Qwen3-Small", variants: [makeVariant({ name: "0.6B", hf_repo: "qwen/qwen3-0.6B", size_gb: 0.5, min_ram_gb: 4 })], recommended: "0.6B" }),
+                makeFamily({ family: "Qwen3-Medium", variants: [makeVariant({ name: "4B", hf_repo: "qwen/qwen3-4B", size_gb: 2.5, min_ram_gb: 8 })], recommended: "4B" }),
             ];
             const plugin = makePlugin({ settings: { serverMode: "external" } });
-            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(families));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             wizard.next();
@@ -407,17 +420,17 @@ describe("SetupWizard", () => {
             const el = wizard.contentEl as unknown as MockElement;
             const texts = collectTexts(el);
             expect(texts.some(t => t.includes("Pick a chat model"))).toBe(true);
-            expect(texts.some(t => t.includes("qwen3:0.6b"))).toBe(true);
-            expect(texts.some(t => t.includes("qwen3:4b"))).toBe(true);
+            expect(texts.some(t => t.includes("Qwen3-Small"))).toBe(true);
+            expect(texts.some(t => t.includes("Qwen3-Medium"))).toBe(true);
         });
 
         it("pre-selects recommended model based on first in list when no memory detection", async () => {
-            const models = [
-                makeCatalogModel({ name: "qwen3:0.6b", size_gb: 0.5, min_ram_gb: 4 }),
-                makeCatalogModel({ name: "qwen3:4b", size_gb: 2.5, min_ram_gb: 8 }),
+            const families = [
+                makeFamily({ family: "Qwen3-Small", variants: [makeVariant({ name: "0.6B", hf_repo: "qwen/qwen3-0.6B", size_gb: 0.5, min_ram_gb: 4 })], recommended: "0.6B" }),
+                makeFamily({ family: "Qwen3-Medium", variants: [makeVariant({ name: "4B", hf_repo: "qwen/qwen3-4B", size_gb: 2.5, min_ram_gb: 8 })], recommended: "4B" }),
             ];
             const plugin = makePlugin({ settings: { serverMode: "external" } });
-            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(families));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             wizard.next();
@@ -430,12 +443,12 @@ describe("SetupWizard", () => {
         });
 
         it("clicking a model option selects it", async () => {
-            const models = [
-                makeCatalogModel({ name: "qwen3:0.6b", size_gb: 0.5, min_ram_gb: 4 }),
-                makeCatalogModel({ name: "qwen3:4b", size_gb: 2.5, min_ram_gb: 8 }),
+            const families = [
+                makeFamily({ family: "Qwen3-Small", variants: [makeVariant({ name: "0.6B", hf_repo: "qwen/qwen3-0.6B", size_gb: 0.5, min_ram_gb: 4 })], recommended: "0.6B" }),
+                makeFamily({ family: "Qwen3-Medium", variants: [makeVariant({ name: "4B", hf_repo: "qwen/qwen3-4B", size_gb: 2.5, min_ram_gb: 8 })], recommended: "4B" }),
             ];
             const plugin = makePlugin({ settings: { serverMode: "external" } });
-            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(families));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             wizard.next();
@@ -461,6 +474,26 @@ describe("SetupWizard", () => {
             expect(texts.some(t => t.includes("Could not load models"))).toBe(true);
         });
 
+        it("falls back to first variant when recommended not found", async () => {
+            const families = [makeFamily({
+                family: "Qwen3",
+                recommended: "nonexistent",
+                variants: [makeVariant({ name: "0.6B", hf_repo: "qwen/qwen3-0.6B", size_gb: 0.5, min_ram_gb: 4 })],
+            })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(families));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const texts = collectTexts(el);
+            expect(texts.some(t => t.includes("Qwen3"))).toBe(true);
+            expect(texts.some(t => t.includes("0.5 GB"))).toBe(true);
+        });
+
+
         it("Download & continue requires model selection", async () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse([]));
@@ -478,9 +511,9 @@ describe("SetupWizard", () => {
         });
 
         it("Download & continue pulls model and advances to sync step", async () => {
-            const models = [makeCatalogModel({ name: "qwen3:0.6b" })];
+            const families = [makeFamily({ family: "Qwen3", variants: [makeVariant({ name: "0.6B", hf_repo: "qwen/qwen3-0.6B" })], recommended: "0.6B" })];
             const plugin = makePlugin({ settings: { serverMode: "external" } });
-            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(families));
             plugin.api.pullModel = vi.fn().mockReturnValue((async function* () {
                 yield { event: SSE_EVENT.PROGRESS, data: { current: 50, total: 100 } };
                 yield { event: SSE_EVENT.PROGRESS, data: { current: 100, total: 100 } };
@@ -501,8 +534,8 @@ describe("SetupWizard", () => {
             await tick();
             await tick();
 
-            expect(plugin.api.pullModel).toHaveBeenCalledWith("qwen3:0.6b", "native", expect.any(AbortSignal));
-            expect(plugin.api.setChatModel).toHaveBeenCalledWith("qwen3:0.6b");
+            expect(plugin.api.pullModel).toHaveBeenCalledWith("qwen/qwen3-0.6B", "native", expect.any(AbortSignal));
+            expect(plugin.api.setChatModel).toHaveBeenCalledWith("qwen/qwen3-0.6B");
             // After pull completes, it goes to step 3 (sync), which auto-starts and finishes, going to step 4 (done)
             await tick();
             await tick();
@@ -512,9 +545,9 @@ describe("SetupWizard", () => {
         });
 
         it("handles pull failure", async () => {
-            const models = [makeCatalogModel({ name: "qwen3:0.6b" })];
+            const families = [makeFamily({ family: "Qwen3", variants: [makeVariant({ name: "0.6B", hf_repo: "qwen/qwen3-0.6B" })], recommended: "0.6B" })];
             const plugin = makePlugin({ settings: { serverMode: "external" } });
-            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(families));
             plugin.api.pullModel = vi.fn().mockReturnValue((async function* () {
                 throw new Error("network error");
             })());
@@ -534,9 +567,9 @@ describe("SetupWizard", () => {
         });
 
         it("handles pull abort", async () => {
-            const models = [makeCatalogModel({ name: "qwen3:0.6b" })];
+            const families = [makeFamily({ family: "Qwen3", variants: [makeVariant({ name: "0.6B", hf_repo: "qwen/qwen3-0.6B" })], recommended: "0.6B" })];
             const plugin = makePlugin({ settings: { serverMode: "external" } });
-            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(families));
             const abortErr = new Error("aborted");
             abortErr.name = "AbortError";
             plugin.api.pullModel = vi.fn().mockReturnValue((async function* () {
@@ -589,9 +622,9 @@ describe("SetupWizard", () => {
 
         it("Browse full catalog button opens CatalogModal", async () => {
             const { CatalogModal } = await import("../../src/views/catalog-modal");
-            const models = [makeCatalogModel()];
+            const families = [makeFamily()];
             const plugin = makePlugin({ settings: { serverMode: "external" } });
-            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(families));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             wizard.next();
@@ -605,9 +638,9 @@ describe("SetupWizard", () => {
         });
 
         it("Back cancels ongoing pull", async () => {
-            const models = [makeCatalogModel({ name: "qwen3:0.6b" })];
+            const families = [makeFamily({ family: "Qwen3", variants: [makeVariant({ name: "0.6B", hf_repo: "qwen/qwen3-0.6B" })], recommended: "0.6B" })];
             const plugin = makePlugin({ settings: { serverMode: "external" } });
-            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(families));
             let abortSignal: AbortSignal | null = null;
             plugin.api.pullModel = vi.fn().mockImplementation((_name: string, _source: string, signal?: AbortSignal) => {
                 abortSignal = signal ?? null;
@@ -637,7 +670,7 @@ describe("SetupWizard", () => {
         it("Skip setup aborts active pull and closes wizard", async () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             plugin.api.catalog = vi.fn().mockResolvedValue({
-                models: [makeCatalogModel({ name: "qwen3:0.6b", size_gb: 0.5, min_ram_gb: 4 })],
+                families: [makeFamily({ family: "Qwen3", variants: [makeVariant({ name: "0.6B", hf_repo: "qwen/qwen3-0.6B", size_gb: 0.5, min_ram_gb: 4 })], recommended: "0.6B" })],
                 total: 1, limit: 20, offset: 0,
             });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
@@ -882,9 +915,9 @@ describe("SetupWizard", () => {
 
     describe("onClose cleanup", () => {
         it("aborts pull controller on close", async () => {
-            const models = [makeCatalogModel({ name: "qwen3:0.6b" })];
+            const families = [makeFamily({ family: "Qwen3", variants: [makeVariant({ name: "0.6B", hf_repo: "qwen/qwen3-0.6B" })], recommended: "0.6B" })];
             const plugin = makePlugin({ settings: { serverMode: "external" } });
-            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(families));
             plugin.api.pullModel = vi.fn().mockReturnValue((async function* () {
                 yield { event: SSE_EVENT.PROGRESS, data: { current: 50, total: 100 } };
                 await new Promise(() => {});
@@ -930,12 +963,12 @@ describe("SetupWizard", () => {
 
     describe("System memory detection", () => {
         it("handles missing os module gracefully", async () => {
-            const models = [
-                makeCatalogModel({ name: "qwen3:0.6b", min_ram_gb: 4 }),
-                makeCatalogModel({ name: "qwen3:4b", min_ram_gb: 8 }),
+            const families = [
+                makeFamily({ family: "Qwen3-Small", variants: [makeVariant({ name: "0.6B", hf_repo: "qwen/qwen3-0.6B", min_ram_gb: 4 })], recommended: "0.6B" }),
+                makeFamily({ family: "Qwen3-Medium", variants: [makeVariant({ name: "4B", hf_repo: "qwen/qwen3-4B", min_ram_gb: 8 })], recommended: "4B" }),
             ];
             const plugin = makePlugin({ settings: { serverMode: "external" } });
-            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(families));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             wizard.next();
@@ -950,9 +983,9 @@ describe("SetupWizard", () => {
 
     describe("Full flow integration", () => {
         it("complete flow: welcome -> model -> sync -> done", async () => {
-            const models = [makeCatalogModel({ name: "qwen3:0.6b" })];
+            const families = [makeFamily({ family: "Qwen3", variants: [makeVariant({ name: "0.6B", hf_repo: "qwen/qwen3-0.6B" })], recommended: "0.6B" })];
             const plugin = makePlugin({ settings: { serverMode: "external" } });
-            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(models));
+            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse(families));
             plugin.api.pullModel = vi.fn().mockReturnValue((async function* () {
                 yield { event: SSE_EVENT.PROGRESS, data: { current: 100, total: 100 } };
             })());


### PR DESCRIPTION
Catalog modal now groups models by family instead of a flat list.

Families are collapsible — click the header to expand/collapse. Each family shows its name and task type (chat/embedding/vision). Variants within a family show size, description, and recommended marker (★). Pull and activate work on individual variants.

Setup wizard flattens featured families to their recommended variant for the simple picker view.

Types: ModelVariant + ModelFamily replace the flat CatalogModel. Server response expected as families[] (server-side grouping is a separate PR).

790 tests, 100% coverage.