### PR TITLE
fix: chat dropdown, crawl errors, wiki sync, wikiEnabled

### DIFF
--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -245,7 +245,11 @@ export class ChatView extends ItemView {
     }
 
     private fillSelectOptions(selectEl: HTMLSelectElement, catalog: ModelCatalog): void {
-        const options = buildModelOptions(catalog);
+        const installedOnly: ModelCatalog = {
+            ...catalog,
+            catalog: catalog.catalog.filter((m) => m.installed),
+        };
+        const options = buildModelOptions(installedOnly);
         for (const [value, label] of Object.entries(options)) {
             const option = selectEl.createEl("option", { text: label });
             (option as HTMLOptionElement).value = value;

--- a/src/views/crawl-modal.ts
+++ b/src/views/crawl-modal.ts
@@ -113,7 +113,8 @@ export class CrawlModal extends Modal {
                         this.decide(true);
                         return;
                     }
-                    case SSE_EVENT.CRAWL_ERROR: {
+                    case SSE_EVENT.CRAWL_ERROR:
+                    case SSE_EVENT.ERROR: {
                         const d = event.data as { message?: string };
                         this.plugin.taskQueue.fail(taskId, d.message ?? "unknown");
                         new Notice(MESSAGES.ERROR_CRAWL_ERROR.replace("{msg}", d.message ?? "unknown"));

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -866,6 +866,33 @@ describe("ChatView.onOpen — model selector", () => {
         expect(plugin.api.setChatModel).not.toHaveBeenCalled();
     });
 
+    it("excludes uninstalled catalog models from dropdown options", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        plugin.api.listModels = vi.fn().mockResolvedValue({
+            chat: {
+                active: "llama3",
+                installed: ["llama3"],
+                catalog: [
+                    { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
+                    { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
+                ],
+            },
+        });
+
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const select = container.find("lilbee-chat-model-select")!;
+        const options = select.children.filter((c: MockElement) => c.tagName === "OPTION");
+        const labels = options.map((o: MockElement) => o.textContent);
+        expect(labels).toContain("llama3");
+        expect(labels).not.toContain("phi3 (not installed)");
+        expect(labels).not.toContain("phi3");
+    });
+
     it("selecting uninstalled catalog model triggers auto-pull with progress", async () => {
         Notice.clear();
         const plugin = makePlugin();


### PR DESCRIPTION
Fixes from QA rounds 6-7:

- Chat model dropdown now only shows installed models. Previously uninstalled catalog models were selectable, causing server crashes when the model wasn't pulled locally.
- Crawl modal handles generic SSE error events (server sends 'error' not 'crawl_error').
- Wiki sync crash fixed — aligned WikiPage type with actual server response shape.
- wikiEnabled setting preserved when server omits wiki status field.