### PR TITLE
server API parity, catalog redesign, wiki, download panels

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -87,6 +87,7 @@ export const MESSAGES = {
     LABEL_NO_QUEUED_TASKS: "No queued tasks",
     LABEL_NO_COMPLETED_TASKS: "No completed tasks",
     LABEL_CANCEL_TASK: "Cancel task",
+    LABEL_DOWNLOAD_QUEUED: "+{count} queued",
     LABEL_CHAT_MODEL_ICON: "Chat model",
     LABEL_VISION_MODEL_ICON: "Vision model",
     LABEL_ADD_FILE: "Add file",

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,7 @@ import { LintModal } from "./views/lint-modal";
 import { ConfirmModal } from "./views/confirm-modal";
 import { StatusModal } from "./views/status-modal";
 import { TaskQueue } from "./task-queue";
+import { DownloadPanel } from "./views/download-panel";
 import { WikiSync } from "./wiki-sync";
 
 interface LintProgressData {
@@ -73,6 +74,7 @@ export default class LilbeePlugin extends Plugin {
     private startingServer = false;
     private serverStartFailed = false;
     taskQueue: TaskQueue = new TaskQueue();
+    downloadPanel: DownloadPanel | null = null;
     wikiEnabled = false;
     wikiPageCount = 0;
     wikiDraftCount = 0;
@@ -89,6 +91,8 @@ export default class LilbeePlugin extends Plugin {
         this.registerView(VIEW_TYPE_WIKI, (leaf) => new WikiView(leaf, this));
         this.addSettingTab(new LilbeeSettingTab(this.app, this));
         this.taskQueue.onChange(() => this.updateStatusBarFromQueue());
+        this.downloadPanel = new DownloadPanel(this);
+        this.downloadPanel.attach();
         this.registerCommands();
 
         this.registerEvent(
@@ -393,6 +397,7 @@ export default class LilbeePlugin extends Plugin {
     }
 
     onunload(): void {
+        this.downloadPanel?.detach();
         if (this.syncTimeout) {
             clearTimeout(this.syncTimeout);
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,8 +32,8 @@ import { WikiView, VIEW_TYPE_WIKI } from "./views/wiki-view";
 import { LintModal } from "./views/lint-modal";
 import { ConfirmModal } from "./views/confirm-modal";
 import { StatusModal } from "./views/status-modal";
-import { TaskQueue } from "./task-queue";
 import { DownloadPanel } from "./views/download-panel";
+import { TaskQueue } from "./task-queue";
 import { WikiSync } from "./wiki-sync";
 
 interface LintProgressData {

--- a/src/types.ts
+++ b/src/types.ts
@@ -368,6 +368,11 @@ export const WIZARD_STEP = {
     DONE: 4,
 } as const satisfies Record<string, number>;
 
+export const DOWNLOAD_PANEL = {
+    MAX_VISIBLE: 5,
+    DISMISS_DELAY_MS: 1500,
+} as const;
+
 export const PLATFORM = {
     DARWIN: "darwin",
     LINUX: "linux",

--- a/src/views/download-panel.ts
+++ b/src/views/download-panel.ts
@@ -1,0 +1,193 @@
+import type LilbeePlugin from "../main";
+import { DOWNLOAD_PANEL, TASK_STATUS, TASK_TYPE, type TaskEntry } from "../types";
+import { MESSAGES } from "../locales/en";
+
+const SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏";
+const SPINNER_INTERVAL_MS = 100;
+const ICON_DONE = "✓";
+const ICON_FAILED = "✗";
+
+export class DownloadPanel {
+    private plugin: LilbeePlugin;
+    private parentEl: HTMLElement | null;
+    private containerEl: HTMLElement | null = null;
+    private panelsEl: HTMLElement | null = null;
+    private queuedEl: HTMLElement | null = null;
+    private panelMap: Map<string, HTMLElement> = new Map();
+    private trackedIds: Set<string> = new Set();
+    private dismissTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+    private unsubscribe: (() => void) | null = null;
+    private spinnerIndex = 0;
+    private spinnerInterval: ReturnType<typeof setInterval> | null = null;
+
+    constructor(plugin: LilbeePlugin, parentEl?: HTMLElement) {
+        this.plugin = plugin;
+        this.parentEl = parentEl ?? null;
+    }
+
+    attach(): void {
+        const parent = this.parentEl ?? document.body;
+        this.containerEl = parent.createDiv({ cls: "lilbee-dp-container" });
+        this.panelsEl = this.containerEl.createDiv({ cls: "lilbee-dp-panels" });
+        this.queuedEl = this.containerEl.createDiv({ cls: "lilbee-dp-queued" });
+        this.unsubscribe = this.plugin.taskQueue.onChange(() => this.render());
+        this.spinnerInterval = setInterval(() => {
+            this.spinnerIndex = (this.spinnerIndex + 1) % SPINNER_FRAMES.length;
+            this.updateSpinners();
+        }, SPINNER_INTERVAL_MS);
+        this.render();
+    }
+
+    detach(): void {
+        this.unsubscribe?.();
+        this.unsubscribe = null;
+        if (this.spinnerInterval) {
+            clearInterval(this.spinnerInterval);
+            this.spinnerInterval = null;
+        }
+        for (const timer of this.dismissTimers.values()) {
+            clearTimeout(timer);
+        }
+        this.dismissTimers.clear();
+        this.panelMap.clear();
+        this.trackedIds.clear();
+        this.containerEl?.remove();
+        this.containerEl = null;
+        this.panelsEl = null;
+        this.queuedEl = null;
+    }
+
+    private render(): void {
+        if (!this.containerEl) return;
+
+        const activeTasks = this.plugin.taskQueue.activeAll.filter((t) => this.isDownloadTask(t));
+        const queuedTasks = this.plugin.taskQueue.queued.filter((t) => this.isDownloadTask(t));
+        const activeIds = new Set(activeTasks.map((t) => t.id));
+
+        const visibleTasks = activeTasks.slice(0, DOWNLOAD_PANEL.MAX_VISIBLE);
+        for (const task of visibleTasks) {
+            if (!this.panelMap.has(task.id)) {
+                this.createPanel(task);
+            } else {
+                this.updatePanel(this.panelMap.get(task.id)!, task);
+            }
+            this.trackedIds.add(task.id);
+        }
+
+        // Detect completed/failed tasks that were tracked
+        for (const id of this.trackedIds) {
+            if (activeIds.has(id)) continue;
+            if (this.dismissTimers.has(id)) continue;
+
+            const completed = this.plugin.taskQueue.completed.find((t) => t.id === id);
+            if (completed && completed.status !== TASK_STATUS.CANCELLED) {
+                this.handleCompletion(id, completed);
+            } else {
+                this.dismissPanel(id);
+            }
+        }
+
+        // Update queued overflow text
+        const overflowCount = Math.max(0, activeTasks.length - DOWNLOAD_PANEL.MAX_VISIBLE) + queuedTasks.length;
+        if (this.queuedEl) {
+            if (overflowCount > 0) {
+                this.queuedEl.textContent = MESSAGES.LABEL_DOWNLOAD_QUEUED.replace("{count}", String(overflowCount));
+                this.queuedEl.style.display = "";
+            } else {
+                this.queuedEl.textContent = "";
+                this.queuedEl.style.display = "none";
+            }
+        }
+
+        this.containerEl.style.display = this.panelMap.size > 0 || overflowCount > 0 ? "" : "none";
+    }
+
+    private createPanel(task: TaskEntry): void {
+        if (!this.panelsEl) return;
+
+        const panel = this.panelsEl.createDiv({ cls: "lilbee-dp-panel" });
+
+        const info = panel.createDiv({ cls: "lilbee-dp-info" });
+        info.createSpan({ cls: "lilbee-dp-icon", text: SPINNER_FRAMES[this.spinnerIndex] });
+        info.createSpan({ cls: "lilbee-dp-name", text: task.name });
+        info.createSpan({ cls: "lilbee-dp-pct", text: `${task.progress}%` });
+
+        const cancelBtn = info.createEl("button", { cls: "lilbee-dp-cancel", text: "×" });
+        cancelBtn.addEventListener("click", () => {
+            this.plugin.taskQueue.cancel(task.id);
+            this.dismissPanel(task.id);
+        });
+
+        const barContainer = panel.createDiv({ cls: "lilbee-dp-bar-container" });
+        barContainer.createDiv({ cls: "lilbee-dp-bar-fill" }).style.width = `${task.progress}%`;
+
+        this.panelMap.set(task.id, panel);
+    }
+
+    private updatePanel(panel: HTMLElement, task: TaskEntry): void {
+        const pct = panel.querySelector(".lilbee-dp-pct") as HTMLElement | null;
+        if (pct) pct.textContent = `${task.progress}%`;
+
+        const barFill = panel.querySelector(".lilbee-dp-bar-fill") as HTMLElement | null;
+        if (barFill) barFill.style.width = `${task.progress}%`;
+    }
+
+    private handleCompletion(taskId: string, task: TaskEntry): void {
+        const panel = this.panelMap.get(taskId);
+        if (!panel) return;
+
+        const icon = panel.querySelector(".lilbee-dp-icon") as HTMLElement | null;
+
+        if (task.status === TASK_STATUS.DONE) {
+            panel.classList.add("lilbee-dp-done");
+            if (icon) icon.textContent = ICON_DONE;
+            const pct = panel.querySelector(".lilbee-dp-pct") as HTMLElement | null;
+            if (pct) pct.textContent = "100%";
+            const barFill = panel.querySelector(".lilbee-dp-bar-fill") as HTMLElement | null;
+            if (barFill) barFill.style.width = "100%";
+        } else if (task.status === TASK_STATUS.FAILED) {
+            panel.classList.add("lilbee-dp-failed");
+            if (icon) icon.textContent = ICON_FAILED;
+            const name = panel.querySelector(".lilbee-dp-name") as HTMLElement | null;
+            if (name && task.error) name.textContent = task.error;
+        }
+
+        const cancelBtn = panel.querySelector(".lilbee-dp-cancel") as HTMLElement | null;
+        if (cancelBtn) cancelBtn.style.display = "none";
+
+        this.scheduleDismiss(taskId);
+    }
+
+    private scheduleDismiss(taskId: string): void {
+        if (this.dismissTimers.has(taskId)) return;
+        const timer = setTimeout(() => {
+            this.dismissPanel(taskId);
+        }, DOWNLOAD_PANEL.DISMISS_DELAY_MS);
+        this.dismissTimers.set(taskId, timer);
+    }
+
+    private dismissPanel(taskId: string): void {
+        const timer = this.dismissTimers.get(taskId);
+        if (timer) clearTimeout(timer);
+        this.dismissTimers.delete(taskId);
+
+        const panel = this.panelMap.get(taskId);
+        if (panel) panel.remove();
+        this.panelMap.delete(taskId);
+        this.trackedIds.delete(taskId);
+
+        this.render();
+    }
+
+    private updateSpinners(): void {
+        for (const [id, panel] of this.panelMap) {
+            if (this.dismissTimers.has(id)) continue;
+            const icon = panel.querySelector(".lilbee-dp-icon") as HTMLElement | null;
+            if (icon) icon.textContent = SPINNER_FRAMES[this.spinnerIndex];
+        }
+    }
+
+    private isDownloadTask(task: TaskEntry): boolean {
+        return task.type === TASK_TYPE.PULL || task.type === TASK_TYPE.DOWNLOAD;
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -1749,11 +1749,14 @@
     bottom: 32px;
     right: 16px;
     z-index: 30;
+    max-width: 320px;
+    pointer-events: none;
+}
+
+.lilbee-dp-panels {
     display: flex;
     flex-direction: column;
     gap: 4px;
-    max-width: 320px;
-    pointer-events: none;
 }
 
 .lilbee-dp-panel {
@@ -1768,10 +1771,6 @@
     box-shadow: var(--shadow-s);
     opacity: 1;
     transition: opacity 300ms ease;
-}
-
-.lilbee-dp-panel.lilbee-dp-dismissing {
-    opacity: 0;
 }
 
 .lilbee-dp-info {

--- a/styles.css
+++ b/styles.css
@@ -1741,3 +1741,112 @@
     background-color: var(--interactive-accent);
     color: #fff;
 }
+
+/* Download progress panel (browser-style) */
+
+.lilbee-dp-container {
+    position: fixed;
+    bottom: 32px;
+    right: 16px;
+    z-index: 30;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-width: 320px;
+    pointer-events: none;
+}
+
+.lilbee-dp-panel {
+    pointer-events: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 8px 12px;
+    background-color: var(--background-secondary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-m, 6px);
+    box-shadow: var(--shadow-s);
+    opacity: 1;
+    transition: opacity 300ms ease;
+}
+
+.lilbee-dp-panel.lilbee-dp-dismissing {
+    opacity: 0;
+}
+
+.lilbee-dp-info {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: var(--font-small, 13px);
+}
+
+.lilbee-dp-icon {
+    flex-shrink: 0;
+    width: 1em;
+    text-align: center;
+}
+
+.lilbee-dp-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.lilbee-dp-pct {
+    color: var(--text-muted);
+    min-width: 2.5em;
+    text-align: right;
+}
+
+.lilbee-dp-cancel {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--text-muted);
+    padding: 0 2px;
+    font-size: 14px;
+}
+
+.lilbee-dp-cancel:hover {
+    color: var(--text-error);
+}
+
+.lilbee-dp-bar-container {
+    height: 3px;
+    background-color: var(--background-modifier-border);
+    border-radius: 2px;
+    overflow: hidden;
+}
+
+.lilbee-dp-bar-fill {
+    height: 100%;
+    background-color: var(--interactive-accent);
+    border-radius: 2px;
+    width: 0%;
+    transition: width 200ms ease-out;
+}
+
+.lilbee-dp-done .lilbee-dp-name {
+    color: var(--color-green);
+}
+
+.lilbee-dp-done .lilbee-dp-bar-fill {
+    background-color: var(--color-green);
+}
+
+.lilbee-dp-failed .lilbee-dp-name {
+    color: var(--color-red);
+}
+
+.lilbee-dp-failed .lilbee-dp-bar-fill {
+    background-color: var(--color-red);
+}
+
+.lilbee-dp-queued {
+    font-size: var(--font-smallest, 10px);
+    color: var(--text-muted);
+    text-align: right;
+    padding: 0 4px;
+}

--- a/tests/locales/en.test.ts
+++ b/tests/locales/en.test.ts
@@ -75,6 +75,7 @@ describe("MESSAGES", () => {
             expect(MESSAGES.LABEL_SIZE_SMALL).toBe("Small");
             expect(MESSAGES.LABEL_SIZE_MEDIUM).toBe("Medium");
             expect(MESSAGES.LABEL_SIZE_LARGE).toBe("Large");
+            expect(MESSAGES.LABEL_DOWNLOAD_QUEUED).toBe("+{count} queued");
         });
     });
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -340,6 +340,14 @@ describe("LilbeePlugin", () => {
             await plugin.onload();
             expect(() => plugin.onunload()).not.toThrow();
         });
+
+        it("calls downloadPanel.detach()", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const detachSpy = plugin.downloadPanel!.detach;
+            plugin.onunload();
+            expect(detachSpy).toHaveBeenCalled();
+        });
     });
 
     describe("loadSettings()", () => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -72,6 +72,13 @@ vi.mock("../src/views/confirm-modal", () => ({
     })),
 }));
 
+vi.mock("../src/views/download-panel", () => ({
+    DownloadPanel: vi.fn().mockImplementation(() => ({
+        attach: vi.fn(),
+        detach: vi.fn(),
+    })),
+}));
+
 const mockEnsureBinary = vi.fn().mockResolvedValue("/fake/bin/lilbee");
 const mockBinaryExists = vi.fn().mockReturnValue(true);
 const mockDownload = vi.fn().mockResolvedValue(undefined);

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { DEFAULT_SETTINGS, SSE_EVENT, JSON_HEADERS, SERVER_MODE } from "../src/types";
+import { DEFAULT_SETTINGS, SSE_EVENT, JSON_HEADERS, SERVER_MODE, DOWNLOAD_PANEL } from "../src/types";
 import type {
     Excerpt,
     DocumentResult,
@@ -324,6 +324,13 @@ describe("SERVER_MODE constants", () => {
     it("has MANAGED and EXTERNAL values", () => {
         expect(SERVER_MODE.MANAGED).toBe("managed");
         expect(SERVER_MODE.EXTERNAL).toBe("external");
+    });
+});
+
+describe("DOWNLOAD_PANEL constants", () => {
+    it("has MAX_VISIBLE and DISMISS_DELAY_MS", () => {
+        expect(DOWNLOAD_PANEL.MAX_VISIBLE).toBe(5);
+        expect(DOWNLOAD_PANEL.DISMISS_DELAY_MS).toBe(1500);
     });
 });
 

--- a/tests/views/download-panel.test.ts
+++ b/tests/views/download-panel.test.ts
@@ -1,0 +1,400 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { MockElement } from "../__mocks__/obsidian";
+import { DownloadPanel } from "../../src/views/download-panel";
+import { TaskQueue } from "../../src/task-queue";
+import { TASK_TYPE, DOWNLOAD_PANEL } from "../../src/types";
+import type LilbeePlugin from "../../src/main";
+
+function makePlugin(): LilbeePlugin {
+    return {
+        taskQueue: new TaskQueue(),
+    } as unknown as LilbeePlugin;
+}
+
+describe("DownloadPanel", () => {
+    let plugin: LilbeePlugin;
+    let parentEl: MockElement;
+    let panel: DownloadPanel;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        plugin = makePlugin();
+        parentEl = new MockElement();
+        panel = new DownloadPanel(plugin, parentEl as unknown as HTMLElement);
+    });
+
+    afterEach(() => {
+        panel.detach();
+        vi.useRealTimers();
+    });
+
+    describe("attach", () => {
+        it("creates container with lilbee-dp-container class", () => {
+            panel.attach();
+            const container = parentEl.find("lilbee-dp-container");
+            expect(container).not.toBeNull();
+        });
+
+        it("creates panels wrapper and queued label", () => {
+            panel.attach();
+            const container = parentEl.find("lilbee-dp-container");
+            expect(container!.find("lilbee-dp-panels")).not.toBeNull();
+            expect(container!.find("lilbee-dp-queued")).not.toBeNull();
+        });
+
+        it("hides container initially when no tasks", () => {
+            panel.attach();
+            const container = parentEl.find("lilbee-dp-container");
+            expect(container!.style.display).toBe("none");
+        });
+    });
+
+    describe("detach", () => {
+        it("removes container from parent", () => {
+            panel.attach();
+            panel.detach();
+            expect(parentEl.find("lilbee-dp-container")).toBeNull();
+        });
+
+        it("clears dismiss timers", () => {
+            panel.attach();
+            const id = plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+            // Complete the task so a dismiss timer is scheduled
+            plugin.taskQueue.complete(id);
+            // Detach should clear the timer without errors
+            panel.detach();
+            // Advancing timers after detach should not throw
+            vi.advanceTimersByTime(DOWNLOAD_PANEL.DISMISS_DELAY_MS + 100);
+        });
+
+        it("clears spinner interval", () => {
+            panel.attach();
+            panel.detach();
+            // Advancing timers should not trigger spinner updates
+            vi.advanceTimersByTime(1000);
+        });
+    });
+
+    describe("pull task panels", () => {
+        it("shows panel when pull task becomes active", () => {
+            panel.attach();
+            plugin.taskQueue.enqueue("Pull llama", TASK_TYPE.PULL);
+            const panelsEl = parentEl.find("lilbee-dp-panels");
+            const dp = panelsEl!.find("lilbee-dp-panel");
+            expect(dp).not.toBeNull();
+            const name = dp!.find("lilbee-dp-name");
+            expect(name!.textContent).toBe("Pull llama");
+        });
+
+        it("shows panel when download task becomes active", () => {
+            panel.attach();
+            plugin.taskQueue.enqueue("Download weights", TASK_TYPE.DOWNLOAD);
+            const dp = parentEl.find("lilbee-dp-panel");
+            expect(dp).not.toBeNull();
+        });
+
+        it("does not show panel for sync tasks", () => {
+            panel.attach();
+            plugin.taskQueue.enqueue("Sync vault", TASK_TYPE.SYNC);
+            expect(parentEl.find("lilbee-dp-panel")).toBeNull();
+        });
+
+        it("does not show panel for add tasks", () => {
+            panel.attach();
+            plugin.taskQueue.enqueue("Add files", TASK_TYPE.ADD);
+            expect(parentEl.find("lilbee-dp-panel")).toBeNull();
+        });
+
+        it("does not show panel for crawl tasks", () => {
+            panel.attach();
+            plugin.taskQueue.enqueue("Crawl site", TASK_TYPE.CRAWL);
+            expect(parentEl.find("lilbee-dp-panel")).toBeNull();
+        });
+
+        it("does not show panel for wiki tasks", () => {
+            panel.attach();
+            plugin.taskQueue.enqueue("Wiki sync", TASK_TYPE.WIKI);
+            expect(parentEl.find("lilbee-dp-panel")).toBeNull();
+        });
+    });
+
+    describe("progress updates", () => {
+        it("updates percentage text on progress", () => {
+            panel.attach();
+            const id = plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+            plugin.taskQueue.update(id, 42, "model.gguf");
+
+            const pct = parentEl.find("lilbee-dp-pct");
+            expect(pct!.textContent).toBe("42%");
+        });
+
+        it("updates progress bar width", () => {
+            panel.attach();
+            const id = plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+            plugin.taskQueue.update(id, 75);
+
+            const barFill = parentEl.find("lilbee-dp-bar-fill");
+            expect(barFill!.style.width).toBe("75%");
+        });
+    });
+
+    describe("completion", () => {
+        it("adds lilbee-dp-done class on task done", () => {
+            panel.attach();
+            const id = plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+            plugin.taskQueue.complete(id);
+
+            const dp = parentEl.find("lilbee-dp-panel");
+            expect(dp!.classList.contains("lilbee-dp-done")).toBe(true);
+        });
+
+        it("shows checkmark icon on done", () => {
+            panel.attach();
+            const id = plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+            plugin.taskQueue.complete(id);
+
+            const icon = parentEl.find("lilbee-dp-icon");
+            expect(icon!.textContent).toBe("✓");
+        });
+
+        it("sets progress to 100% on done", () => {
+            panel.attach();
+            const id = plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+            plugin.taskQueue.complete(id);
+
+            const pct = parentEl.find("lilbee-dp-pct");
+            expect(pct!.textContent).toBe("100%");
+            const barFill = parentEl.find("lilbee-dp-bar-fill");
+            expect(barFill!.style.width).toBe("100%");
+        });
+
+        it("hides cancel button on done", () => {
+            panel.attach();
+            const id = plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+            plugin.taskQueue.complete(id);
+
+            const cancelBtn = parentEl.find("lilbee-dp-cancel");
+            expect(cancelBtn!.style.display).toBe("none");
+        });
+
+        it("auto-dismisses panel after DISMISS_DELAY_MS", () => {
+            panel.attach();
+            const id = plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+            plugin.taskQueue.complete(id);
+
+            expect(parentEl.find("lilbee-dp-panel")).not.toBeNull();
+            vi.advanceTimersByTime(DOWNLOAD_PANEL.DISMISS_DELAY_MS);
+            expect(parentEl.find("lilbee-dp-panel")).toBeNull();
+        });
+    });
+
+    describe("failure", () => {
+        it("adds lilbee-dp-failed class on task failure", () => {
+            panel.attach();
+            const id = plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+            plugin.taskQueue.fail(id, "Network error");
+
+            const dp = parentEl.find("lilbee-dp-panel");
+            expect(dp!.classList.contains("lilbee-dp-failed")).toBe(true);
+        });
+
+        it("shows X icon on failure", () => {
+            panel.attach();
+            const id = plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+            plugin.taskQueue.fail(id, "timeout");
+
+            const icon = parentEl.find("lilbee-dp-icon");
+            expect(icon!.textContent).toBe("✗");
+        });
+
+        it("shows error message in name on failure", () => {
+            panel.attach();
+            const id = plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+            plugin.taskQueue.fail(id, "Connection refused");
+
+            const name = parentEl.find("lilbee-dp-name");
+            expect(name!.textContent).toBe("Connection refused");
+        });
+
+        it("auto-dismisses failed panel after DISMISS_DELAY_MS", () => {
+            panel.attach();
+            const id = plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+            plugin.taskQueue.fail(id, "error");
+
+            vi.advanceTimersByTime(DOWNLOAD_PANEL.DISMISS_DELAY_MS);
+            expect(parentEl.find("lilbee-dp-panel")).toBeNull();
+        });
+    });
+
+    describe("cancel", () => {
+        it("dismisses panel immediately on cancel button click", () => {
+            panel.attach();
+            plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+
+            const cancelBtn = parentEl.find("lilbee-dp-cancel") as MockElement;
+            cancelBtn.trigger("click");
+
+            expect(parentEl.find("lilbee-dp-panel")).toBeNull();
+        });
+
+        it("dismisses panel when task is cancelled externally", () => {
+            panel.attach();
+            const id = plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+            expect(parentEl.find("lilbee-dp-panel")).not.toBeNull();
+
+            // Cancel via task queue directly (not via button)
+            plugin.taskQueue.cancel(id);
+            expect(parentEl.find("lilbee-dp-panel")).toBeNull();
+        });
+    });
+
+    describe("multiple concurrent downloads", () => {
+        it("shows separate panels for each download", () => {
+            panel.attach();
+            plugin.taskQueue.enqueue("Pull A", TASK_TYPE.PULL);
+            plugin.taskQueue.enqueue("Pull B", TASK_TYPE.DOWNLOAD);
+
+            const panels = parentEl.findAll("lilbee-dp-panel");
+            expect(panels.length).toBe(2);
+        });
+
+        it("caps visible panels at MAX_VISIBLE", () => {
+            panel.attach();
+            for (let i = 0; i < DOWNLOAD_PANEL.MAX_VISIBLE + 2; i++) {
+                plugin.taskQueue.enqueue(`Pull ${i}`, TASK_TYPE.PULL);
+            }
+
+            // Only first one is active (per-type queue), rest are queued
+            // The TaskQueue only activates one per type at a time
+            const panels = parentEl.findAll("lilbee-dp-panel");
+            expect(panels.length).toBe(1);
+        });
+
+        it("shows queued overflow text", () => {
+            panel.attach();
+            // Enqueue multiple — only 1 active per type, rest queued
+            const firstId = plugin.taskQueue.enqueue(`Pull 0`, TASK_TYPE.PULL);
+            plugin.taskQueue.enqueue(`Pull 1`, TASK_TYPE.PULL);
+            plugin.taskQueue.enqueue(`Pull 2`, TASK_TYPE.PULL);
+            plugin.taskQueue.enqueue(`Pull 3`, TASK_TYPE.PULL);
+            // Trigger re-render by updating the active task (enqueue only notifies for first)
+            plugin.taskQueue.update(firstId, 10);
+
+            const queuedEl = parentEl.find("lilbee-dp-queued");
+            expect(queuedEl!.textContent).toContain("+3 queued");
+        });
+    });
+
+    describe("container visibility", () => {
+        it("shows container when tasks exist", () => {
+            panel.attach();
+            plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+
+            const container = parentEl.find("lilbee-dp-container");
+            expect(container!.style.display).toBe("");
+        });
+
+        it("hides container when all panels dismissed", () => {
+            panel.attach();
+            const id = plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+            plugin.taskQueue.complete(id);
+            vi.advanceTimersByTime(DOWNLOAD_PANEL.DISMISS_DELAY_MS);
+
+            const container = parentEl.find("lilbee-dp-container");
+            expect(container!.style.display).toBe("none");
+        });
+    });
+
+    describe("spinner", () => {
+        it("updates spinner icon on interval", () => {
+            panel.attach();
+            plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+
+            const icon = parentEl.find("lilbee-dp-icon");
+            const initial = icon!.textContent;
+
+            vi.advanceTimersByTime(100);
+            expect(icon!.textContent).not.toBe(initial);
+        });
+
+        it("does not update spinner on completed panels", () => {
+            panel.attach();
+            const id = plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+            plugin.taskQueue.complete(id);
+
+            const icon = parentEl.find("lilbee-dp-icon");
+            expect(icon!.textContent).toBe("✓");
+
+            vi.advanceTimersByTime(100);
+            expect(icon!.textContent).toBe("✓");
+        });
+    });
+
+    describe("render without attach", () => {
+        it("render is no-op when containerEl is null", () => {
+            panel.attach();
+            // Null out containerEl to simulate detached state
+            (panel as any).containerEl = null;
+            // Trigger render via task queue — should not throw
+            plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+        });
+    });
+
+    describe("edge cases", () => {
+        it("skips already-dismissing tasks in render", () => {
+            panel.attach();
+            const id = plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+            plugin.taskQueue.complete(id);
+
+            // Completing already scheduled a dismiss timer; completing again should not double-schedule
+            // Trigger another render
+            plugin.taskQueue.enqueue("Pull other", TASK_TYPE.DOWNLOAD);
+            // No error means the dismissTimers.has() guard worked
+        });
+
+        it("handles completion when panel is missing from map", () => {
+            panel.attach();
+            const id = plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+            // Manually remove from panelMap to simulate edge case
+            (panel as any).panelMap.delete(id);
+            // Complete should not throw
+            plugin.taskQueue.complete(id);
+        });
+
+        it("does not double-schedule dismiss timer", () => {
+            panel.attach();
+            const id = plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+            plugin.taskQueue.complete(id);
+
+            // Call scheduleDismiss again for the same task — should be a no-op
+            (panel as any).scheduleDismiss(id);
+            // Advancing time should dismiss only once
+            vi.advanceTimersByTime(DOWNLOAD_PANEL.DISMISS_DELAY_MS);
+            expect(parentEl.find("lilbee-dp-panel")).toBeNull();
+        });
+
+        it("handles createPanel when panelsEl is null", () => {
+            panel.attach();
+            // Null out panelsEl
+            (panel as any).panelsEl = null;
+            // Enqueue should not throw even though panelsEl is null
+            plugin.taskQueue.enqueue("Pull model", TASK_TYPE.PULL);
+        });
+
+        it("detach is safe when called without attach", () => {
+            // Detach without prior attach — containerEl is null
+            panel.detach();
+        });
+
+        it("defaults parentEl to document.body", () => {
+            const mockBody = new MockElement() as unknown as HTMLElement;
+            vi.stubGlobal("document", { body: mockBody });
+            const p = new DownloadPanel(plugin);
+            p.attach();
+            const container = (mockBody as unknown as MockElement).find("lilbee-dp-container");
+            expect(container).not.toBeNull();
+            p.detach();
+            vi.unstubAllGlobals();
+        });
+    });
+});


### PR DESCRIPTION
## What changed

Full rewrite of the Obsidian plugin to reach feature parity with the lilbee TUI. Ollama dependency is gone — all model management goes through the lilbee server. New catalog, wiki sidebar, download progress, setup wizard, task center, and tooling overhaul.

### Model Catalog

Browse, search, and install models without leaving Obsidian. Two views, toggled from the filter bar:

<table>
<tr><td>

**Grid view** (default) — visual browsing
```
 ┌─ Model Catalog ──────────────────────┐
 │ Filter: [All tasks ▾] [All sizes ▾]  │
 │         [Featured ▾]  🔍 search...   │
 │                                       │
 │ Our picks                             │
 │ ┌───────────┐ ┌───────────┐          │
 │ │ Qwen3 8B  │ │ Nomic     │          │
 │ │ ▌chat▐    │ │ ▌embed▐   │          │
 │ │ 4.9 GB  ✓ │ │ 274 MB    │          │
 │ │   [Use]   │ │   [Pull]  │          │
 │ └───────────┘ └───────────┘          │
 │                                       │
 │ Chat                                  │
 │ ┌───────────┐ ┌───────────┐          │
 │ │ Phi-4 14B │ │ Mistral   │          │
 │ │ 9.1 GB    │ │ 4.1 GB    │          │
 │ │   [Pull]  │ │   [Pull]  │          │
 │ └───────────┘ └───────────┘          │
 │                                       │
 │ ┌╌╌╌╌╌╌╌╌╌╌╌┐                       │
 │ ╎ Browse more╎                       │
 │ ╎   models   ╎                       │
 │ └╌╌╌╌╌╌╌╌╌╌╌┘                       │
 └───────────────────────────────────────┘
```

</td><td>

**List view** — full HuggingFace catalog
```
 ┌─ Model Catalog ──────────────────────┐
 │ Filter: [All tasks ▾] [All sizes ▾]  │
 │         [Downloads ▾]  🔍 search...  │
 │                                       │
 │ Name       Task   Size   Downloads   │
 │ ─────────────────────────────────── │
 │ ★ Qwen3    chat   4.9GB  2.1M  [Use]│
 │ ★ Nomic    embed  274MB  420K [Pull]│
 │   Phi-4    chat   9.1GB  1.8M [Pull]│
 │   Mistral  chat   4.1GB  1.2M [Pull]│
 │   BGE-M3   embed  1.2GB  350K [Pull]│
 │   LLaVA    vision 4.7GB  280K [Pull]│
 │   ...                                │
 │                                       │
 │        [Load more]                    │
 └───────────────────────────────────────┘
```

</td></tr>
</table>

Featured models load instantly with zero API calls. Full HuggingFace catalog loads on demand when you search or click "Browse more models." Setup wizard uses the same card grid for the initial model picker.

### Download Progress Panel

Browser-style fixed panel at bottom-right, mimicking the TUI task bar from PR #59.

```
                          ┌──────────────────────────────┐
                          │ ⠹ Pull qwen3:8b        42%  ×│
                          │ ████████░░░░░░░░░░░░░░░░░░░░ │
                          │ ⠼ Pull nomic-embed      8%  ×│
                          │ ██░░░░░░░░░░░░░░░░░░░░░░░░░░ │
                          │                  +1 queued    │
                          └──────────────────────────────┘

  done:                             failed:
  ┌──────────────────────────────┐  ┌──────────────────────────────┐
  │ ✓ Pull qwen3:8b       100%  │  │ ✗ Connection refused         │
  │ ██████████████████████████████│  │ ██████░░░░░░░░░░░░░░░░░░░░░░│
  └──────────────────────────────┘  └──────────────────────────────┘
          (auto-dismiss 1.5s)                (auto-dismiss 1.5s)
```

Each active pull/download gets its own row with animated spinner, model name, progress bar, percentage, and cancel button. Completed panels flash green, failed panels flash red with the error detail. Both auto-dismiss after 1.5 seconds. Max 5 visible panels with overflow count.

### Wiki Sidebar

Browse auto-generated wiki pages from a dedicated sidebar view. Only appears when wiki is enabled server-side.

```
 ┌─ Wiki ───────────────────────────────┐
 │ 🔍 Filter pages...                   │
 │                                       │
 │ Summaries (12)                        │
 │   Oil System Overview          3 src  │
 │   Cooling System               2 src  │
 │   Brake Components             4 src  │
 │                                       │
 │ Concepts (8)                          │
 │   Maintenance Schedule         5 src  │
 │   Fluid Types                  3 src  │
 │                                       │
 │ Drafts (2)                            │
 │   Tire Pressure                1 src  │
 │──────────────────────────────────────│
 │ ┌─ Oil System Overview ────────────┐ │
 │ │ summary · 3 sources · 0.92      │ │
 │ │ qwen3:8b · 2026-04-01           │ │
 │ │                                   │ │
 │ │ The oil system uses a wet-sump   │ │
 │ │ design with a capacity of 5      │ │
 │ │ quarts including filter.[¹]      │ │
 │ │                                   │ │
 │ │ [1] owners-manual.pdf:42         │ │
 │ └───────────────────────────────────┘ │
 └───────────────────────────────────────┘
```

Pages grouped by type with source counts. Content area renders full markdown with citation footnotes. Search filters the page list. Generate, lint, and prune commands available from the command palette.

### Task Center

Dedicated sidebar view showing all background tasks across the plugin.

```
 ┌─ Task Center ──────────────────[Clear]┐
 │                                        │
 │ ACTIVE                                 │
 │ ┌────────────────────────────────────┐ │
 │ │ ████████████░░░░░░░░░░░░░░░ 42%   │ │
 │ │ PULL Pull qwen3:8b                 │ │
 │ │      model.gguf                    │ │
 │ └────────────────────────────────────┘ │
 │                                        │
 │ QUEUED                                 │
 │   Sync vault (sync)                    │
 │                                        │
 │ COMPLETED                              │
 │ ✓ SYNC  Sync vault        2 min ago   │
 │ ✗ PULL  Pull mistral      5 min ago   │
 │ ✓ ADD   Adding files     12 min ago   │
 └────────────────────────────────────────┘
```

Per-type concurrent queues — downloads, syncs, crawls, and model pulls run independently. Cancel active tasks. Color-coded type badges. Relative timestamps on completed tasks.

### Settings

<table>
<tr><td>

**HuggingFace token**
```
 ▼ Advanced
   HF Token  [••••••••••••••]
              For gated models
```

</td><td>

**Settings filter**
```
 🔍 [temper          ]

 ▼ Generation
   temperature   [0.7      ]
```

</td><td>

**Status modal**
```
 ┌─ Status ─────────────┐
 │ Documents: 42         │
 │ Chat: qwen3:8b        │
 │   arch: llama         │
 │   ctx: 32768          │
 │ Embed: nomic-embed    │
 │ Wiki: 12 pages        │
 └───────────────────────┘
```

</td></tr>
</table>

### Setup Wizard

5-step guided setup for first-time users. Welcome → Server Mode → Model Picker (card grid with RAM recommendation) → Vault Indexing (SSE progress) → Done. Every step has Skip. Re-accessible via command palette.

### Other

- **Chat sidebar** with model display, reasoning blocks, source citations, file attachments, search/ask toggle
- **Search modal** with document cards, source chips, excerpts
- **Crawl modal** for web pages
- **Documents modal** with search, multi-select delete
- **Confirm pull modal** showing model size and RAM requirements
- Command palette commands for all features
- Auto-sync on vault changes with debounce
- Managed server binary download and lifecycle

### Tooling

ESLint + Prettier + strict TypeScript + lint-staged pre-commit hooks. All raw string literals replaced with `as const` constant objects. Full locale catalog. 1234 tests, 100% statement/branch/function/line coverage.