### PR TITLE
Add embedding model selector to chat toolbar

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -99,6 +99,7 @@ export const MESSAGES = {
     LABEL_CANCEL_TASK: "Cancel task",
     LABEL_DOWNLOAD_QUEUED: "+{count} queued",
     LABEL_CHAT_MODEL_ICON: "Chat model",
+    LABEL_EMBEDDING_MODEL_ICON: "Embed",
     LABEL_ADD_FILE: "Add file",
     LABEL_SAVE_VAULT: "Save to vault",
     LABEL_THINKING: "Thinking...",

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -10,11 +10,20 @@ import {
 } from "obsidian";
 import type LilbeePlugin from "../main";
 import { SSE_EVENT, TASK_TYPE, ERROR_NAME, MODEL_SOURCE } from "../types";
-import type { GenerationOptions, Message, ModelCatalog, SearchChunkType, Source, SSEEvent } from "../types";
+import type {
+    CatalogEntry,
+    GenerationOptions,
+    Message,
+    ModelCatalog,
+    SearchChunkType,
+    Source,
+    SSEEvent,
+} from "../types";
 
 import { renderSourceChip } from "./results";
 import { buildModelOptions, SEPARATOR_KEY } from "../settings";
 import { ConfirmPullModal } from "./confirm-pull-modal";
+import { ConfirmModal } from "./confirm-modal";
 import { CatalogModal } from "./catalog-modal";
 import { CrawlModal } from "./crawl-modal";
 import { MESSAGES } from "../locales/en";
@@ -74,6 +83,9 @@ export class ChatView extends ItemView {
     private pullController: AbortController | null = null;
     private chatCatalog: ModelCatalog | null = null;
     private chatSelectEl: HTMLSelectElement | null = null;
+    private embeddingSelectEl: HTMLSelectElement | null = null;
+    private embeddingModels: CatalogEntry[] = [];
+    private activeEmbeddingModel = "";
     private ocrToggleEl: HTMLElement | null = null;
     private static readonly OFFLINE_THRESHOLD = 3;
     private retryTimer: ReturnType<typeof setTimeout> | null = null;
@@ -129,6 +141,16 @@ export class ChatView extends ItemView {
             cls: "lilbee-chat-model-select",
         }) as HTMLSelectElement;
         this.attachChatListener(this.chatSelectEl);
+
+        const embedGroup = toolbar.createDiv({ cls: "lilbee-toolbar-group lilbee-toolbar-group-embed" });
+        const embedIcon = embedGroup.createDiv({ cls: "lilbee-toolbar-icon" });
+        setIcon(embedIcon, "database");
+        embedIcon.setAttribute("title", MESSAGES.LABEL_EMBEDDING_MODEL_ICON);
+
+        this.embeddingSelectEl = embedGroup.createEl("select", {
+            cls: "lilbee-embed-model-select",
+        }) as HTMLSelectElement;
+        this.attachEmbeddingListener(this.embeddingSelectEl);
 
         this.ocrToggleEl = toolbar.createDiv({ cls: "lilbee-ocr-toggle" });
         this.updateOcrToggle();
@@ -214,8 +236,13 @@ export class ChatView extends ItemView {
     }
 
     private fetchAndFillSelectors(): void {
-        Promise.all([this.plugin.api.listModels(), this.plugin.api.installedModels().catch(() => ({ models: [] }))])
-            .then(([models, installed]) => {
+        Promise.all([
+            this.plugin.api.listModels(),
+            this.plugin.api.installedModels().catch(() => ({ models: [] })),
+            this.plugin.api.catalog({ task: "embedding" }).catch(() => null),
+            this.plugin.api.config().catch(() => null),
+        ])
+            .then(([models, installed, embeddingResult, serverConfig]) => {
                 if (this.retryTimer) {
                     clearTimeout(this.retryTimer);
                     this.retryTimer = null;
@@ -225,6 +252,9 @@ export class ChatView extends ItemView {
                 this.chatCatalog = models.chat;
                 const sourceMap = new Map(installed.models.map((m) => [m.name, m.source]));
                 if (this.chatSelectEl) this.fillSelectOptions(this.chatSelectEl, models.chat, sourceMap);
+
+                this.fillEmbeddingSelector(embeddingResult, serverConfig);
+
                 // No models installed — show empty state with catalog button
                 if (models.chat.installed.length === 0) {
                     this.showEmptyState();
@@ -241,11 +271,44 @@ export class ChatView extends ItemView {
                     this.chatSelectEl.empty();
                     this.chatSelectEl.createEl("option", { text: label });
                 }
+                if (this.embeddingSelectEl) {
+                    this.embeddingSelectEl.empty();
+                    this.embeddingSelectEl.createEl("option", { text: label });
+                }
                 if (this.retryCount === ChatView.OFFLINE_THRESHOLD) {
                     new Notice(MESSAGES.ERROR_SERVER_UNREACHABLE);
                 }
                 this.retryTimer = setTimeout(() => this.fetchAndFillSelectors(), RETRY_INTERVAL_MS);
             });
+    }
+
+    private fillEmbeddingSelector(
+        embeddingResult: import("neverthrow").Result<import("../types").CatalogResponse, Error> | null,
+        serverConfig: Record<string, unknown> | null,
+    ): void {
+        if (!this.embeddingSelectEl) return;
+        this.embeddingSelectEl.empty();
+
+        const activeModel = serverConfig ? String(serverConfig["embedding_model"] ?? "") : "";
+        this.activeEmbeddingModel = activeModel;
+
+        const models =
+            embeddingResult && embeddingResult.isOk() ? embeddingResult.value.models.filter((m) => m.installed) : [];
+        this.embeddingModels = models;
+
+        for (const model of models) {
+            const option = this.embeddingSelectEl.createEl("option", { text: model.name });
+            (option as HTMLOptionElement).value = model.name;
+            if (model.name === activeModel) {
+                (option as HTMLOptionElement).selected = true;
+            }
+        }
+
+        if (models.length === 0 && activeModel) {
+            const option = this.embeddingSelectEl.createEl("option", { text: activeModel });
+            (option as HTMLOptionElement).value = activeModel;
+            (option as HTMLOptionElement).selected = true;
+        }
     }
 
     private fillSelectOptions(
@@ -295,6 +358,43 @@ export class ChatView extends ItemView {
                 }
             });
         });
+    }
+
+    private attachEmbeddingListener(el: HTMLSelectElement): void {
+        el.addEventListener("change", () => {
+            if (!el.value) return;
+            const previous = this.activeEmbeddingModel;
+            const modal = new ConfirmModal(this.plugin.app, MESSAGES.DESC_EMBEDDING_REINDEX_WARNING);
+            modal.open();
+            void modal.result.then((confirmed) => {
+                if (confirmed) {
+                    this.plugin.api
+                        .setEmbeddingModel(el.value)
+                        .then((result) => {
+                            if (result.isOk()) {
+                                this.activeEmbeddingModel = el.value;
+                                new Notice(MESSAGES.NOTICE_EMBEDDING_UPDATED);
+                                new Notice(MESSAGES.NOTICE_REINDEX_REQUIRED);
+                                void this.plugin.triggerSync();
+                            } else {
+                                new Notice(MESSAGES.NOTICE_FAILED_EMBEDDING);
+                                this.revertEmbeddingSelect(previous);
+                            }
+                        })
+                        .catch(() => {
+                            new Notice(MESSAGES.NOTICE_FAILED_EMBEDDING);
+                            this.revertEmbeddingSelect(previous);
+                        });
+                } else {
+                    this.revertEmbeddingSelect(previous);
+                }
+            });
+        });
+    }
+
+    private revertEmbeddingSelect(previousValue: string): void {
+        if (!this.embeddingSelectEl) return;
+        this.embeddingSelectEl.value = previousValue;
     }
 
     private async autoPullAndSet(model: { name: string }): Promise<void> {
@@ -371,6 +471,7 @@ export class ChatView extends ItemView {
 
     private refreshModelSelector(): void {
         if (this.chatSelectEl) this.chatSelectEl.empty();
+        if (this.embeddingSelectEl) this.embeddingSelectEl.empty();
         this.fetchAndFillSelectors();
     }
 

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -46,6 +46,17 @@ vi.mock("../../src/views/catalog-modal", () => ({
         open: vi.fn(),
     })),
 }));
+
+let confirmModalResult = true;
+vi.mock("../../src/views/confirm-modal", () => ({
+    ConfirmModal: vi.fn().mockImplementation(() => ({
+        open: vi.fn(),
+        get result() {
+            return Promise.resolve(confirmModalResult);
+        },
+        close: vi.fn(),
+    })),
+}));
 import type { SSEEvent, Source } from "../../src/types";
 import { TaskQueue } from "../../src/task-queue";
 
@@ -93,13 +104,41 @@ function makePlugin(): LilbeePlugin {
                 ],
             }),
             setChatModel: vi.fn().mockResolvedValue(ok({ model: "phi3" })),
