### PR TITLE
Suppress wiki search mode when wiki is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,14 @@
 ![Platforms](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey.svg)
 [![Obsidian](https://img.shields.io/badge/Obsidian-Plugin-7c3aed?logo=obsidian&logoColor=white)](https://obsidian.md)
 
-> Beta — feedback and bug reports welcome. [Open an issue](https://github.com/tobocop2/obsidian-lilbee/issues).
->
-> If you delete a file from your vault, it will still show up in search results. Removing deleted files from the index is coming soon.
-
-Chat with your documents privately, entirely on your own machine. Ask questions about your notes, PDFs, code, spreadsheets, and images — and get answers grounded in what you've actually written, with source citations. Save conversations back to your vault as markdown. No cloud services, no API keys, no data leaves your computer.
+> This is in active development. Cool things coming, bear with me please: https://github.com/tobocop2/obsidian-lilbee/pull/7 
+> Feel free to use latest published versions but the entire project is actively being rebuilt and will be much more useful soon My motivation is a single executable that I can use for q&a, programming, and just having a locally curated encyclopedia like I used to have with Encarta 99, but this time I can talk to it instead and get responses without any need for reaching the Internet. Having a local search engine is awesome and being in full control of the inputs and outputs is even better.
+> Gain back some privacy while still having the awesome power of AI. Frontier AI's are awesome and local LLM's are no replacement but they certainly should be used much more than they currently are. Graphics cards not just for gamers and crypto miners, but now they have become very useful to my friends and I on a daily basis thanks to lilbee.
+> It's time the masses have something simple to use, fully local, and all in one process / install. Computers can be more than frontends for agents and web browsers and it's time to take advantage of our hardware. This is my attempt at a solution to this problem. I think existing solutions have too many moving pieces and require too many heavy dependencies and often use sidecar style solutions.
+> There's no simple way to make local AI immediately useful.  A single executable that anyone can run is much more ideal and shareable and democratic. It's easier to install and use that way for everyone.
+> Local AI at this time is for nerds but it doesn't have to be and this approach I think is the right direction towards that goal. There's a lot to this project so check out the description below for what to expect For the GUI option, I'm releasing an obsidian plugin on top of lilbee with feature parity to the terminal UI here https://github.com/tobocop2/obsidian-lilbee
+> Chat with your documents privately, entirely on your own machine. Ask questions about your notes, PDFs, code, spreadsheets, and images — and get answers grounded in what you've actually written, with source citations. Save conversations back to your vault as markdown. No cloud services, no API keys, no data leaves your computer.
+> This plugin installs the lilbee server and manages it. It's one single sidecar app that can run alongside any GUI. 
 
 ## Demo
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,14 @@ export const NOTICE = {
     ADD_CANCELLED: "lilbee: add cancelled",
 } as const;
 
+export type SearchChunkType = "all" | "raw" | "wiki";
+
+export const SEARCH_CHUNK_TYPE = {
+    ALL: "all",
+    RAW: "raw",
+    WIKI: "wiki",
+} as const satisfies Record<string, SearchChunkType>;
+
 export interface LilbeeSettings {
     serverUrl: string;
     topK: number;
@@ -142,6 +150,8 @@ export interface LilbeeSettings {
     serverPort: number | null;
     lilbeeVersion: string;
     systemPrompt: string;
+    wikiEnabled: boolean;
+    searchChunkType: SearchChunkType;
 }
 
 export const DEFAULT_SETTINGS: LilbeeSettings = {
@@ -160,6 +170,8 @@ export const DEFAULT_SETTINGS: LilbeeSettings = {
     serverPort: null,
     lilbeeVersion: "",
     systemPrompt: "",
+    wikiEnabled: false,
+    searchChunkType: "raw",
 };
 
 /** SSE event type constants — shared across chat, sync, and model pull streams. */

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -1,7 +1,7 @@
 import { FuzzySuggestModal, ItemView, MarkdownRenderer, Menu, Notice, setIcon, type TFile, WorkspaceLeaf } from "obsidian";
 import type LilbeePlugin from "../main";
-import { MODEL_TYPE, NOTICE, SSE_EVENT } from "../types";
-import type { GenerationOptions, Message, ModelCatalog, ModelType, OllamaPullProgress, Source, SSEEvent } from "../types";
+import { MODEL_TYPE, NOTICE, SEARCH_CHUNK_TYPE, SSE_EVENT } from "../types";
+import type { GenerationOptions, Message, ModelCatalog, ModelType, OllamaPullProgress, SearchChunkType, Source, SSEEvent } from "../types";
 import { PullQueue } from "../pull-queue";
 import { renderSourceChip } from "./results";
 import { buildModelOptions, SEPARATOR_KEY } from "../settings";
@@ -159,6 +159,8 @@ export class ChatView extends ItemView {
 
         this.fetchAndFillSelectors();
 
+        this.renderSearchModeToggle(toolbar);
+
         toolbar.createDiv({ cls: "lilbee-toolbar-spacer" });
 
         const saveBtn = toolbar.createEl("button", { cls: "lilbee-chat-save" });
@@ -171,6 +173,33 @@ export class ChatView extends ItemView {
             cls: "lilbee-chat-clear",
         });
         clearBtn.addEventListener("click", () => this.clearChat());
+    }
+
+    private renderSearchModeToggle(container: HTMLElement): void {
+        if (!this.plugin.settings.wikiEnabled
+            && this.plugin.settings.searchChunkType === SEARCH_CHUNK_TYPE.WIKI) {
+            this.plugin.settings.searchChunkType = SEARCH_CHUNK_TYPE.ALL;
+        }
+        const group = container.createDiv({ cls: "lilbee-search-mode-toggle" });
+        const modes: SearchChunkType[] = this.plugin.settings.wikiEnabled
+            ? [SEARCH_CHUNK_TYPE.ALL, SEARCH_CHUNK_TYPE.RAW, SEARCH_CHUNK_TYPE.WIKI]
+            : [SEARCH_CHUNK_TYPE.ALL, SEARCH_CHUNK_TYPE.RAW];
+        const buttons: HTMLElement[] = [];
+        for (const mode of modes) {
+            const btn = group.createEl("button", {
+                text: mode,
+                cls: "lilbee-search-mode-btn",
+            });
+            if (mode === this.plugin.settings.searchChunkType) {
+                btn.addClass("is-active");
+            }
+            btn.addEventListener("click", () => {
+                this.plugin.settings.searchChunkType = mode;
+                for (const b of buttons) b.removeClass("is-active");
+                btn.addClass("is-active");
+            });
+            buttons.push(btn);
+        }
     }
 
     private createBanner(

--- a/src/views/search-modal.ts
+++ b/src/views/search-modal.ts
@@ -1,6 +1,7 @@
 import { App, Modal } from "obsidian";
 import type LilbeePlugin from "../main";
-import type { DocumentResult } from "../types";
+import type { DocumentResult, SearchChunkType } from "../types";
+import { SEARCH_CHUNK_TYPE } from "../types";
 import { renderDocumentResult, renderSourceChip } from "./results";
 
 const SEARCH_DEBOUNCE_MS = 300;
@@ -31,6 +32,7 @@ export class SearchModal extends Modal {
             placeholder: this.mode === "search" ? "Type to search..." : "Ask anything...",
         });
 
+        this.renderSearchModeToggle(contentEl);
         this.resultsContainer = contentEl.createDiv({ cls: "lilbee-modal-results" });
         this.renderEmptyState("Enter a query to begin.");
 
@@ -72,6 +74,33 @@ export class SearchModal extends Modal {
         if (!this.resultsContainer) return;
         this.resultsContainer.empty();
         this.resultsContainer.createDiv({ cls: "lilbee-loading" });
+    }
+
+    private renderSearchModeToggle(container: HTMLElement): void {
+        if (!this.plugin.settings.wikiEnabled
+            && this.plugin.settings.searchChunkType === SEARCH_CHUNK_TYPE.WIKI) {
+            this.plugin.settings.searchChunkType = SEARCH_CHUNK_TYPE.ALL;
+        }
+        const group = container.createDiv({ cls: "lilbee-search-mode-toggle" });
+        const modes: SearchChunkType[] = this.plugin.settings.wikiEnabled
+            ? [SEARCH_CHUNK_TYPE.ALL, SEARCH_CHUNK_TYPE.RAW, SEARCH_CHUNK_TYPE.WIKI]
+            : [SEARCH_CHUNK_TYPE.ALL, SEARCH_CHUNK_TYPE.RAW];
+        const buttons: HTMLElement[] = [];
+        for (const mode of modes) {
+            const btn = group.createEl("button", {
+                text: mode,
+                cls: "lilbee-search-mode-btn",
+            });
+            if (mode === this.plugin.settings.searchChunkType) {
+                btn.addClass("is-active");
+            }
+            btn.addEventListener("click", () => {
+                this.plugin.settings.searchChunkType = mode;
+                for (const b of buttons) b.removeClass("is-active");
+                btn.addClass("is-active");
+            });
+            buttons.push(btn);
+        }
     }
 
     private async runSearch(query: string): Promise<void> {

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,5 +1,5 @@
 import { vi, describe, it, expect } from "vitest";
-import { DEFAULT_SETTINGS, SSE_EVENT, JSON_HEADERS, SERVER_MODE } from "../src/types";
+import { DEFAULT_SETTINGS, SSE_EVENT, JSON_HEADERS, SERVER_MODE, SEARCH_CHUNK_TYPE } from "../src/types";
 import type {
     Excerpt,
     DocumentResult,
@@ -14,6 +14,7 @@ import type {
     Message,
     LilbeeSettings,
     GenerationOptions,
+    SearchChunkType,
 } from "../src/types";
 
 describe("DEFAULT_SETTINGS", () => {
@@ -33,9 +34,17 @@ describe("DEFAULT_SETTINGS", () => {
         expect(DEFAULT_SETTINGS.syncDebounceMs).toBe(5000);
     });
 
+    it("has wikiEnabled set to false", () => {
+        expect(DEFAULT_SETTINGS.wikiEnabled).toBe(false);
+    });
+
+    it("has searchChunkType set to raw", () => {
+        expect(DEFAULT_SETTINGS.searchChunkType).toBe("raw");
+    });
+
     it("is a plain object with exactly the expected keys", () => {
         const keys = Object.keys(DEFAULT_SETTINGS).sort();
-        expect(keys).toEqual(["lilbeeVersion", "num_ctx", "ollamaUrl", "repeat_penalty", "seed", "serverMode", "serverPort", "serverUrl", "syncDebounceMs", "syncMode", "systemPrompt", "temperature", "topK", "top_k_sampling", "top_p"].sort());
+        expect(keys).toEqual(["lilbeeVersion", "num_ctx", "ollamaUrl", "repeat_penalty", "searchChunkType", "seed", "serverMode", "serverPort", "serverUrl", "syncDebounceMs", "syncMode", "systemPrompt", "temperature", "topK", "top_k_sampling", "top_p", "wikiEnabled"].sort());
     });
 });
 
@@ -229,6 +238,8 @@ describe("LilbeeSettings interface", () => {
             num_ctx: null,
             seed: null,
             systemPrompt: "",
+            wikiEnabled: false,
+            searchChunkType: "raw",
         };
         expect(s.syncMode).toBe("manual");
     });
@@ -247,8 +258,17 @@ describe("LilbeeSettings interface", () => {
             num_ctx: null,
             seed: null,
             systemPrompt: "",
+            wikiEnabled: true,
+            searchChunkType: "wiki",
         };
         expect(s.syncMode).toBe("auto");
+    });
+});
+
+describe("SearchChunkType type", () => {
+    it("accepts all valid values", () => {
+        const values: SearchChunkType[] = ["all", "raw", "wiki"];
+        expect(values).toHaveLength(3);
     });
 });
 
@@ -271,6 +291,14 @@ describe("SERVER_MODE constants", () => {
     it("has MANAGED and EXTERNAL values", () => {
         expect(SERVER_MODE.MANAGED).toBe("managed");
         expect(SERVER_MODE.EXTERNAL).toBe("external");
+    });
+});
+
+describe("SEARCH_CHUNK_TYPE constants", () => {
+    it("has ALL, RAW, and WIKI values", () => {
+        expect(SEARCH_CHUNK_TYPE.ALL).toBe("all");
+        expect(SEARCH_CHUNK_TYPE.RAW).toBe("raw");
+        expect(SEARCH_CHUNK_TYPE.WIKI).toBe("wiki");
     });
 });
 

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -68,7 +68,7 @@ function makePlugin(): LilbeePlugin {
             pull: vi.fn(),
             delete: vi.fn(),
         },
-        settings: { topK: 5 },
+        settings: { topK: 5, wikiEnabled: false, searchChunkType: "raw" },
         activeModel: "llama3",
         activeVisionModel: "",
         fetchActiveModel: vi.fn(),
@@ -2764,6 +2764,67 @@ describe("ChatView — offline retry", () => {
         await vi.advanceTimersByTimeAsync(5000);
         expect((view as any).retryCount).toBe(0);
 
+        await view.onClose();
+    });
+});
+
+describe("ChatView.renderSearchModeToggle", () => {
+    beforeEach(() => {
+        Notice.clear();
+    });
+
+    it("hides wiki button when wikiEnabled is false", async () => {
+        const plugin = makePlugin();
+        plugin.settings.wikiEnabled = false;
+        plugin.settings.searchChunkType = "raw";
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const toggle = container.find("lilbee-search-mode-toggle");
+        expect(toggle).not.toBeNull();
+        const buttons = toggle!.children.filter(c => c.tagName === "BUTTON");
+        expect(buttons.map(b => b.textContent)).toEqual(["all", "raw"]);
+        await view.onClose();
+    });
+
+    it("shows wiki button when wikiEnabled is true", async () => {
+        const plugin = makePlugin();
+        plugin.settings.wikiEnabled = true;
+        plugin.settings.searchChunkType = "raw";
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const toggle = container.find("lilbee-search-mode-toggle");
+        const buttons = toggle!.children.filter(c => c.tagName === "BUTTON");
+        expect(buttons.map(b => b.textContent)).toEqual(["all", "raw", "wiki"]);
+        await view.onClose();
+    });
+
+    it("falls back to all when wiki disabled and searchChunkType is wiki", async () => {
+        const plugin = makePlugin();
+        plugin.settings.wikiEnabled = false;
+        plugin.settings.searchChunkType = "wiki";
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        expect(plugin.settings.searchChunkType).toBe("all");
+        await view.onClose();
+    });
+
+    it("clicking a button updates searchChunkType", async () => {
+        const plugin = makePlugin();
+        plugin.settings.wikiEnabled = false;
+        plugin.settings.searchChunkType = "raw";
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const toggle = container.find("lilbee-search-mode-toggle")!;
+        const buttons = toggle.children.filter(c => c.tagName === "BUTTON");
+        const allBtn = buttons.find(b => b.textContent === "all")!;
+        allBtn.trigger("click");
+        expect(plugin.settings.searchChunkType).toBe("all");
+        expect(allBtn.classList.contains("is-active")).toBe(true);
+        const rawBtn = buttons.find(b => b.textContent === "raw")!;
+        expect(rawBtn.classList.contains("is-active")).toBe(false);
         await view.onClose();
     });
 });

