### PR TITLE
Ribbon badge + stream-idle timeout

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -126,6 +126,8 @@ export const MESSAGES = {
     LABEL_OFFLINE: "(offline)",
     LABEL_CHAT_VIEW: "lilbee Chat",
     LABEL_TASKS_VIEW: "lilbee Tasks",
+    LABEL_RIBBON_OPEN_TASK_CENTER: "Open lilbee Task Center",
+    ERROR_STREAM_IDLE: "server stopped sending events — check that lilbee is running",
     LABEL_SKIP_SETUP: "Skip setup",
     LABEL_OUR_PICKS: "Our picks",
     LABEL_SECTION_INSTALLED: "Installed",

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,9 @@ import {
     NOTICE_DURATION_MS,
     NOTICE_ERROR_DURATION_MS,
     NOTICE_PERMANENT,
+    STREAM_IDLE_TIMEOUT_MS,
+    StreamIdleError,
+    withIdleTimeout,
 } from "./utils";
 import { CatalogModal } from "./views/catalog-modal";
 import { ChatView, VIEW_TYPE_CHAT } from "./views/chat-view";
@@ -139,6 +142,7 @@ export default class LilbeePlugin extends Plugin {
     api: LilbeeClient = new LilbeeClient(DEFAULT_SETTINGS.serverUrl);
     activeModel = "";
     statusBarEl: HTMLElement | null = null;
+    ribbonIconEl: HTMLElement | null = null;
     binaryManager: BinaryManager | null = null;
     serverManager: ServerManager | null = null;
     syncController: AbortController | null = null;
@@ -162,11 +166,16 @@ export default class LilbeePlugin extends Plugin {
         this.statusBarEl = this.addStatusBarItem();
         this.statusBarEl.style.cursor = "pointer";
         this.statusBarEl.addEventListener("click", () => this.activateTaskView());
+        this.ribbonIconEl = this.addRibbonIcon("list-checks", MESSAGES.LABEL_RIBBON_OPEN_TASK_CENTER, () =>
+            this.activateTaskView(),
+        );
+        this.ribbonIconEl.addClass("lilbee-ribbon-icon");
         this.registerView(VIEW_TYPE_CHAT, (leaf) => new ChatView(leaf, this));
         this.registerView(VIEW_TYPE_TASKS, (leaf) => new TaskCenterView(leaf, this));
         this.registerView(VIEW_TYPE_WIKI, (leaf) => new WikiView(leaf, this));
         this.addSettingTab(new LilbeeSettingTab(this.app, this));
         this.taskQueue.onChange(() => this.updateStatusBarFromQueue());
+        this.taskQueue.onChange(() => this.updateRibbonFromQueue());
         this.taskQueue.onChange(() => this.schedulePersistHistory());
         this.registerCommands();
 
@@ -656,6 +665,24 @@ export default class LilbeePlugin extends Plugin {
         this.setStatusClass("lilbee-status-adding");
     }
 
+    private updateRibbonFromQueue(): void {
+        if (!this.ribbonIconEl) return;
+        const el = this.ribbonIconEl;
+        el.removeClass("lilbee-ribbon-active", "lilbee-ribbon-success", "lilbee-ribbon-error");
+        const allActive = this.taskQueue.activeAll;
+        const queued = this.taskQueue.queued;
+        const completed = this.taskQueue.completed;
+        if (allActive.length > 0 || queued.length > 0) {
+            el.addClass("lilbee-ribbon-active");
+            return;
+        }
+        const recent = completed[0];
+        if (!recent || recent.completedAt === null) return;
+        if (Date.now() - recent.completedAt >= TASK_FLASH_WINDOW_MS) return;
+        if (recent.status === TASK_STATUS.DONE) el.addClass("lilbee-ribbon-success");
+        else if (recent.status === TASK_STATUS.FAILED) el.addClass("lilbee-ribbon-error");
+    }
+
     private renderStatusFlash(recent: TaskEntry, completed: readonly TaskEntry[]): void {
         if (recent.status === TASK_STATUS.DONE) {
             const recentDone = countRecentByStatus(completed, TASK_STATUS.DONE);
@@ -785,12 +812,9 @@ export default class LilbeePlugin extends Plugin {
         try {
             const progress = new FileProgressTracker();
             let syncResult: SyncDone | null = null;
-            for await (const event of this.api.addFiles(
-                paths,
-                true,
-                this.settings.enableOcr,
-                this.syncController.signal,
-            )) {
+            const controller = this.syncController;
+            const rawStream = this.api.addFiles(paths, true, this.settings.enableOcr, controller.signal);
+            for await (const event of withIdleTimeout(rawStream, STREAM_IDLE_TIMEOUT_MS, () => controller.abort())) {
                 if (event.event === SSE_EVENT.FILE_START) {
                     const d = event.data as { current_file: number; total_files: number };
                     progress.startFile(d.current_file, d.total_files);
@@ -841,7 +865,10 @@ export default class LilbeePlugin extends Plugin {
             }
             this.taskQueue.complete(taskId);
         } catch (err) {
-            if (err instanceof Error && err.name === ERROR_NAME.ABORT_ERROR) {
+            if (err instanceof StreamIdleError) {
+                new Notice(MESSAGES.ERROR_STREAM_IDLE);
+                this.taskQueue.fail(taskId, MESSAGES.ERROR_STREAM_IDLE);
+            } else if (err instanceof Error && err.name === ERROR_NAME.ABORT_ERROR) {
                 new Notice(MESSAGES.STATUS_ADD_CANCELLED);
                 this.taskQueue.cancel(taskId);
             } else {
@@ -1084,7 +1111,9 @@ export default class LilbeePlugin extends Plugin {
         try {
             const progress = new FileProgressTracker();
             let syncResult: SyncDone | null = null;
-            for await (const event of this.api.syncStream(this.settings.enableOcr, this.syncController.signal)) {
+            const controller = this.syncController;
+            const rawStream = this.api.syncStream(this.settings.enableOcr, controller.signal);
+            for await (const event of withIdleTimeout(rawStream, STREAM_IDLE_TIMEOUT_MS, () => controller.abort())) {
                 if (event.event === SSE_EVENT.FILE_START) {
                     const d = event.data as { current_file: number; total_files: number };
                     progress.startFile(d.current_file, d.total_files);
@@ -1135,7 +1164,10 @@ export default class LilbeePlugin extends Plugin {
             }
             this.taskQueue.complete(taskId);
         } catch (err) {
-            if (err instanceof Error && err.name === ERROR_NAME.ABORT_ERROR) {
+            if (err instanceof StreamIdleError) {
+                new Notice(MESSAGES.ERROR_STREAM_IDLE);
+                this.taskQueue.fail(taskId, MESSAGES.ERROR_STREAM_IDLE);
+            } else if (err instanceof Error && err.name === ERROR_NAME.ABORT_ERROR) {
                 new Notice(MESSAGES.STATUS_SYNC_CANCELLED);
                 this.taskQueue.cancel(taskId);
             } else {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1065,7 +1065,8 @@ export default class LilbeePlugin extends Plugin {
         this.taskQueue.registerAbort(taskId, controller);
         try {
             let pageCount = 0;
-            for await (const event of this.api.crawl(url, depth, maxPages, controller.signal)) {
+            const rawStream = this.api.crawl(url, depth, maxPages, controller.signal);
+            for await (const event of withIdleTimeout(rawStream, STREAM_IDLE_TIMEOUT_MS, () => controller.abort())) {
                 switch (event.event) {
                     case SSE_EVENT.CRAWL_START:
                         break;
@@ -1092,6 +1093,11 @@ export default class LilbeePlugin extends Plugin {
             }
             this.taskQueue.complete(taskId);
         } catch (err) {
+            if (err instanceof StreamIdleError) {
+                new Notice(MESSAGES.ERROR_STREAM_IDLE);
+                this.taskQueue.fail(taskId, MESSAGES.ERROR_STREAM_IDLE);
+                return;
+            }
             const msg = errorMessage(err, MESSAGES.ERROR_UNKNOWN);
             this.taskQueue.fail(taskId, msg);
             new Notice(MESSAGES.ERROR_CRAWL_FAILED.replace("{msg}", msg));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,6 +25,11 @@ export const NOTICE_PERMANENT = 0;
 export const TIME_REFRESH_INTERVAL_MS = 30000;
 export const HEALTH_PROBE_INTERVAL_MS = 30_000;
 export const SPINNER_MIN_DISPLAY_MS = 800;
+// 2 minutes without a single SSE event is long enough to mean "server is wedged" —
+// legitimate OCR/embed pauses are shorter. Larger than this and users think the
+// plugin hung; smaller and a slow page-OCR pass could trip it. Applies to sync /
+// add / crawl streams; pull streams are excluded because long-download idleness
+// is expected.
 export const STREAM_IDLE_TIMEOUT_MS = 120_000;
 
 export class StreamIdleError extends Error {
@@ -46,9 +51,16 @@ export async function* withIdleTimeout<T>(
             timer = setTimeout(() => resolve("idle"), timeoutMs);
         });
         const race = await Promise.race([iter.next(), idle]);
+        // Guard against vitest's fake-timer lifecycle leaving clearTimeout undefined
+        // across test-file boundaries; in production both are always defined.
         if (timer !== null && typeof clearTimeout === "function") clearTimeout(timer);
         if (race === "idle") {
             abort();
+            // Fire-and-forget: iter.return() lets the source generator exit its
+            // try/finally blocks, but we don't await it — when the underlying
+            // fetch is aborted mid-read, the current iter.next() may hang, and
+            // awaiting return() would hang with it. abort() already propagates.
+            void iter.return?.(undefined);
             throw new StreamIdleError(timeoutMs);
         }
         const { done, value } = race as IteratorResult<T>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,6 +25,37 @@ export const NOTICE_PERMANENT = 0;
 export const TIME_REFRESH_INTERVAL_MS = 30000;
 export const HEALTH_PROBE_INTERVAL_MS = 30_000;
 export const SPINNER_MIN_DISPLAY_MS = 800;
+export const STREAM_IDLE_TIMEOUT_MS = 120_000;
+
+export class StreamIdleError extends Error {
+    constructor(timeoutMs: number) {
+        super(`stream idle for ${Math.round(timeoutMs / 1000)}s`);
+        this.name = "StreamIdleError";
+    }
+}
+
+export async function* withIdleTimeout<T>(
+    gen: AsyncGenerator<T>,
+    timeoutMs: number,
+    abort: () => void,
+): AsyncGenerator<T> {
+    const iter = gen[Symbol.asyncIterator]();
+    while (true) {
+        let timer: ReturnType<typeof setTimeout> | null = null;
+        const idle = new Promise<"idle">((resolve) => {
+            timer = setTimeout(() => resolve("idle"), timeoutMs);
+        });
+        const race = await Promise.race([iter.next(), idle]);
+        if (timer !== null && typeof clearTimeout === "function") clearTimeout(timer);
+        if (race === "idle") {
+            abort();
+            throw new StreamIdleError(timeoutMs);
+        }
+        const { done, value } = race as IteratorResult<T>;
+        if (done) return;
+        yield value;
+    }
+}
 
 export function formatAbbreviatedCount(count: number): string {
     if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;

--- a/styles.css
+++ b/styles.css
@@ -1773,13 +1773,13 @@
     100% { background-position: -200% 0; }
 }
 
-.lilbee-ribbon-icon {
+.side-dock-ribbon-action.lilbee-ribbon-icon {
     position: relative;
 }
 
-.lilbee-ribbon-icon.lilbee-ribbon-active::after,
-.lilbee-ribbon-icon.lilbee-ribbon-success::after,
-.lilbee-ribbon-icon.lilbee-ribbon-error::after {
+.side-dock-ribbon-action.lilbee-ribbon-icon.lilbee-ribbon-active::after,
+.side-dock-ribbon-action.lilbee-ribbon-icon.lilbee-ribbon-success::after,
+.side-dock-ribbon-action.lilbee-ribbon-icon.lilbee-ribbon-error::after {
     content: "";
     position: absolute;
     top: 4px;
@@ -1791,21 +1791,21 @@
     pointer-events: none;
 }
 
-.lilbee-ribbon-icon.lilbee-ribbon-active::after {
+.side-dock-ribbon-action.lilbee-ribbon-icon.lilbee-ribbon-active::after {
     background-color: var(--interactive-accent);
     animation: lilbee-dot-pulse 1s ease-in-out infinite;
 }
 
-.lilbee-ribbon-icon.lilbee-ribbon-success::after {
+.side-dock-ribbon-action.lilbee-ribbon-icon.lilbee-ribbon-success::after {
     background-color: var(--text-success, #22c55e);
 }
 
-.lilbee-ribbon-icon.lilbee-ribbon-error::after {
+.side-dock-ribbon-action.lilbee-ribbon-icon.lilbee-ribbon-error::after {
     background-color: var(--text-error, #ef4444);
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .lilbee-ribbon-icon.lilbee-ribbon-active::after {
+    .side-dock-ribbon-action.lilbee-ribbon-icon.lilbee-ribbon-active::after {
         animation: none;
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -1773,6 +1773,43 @@
     100% { background-position: -200% 0; }
 }
 
+.lilbee-ribbon-icon {
+    position: relative;
+}
+
+.lilbee-ribbon-icon.lilbee-ribbon-active::after,
+.lilbee-ribbon-icon.lilbee-ribbon-success::after,
+.lilbee-ribbon-icon.lilbee-ribbon-error::after {
+    content: "";
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    border: 1.5px solid var(--background-primary);
+    pointer-events: none;
+}
+
+.lilbee-ribbon-icon.lilbee-ribbon-active::after {
+    background-color: var(--interactive-accent);
+    animation: lilbee-dot-pulse 1s ease-in-out infinite;
+}
+
+.lilbee-ribbon-icon.lilbee-ribbon-success::after {
+    background-color: var(--text-success, #22c55e);
+}
+
+.lilbee-ribbon-icon.lilbee-ribbon-error::after {
+    background-color: var(--text-error, #ef4444);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .lilbee-ribbon-icon.lilbee-ribbon-active::after {
+        animation: none;
+    }
+}
+
 .lilbee-task-cancel {
     background: none;
     border: 1px solid transparent;

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -376,6 +376,11 @@ export class Plugin {
         return el;
     });
 
+    addRibbonIcon = vi.fn((_icon: string, _title: string, _callback: () => void) => {
+        const el = new MockElement("div");
+        return el;
+    });
+
     registerView = vi.fn();
     registerEvent = vi.fn();
     registerInterval = vi.fn((handle: number) => handle);

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1495,6 +1495,23 @@ describe("LilbeePlugin", () => {
             expect(plugin.taskQueue.completed.some((t) => t.status === "failed")).toBe(true);
         });
 
+        it("fails the task and shows idle-stream notice when crawl stream hangs", async () => {
+            const { StreamIdleError } = await import("../src/utils");
+            const plugin = await createPlugin();
+            await plugin.onload();
+
+            plugin.api.crawl = vi.fn().mockReturnValue(
+                (async function* (): AsyncGenerator<never> {
+                    throw new StreamIdleError(1);
+                })(),
+            );
+
+            await plugin.runCrawl("https://example.com", 0, 50);
+
+            expect(Notice.instances.some((n) => n.message.includes("stopped sending events"))).toBe(true);
+            expect(plugin.taskQueue.completed[0]?.status).toBe("failed");
+        });
+
         it("handles non-Error throw", async () => {
             const plugin = await createPlugin();
             await plugin.onload();

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -654,6 +654,22 @@ describe("LilbeePlugin", () => {
 
             expect(syncStreamSpy).not.toHaveBeenCalled();
         });
+
+        it("fails the task and shows idle-stream notice when server stops sending events", async () => {
+            const { StreamIdleError } = await import("../src/utils");
+            const plugin = await createPlugin();
+            await plugin.onload();
+
+            async function* throwIdle(): AsyncGenerator<never> {
+                throw new StreamIdleError(1);
+            }
+            plugin.api.syncStream = vi.fn().mockReturnValue(throwIdle());
+
+            await plugin.triggerSync();
+
+            expect(Notice.instances.some((n) => n.message.includes("stopped sending events"))).toBe(true);
+            expect(plugin.taskQueue.completed[0]?.status).toBe("failed");
+        });
     });
 
     describe("commands", () => {
@@ -1264,6 +1280,23 @@ describe("LilbeePlugin", () => {
             await plugin.addExternalFiles(["/some/file.pdf"]);
 
             expect(Notice.instances.some((n) => n.message.includes("add failed"))).toBe(true);
+        });
+
+        it("fails the task and shows idle-stream notice when add stream hangs", async () => {
+            const { StreamIdleError } = await import("../src/utils");
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+
+            async function* throwIdle(): AsyncGenerator<never> {
+                throw new StreamIdleError(1);
+            }
+            plugin.api.addFiles = vi.fn().mockReturnValue(throwIdle());
+
+            await plugin.addExternalFiles(["/some/file.pdf"]);
+
+            expect(Notice.instances.some((n) => n.message.includes("stopped sending events"))).toBe(true);
+            expect(plugin.taskQueue.completed[0]?.status).toBe("failed");
         });
 
         it("shows failed count in Notice", async () => {
@@ -2007,6 +2040,105 @@ describe("LilbeePlugin", () => {
             expect(() => {
                 (plugin as any).setStatusClass("lilbee-status-ready");
             }).not.toThrow();
+        });
+
+        it("ribbon icon click invokes activateTaskView", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const spy = vi.spyOn(plugin, "activateTaskView").mockResolvedValue(undefined);
+            const calls = (plugin.addRibbonIcon as ReturnType<typeof vi.fn>).mock.calls;
+            const callback = calls[0]?.[2] as () => void;
+            callback();
+            expect(spy).toHaveBeenCalledTimes(1);
+        });
+
+        it("ribbon icon toggles lilbee-ribbon-active while any task is active", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const ribbon = (plugin as any).ribbonIconEl as any;
+            expect(ribbon.classList.contains("lilbee-ribbon-active")).toBe(false);
+
+            plugin.taskQueue.enqueue("Sync vault", "sync");
+            expect(ribbon.classList.contains("lilbee-ribbon-active")).toBe(true);
+        });
+
+        it("ribbon icon shows success dot during flash window after done", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const ribbon = (plugin as any).ribbonIconEl as any;
+
+            const id = plugin.taskQueue.enqueue("Sync vault", "sync");
+            plugin.taskQueue.complete(id);
+
+            expect(ribbon.classList.contains("lilbee-ribbon-success")).toBe(true);
+            expect(ribbon.classList.contains("lilbee-ribbon-active")).toBe(false);
+        });
+
+        it("ribbon icon shows error dot during flash window after fail", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const ribbon = (plugin as any).ribbonIconEl as any;
+
+            const id = plugin.taskQueue.enqueue("Sync vault", "sync");
+            plugin.taskQueue.fail(id, "boom");
+
+            expect(ribbon.classList.contains("lilbee-ribbon-error")).toBe(true);
+        });
+
+        it("ribbon icon clears after flash window expires", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const ribbon = (plugin as any).ribbonIconEl as any;
+
+            const id = plugin.taskQueue.enqueue("Sync vault", "sync");
+            plugin.taskQueue.complete(id);
+            const completed = plugin.taskQueue.completed[0]!;
+            (completed as any).completedAt = Date.now() - 10_000;
+            (plugin as any).updateRibbonFromQueue();
+
+            expect(ribbon.classList.contains("lilbee-ribbon-success")).toBe(false);
+            expect(ribbon.classList.contains("lilbee-ribbon-error")).toBe(false);
+            expect(ribbon.classList.contains("lilbee-ribbon-active")).toBe(false);
+        });
+
+        it("updateRibbonFromQueue no-ops when ribbonIconEl is null", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            (plugin as any).ribbonIconEl = null;
+            expect(() => {
+                (plugin as any).updateRibbonFromQueue();
+            }).not.toThrow();
+        });
+
+        it("updateRibbonFromQueue no-ops when last completed has null completedAt", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const ribbon = (plugin as any).ribbonIconEl as any;
+            const id = plugin.taskQueue.enqueue("Sync vault", "sync");
+            plugin.taskQueue.complete(id);
+            (plugin.taskQueue.completed[0] as any).completedAt = null;
+            (plugin as any).updateRibbonFromQueue();
+            expect(ribbon.classList.contains("lilbee-ribbon-active")).toBe(false);
+            expect(ribbon.classList.contains("lilbee-ribbon-success")).toBe(false);
+        });
+
+        it("updateRibbonFromQueue leaves classes cleared when no tasks at all", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const ribbon = (plugin as any).ribbonIconEl as any;
+            (plugin as any).updateRibbonFromQueue();
+            expect(ribbon.classList.contains("lilbee-ribbon-active")).toBe(false);
+        });
+
+        it("ribbon icon does not highlight for cancelled tasks", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const ribbon = (plugin as any).ribbonIconEl as any;
+            const id = plugin.taskQueue.enqueue("Sync vault", "sync");
+            plugin.taskQueue.cancel(id);
+            expect(ribbon.classList.contains("lilbee-ribbon-success")).toBe(false);
+            expect(ribbon.classList.contains("lilbee-ribbon-error")).toBe(false);
+            expect(ribbon.classList.contains("lilbee-ribbon-active")).toBe(false);
         });
     });
 

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect } from "vitest";
-import { ensureUrlScheme, formatBytes, formatRate, formatElapsed, percentFromSse } from "../src/utils";
+import { describe, it, expect, vi } from "vitest";
+import {
+    ensureUrlScheme,
+    formatBytes,
+    formatRate,
+    formatElapsed,
+    percentFromSse,
+    StreamIdleError,
+    withIdleTimeout,
+} from "../src/utils";
 
 describe("ensureUrlScheme", () => {
     it("returns URL unchanged when it starts with https://", () => {
@@ -115,5 +123,43 @@ describe("percentFromSse", () => {
 
     it("returns undefined when nothing is usable", () => {
         expect(percentFromSse({})).toBeUndefined();
+    });
+});
+
+describe("withIdleTimeout", () => {
+    it("yields events when they arrive before the idle timeout", async () => {
+        async function* gen() {
+            yield "a";
+            yield "b";
+        }
+        const abort = vi.fn();
+        const out: string[] = [];
+        for await (const v of withIdleTimeout(gen(), 1000, abort)) out.push(v);
+        expect(out).toEqual(["a", "b"]);
+        expect(abort).not.toHaveBeenCalled();
+    });
+
+    it("throws StreamIdleError and calls abort when no event arrives in timeout", async () => {
+        async function* gen(): AsyncGenerator<string> {
+            await new Promise(() => {});
+        }
+        const abort = vi.fn();
+        let caught: unknown = null;
+        try {
+            for await (const _ of withIdleTimeout(gen(), 10, abort)) void _;
+        } catch (e) {
+            caught = e;
+        }
+        expect(caught).toBeInstanceOf(StreamIdleError);
+        expect(abort).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops cleanly when source generator completes", async () => {
+        async function* gen() {
+            yield 1;
+        }
+        const out: number[] = [];
+        for await (const v of withIdleTimeout(gen(), 1000, vi.fn())) out.push(v);
+        expect(out).toEqual([1]);
     });
 });


### PR DESCRIPTION


## Ribbon icon badge

New left-ribbon entry opens the Task Center. A colored dot overlays the icon when work is in flight:

- pulsing primary while any task is active or queued
- green during the 2s flash window after a task completes
- red during the 2s flash window after a task fails

Mirrors the status-bar `DOT_STATE` so users notice background work without needing the Task Center view open. Namespaced selector `.side-dock-ribbon-action.lilbee-ribbon-icon` to avoid clashing with future upstream ribbon styles. `prefers-reduced-motion` suppresses the pulse.

## Stream-idle timeout

Sync, add, and crawl paths now abort with a clear "server stopped sending events" notice after 120s of silence from the SSE stream. Before this, a wedged server left the task infinitely active with a pulsing rail and no recovery short of disabling the plugin.

New utility `withIdleTimeout(gen, timeoutMs, abort)` wraps the SSE async generator. On timeout it calls `abort()` (aborting the underlying fetch), fires `iter.return?.()` so the source generator can run its `try/finally`, and throws `StreamIdleError`. Each caller catches `StreamIdleError` specifically and fails the task with a localized message.

Pull streams are **not** wrapped — long download pauses are legitimate. Constant is documented near its definition.
