### PR TITLE
feat: add wiki enable/disable toggle to settings

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -366,6 +366,8 @@ export const MESSAGES = {
     // Wiki settings
     LABEL_WIKI_SECTION: "Wiki",
     LABEL_WIKI_NOT_ENABLED: "Wiki (not enabled)",
+    LABEL_WIKI_ENABLE_TOGGLE: "Enable wiki",
+    DESC_WIKI_ENABLE_TOGGLE: "Show wiki search mode and use wiki-enhanced results",
     LABEL_WIKI_STATUS: "Wiki status",
     LABEL_WIKI_PRUNE_RAW: "Prune raw chunks",
     LABEL_WIKI_FAITHFULNESS: "Faithfulness threshold",

--- a/src/main.ts
+++ b/src/main.ts
@@ -554,7 +554,8 @@ export default class LilbeePlugin extends Plugin {
             const status = await this.api.status();
             if (status.isOk()) {
                 if (status.value.wiki != null) {
-                    this.wikiEnabled = !!status.value.wiki.enabled;
+                    const serverWikiEnabled = !!status.value.wiki.enabled;
+                    this.wikiEnabled = this.settings.wikiEnabled ? serverWikiEnabled : false;
                 }
                 this.wikiPageCount = status.value.wiki?.page_count ?? 0;
                 this.wikiDraftCount = status.value.wiki?.draft_count ?? 0;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -566,12 +566,29 @@ export class LilbeeSettingTab extends PluginSettingTab {
             return;
         }
 
+        // Enable wiki toggle (user preference)
+        const subSettingsContainer = details.createDiv({ cls: "lilbee-wiki-sub-settings" });
+
+        new Setting(details)
+            .setName(MESSAGES.LABEL_WIKI_ENABLE_TOGGLE)
+            .setDesc(MESSAGES.DESC_WIKI_ENABLE_TOGGLE)
+            .addToggle((toggle) => {
+                toggle.setValue(this.plugin.settings.wikiEnabled);
+                toggle.onChange(async (value) => {
+                    this.plugin.settings.wikiEnabled = value;
+                    await this.plugin.saveSettings();
+                    this.setSubSettingsVisible(subSettingsContainer, value);
+                });
+            });
+
+        this.setSubSettingsVisible(subSettingsContainer, this.plugin.settings.wikiEnabled);
+
         // Wiki status (display only)
         const statusDesc = `Enabled — ${this.plugin.wikiPageCount} pages, ${this.plugin.wikiDraftCount} drafts`;
-        new Setting(details).setName(MESSAGES.LABEL_WIKI_STATUS).setDesc(statusDesc).setDisabled(true);
+        new Setting(subSettingsContainer).setName(MESSAGES.LABEL_WIKI_STATUS).setDesc(statusDesc).setDisabled(true);
 
         // Prune raw chunks
-        new Setting(details)
+        new Setting(subSettingsContainer)
             .setName(MESSAGES.LABEL_WIKI_PRUNE_RAW)
             .setDesc(MESSAGES.DESC_WIKI_PRUNE_RAW)
             .addToggle((toggle) => {
@@ -589,7 +606,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             });
 
         // Faithfulness threshold
-        new Setting(details)
+        new Setting(subSettingsContainer)
             .setName(MESSAGES.LABEL_WIKI_FAITHFULNESS)
             .setDesc(MESSAGES.DESC_WIKI_FAITHFULNESS)
             .addSlider((slider) => {
@@ -610,7 +627,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             });
 
         // Default search mode
-        new Setting(details)
+        new Setting(subSettingsContainer)
             .setName(MESSAGES.LABEL_WIKI_SEARCH_MODE)
             .setDesc(MESSAGES.DESC_WIKI_SEARCH_MODE)
             .addDropdown((dropdown) => {
@@ -626,7 +643,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             });
 
         // Sync wiki to vault
-        new Setting(details)
+        new Setting(subSettingsContainer)
             .setName(MESSAGES.LABEL_WIKI_SYNC_TO_VAULT)
             .setDesc(MESSAGES.DESC_WIKI_SYNC_TO_VAULT)
             .addToggle((toggle) => {
@@ -644,7 +661,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             });
 
         // Wiki vault folder
-        new Setting(details)
+        new Setting(subSettingsContainer)
             .setName(MESSAGES.LABEL_WIKI_VAULT_FOLDER)
             .setDesc(MESSAGES.DESC_WIKI_VAULT_FOLDER)
             .addText((text) => {
@@ -659,7 +676,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             });
 
         // Run lint button
-        new Setting(details).setName(MESSAGES.LABEL_WIKI_RUN_LINT).addButton((btn) => {
+        new Setting(subSettingsContainer).setName(MESSAGES.LABEL_WIKI_RUN_LINT).addButton((btn) => {
             btn.setButtonText(MESSAGES.LABEL_WIKI_RUN_LINT);
             btn.onClick(() => {
                 void this.plugin.runWikiLint();
@@ -667,12 +684,16 @@ export class LilbeeSettingTab extends PluginSettingTab {
         });
 
         // Run prune button
-        new Setting(details).setName(MESSAGES.LABEL_WIKI_RUN_PRUNE).addButton((btn) => {
+        new Setting(subSettingsContainer).setName(MESSAGES.LABEL_WIKI_RUN_PRUNE).addButton((btn) => {
             btn.setButtonText(MESSAGES.LABEL_WIKI_RUN_PRUNE);
             btn.onClick(() => {
                 void this.plugin.runWikiPrune();
             });
         });
+    }
+
+    private setSubSettingsVisible(container: HTMLElement, visible: boolean): void {
+        container.style.display = visible ? "" : "none";
     }
 
     private renderAdvancedSettings(containerEl: HTMLElement): void {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -576,6 +576,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 toggle.setValue(this.plugin.settings.wikiEnabled);
                 toggle.onChange(async (value) => {
                     this.plugin.settings.wikiEnabled = value;
+                    this.plugin.wikiEnabled = value && this.plugin.wikiEnabled;
                     await this.plugin.saveSettings();
                     this.setSubSettingsVisible(subSettingsContainer, value);
                 });

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -2940,8 +2940,8 @@ describe("LilbeePlugin", () => {
     });
 
     describe("fetchActiveModel — wiki detection", () => {
-        it("sets wikiEnabled from status response", async () => {
-            const plugin = await createPlugin();
+        it("sets wikiEnabled from status response when user toggle is on", async () => {
+            const plugin = await createPlugin({ wikiEnabled: true });
             await plugin.onload();
 
             plugin.api.listModels = vi.fn().mockResolvedValue({
@@ -2958,7 +2958,7 @@ describe("LilbeePlugin", () => {
             expect((plugin as any).wikiEnabled).toBe(true);
         });
 
-        it("does not overwrite settings.wikiEnabled with server status", async () => {
+        it("server wiki enabled does not override user-disabled setting", async () => {
             const plugin = await createPlugin({ serverMode: "external", wikiEnabled: false });
             await plugin.onload();
 
@@ -2972,8 +2972,8 @@ describe("LilbeePlugin", () => {
 
             await plugin.fetchActiveModel();
 
-            // Runtime flag reflects server, but settings preserve user preference
-            expect((plugin as any).wikiEnabled).toBe(true);
+            // User toggle is off — runtime flag stays false even though server has wiki
+            expect((plugin as any).wikiEnabled).toBe(false);
             expect(plugin.settings.wikiEnabled).toBe(false);
         });
 
@@ -3017,6 +3017,7 @@ describe("LilbeePlugin", () => {
         it("fetchActiveModel initializes WikiSync when wikiSyncToVault is true", async () => {
             const plugin = await createPlugin({
                 serverMode: "external",
+                wikiEnabled: true,
                 wikiSyncToVault: true,
                 wikiVaultFolder: "lilbee-wiki",
             });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -2928,14 +2928,7 @@ describe("managed mode settings", () => {
             const tab = makeTab(plugin);
             const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
 
-            // Find the wiki enable toggle by effect: it's the one that changes wikiEnabled
-            const wikiToggle = toggleOnChanges.find((cb) => {
-                const before = plugin.settings.wikiEnabled;
-                // dry-run: call with opposite value and check if wikiEnabled changed
-                plugin.settings.wikiEnabled = before; // reset after find
-                return true; // we'll identify by calling each and checking
-            });
-            // Instead of fragile index, call each toggle with false until wikiEnabled flips
+            // Find the wiki enable toggle by effect: call each with false until wikiEnabled flips
             let wikiToggleIdx = -1;
             for (let i = 0; i < toggleOnChanges.length; i++) {
                 plugin.settings.wikiEnabled = true; // reset

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -2915,10 +2915,62 @@ describe("managed mode settings", () => {
             (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
             const tab = makeTab(plugin);
             const { toggleOnChanges, buttonOnClicks } = captureSettingCallbacks(() => tab.display());
-            // Wiki section adds: 1 toggle (prune raw) + 1 slider (faithfulness) + 1 dropdown (search mode) + 2 buttons (lint, prune)
-            // toggleOnChanges: adaptiveThreshold + wikiPruneRaw
-            expect(toggleOnChanges.length).toBeGreaterThanOrEqual(2);
+            // Wiki section adds: 1 toggle (enable) + 1 toggle (prune raw) + 1 slider (faithfulness) + 1 dropdown (search mode) + 2 buttons (lint, prune)
+            // toggleOnChanges: adaptiveThreshold + wikiEnable + wikiPruneRaw + wikiSyncToVault
+            expect(toggleOnChanges.length).toBeGreaterThanOrEqual(3);
             expect(buttonOnClicks.length).toBeGreaterThanOrEqual(2);
+        });
+
+        it("wiki enable toggle saves setting and toggles sub-settings visibility", async () => {
+            const plugin = makePlugin({ wikiEnabled: true });
+            (plugin as any).wikiEnabled = true;
+            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            const tab = makeTab(plugin);
+            const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
+
+            // The wiki enable toggle is third from the end (enable, prune raw, sync-to-vault)
+            const wikiEnableToggleIdx = toggleOnChanges.length - 3;
+            await toggleOnChanges[wikiEnableToggleIdx](false);
+            expect(plugin.settings.wikiEnabled).toBe(false);
+            expect(plugin.saveSettings).toHaveBeenCalled();
+        });
+
+        it("sub-settings hidden when wikiEnabled setting is false", () => {
+            const plugin = makePlugin({ wikiEnabled: false });
+            (plugin as any).wikiEnabled = true; // server says enabled, but user toggle off
+            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            const tab = makeTab(plugin);
+            tab.display();
+            const details = tab.containerEl.children.find(
+                (c) =>
+                    c.tagName === "DETAILS" &&
+                    c.children.some((s: any) => s.tagName === "SUMMARY" && s.textContent.includes("Wiki")),
+            );
+            expect(details).toBeDefined();
+            const subContainer = details!.children.find(
+                (c: any) => c.classList && c.classList.contains("lilbee-wiki-sub-settings"),
+            );
+            expect(subContainer).toBeDefined();
+            expect((subContainer as any).style.display).toBe("none");
+        });
+
+        it("sub-settings visible when wikiEnabled setting is true", () => {
+            const plugin = makePlugin({ wikiEnabled: true });
+            (plugin as any).wikiEnabled = true;
+            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            const tab = makeTab(plugin);
+            tab.display();
+            const details = tab.containerEl.children.find(
+                (c) =>
+                    c.tagName === "DETAILS" &&
+                    c.children.some((s: any) => s.tagName === "SUMMARY" && s.textContent.includes("Wiki")),
+            );
+            expect(details).toBeDefined();
+            const subContainer = details!.children.find(
+                (c: any) => c.classList && c.classList.contains("lilbee-wiki-sub-settings"),
+            );
+            expect(subContainer).toBeDefined();
+            expect((subContainer as any).style.display).toBe("");
         });
 
         it("prune raw toggle calls updateConfig", async () => {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -2921,17 +2921,57 @@ describe("managed mode settings", () => {
             expect(buttonOnClicks.length).toBeGreaterThanOrEqual(2);
         });
 
-        it("wiki enable toggle saves setting and toggles sub-settings visibility", async () => {
+        it("wiki enable toggle saves setting and syncs runtime flag", async () => {
             const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
             (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
             const tab = makeTab(plugin);
             const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
 
-            // The wiki enable toggle is third from the end (enable, prune raw, sync-to-vault)
-            const wikiEnableToggleIdx = toggleOnChanges.length - 3;
-            await toggleOnChanges[wikiEnableToggleIdx](false);
+            // Find the wiki enable toggle by effect: it's the one that changes wikiEnabled
+            const wikiToggle = toggleOnChanges.find((cb) => {
+                const before = plugin.settings.wikiEnabled;
+                // dry-run: call with opposite value and check if wikiEnabled changed
+                plugin.settings.wikiEnabled = before; // reset after find
+                return true; // we'll identify by calling each and checking
+            });
+            // Instead of fragile index, call each toggle with false until wikiEnabled flips
+            let wikiToggleIdx = -1;
+            for (let i = 0; i < toggleOnChanges.length; i++) {
+                plugin.settings.wikiEnabled = true; // reset
+                await toggleOnChanges[i](false);
+                if (plugin.settings.wikiEnabled === false) {
+                    wikiToggleIdx = i;
+                    break;
+                }
+                plugin.settings.wikiEnabled = true; // restore
+            }
+            expect(wikiToggleIdx).not.toBe(-1);
             expect(plugin.settings.wikiEnabled).toBe(false);
+            expect((plugin as any).wikiEnabled).toBe(false);
+            expect(plugin.saveSettings).toHaveBeenCalled();
+        });
+
+        it("wiki enable toggle re-enables sub-settings when toggled back on", async () => {
+            const plugin = makePlugin({ wikiEnabled: false });
+            (plugin as any).wikiEnabled = true; // server supports wiki, but user has toggle off
+            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            const tab = makeTab(plugin);
+            const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
+
+            // Find wiki toggle by effect
+            let wikiToggleIdx = -1;
+            for (let i = 0; i < toggleOnChanges.length; i++) {
+                plugin.settings.wikiEnabled = false; // reset
+                await toggleOnChanges[i](true);
+                if (plugin.settings.wikiEnabled === true) {
+                    wikiToggleIdx = i;
+                    break;
+                }
+                plugin.settings.wikiEnabled = false; // restore
+            }
+            expect(wikiToggleIdx).not.toBe(-1);
+            expect(plugin.settings.wikiEnabled).toBe(true);
             expect(plugin.saveSettings).toHaveBeenCalled();
         });
 


### PR DESCRIPTION
Adds a user-facing toggle at the top of the Wiki settings section that controls whether wiki features are active. When off, all wiki sub-settings (prune, faithfulness, vault folder, lint, prune) are hidden. When on, everything is shown as before.

The toggle is the source of truth for wiki state. `fetchActiveModel` no longer lets the server override the user's choice — if the user has wiki disabled in settings, the runtime `wikiEnabled` flag stays `false` even when the server reports wiki as enabled.

Locale strings added for the toggle label and description. Tests updated for the new behavior with 100% coverage maintained.