### PR TITLE
fix: prepend https:// to crawl URLs missing a scheme

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,6 +32,11 @@ export function formatAbbreviatedCount(count: number): string {
     return String(count);
 }
 
+export function ensureUrlScheme(url: string): string {
+    if (/^https?:\/\//i.test(url)) return url;
+    return `https://${url}`;
+}
+
 export function relativeTime(timestamp: number): string {
     const seconds = Math.floor((Date.now() - timestamp) / 1000);
     if (seconds < 60) return "just now";

--- a/src/views/crawl-modal.ts
+++ b/src/views/crawl-modal.ts
@@ -1,6 +1,7 @@
 import { App, Modal, Notice } from "obsidian";
 import type LilbeePlugin from "../main";
 import { MESSAGES } from "../locales/en";
+import { ensureUrlScheme } from "../utils";
 
 export class CrawlModal extends Modal {
     private plugin: LilbeePlugin;
@@ -42,11 +43,12 @@ export class CrawlModal extends Modal {
         const actions = contentEl.createDiv({ cls: "lilbee-crawl-actions" });
         const crawlBtn = actions.createEl("button", { text: MESSAGES.BUTTON_CRAWL, cls: "mod-cta" });
         crawlBtn.addEventListener("click", () => {
-            const url = (urlInput as unknown as HTMLInputElement).value.trim();
-            if (!url) {
+            const raw = (urlInput as unknown as HTMLInputElement).value.trim();
+            if (!raw) {
                 new Notice(MESSAGES.NOTICE_ENTER_URL);
                 return;
             }
+            const url = ensureUrlScheme(raw);
             const depth = parseInt((depthInput as unknown as HTMLInputElement).value, 10) || 0;
             const maxPages = parseInt((maxInput as unknown as HTMLInputElement).value, 10) || 50;
             this.plugin.runCrawl(url, depth, maxPages);

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { ensureUrlScheme } from "../src/utils";
+
+describe("ensureUrlScheme", () => {
+    it("returns URL unchanged when it starts with https://", () => {
+        expect(ensureUrlScheme("https://example.com")).toBe("https://example.com");
+    });
+
+    it("returns URL unchanged when it starts with http://", () => {
+        expect(ensureUrlScheme("http://example.com")).toBe("http://example.com");
+    });
+
+    it("is case-insensitive for existing scheme", () => {
+        expect(ensureUrlScheme("HTTP://example.com")).toBe("HTTP://example.com");
+        expect(ensureUrlScheme("HTTPS://example.com")).toBe("HTTPS://example.com");
+        expect(ensureUrlScheme("Https://example.com")).toBe("Https://example.com");
+    });
+
+    it("prepends https:// when no scheme is present", () => {
+        expect(ensureUrlScheme("example.com")).toBe("https://example.com");
+    });
+
+    it("prepends https:// for URLs with paths but no scheme", () => {
+        expect(ensureUrlScheme("example.com/page")).toBe("https://example.com/page");
+    });
+
+    it("prepends https:// for URLs with subdomains but no scheme", () => {
+        expect(ensureUrlScheme("www.example.com")).toBe("https://www.example.com");
+    });
+});

--- a/tests/views/crawl-modal.test.ts
+++ b/tests/views/crawl-modal.test.ts
@@ -129,6 +129,36 @@ describe("CrawlModal", () => {
         expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", 0, 50);
     });
 
+    it("prepends https:// when URL has no scheme", () => {
+        const app = new App();
+        const plugin = makePlugin();
+        const modal = new CrawlModal(app as any, plugin as any);
+        modal.onOpen();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const urlInput = el.find("lilbee-crawl-url")!;
+        (urlInput as any).value = "example.com";
+        const crawlBtn = findButtons(el).find((b) => b.textContent === "Crawl")!;
+        crawlBtn.trigger("click");
+
+        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", 0, 50);
+    });
+
+    it("preserves http:// when already present", () => {
+        const app = new App();
+        const plugin = makePlugin();
+        const modal = new CrawlModal(app as any, plugin as any);
+        modal.onOpen();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const urlInput = el.find("lilbee-crawl-url")!;
+        (urlInput as any).value = "http://example.com";
+        const crawlBtn = findButtons(el).find((b) => b.textContent === "Crawl")!;
+        crawlBtn.trigger("click");
+
+        expect(plugin.runCrawl).toHaveBeenCalledWith("http://example.com", 0, 50);
+    });
+
     it("passes custom depth and maxPages", () => {
         const app = new App();
         const plugin = makePlugin();


### PR DESCRIPTION
## Summary
- URLs entered without `http://` or `https://` in the Crawl modal (e.g. `example.com`) were passed verbatim to the server, causing crawl failures
- Add `ensureUrlScheme()` utility in `utils.ts` that prepends `https://` when no scheme is present (case-insensitive, preserves existing `http://`)
- Apply the utility in `CrawlModal` before dispatching `runCrawl`

## Test Plan
- 6 unit tests for `ensureUrlScheme()` covering: scheme preservation, case insensitivity, bare domains, paths, subdomains
- 2 integration tests in `crawl-modal.test.ts` verifying schemeless URLs get `https://` and `http://` is preserved
- Verified end-to-end in Obsidian: typed `jsonplaceholder.typicode.com` (no scheme) → server received and crawled `https://jsonplaceholder.typicode.com`