### PR TITLE
Restore catalog task pill, featured star, downloads

### DIFF
--- a/src/components/model-card.ts
+++ b/src/components/model-card.ts
@@ -1,10 +1,11 @@
 import type { CatalogEntry, ModelCardOptions } from "../types";
 import { MESSAGES } from "../locales/en";
-import { renderPill, PILL_CLS } from "./pill";
+import { formatAbbreviatedCount } from "../utils";
+import { renderPill, renderTaskPill, renderPickPill, PILL_CLS } from "./pill";
 
 export function renderModelCard(container: HTMLElement, entry: CatalogEntry, options: ModelCardOptions): HTMLElement {
     const card = container.createDiv({ cls: "lilbee-model-card" });
-    card.dataset.name = entry.name;
+    card.dataset.repo = entry.hf_repo;
     if (options.isActive) card.addClass("is-selected");
 
     renderCardHeader(card, entry);
@@ -28,6 +29,8 @@ export function renderModelCard(container: HTMLElement, entry: CatalogEntry, opt
 function renderCardHeader(card: HTMLElement, entry: CatalogEntry): void {
     const header = card.createDiv({ cls: "lilbee-model-card-header" });
     header.createEl("span", { text: entry.display_name, cls: "lilbee-model-card-name" });
+    renderTaskPill(header, entry.task);
+    if (entry.featured) renderPickPill(header);
 }
 
 function renderCardSpecs(card: HTMLElement, entry: CatalogEntry): void {
@@ -39,6 +42,11 @@ function renderCardStatus(card: HTMLElement, entry: CatalogEntry): void {
     const status = card.createDiv({ cls: "lilbee-model-card-status" });
     if (entry.installed) {
         renderPill(status, MESSAGES.LABEL_INSTALLED, PILL_CLS.INSTALLED);
+    } else if (entry.downloads > 0) {
+        status.createEl("span", {
+            text: MESSAGES.LABEL_DOWNLOADS_COUNT(formatAbbreviatedCount(entry.downloads)),
+            cls: "lilbee-model-card-downloads",
+        });
     }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,6 +209,12 @@ export interface CatalogEntry {
     quality_tier: string;
     installed: boolean;
     source: "native" | "litellm";
+    hf_repo: string;
+    tag: string;
+    task: ModelTask;
+    featured: boolean;
+    downloads: number;
+    param_count?: string;
 }
 
 export interface CatalogResponse {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,6 +25,12 @@ export const NOTICE_PERMANENT = 0;
 export const TIME_REFRESH_INTERVAL_MS = 30000;
 export const HEALTH_PROBE_INTERVAL_MS = 30_000;
 
+export function formatAbbreviatedCount(count: number): string {
+    if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+    if (count >= 1_000) return `${(count / 1_000).toFixed(1)}K`;
+    return String(count);
+}
+
 export function relativeTime(timestamp: number): string {
     const seconds = Math.floor((Date.now() - timestamp) / 1000);
     if (seconds < 60) return "just now";

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -5,14 +5,20 @@ import { MODEL_TASK, SSE_EVENT, TASK_TYPE, CATALOG_VIEW_MODE, ERROR_NAME } from 
 import { MESSAGES, FILTERS, CATALOG_FILTERS } from "../locales/en";
 import { ConfirmModal } from "./confirm-modal";
 import { ConfirmPullModal } from "./confirm-pull-modal";
-import { debounce, DEBOUNCE_MS } from "../utils";
-import { renderModelCard } from "../components/model-card";
+import { debounce, DEBOUNCE_MS, formatAbbreviatedCount } from "../utils";
+import { renderModelCard, renderBrowseMoreCard } from "../components/model-card";
 
 const PAGE_SIZE = 20;
 
 type TaskFilter = (typeof FILTERS.TASK)[keyof typeof FILTERS.TASK];
 type SizeFilter = "" | typeof FILTERS.SIZE.SMALL | typeof FILTERS.SIZE.MEDIUM | typeof FILTERS.SIZE.LARGE;
 type SortFilter = (typeof FILTERS.SORT)[keyof typeof FILTERS.SORT];
+
+const TASK_SECTION_LABEL: Record<ModelTask, string> = {
+    [MODEL_TASK.CHAT]: MESSAGES.LABEL_SECTION_CHAT,
+    [MODEL_TASK.VISION]: MESSAGES.LABEL_SECTION_VISION,
+    [MODEL_TASK.EMBEDDING]: MESSAGES.LABEL_SECTION_EMBEDDING,
+};
 
 export class CatalogModal extends Modal {
     private plugin: LilbeePlugin;
@@ -26,6 +32,7 @@ export class CatalogModal extends Modal {
     private resultsEl: HTMLElement | null = null;
     private loadMoreBtn: HTMLElement | null = null;
     private viewMode: CatalogViewMode = CATALOG_VIEW_MODE.GRID;
+    private fullCatalogLoaded = false;
     private sortColumn = "";
     private sortAscending = true;
     private viewToggleBtn: HTMLElement | null = null;
@@ -136,6 +143,14 @@ export class CatalogModal extends Modal {
         void this.fetchPage();
     }
 
+    private loadFullCatalog(): void {
+        // "Browse more" semantics: show the long tail ranked by popularity.
+        // This deliberately overrides any sort the user picked.
+        this.fullCatalogLoaded = true;
+        this.filterSort = FILTERS.SORT.DOWNLOADS;
+        this.resetAndFetch();
+    }
+
     private async fetchPage(): Promise<void> {
         const params: Parameters<typeof this.plugin.api.catalog>[0] = {
             limit: PAGE_SIZE,
@@ -182,13 +197,36 @@ export class CatalogModal extends Modal {
 
     private renderGridView(entries: CatalogEntry[]): void {
         if (!this.resultsEl) return;
-        const installed = entries.filter((e) => e.installed);
-        const rest = entries.filter((e) => !e.installed);
+        const picks = entries.filter((e) => e.featured);
+        const installed = entries.filter((e) => !e.featured && e.installed);
+        const rest = entries.filter((e) => !e.featured && !e.installed);
 
+        if (picks.length > 0) this.renderSection(MESSAGES.LABEL_OUR_PICKS, picks);
         if (installed.length > 0) this.renderSection(MESSAGES.LABEL_SECTION_INSTALLED, installed);
-        if (rest.length > 0) this.renderSection(MESSAGES.LABEL_SECTION_CHAT, rest);
+
+        for (const [task, group] of this.groupByTask(rest)) {
+            this.renderSection(TASK_SECTION_LABEL[task] ?? task, group);
+        }
+
+        if (!this.fullCatalogLoaded) {
+            const grid = this.resultsEl.createDiv({ cls: "lilbee-catalog-grid" });
+            renderBrowseMoreCard(grid, () => this.loadFullCatalog());
+        }
 
         this.renderViewToggleCta();
+    }
+
+    private groupByTask(entries: CatalogEntry[]): [ModelTask, CatalogEntry[]][] {
+        const groups = new Map<ModelTask, CatalogEntry[]>();
+        for (const entry of entries) {
+            const group = groups.get(entry.task);
+            if (group) {
+                group.push(entry);
+            } else {
+                groups.set(entry.task, [entry]);
+            }
+        }
+        return [...groups.entries()];
     }
 
     private renderSection(heading: string, entries: CatalogEntry[]): void {
@@ -204,7 +242,7 @@ export class CatalogModal extends Modal {
     }
 
     private renderCard(container: HTMLElement, entry: CatalogEntry): void {
-        const isActive = this.plugin.activeModel === entry.name || this.plugin.activeVisionModel === entry.name;
+        const isActive = this.isActiveEntry(entry);
         renderModelCard(container, entry, {
             showActions: true,
             isActive,
@@ -212,6 +250,10 @@ export class CatalogModal extends Modal {
             onUse: (e, btn) => this.handleUse(e, btn),
             onRemove: (e, btn) => this.handleRemove(e, btn),
         });
+    }
+
+    private isActiveEntry(entry: CatalogEntry): boolean {
+        return this.plugin.activeModel === entry.hf_repo || this.plugin.activeVisionModel === entry.hf_repo;
     }
 
     private renderViewToggleCta(): void {
@@ -238,8 +280,9 @@ export class CatalogModal extends Modal {
         const header = listEl.createDiv({ cls: "lilbee-catalog-list-header" });
         const cols = [
             { key: "name", label: MESSAGES.LABEL_NAME, cls: "lilbee-catalog-list-col-name" },
+            { key: "task", label: MESSAGES.LABEL_TASK, cls: "lilbee-catalog-list-col-task" },
             { key: "size", label: MESSAGES.LABEL_SIZE, cls: "lilbee-catalog-list-col-size" },
-            { key: "quant", label: MESSAGES.LABEL_QUANT, cls: "lilbee-catalog-list-col-quant" },
+            { key: "downloads", label: MESSAGES.LABEL_DOWNLOADS, cls: "lilbee-catalog-list-col-downloads" },
             { key: "action", label: "", cls: "lilbee-catalog-list-col-action" },
         ];
         for (const col of cols) {
@@ -252,12 +295,17 @@ export class CatalogModal extends Modal {
 
     private renderListRow(listEl: HTMLElement, entry: CatalogEntry): void {
         const row = listEl.createDiv({ cls: "lilbee-catalog-list-row" });
-        row.createEl("span", { text: entry.display_name, cls: "lilbee-catalog-list-col-name" });
+        const nameText = entry.featured ? `\u2605 ${entry.display_name}` : entry.display_name;
+        row.createEl("span", { text: nameText, cls: "lilbee-catalog-list-col-name" });
+        row.createEl("span", { text: entry.task, cls: "lilbee-catalog-list-col-task" });
         row.createEl("span", { text: `${entry.size_gb} GB`, cls: "lilbee-catalog-list-col-size" });
-        row.createEl("span", { text: entry.quality_tier, cls: "lilbee-catalog-list-col-quant" });
+        row.createEl("span", {
+            text: formatAbbreviatedCount(entry.downloads),
+            cls: "lilbee-catalog-list-col-downloads",
+        });
 
         const actionEl = row.createDiv({ cls: "lilbee-catalog-list-col-action" });
-        const isActive = this.plugin.activeModel === entry.name || this.plugin.activeVisionModel === entry.name;
+        const isActive = this.isActiveEntry(entry);
 
         if (isActive) {
             actionEl.createEl("span", { text: MESSAGES.LABEL_ACTIVE, cls: "lilbee-catalog-active" });
@@ -302,10 +350,12 @@ export class CatalogModal extends Modal {
         switch (column) {
             case "name":
                 return entry.display_name;
+            case "task":
+                return entry.task;
             case "size":
                 return entry.size_gb;
-            case "quant":
-                return entry.quality_tier;
+            case "downloads":
+                return entry.downloads;
             default:
                 return "";
         }
@@ -317,7 +367,7 @@ export class CatalogModal extends Modal {
     }
 
     private handleRemove(entry: CatalogEntry, btn: HTMLElement): void {
-        const confirmModal = new ConfirmModal(this.app, MESSAGES.NOTICE_CONFIRM_REMOVE(entry.name));
+        const confirmModal = new ConfirmModal(this.app, MESSAGES.NOTICE_CONFIRM_REMOVE(entry.hf_repo));
         confirmModal.open();
         void confirmModal.result.then((confirmed) => {
             if (!confirmed) return;
@@ -329,15 +379,15 @@ export class CatalogModal extends Modal {
         btn.textContent = MESSAGES.STATUS_REMOVING;
         (btn as HTMLButtonElement).disabled = true;
 
-        const result = await this.plugin.api.deleteModel(entry.name, entry.source);
+        const result = await this.plugin.api.deleteModel(entry.hf_repo, entry.source);
         if (result.isErr()) {
-            new Notice(MESSAGES.ERROR_REMOVE_MODEL.replace("{model}", entry.name));
+            new Notice(MESSAGES.ERROR_REMOVE_MODEL.replace("{model}", entry.hf_repo));
             btn.textContent = MESSAGES.BUTTON_REMOVE;
             (btn as HTMLButtonElement).disabled = false;
             return;
         }
 
-        new Notice(MESSAGES.NOTICE_REMOVED(entry.name));
+        new Notice(MESSAGES.NOTICE_REMOVED(entry.hf_repo));
         this.plugin.fetchActiveModel();
         this.resetAndFetch();
     }
@@ -349,34 +399,34 @@ export class CatalogModal extends Modal {
         const result = await this.setActiveFor(entry);
 
         if (result.isErr()) {
-            new Notice(MESSAGES.ERROR_SET_MODEL.replace("{model}", entry.name));
+            new Notice(MESSAGES.ERROR_SET_MODEL.replace("{model}", entry.hf_repo));
             btn.textContent = MESSAGES.BUTTON_USE;
             (btn as HTMLButtonElement).disabled = false;
             return;
         }
 
         this.plugin.fetchActiveModel();
-        new Notice(MESSAGES.NOTICE_MODEL_ACTIVATED(entry.name));
+        new Notice(MESSAGES.NOTICE_MODEL_ACTIVATED(entry.hf_repo));
         this.resetAndFetch();
     }
 
     private async setActiveFor(entry: CatalogEntry): ReturnType<typeof this.plugin.api.setChatModel> {
-        if (this.filterTask === MODEL_TASK.VISION) {
-            const result = await this.plugin.api.setVisionModel(entry.name);
-            if (result.isOk()) this.plugin.activeVisionModel = entry.name;
+        if (entry.task === MODEL_TASK.VISION) {
+            const result = await this.plugin.api.setVisionModel(entry.hf_repo);
+            if (result.isOk()) this.plugin.activeVisionModel = entry.hf_repo;
             return result;
         }
-        if (this.filterTask === MODEL_TASK.EMBEDDING) {
-            return this.plugin.api.setEmbeddingModel(entry.name);
+        if (entry.task === MODEL_TASK.EMBEDDING) {
+            return this.plugin.api.setEmbeddingModel(entry.hf_repo);
         }
-        const result = await this.plugin.api.setChatModel(entry.name);
-        if (result.isOk()) this.plugin.activeModel = entry.name;
+        const result = await this.plugin.api.setChatModel(entry.hf_repo);
+        if (result.isOk()) this.plugin.activeModel = entry.hf_repo;
         return result;
     }
 
     private handlePull(entry: CatalogEntry, btn: HTMLElement): void {
         const info = {
-            name: entry.name,
+            name: entry.hf_repo,
             size_gb: entry.size_gb,
             min_ram_gb: entry.min_ram_gb,
             description: entry.description,
@@ -391,18 +441,18 @@ export class CatalogModal extends Modal {
     }
 
     private async executePull(entry: CatalogEntry, btn: HTMLElement): Promise<void> {
-        btn.textContent = MESSAGES.STATUS_PULLING.replace("{model}", entry.name);
+        btn.textContent = MESSAGES.STATUS_PULLING.replace("{model}", entry.hf_repo);
         (btn as HTMLButtonElement).disabled = true;
-        const taskId = this.plugin.taskQueue.enqueue(`Pull ${entry.name}`, TASK_TYPE.PULL);
+        const taskId = this.plugin.taskQueue.enqueue(`Pull ${entry.hf_repo}`, TASK_TYPE.PULL);
 
         try {
-            for await (const event of this.plugin.api.pullModel(entry.name, entry.source)) {
+            for await (const event of this.plugin.api.pullModel(entry.hf_repo, entry.source)) {
                 if (event.event === SSE_EVENT.PROGRESS) {
                     const d = event.data as { current?: number; total?: number };
                     if (d.total && d.current !== undefined) {
                         const pct = Math.round((d.current / d.total) * 100);
                         btn.textContent = `${pct}%`;
-                        this.plugin.taskQueue.update(taskId, pct, entry.name);
+                        this.plugin.taskQueue.update(taskId, pct, entry.hf_repo);
                     }
                 }
             }
@@ -431,7 +481,7 @@ export class CatalogModal extends Modal {
 
         this.plugin.fetchActiveModel();
         this.plugin.taskQueue.complete(taskId);
-        new Notice(MESSAGES.NOTICE_MODEL_ACTIVATED_FULL(entry.name));
+        new Notice(MESSAGES.NOTICE_MODEL_ACTIVATED_FULL(entry.hf_repo));
         btn.textContent = MESSAGES.LABEL_ACTIVE;
         (btn as HTMLButtonElement).disabled = true;
     }

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -300,7 +300,7 @@ export class SetupWizard extends Modal {
         this.selectedModel = model;
         for (const child of Array.from(grid.children)) {
             const el = child as HTMLElement;
-            if (el.dataset.name === model.name) {
+            if (el.dataset.repo === model.hf_repo) {
                 el.classList.add("is-selected");
             } else {
                 el.classList.remove("is-selected");
@@ -318,11 +318,15 @@ export class SetupWizard extends Modal {
         if (!this.selectedModel) return;
         const model = this.selectedModel;
         progressEl.style.display = "";
-        progressLabel.textContent = MESSAGES.STATUS_DOWNLOADING_MODEL.replace("{model}", model.name);
+        progressLabel.textContent = MESSAGES.STATUS_DOWNLOADING_MODEL.replace("{model}", model.hf_repo);
         this.pullController = new AbortController();
 
         try {
-            for await (const event of this.plugin.api.pullModel(model.name, model.source, this.pullController.signal)) {
+            for await (const event of this.plugin.api.pullModel(
+                model.hf_repo,
+                model.source,
+                this.pullController.signal,
+            )) {
                 if (event.event === SSE_EVENT.PROGRESS) {
                     const d = event.data as { current?: number; total?: number };
                     if (d.total && d.current !== undefined) {
@@ -330,16 +334,16 @@ export class SetupWizard extends Modal {
                         progressFill.style.width = `${pct}%`;
                         progressLabel.textContent = MESSAGES.STATUS_DOWNLOADING_MODEL_PCT.replace(
                             "{model}",
-                            model.name,
+                            model.hf_repo,
                         ).replace("{pct}", String(pct));
                     }
                 }
             }
 
-            await this.plugin.api.setChatModel(model.name);
-            this.plugin.activeModel = model.name;
+            await this.plugin.api.setChatModel(model.hf_repo);
+            this.plugin.activeModel = model.hf_repo;
             this.plugin.fetchActiveModel();
-            this.pulledModelName = model.name;
+            this.pulledModelName = model.hf_repo;
             this.step = WIZARD_STEP.SYNC;
             this.renderStep();
         } catch (err) {

--- a/styles.css
+++ b/styles.css
@@ -864,6 +864,11 @@
     font-size: 11px;
 }
 
+.lilbee-model-card-downloads {
+    color: var(--text-muted);
+    font-size: 11px;
+}
+
 .lilbee-model-card-actions {
     margin-top: 8px;
     display: flex;
@@ -992,6 +997,12 @@
 
 .lilbee-catalog-list-col-quant {
     flex: 0.8;
+}
+
+.lilbee-catalog-list-col-downloads {
+    flex: 0.8;
+    text-align: right;
+    color: var(--text-muted);
 }
 
 .lilbee-catalog-list-col-action {

--- a/tests/components/model-card.test.ts
+++ b/tests/components/model-card.test.ts
@@ -15,6 +15,11 @@ function makeEntry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
         quality_tier: "balanced",
         installed: false,
         source: "native",
+        hf_repo: "qwen/qwen3-8b",
+        tag: "8b",
+        task: "chat",
+        featured: false,
+        downloads: 0,
         ...overrides,
     };
 }
@@ -29,7 +34,7 @@ describe("renderModelCard", () => {
         const card = renderModelCard(c, makeEntry(), {}) as unknown as MockElement;
 
         expect(card.classList.contains("lilbee-model-card")).toBe(true);
-        expect(card.dataset.name).toBe("qwen3:8b");
+        expect(card.dataset.repo).toBe("qwen/qwen3-8b");
         expect(card.find("lilbee-model-card-header")).not.toBeNull();
         expect(card.find("lilbee-model-card-specs")).not.toBeNull();
         expect(card.find("lilbee-model-card-status")).not.toBeNull();
@@ -68,6 +73,43 @@ describe("renderModelCard", () => {
         const c = container();
         const card = renderModelCard(c, makeEntry(), {}) as unknown as MockElement;
         expect(card.find(PILL_CLS.INSTALLED)).toBeNull();
+    });
+
+    it("shows a download count when not installed and downloads > 0", () => {
+        const c = container();
+        const card = renderModelCard(c, makeEntry({ downloads: 42 }), {}) as unknown as MockElement;
+        const dl = card.find("lilbee-model-card-downloads");
+        expect(dl?.textContent).toBe("42 downloads");
+    });
+
+    it("formats download counts in thousands", () => {
+        const c = container();
+        const card = renderModelCard(c, makeEntry({ downloads: 1500 }), {}) as unknown as MockElement;
+        expect(card.find("lilbee-model-card-downloads")?.textContent).toBe("1.5K downloads");
+    });
+
+    it("formats download counts in millions", () => {
+        const c = container();
+        const card = renderModelCard(c, makeEntry({ downloads: 2_500_000 }), {}) as unknown as MockElement;
+        expect(card.find("lilbee-model-card-downloads")?.textContent).toBe("2.5M downloads");
+    });
+
+    it("renders a task pill in the header", () => {
+        const c = container();
+        const card = renderModelCard(c, makeEntry({ task: "vision" }), {}) as unknown as MockElement;
+        expect(card.find(PILL_CLS.TASK_VISION)).not.toBeNull();
+    });
+
+    it("renders a pick pill when the entry is featured", () => {
+        const c = container();
+        const card = renderModelCard(c, makeEntry({ featured: true }), {}) as unknown as MockElement;
+        expect(card.find(PILL_CLS.PICK)).not.toBeNull();
+    });
+
+    it("omits the pick pill when the entry is not featured", () => {
+        const c = container();
+        const card = renderModelCard(c, makeEntry({ featured: false }), {}) as unknown as MockElement;
+        expect(card.find(PILL_CLS.PICK)).toBeNull();
     });
 
     describe("actions", () => {

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -31,7 +31,7 @@ vi.mock("../../src/views/confirm-modal", () => ({
 
 function makeEntry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
     return {
-        name: "qwen3:8b",
+        name: "qwen3",
         display_name: "Qwen3 8B",
         size_gb: 5,
         min_ram_gb: 8,
@@ -39,6 +39,11 @@ function makeEntry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
         quality_tier: "balanced",
         installed: false,
         source: "native",
+        hf_repo: "qwen/qwen3-8b",
+        tag: "8b",
+        task: "chat",
+        featured: false,
+        downloads: 0,
         ...overrides,
     };
 }
@@ -150,7 +155,7 @@ describe("CatalogModal", () => {
                 ok(
                     makeCatalogResponse([
                         makeEntry({ name: "qwen3:0.6b", display_name: "Qwen3 0.6B", installed: true }),
-                        makeEntry({ name: "qwen3:8b", display_name: "Qwen3 8B", installed: false }),
+                        makeEntry({ hf_repo: "qwen/qwen3-8b", display_name: "Qwen3 8B", installed: false }),
                     ]),
                 ),
             );
@@ -158,6 +163,73 @@ describe("CatalogModal", () => {
             const content = contentEl(modal);
             const headings = content.findAll("lilbee-catalog-section-heading").map((el) => el.textContent);
             expect(headings).toContain(MESSAGES.LABEL_SECTION_INSTALLED);
+        });
+
+        it("renders an 'Our picks' section for featured entries", async () => {
+            const plugin = makePlugin();
+            plugin.api.catalog.mockResolvedValue(
+                ok(
+                    makeCatalogResponse([
+                        makeEntry({ hf_repo: "r1", display_name: "R1", featured: true }),
+                        makeEntry({ hf_repo: "r2", display_name: "R2", featured: false }),
+                    ]),
+                ),
+            );
+            const modal = await openModal(plugin);
+            const content = contentEl(modal);
+            const headings = content.findAll("lilbee-catalog-section-heading").map((el) => el.textContent);
+            expect(headings).toContain(MESSAGES.LABEL_OUR_PICKS);
+        });
+
+        it("groups non-featured entries by task", async () => {
+            const plugin = makePlugin();
+            plugin.api.catalog.mockResolvedValue(
+                ok(
+                    makeCatalogResponse([
+                        makeEntry({ hf_repo: "a", display_name: "Chat A", task: "chat" }),
+                        makeEntry({ hf_repo: "b", display_name: "Vision B", task: "vision" }),
+                        makeEntry({ hf_repo: "c", display_name: "Embed C", task: "embedding" }),
+                    ]),
+                ),
+            );
+            const modal = await openModal(plugin);
+            const content = contentEl(modal);
+            const headings = content.findAll("lilbee-catalog-section-heading").map((el) => el.textContent);
+            expect(headings).toContain(MESSAGES.LABEL_SECTION_CHAT);
+            expect(headings).toContain(MESSAGES.LABEL_SECTION_VISION);
+            expect(headings).toContain(MESSAGES.LABEL_SECTION_EMBEDDING);
+        });
+
+        it("uses the raw task string when an unknown task appears", async () => {
+            const plugin = makePlugin();
+            plugin.api.catalog.mockResolvedValue(
+                ok(makeCatalogResponse([makeEntry({ hf_repo: "x", display_name: "X", task: "custom" as any })])),
+            );
+            const modal = await openModal(plugin);
+            const content = contentEl(modal);
+            const headings = content.findAll("lilbee-catalog-section-heading").map((el) => el.textContent);
+            expect(headings).toContain("custom");
+        });
+
+        it("renders a Browse more models card until the full catalog is loaded", async () => {
+            const plugin = makePlugin();
+            plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry({ featured: true })])));
+            const modal = await openModal(plugin);
+            const content = contentEl(modal);
+            expect(content.find("lilbee-browse-more-card")).not.toBeNull();
+        });
+
+        it("clicking the Browse more card loads the full catalog and drops the card", async () => {
+            const plugin = makePlugin();
+            plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry({ featured: true })])));
+            const modal = await openModal(plugin);
+            const content = contentEl(modal);
+            content.find("lilbee-browse-more-card")!.trigger("click");
+            await tick();
+            await tick();
+            expect(content.find("lilbee-browse-more-card")).toBeNull();
+            // The sort filter should now be downloads (loadFullCatalog side effect)
+            expect(plugin.api.catalog).toHaveBeenLastCalledWith(expect.objectContaining({ sort: "downloads" }));
         });
 
         it("renders the view-toggle CTA banner", async () => {
@@ -203,7 +275,7 @@ describe("CatalogModal", () => {
         });
 
         it("shows Active when the entry is the plugin's active model", async () => {
-            const plugin = makePlugin({ activeModel: "qwen3:8b" });
+            const plugin = makePlugin({ activeModel: "qwen/qwen3-8b" });
             plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry({ installed: true })])));
             const modal = await openModal(plugin);
             const content = contentEl(modal);
@@ -291,13 +363,13 @@ describe("CatalogModal", () => {
             expect(rows.length).toBe(2);
         });
 
-        it("sorts by quant column (string comparison)", async () => {
+        it("sorts alphabetically on task column", async () => {
             const plugin = makePlugin();
             plugin.api.catalog.mockResolvedValue(
                 ok(
                     makeCatalogResponse([
-                        makeEntry({ name: "a", display_name: "A", quality_tier: "balanced" }),
-                        makeEntry({ name: "b", display_name: "B", quality_tier: "accurate" }),
+                        makeEntry({ hf_repo: "a", display_name: "A", task: "vision" }),
+                        makeEntry({ hf_repo: "b", display_name: "B", task: "chat" }),
                     ]),
                 ),
             );
@@ -307,13 +379,82 @@ describe("CatalogModal", () => {
             await tick();
 
             const header = content.find("lilbee-catalog-list-header")!;
-            const quantCol = header.findAll("lilbee-catalog-list-col-quant")[0];
-            quantCol.trigger("click");
+            const taskCol = header.findAll("lilbee-catalog-list-col-task")[0];
+            taskCol.trigger("click");
             await tick();
             const rows = content
                 .findAll("lilbee-catalog-list-row")
                 .map((r) => r.findAll("lilbee-catalog-list-col-name")[0].textContent);
-            expect(rows[0]).toBe("B"); // "accurate" < "balanced"
+            expect(rows[0]).toBe("B"); // "chat" < "vision"
+        });
+
+        it("formats download counts with K and M abbreviations in the list view", async () => {
+            const plugin = makePlugin();
+            plugin.api.catalog.mockResolvedValue(
+                ok(
+                    makeCatalogResponse([
+                        makeEntry({ hf_repo: "a", display_name: "Millions", downloads: 2_500_000 }),
+                        makeEntry({ hf_repo: "b", display_name: "Thousands", downloads: 1500 }),
+                        makeEntry({ hf_repo: "c", display_name: "Raw", downloads: 42 }),
+                    ]),
+                ),
+            );
+            const modal = await openModal(plugin);
+            const content = contentEl(modal);
+            content.find("lilbee-catalog-view-toggle")!.trigger("click");
+            await tick();
+            const dls = content
+                .findAll("lilbee-catalog-list-row")
+                .map((r) => r.findAll("lilbee-catalog-list-col-downloads")[0].textContent);
+            expect(dls).toContain("2.5M");
+            expect(dls).toContain("1.5K");
+            expect(dls).toContain("42");
+        });
+
+        it("renders a star prefix on featured rows", async () => {
+            const plugin = makePlugin();
+            plugin.api.catalog.mockResolvedValue(
+                ok(
+                    makeCatalogResponse([
+                        makeEntry({ hf_repo: "a", display_name: "Featured A", featured: true }),
+                        makeEntry({ hf_repo: "b", display_name: "Plain B", featured: false }),
+                    ]),
+                ),
+            );
+            const modal = await openModal(plugin);
+            const content = contentEl(modal);
+            content.find("lilbee-catalog-view-toggle")!.trigger("click");
+            await tick();
+            const names = content
+                .findAll("lilbee-catalog-list-row")
+                .map((r) => r.findAll("lilbee-catalog-list-col-name")[0].textContent);
+            expect(names).toContain("\u2605 Featured A");
+            expect(names).toContain("Plain B");
+        });
+
+        it("sorts numerically on downloads column", async () => {
+            const plugin = makePlugin();
+            plugin.api.catalog.mockResolvedValue(
+                ok(
+                    makeCatalogResponse([
+                        makeEntry({ name: "a", display_name: "A", downloads: 100 }),
+                        makeEntry({ name: "b", display_name: "B", downloads: 5 }),
+                    ]),
+                ),
+            );
+            const modal = await openModal(plugin);
+            const content = contentEl(modal);
+            content.find("lilbee-catalog-view-toggle")!.trigger("click");
+            await tick();
+
+            const header = content.find("lilbee-catalog-list-header")!;
+            const dlCol = header.findAll("lilbee-catalog-list-col-downloads")[0];
+            dlCol.trigger("click");
+            await tick();
+            const rows = content
+                .findAll("lilbee-catalog-list-row")
+                .map((r) => r.findAll("lilbee-catalog-list-col-name")[0].textContent);
+            expect(rows[0]).toBe("B"); // 5 downloads sorts before 100
         });
     });
 
@@ -429,7 +570,7 @@ describe("CatalogModal", () => {
             pullBtn.trigger("click");
             await tick();
             await tick();
-            expect(plugin.api.pullModel).toHaveBeenCalledWith("qwen3:8b", "native");
+            expect(plugin.api.pullModel).toHaveBeenCalledWith("qwen/qwen3-8b", "native");
         });
 
         it("does not run pull when user cancels the confirm modal", async () => {
@@ -462,31 +603,32 @@ describe("CatalogModal", () => {
             expect(plugin.taskQueue.completed.length).toBeGreaterThan(0);
         });
 
-        it("uses setVisionModel when the task filter is vision", async () => {
+        it("uses setVisionModel when the entry is a vision task", async () => {
             const plugin = makePlugin();
-            plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry({ installed: true })])));
+            plugin.api.catalog.mockResolvedValue(
+                ok(makeCatalogResponse([makeEntry({ installed: true, task: "vision" })])),
+            );
             const modal = await openModal(plugin);
-            // Switch filter to vision so handleUse takes the vision path
-            (modal as any).filterTask = "vision";
             const content = contentEl(modal);
             const useBtn = findButtons(content).find((b) => b.textContent === MESSAGES.BUTTON_USE)!;
             useBtn.trigger("click");
             await tick();
             await tick();
-            expect(plugin.api.setVisionModel).toHaveBeenCalledWith("qwen3:8b");
+            expect(plugin.api.setVisionModel).toHaveBeenCalledWith("qwen/qwen3-8b");
         });
 
-        it("uses setEmbeddingModel when the task filter is embedding", async () => {
+        it("uses setEmbeddingModel when the entry is an embedding task", async () => {
             const plugin = makePlugin();
-            plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry({ installed: true })])));
+            plugin.api.catalog.mockResolvedValue(
+                ok(makeCatalogResponse([makeEntry({ installed: true, task: "embedding" })])),
+            );
             const modal = await openModal(plugin);
-            (modal as any).filterTask = "embedding";
             const content = contentEl(modal);
             const useBtn = findButtons(content).find((b) => b.textContent === MESSAGES.BUTTON_USE)!;
             useBtn.trigger("click");
             await tick();
             await tick();
-            expect(plugin.api.setEmbeddingModel).toHaveBeenCalledWith("qwen3:8b");
+            expect(plugin.api.setEmbeddingModel).toHaveBeenCalledWith("qwen/qwen3-8b");
         });
 
         it("uses setChatModel by default", async () => {
@@ -498,7 +640,7 @@ describe("CatalogModal", () => {
             useBtn.trigger("click");
             await tick();
             await tick();
-            expect(plugin.api.setChatModel).toHaveBeenCalledWith("qwen3:8b");
+            expect(plugin.api.setChatModel).toHaveBeenCalledWith("qwen/qwen3-8b");
         });
 
         it("notices failure when Use fails", async () => {
@@ -512,20 +654,22 @@ describe("CatalogModal", () => {
             await tick();
             await tick();
             const messages = Notice.instances.map((n) => n.message);
-            expect(messages.some((m) => m.includes("qwen3:8b"))).toBe(true);
+            expect(messages.some((m) => m.includes("qwen/qwen3-8b"))).toBe(true);
         });
 
         it("opens confirm-remove modal and deletes the model on confirm", async () => {
             const plugin = makePlugin();
             plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry({ installed: true })])));
-            plugin.api.deleteModel = vi.fn().mockResolvedValue(ok({ deleted: true, model: "qwen3:8b", freed_gb: 5 }));
+            plugin.api.deleteModel = vi
+                .fn()
+                .mockResolvedValue(ok({ deleted: true, model: "qwen/qwen3-8b", freed_gb: 5 }));
             const modal = await openModal(plugin);
             const content = contentEl(modal);
             const removeBtn = findButtons(content).find((b) => b.textContent === MESSAGES.BUTTON_REMOVE)!;
             removeBtn.trigger("click");
             await tick();
             await tick();
-            expect(plugin.api.deleteModel).toHaveBeenCalledWith("qwen3:8b", "native");
+            expect(plugin.api.deleteModel).toHaveBeenCalledWith("qwen/qwen3-8b", "native");
         });
 
         it("skips delete when confirm is cancelled", async () => {
@@ -553,7 +697,7 @@ describe("CatalogModal", () => {
             await tick();
             await tick();
             const messages = Notice.instances.map((n) => n.message);
-            expect(messages.some((m) => m.includes("qwen3:8b"))).toBe(true);
+            expect(messages.some((m) => m.includes("qwen/qwen3-8b"))).toBe(true);
         });
 
         it("fails the task and surfaces a Notice when pull aborts", async () => {

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -15,7 +15,7 @@ vi.mock("../../src/views/catalog-modal", () => ({
 
 function makeEntry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
     return {
-        name: "qwen3:0.6b",
+        name: "qwen3",
         display_name: "Qwen3 0.6B",
         size_gb: 0.5,
         min_ram_gb: 4,
@@ -23,6 +23,11 @@ function makeEntry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
         quality_tier: "balanced",
         installed: false,
         source: "native",
+        hf_repo: "qwen/qwen3-0.6B",
+        tag: "0.6b",
+        task: "chat",
+        featured: true,
+        downloads: 0,
         ...overrides,
     };
 }
@@ -463,8 +468,8 @@ describe("SetupWizard", () => {
 
         it("clicking a model card selects it", async () => {
             const entries = [
-                makeEntry({ name: "qwen/qwen3-0.6B", size_gb: 0.5, min_ram_gb: 4 }),
-                makeEntry({ name: "qwen/qwen3-4B", size_gb: 2.5, min_ram_gb: 8 }),
+                makeEntry({ hf_repo: "qwen/qwen3-0.6B", size_gb: 0.5, min_ram_gb: 4 }),
+                makeEntry({ hf_repo: "qwen/qwen3-4B", size_gb: 2.5, min_ram_gb: 8 }),
             ];
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));


### PR DESCRIPTION
Updates the plugin to consume the enriched catalog response (hf_repo, tag, task, featured, downloads) that the server is adding in parallel (bb-ftqz).

- Task pill + featured star on each model card
- "Our picks" section for featured models in grid view
- Downloads column in list view with K/M formatting
- Pull/use/remove all route via entry.hf_repo
- setActiveFor routes via entry.task, not the filter dropdown
- Flat list only — no family grouping