+            setEmbeddingModel: vi.fn().mockResolvedValue(ok(undefined)),
             pullModel: vi.fn(),
+            catalog: vi.fn().mockResolvedValue(
+                ok({
+                    total: 1,
+                    limit: 50,
+                    offset: 0,
+                    models: [
+                        {
+                            name: "nomic-embed-text",
+                            display_name: "nomic-embed-text",
+                            size_gb: 0.3,
+                            min_ram_gb: 1,
+                            description: "Embedding",
+                            installed: true,
+                            source: "native",
+                            hf_repo: "nomic-embed-text",
+                            tag: "",
+                            task: "embedding",
+                            featured: true,
+                            downloads: 1000,
+                            quality_tier: "good",
+                        },
+                    ],
+                    has_more: false,
+                }),
+            ),
+            config: vi.fn().mockResolvedValue({ embedding_model: "nomic-embed-text" }),
         },
         settings: { topK: 5, enableOcr: null as boolean | null, wikiEnabled: true, searchChunkType: "all" as const },
         activeModel: "llama3",
         fetchActiveModel: vi.fn(),
         saveSettings: vi.fn().mockResolvedValue(undefined),
         cancelSync: vi.fn(),
+        triggerSync: vi.fn().mockResolvedValue(undefined),
         taskQueue: new TaskQueue(),
         app: {
             vault: {
@@ -188,7 +227,7 @@ describe("ChatView.onOpen — DOM structure", () => {
 
     it("creates toolbar groups for icon+select pairs", () => {
         const groups = container.findAll("lilbee-toolbar-group");
-        expect(groups.length).toBe(1);
+        expect(groups.length).toBe(2);
     });
 
     it("creates a spacer div in the toolbar", () => {
@@ -1409,7 +1448,7 @@ describe("ChatView — toolbar groups and tooltips", () => {
         await view.onOpen();
         const container = view.containerEl.children[1] as unknown as MockElement;
         const groups = container.findAll("lilbee-toolbar-group");
-        expect(groups.length).toBe(1);
+        expect(groups.length).toBe(2);
         const chatGroup = groups[0];
         expect(chatGroup.find("lilbee-toolbar-icon")).not.toBeNull();
         expect(chatGroup.find("lilbee-chat-model-select")).not.toBeNull();
@@ -2241,17 +2280,20 @@ describe("ChatView.createToolbar — search mode buttons", () => {
 });
 
 describe("ChatView.createToolbar — toolbar icons", () => {
-    it("renders message-circle and eye icons inside toolbar groups", async () => {
+    it("renders message-circle and database icons inside toolbar groups", async () => {
         Notice.clear();
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
         const container = view.containerEl.children[1] as unknown as MockElement;
         const groups = container.findAll("lilbee-toolbar-group");
-        expect(groups.length).toBe(1);
+        expect(groups.length).toBe(2);
         const chatIcon = groups[0].find("lilbee-toolbar-icon")!;
         expect(chatIcon.attributes["data-icon"]).toBe("message-circle");
         expect(chatIcon.attributes["title"]).toBe("Chat model");
+        const embedIcon = groups[1].find("lilbee-toolbar-icon")!;
+        expect(embedIcon.attributes["data-icon"]).toBe("database");
+        expect(embedIcon.attributes["title"]).toBe("Embed");
         // OCR toggle is a separate element, not in a toolbar-group
         const ocrToggle = container.find("lilbee-ocr-toggle");
         expect(ocrToggle).not.toBeNull();
@@ -2531,5 +2573,348 @@ describe("ChatView — offline retry", () => {
         expect((view as any).retryCount).toBe(0);
 
         await view.onClose();
+    });
+});
+
+describe("ChatView — embedding model selector", () => {
+    beforeEach(() => {
+        Notice.clear();
+        confirmModalResult = true;
+    });
+
+    it("creates an embedding select element with class lilbee-embed-model-select", async () => {
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const select = container.find("lilbee-embed-model-select");
+        expect(select).not.toBeNull();
+        expect(select!.tagName).toBe("SELECT");
+    });
+
+    it("populates embedding options from catalog API", async () => {
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const select = container.find("lilbee-embed-model-select")!;
+        const options = select.children.filter((c) => c.tagName === "OPTION");
+        expect(options.length).toBe(1);
+        expect(options[0].textContent).toBe("nomic-embed-text");
+        expect(options[0].value).toBe("nomic-embed-text");
+    });
+
+    it("marks the active embedding model as selected", async () => {
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const select = container.find("lilbee-embed-model-select")!;
+        const options = select.children.filter((c) => c.tagName === "OPTION");
+        expect(options[0].selected).toBe(true);
+    });
+
+    it("shows fallback option from config when catalog is empty", async () => {
+        const plugin = makePlugin();
+        plugin.api.catalog = vi
+            .fn()
+            .mockResolvedValue(ok({ total: 0, limit: 50, offset: 0, models: [], has_more: false }));
+        plugin.api.config = vi.fn().mockResolvedValue({ embedding_model: "custom-embed" });
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const select = container.find("lilbee-embed-model-select")!;
+        const options = select.children.filter((c) => c.tagName === "OPTION");
+        expect(options.length).toBe(1);
+        expect(options[0].textContent).toBe("custom-embed");
+        expect(options[0].selected).toBe(true);
+    });
+
+    it("shows fallback option when catalog returns error", async () => {
+        const plugin = makePlugin();
+        plugin.api.catalog = vi.fn().mockResolvedValue(err(new Error("fail")));
+        plugin.api.config = vi.fn().mockResolvedValue({ embedding_model: "fallback-embed" });
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const select = container.find("lilbee-embed-model-select")!;
+        const options = select.children.filter((c) => c.tagName === "OPTION");
+        expect(options.length).toBe(1);
+        expect(options[0].textContent).toBe("fallback-embed");
+    });
+
+    it("shows no options when catalog is empty and config has no embedding_model", async () => {
+        const plugin = makePlugin();
+        plugin.api.catalog = vi
+            .fn()
+            .mockResolvedValue(ok({ total: 0, limit: 50, offset: 0, models: [], has_more: false }));
+        plugin.api.config = vi.fn().mockResolvedValue({});
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const select = container.find("lilbee-embed-model-select")!;
+        const options = select.children.filter((c) => c.tagName === "OPTION");
+        expect(options.length).toBe(0);
+    });
+
+    it("shows confirmation modal when embedding model is changed", async () => {
+        const { ConfirmModal } = await import("../../src/views/confirm-modal");
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const select = container.find("lilbee-embed-model-select")!;
+        (select as any).value = "nomic-embed-text";
+        select.trigger("change");
+        await tick();
+
+        expect(ConfirmModal).toHaveBeenCalled();
+    });
+
+    it("calls setEmbeddingModel and shows notices on confirm", async () => {
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const select = container.find("lilbee-embed-model-select")!;
+        (select as any).value = "nomic-embed-text";
+        select.trigger("change");
+        await tick();
+
+        expect(plugin.api.setEmbeddingModel).toHaveBeenCalledWith("nomic-embed-text");
+        expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_EMBEDDING_UPDATED)).toBe(true);
+        expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_REINDEX_REQUIRED)).toBe(true);
+        expect(plugin.triggerSync).toHaveBeenCalled();
+    });
+
+    it("reverts dropdown on cancel", async () => {
+        confirmModalResult = false;
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const select = container.find("lilbee-embed-model-select")!;
+        (select as any).value = "other-model";
+        select.trigger("change");
+        await tick();
+
+        expect(plugin.api.setEmbeddingModel).not.toHaveBeenCalled();
+        expect(select.value).toBe("nomic-embed-text");
+    });
+
+    it("reverts dropdown and shows notice on setEmbeddingModel failure", async () => {
+        const plugin = makePlugin();
+        plugin.api.setEmbeddingModel = vi.fn().mockResolvedValue(err(new Error("fail")));
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const select = container.find("lilbee-embed-model-select")!;
+        (select as any).value = "other-model";
+        select.trigger("change");
+        await tick();
+
+        expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_FAILED_EMBEDDING)).toBe(true);
+        expect(select.value).toBe("nomic-embed-text");
+    });
+
+    it("reverts dropdown and shows notice on setEmbeddingModel network error", async () => {
+        const plugin = makePlugin();
+        plugin.api.setEmbeddingModel = vi.fn().mockRejectedValue(new Error("network"));
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const select = container.find("lilbee-embed-model-select")!;
+        (select as any).value = "other-model";
+        select.trigger("change");
+        await tick();
+
+        expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_FAILED_EMBEDDING)).toBe(true);
+        expect(select.value).toBe("nomic-embed-text");
+    });
+
+    it("does nothing when change value is empty", async () => {
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const select = container.find("lilbee-embed-model-select")!;
+        (select as any).value = "";
+        select.trigger("change");
+        await tick();
+
+        expect(plugin.api.setEmbeddingModel).not.toHaveBeenCalled();
+    });
+
+    it("shows connecting label on embedding select when offline", async () => {
+        vi.useFakeTimers();
+        const plugin = makePlugin();
+        plugin.api.listModels = vi.fn().mockRejectedValue(new Error("offline"));
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await vi.advanceTimersByTimeAsync(0);
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const embedSelect = container.find("lilbee-embed-model-select")!;
+        const options = embedSelect.children.filter((c) => c.tagName === "OPTION");
+        expect(options.some((o) => o.textContent === "(connecting...)")).toBe(true);
+
+        await view.onClose();
+        vi.useRealTimers();
+    });
+
+    it("shows offline label on embedding select after threshold", async () => {
+        vi.useFakeTimers();
+        const plugin = makePlugin();
+        plugin.api.listModels = vi.fn().mockRejectedValue(new Error("offline"));
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+
+        // Failure 1
+        await vi.advanceTimersByTimeAsync(0);
+        // Failure 2
+        await vi.advanceTimersByTimeAsync(5000);
+        // Failure 3 — threshold
+        await vi.advanceTimersByTimeAsync(5000);
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const embedSelect = container.find("lilbee-embed-model-select")!;
+        const options = embedSelect.children.filter((c) => c.tagName === "OPTION");
+        expect(options.some((o) => o.textContent === "(offline)")).toBe(true);
+
+        await view.onClose();
+        vi.useRealTimers();
+    });
+
+    it("embedding group has lilbee-toolbar-group-embed class", async () => {
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const embedGroup = container.find("lilbee-toolbar-group-embed");
+        expect(embedGroup).not.toBeNull();
+        expect(embedGroup!.find("lilbee-embed-model-select")).not.toBeNull();
+    });
+
+    it("filters to only installed models from catalog", async () => {
+        const plugin = makePlugin();
+        plugin.api.catalog = vi.fn().mockResolvedValue(
+            ok({
+                total: 2,
+                limit: 50,
+                offset: 0,
+                models: [
+                    {
+                        name: "nomic-embed-text",
+                        display_name: "nomic-embed-text",
+                        size_gb: 0.3,
+                        min_ram_gb: 1,
+                        description: "Embedding",
+                        installed: true,
+                        source: "native",
+                        hf_repo: "nomic",
+                        tag: "",
+                        task: "embedding",
+                        featured: true,
+                        downloads: 1000,
+                        quality_tier: "good",
+                    },
+                    {
+                        name: "bge-large",
+                        display_name: "bge-large",
+                        size_gb: 1.3,
+                        min_ram_gb: 4,
+                        description: "BGE",
+                        installed: false,
+                        source: "native",
+                        hf_repo: "bge",
+                        tag: "",
+                        task: "embedding",
+                        featured: false,
+                        downloads: 500,
+                        quality_tier: "good",
+                    },
+                ],
+                has_more: false,
+            }),
+        );
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const select = container.find("lilbee-embed-model-select")!;
+        const options = select.children.filter((c) => c.tagName === "OPTION");
+        expect(options.length).toBe(1);
+        expect(options[0].textContent).toBe("nomic-embed-text");
+    });
+
+    it("handles null config gracefully", async () => {
+        const plugin = makePlugin();
+        plugin.api.config = vi.fn().mockRejectedValue(new Error("fail"));
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const select = container.find("lilbee-embed-model-select")!;
+        const options = select.children.filter((c) => c.tagName === "OPTION");
+        // Should still show models from catalog, just none marked active
+        expect(options.length).toBe(1);
+        expect(options[0].textContent).toBe("nomic-embed-text");
+    });
+
+    it("revertEmbeddingSelect no-ops when embeddingSelectEl is null", async () => {
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        (view as any).embeddingSelectEl = null;
+        // Should not throw
+        (view as any).revertEmbeddingSelect("test");
+    });
+
+    it("handles null catalog result in fillEmbeddingSelector", async () => {
+        const plugin = makePlugin();
+        plugin.api.catalog = vi.fn().mockRejectedValue(new Error("fail"));
+        plugin.api.config = vi.fn().mockResolvedValue({ embedding_model: "fallback" });
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const select = container.find("lilbee-embed-model-select")!;
+        const options = select.children.filter((c) => c.tagName === "OPTION");
+        expect(options.length).toBe(1);
+        expect(options[0].textContent).toBe("fallback");
+    });
+
+    it("fillEmbeddingSelector with null embeddingSelectEl is a no-op", async () => {
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        (view as any).embeddingSelectEl = null;
+        // Should not throw
+        (view as any).fillEmbeddingSelector(null, null);
     });
 });


### PR DESCRIPTION
Adds an embedding model dropdown to the chat sidebar toolbar, right next to the chat model selector — matching the TUI layout where both are side by side.

The embedding selector shows installed embedding models, highlights the active one, and includes a re-index confirmation when changing. Uses a database icon to distinguish from the chat model.

1356 tests pass at 100% coverage.