--- a/tests/views/search-modal.test.ts
+++ b/tests/views/search-modal.test.ts
@@ -12,7 +12,7 @@ vi.mock("../../src/views/results", () => ({
 import { SearchModal } from "../../src/views/search-modal";
 import { renderDocumentResult, renderSourceChip } from "../../src/views/results";
 
-function makePlugin(): LilbeePlugin {
+function makePlugin(overrides: Record<string, unknown> = {}): LilbeePlugin {
     return {
         api: {
             search: vi.fn(),
@@ -23,6 +23,9 @@ function makePlugin(): LilbeePlugin {
             topK: 5,
             syncMode: "manual" as const,
             syncDebounceMs: 5000,
+            wikiEnabled: false,
+            searchChunkType: "raw",
+            ...overrides,
         },
     } as unknown as LilbeePlugin;
 }
@@ -223,6 +226,56 @@ describe("SearchModal", () => {
             await vi.runAllTimersAsync();
 
             expect(plugin.api.ask).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("renderSearchModeToggle", () => {
+        it("hides wiki button when wikiEnabled is false", () => {
+            const modal = new SearchModal(app, plugin, "search");
+            modal.open();
+            const toggle = modal.contentEl.find("lilbee-search-mode-toggle");
+            expect(toggle).not.toBeNull();
+            const buttons = toggle!.children.filter(c => c.tagName === "BUTTON");
+            expect(buttons.map(b => b.textContent)).toEqual(["all", "raw"]);
+        });
+
+        it("shows wiki button when wikiEnabled is true", () => {
+            const wikiPlugin = makePlugin({ wikiEnabled: true });
+            const modal = new SearchModal(app, wikiPlugin, "search");
+            modal.open();
+            const toggle = modal.contentEl.find("lilbee-search-mode-toggle");
+            const buttons = toggle!.children.filter(c => c.tagName === "BUTTON");
+            expect(buttons.map(b => b.textContent)).toEqual(["all", "raw", "wiki"]);
+        });
+
+        it("falls back to all when wiki disabled and searchChunkType is wiki", () => {
+            const wikiPlugin = makePlugin({ wikiEnabled: false, searchChunkType: "wiki" });
+            const modal = new SearchModal(app, wikiPlugin, "search");
+            modal.open();
+            expect(wikiPlugin.settings.searchChunkType).toBe("all");
+        });
+
+        it("marks active button with is-active class", () => {
+            const modal = new SearchModal(app, plugin, "search");
+            modal.open();
+            const toggle = modal.contentEl.find("lilbee-search-mode-toggle");
+            const buttons = toggle!.children.filter(c => c.tagName === "BUTTON");
+            const active = buttons.filter(b => b.classList.contains("is-active"));
+            expect(active).toHaveLength(1);
+            expect(active[0].textContent).toBe("raw");
+        });
+
+        it("clicking a button updates searchChunkType and active class", () => {
+            const modal = new SearchModal(app, plugin, "search");
+            modal.open();
+            const toggle = modal.contentEl.find("lilbee-search-mode-toggle");
+            const buttons = toggle!.children.filter(c => c.tagName === "BUTTON");
+            const allBtn = buttons.find(b => b.textContent === "all")!;
+            allBtn.trigger("click");
+            expect(plugin.settings.searchChunkType).toBe("all");
+            expect(allBtn.classList.contains("is-active")).toBe(true);
+            const rawBtn = buttons.find(b => b.textContent === "raw")!;
+            expect(rawBtn.classList.contains("is-active")).toBe(false);
         });
     });
 


### PR DESCRIPTION
Adds wikiEnabled and searchChunkType fields to plugin settings (defaults: false and "raw"). Both the search modal and chat view now render a search mode toggle with "all", "raw", and conditionally "wiki" buttons. When wiki is disabled, the wiki button is hidden and any existing wiki selection falls back to "all".

This pairs with a server-side PR that guards prefer_wiki() behind the wiki config flag and threads chunk_type through the search pipeline.