### PR TITLE
Use server has_more field for catalog pagination

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -213,6 +213,7 @@ export interface CatalogResponse {
     limit: number;
     offset: number;
     models: CatalogEntry[];
+    has_more: boolean;
 }
 
 export interface InstalledModel {

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -27,7 +27,7 @@ export class CatalogModal extends Modal {
     private filterSort: SortFilter = FILTERS.SORT.FEATURED;
     private filterSearch = "";
     private offset = 0;
-    private total = 0;
+    private hasMore = false;
     private entries: CatalogEntry[] = [];
     private resultsEl: HTMLElement | null = null;
     private loadMoreBtn: HTMLElement | null = null;
@@ -168,7 +168,7 @@ export class CatalogModal extends Modal {
         }
 
         const response = result.value;
-        this.total = response.total;
+        this.hasMore = response.has_more;
         this.entries.push(...response.models);
         this.offset += response.models.length;
 
@@ -365,7 +365,7 @@ export class CatalogModal extends Modal {
 
     private updateLoadMore(): void {
         if (!this.loadMoreBtn) return;
-        this.loadMoreBtn.style.display = this.offset < this.total ? "" : "none";
+        this.loadMoreBtn.style.display = this.hasMore ? "" : "none";
     }
 
     private handleRemove(entry: CatalogEntry, btn: HTMLElement): void {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -515,7 +515,7 @@ describe("pullModel()", () => {
         });
 
         it("appends query params when provided", async () => {
-            fetchMock.mockResolvedValue(jsonResponse({ total: 0, limit: 10, offset: 0, models: [] }));
+            fetchMock.mockResolvedValue(jsonResponse({ total: 0, limit: 10, offset: 0, models: [], has_more: false }));
 
             await client.catalog({
                 task: "chat",

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -2077,6 +2077,18 @@ describe("buildModelOptions()", () => {
         expect(Object.keys(options).length).toBe(0);
     });
 
+    it("shows source tag when model has source", () => {
+        const catalog: ModelCatalog = {
+            active: "llama3",
+            catalog: [
+                { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true, source: "native" },
+            ],
+            installed: ["llama3"],
+        };
+        const options = buildModelOptions(catalog);
+        expect(options["llama3"]).toBe("llama3 [native]");
+    });
+
     it("deduplicates :latest when a specific tag exists", () => {
         const catalog: ModelCatalog = {
             active: "mistral:7b",

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -381,7 +381,8 @@ describe("CatalogResponse interface", () => {
             total: 50,
             limit: 20,
             offset: 0,
-            families: [],
+            models: [],
+            has_more: false,
         };
         expect(r.total).toBe(50);
     });

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -48,8 +48,12 @@ function makeEntry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
     };
 }
 
-function makeCatalogResponse(models: CatalogEntry[] = [makeEntry()], total?: number): CatalogResponse {
-    return { total: total ?? models.length, limit: 20, offset: 0, models };
+function makeCatalogResponse(
+    models: CatalogEntry[] = [makeEntry()],
+    total?: number,
+    has_more = false,
+): CatalogResponse {
+    return { total: total ?? models.length, limit: 20, offset: 0, models, has_more };
 }
 
 function makePlugin(overrides: Record<string, unknown> = {}) {
@@ -521,18 +525,22 @@ describe("CatalogModal", () => {
     });
 
     describe("load more", () => {
-        it("shows load-more button when offset < total", async () => {
+        it("shows load-more button when has_more is true", async () => {
             const plugin = makePlugin();
-            plugin.api.catalog.mockResolvedValue(ok({ total: 40, limit: 20, offset: 0, models: [makeEntry()] }));
+            plugin.api.catalog.mockResolvedValue(
+                ok({ total: 40, limit: 20, offset: 0, models: [makeEntry()], has_more: true }),
+            );
             const modal = await openModal(plugin);
             const content = contentEl(modal);
             const btn = content.find("lilbee-catalog-load-more")! as unknown as MockElement;
             expect(btn.style.display).toBe("");
         });
 
-        it("hides load-more button when offset >= total", async () => {
+        it("hides load-more button when has_more is false", async () => {
             const plugin = makePlugin();
-            plugin.api.catalog.mockResolvedValue(ok({ total: 1, limit: 20, offset: 0, models: [makeEntry()] }));
+            plugin.api.catalog.mockResolvedValue(
+                ok({ total: 1, limit: 20, offset: 0, models: [makeEntry()], has_more: false }),
+            );
             const modal = await openModal(plugin);
             const content = contentEl(modal);
             const btn = content.find("lilbee-catalog-load-more")! as unknown as MockElement;
@@ -544,8 +552,8 @@ describe("CatalogModal", () => {
             const first = makeEntry({ name: "a", display_name: "A" });
             const second = makeEntry({ name: "b", display_name: "B" });
             plugin.api.catalog
-                .mockResolvedValueOnce(ok({ total: 2, limit: 1, offset: 0, models: [first] }))
-                .mockResolvedValueOnce(ok({ total: 2, limit: 1, offset: 1, models: [second] }));
+                .mockResolvedValueOnce(ok({ total: 2, limit: 1, offset: 0, models: [first], has_more: true }))
+                .mockResolvedValueOnce(ok({ total: 2, limit: 1, offset: 1, models: [second], has_more: false }));
             const modal = await openModal(plugin);
             const content = contentEl(modal);
             content.find("lilbee-catalog-load-more")!.trigger("click");

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -38,6 +38,7 @@ function makeCatalogResponse(models: CatalogEntry[] = []): CatalogResponse {
         limit: 4,
         offset: 0,
         models,
+        has_more: false,
     };
 }
 


### PR DESCRIPTION
The catalog modal's Load More button relied on `offset < total` to decide visibility, but `total` from the server is just the current page count — not the true HuggingFace total. This meant the button could disappear before all results were loaded.

The server API is adding a `has_more` boolean to the catalog response (BEE-ep0). This PR updates the plugin to use it:

- **CatalogResponse** gets `has_more: boolean`
- **CatalogModal** stores `hasMore` from the response and uses it directly in `updateLoadMore()`, replacing the `offset < total` comparison
- The `total` instance property is removed from the modal since it was only used for this check
