### PR TITLE
fix: QA round 2 followups — session token, catalog parity, UI polish

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -10,7 +10,7 @@ export const MESSAGES = {
     BUTTON_PULL: "Pull",
     BUTTON_PULL_MODEL: "Pull Model",
     BUTTON_USE: "Use",
-    BUTTON_REMOVE: "Remove",
+    BUTTON_REMOVE: "Delete",
     BUTTON_REFRESH: "Refresh",
     BUTTON_BROWSE_CATALOG: "Browse Catalog",
     BUTTON_BROWSE_FULL_CATALOG: "Browse full catalog",

--- a/styles.css
+++ b/styles.css
@@ -1007,7 +1007,10 @@
 
 .lilbee-catalog-list-col-action {
     flex: 0.8;
-    text-align: right;
+    display: flex;
+    gap: 4px;
+    justify-content: flex-end;
+    align-items: center;
 }
 
 /* Crawl Modal */

--- a/tests/locales/en.test.ts
+++ b/tests/locales/en.test.ts
@@ -14,7 +14,7 @@ describe("MESSAGES", () => {
             expect(MESSAGES.BUTTON_PULL).toBe("Pull");
             expect(MESSAGES.BUTTON_PULL_MODEL).toBe("Pull Model");
             expect(MESSAGES.BUTTON_USE).toBe("Use");
-            expect(MESSAGES.BUTTON_REMOVE).toBe("Remove");
+            expect(MESSAGES.BUTTON_REMOVE).toBe("Delete");
             expect(MESSAGES.BUTTON_REFRESH).toBe("Refresh");
             expect(MESSAGES.BUTTON_BROWSE_CATALOG).toBe("Browse Catalog");
             expect(MESSAGES.BUTTON_BROWSE_FULL_CATALOG).toBe("Browse full catalog");


### PR DESCRIPTION
Rolls up the remaining work from the QA round 2 run against release/next. Session-token auto-discovery for external mode, catalog task pill / featured badge / downloads / hf_repo routing parity with the server, and a few UI polish items found during live testing.

Highlights:
- Session token is read automatically from the lilbee data directory — no manual paste field
- Catalog list view buttons (Use/Delete) no longer overlap
- "Remove" renamed to "Delete" across catalog and model cards
- Auth, SSE streaming, status-bar probes aligned with release/next server API