### PR TITLE
Task Center polish: canCancel preservation, ribbon badge, stream-idle timeout

### DIFF
--- a/src/task-queue.ts
+++ b/src/task-queue.ts
@@ -109,7 +109,7 @@ export class TaskQueue {
         if (task.status !== TASK_STATUS.QUEUED) return;
 
         task.status = TASK_STATUS.ACTIVE;
-        task.canCancel = false;
+        task.canCancel = this.aborts.has(id);
         this.activeIds.set(task.type, id);
         this.notify();
     }

--- a/tests/task-queue.test.ts
+++ b/tests/task-queue.test.ts
@@ -591,5 +591,15 @@ describe("TaskQueue", () => {
             queue.cancel(id);
             expect(controller.signal.aborted).toBe(false);
         });
+
+        it("auto-promoted task keeps canCancel=true when abort was registered while queued", () => {
+            const active = queue.enqueue("Active sync", TASK_TYPE.SYNC);
+            const queued = queue.enqueue("Queued sync", TASK_TYPE.SYNC);
+            queue.registerAbort(queued, new AbortController());
+            queue.cancel(active);
+            const promoted = queue.tasks.get(queued)!;
+            expect(promoted.status).toBe(TASK_STATUS.ACTIVE);
+            expect(promoted.canCancel).toBe(true);
+        });
     });
 });


### PR DESCRIPTION
Three follow-up fixes to the flight-deck Task Center work.

### 1. Preserve `canCancel` on queue auto-promotion (`d925f0b`)

`activate()` was clobbering `task.canCancel = false`, which erased any `registerAbort()` call that ran while the task was queued. A sync that got auto-promoted (because the previous sync was cancelled) rendered without a cancel glyph and could only be killed by disabling the plugin. Now `canCancel` tracks whether an abort controller is actually registered, so auto-promoted tasks keep their cancel button.

### 2. Ribbon icon badge (`b1cb79b`, part 1)

New left-ribbon entry opens the Task Center. A small colored dot appears on the icon when work is in flight:

- **pulsing primary** while any task is active or queued
- **green** during the 2 s flash window after a task completes
- **red** during the 2 s flash window after a task fails

Mirrors the status-bar `DOT_STATE` so users notice background work without needing the Task Center view open. `prefers-reduced-motion` suppresses the pulse.

### 3. Stream-idle timeout (`b1cb79b`, part 2)

Sync and add paths now abort with a clear "server stopped sending events — check that lilbee is running" notice after **120 s** of silence from the SSE stream. Before this, a wedged server left the task infinitely active with a pulsing rail and no recovery short of disabling the plugin.

Implementation: `withIdleTimeout(gen, timeoutMs, abort)` wraps the SSE async generator; if `iter.next()` doesn't resolve within `timeoutMs`, it calls `abort()` (which aborts the underlying fetch) and throws `StreamIdleError`. Both `triggerSync` and `runAdd` catch `StreamIdleError` specifically and fail the task with the localized message.

---

- 1444 tests, 100% coverage
- Targets `feat/task-center-concurrency` — merges cleanly before PR #36 lands on `feature/server-api-parity`