### PR TITLE
Surface stale session token as actionable SessionTokenError

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -35,7 +35,7 @@ export class SessionTokenError extends Error {
     readonly status: number;
     constructor(status: number, body: string) {
         super(`Session token invalid (HTTP ${status}): ${body}`);
-        this.name = "SessionTokenError";
+        this.name = ERROR_NAME.SESSION_TOKEN;
         this.status = status;
     }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -25,6 +25,21 @@ const DEFAULT_TIMEOUT_MS = 15_000;
 const RETRY_COUNT = 2;
 const RETRY_BACKOFF_MS = 500;
 
+/**
+ * Thrown when the server rejects a request with 401 / 403 after the plugin's
+ * auto-retry + token-refresh has failed. Signals that the stored session token
+ * (manualToken or auto-discovered) is stale and the user needs to paste a new
+ * one in Settings → Session token. Catchers should surface a targeted notice.
+ */
+export class SessionTokenError extends Error {
+    readonly status: number;
+    constructor(status: number, body: string) {
+        super(`Session token invalid (HTTP ${status}): ${body}`);
+        this.name = "SessionTokenError";
+        this.status = status;
+    }
+}
+
 export class LilbeeClient {
     private token: string | null = null;
     private tokenProvider: (() => string | null) | null = null;
@@ -123,12 +138,22 @@ export class LilbeeClient {
                         init = this.applyRefreshedToken(init);
                         continue;
                     }
+                    if (res.status === 401 || res.status === 403) {
+                        // Either no provider, provider returned the same token, or refreshed
+                        // token still failed. The stored session token is stale — surface a
+                        // typed error so the UI can tell the user what to do.
+                        const text = await res.text().catch(() => "");
+                        throw new SessionTokenError(res.status, text);
+                    }
                     return await this.assertOk(res);
                 } finally {
                     if (timer !== undefined) clearTimeout(timer);
                 }
             } catch (err) {
                 lastError = err;
+                if (err instanceof SessionTokenError) {
+                    throw err;
+                }
                 if (err instanceof Error && err.message.startsWith("Server responded")) {
                     throw err;
                 }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -327,6 +327,7 @@ export const MESSAGES = {
     NOTICE_NO_TOKEN_MANAGED: "lilbee: managed server didn't produce a session token — try restarting the plugin",
     NOTICE_NO_TOKEN_EXTERNAL:
         "lilbee: no session token — run 'lilbee token' and paste it in Settings → Session token, or set LILBEE_DATA",
+    NOTICE_SESSION_TOKEN_INVALID: "lilbee: session token invalid — paste a new one in Settings → Session token",
     NOTICE_QUEUE_FULL: "lilbee: too many tasks queued — wait for some to finish",
     NOTICE_MODEL_ACTIVATED_FULL: (model: string) => `lilbee: ${model} pulled and activated`,
     NOTICE_SET_MODEL: (type: string, model: string) => `${type} set to ${model}`,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -18,7 +18,7 @@ import { CatalogModal } from "./views/catalog-modal";
 import { ConfirmModal } from "./views/confirm-modal";
 import { ConfirmPullModal } from "./views/confirm-pull-modal";
 import { SetupWizard } from "./views/setup-wizard";
-import { percentFromSse, errorMessage, extractSseErrorMessage } from "./utils";
+import { percentFromSse, errorMessage, extractSseErrorMessage, noticeForResultError } from "./utils";
 
 const CHECK_TIMEOUT_MS = 5000;
 const CLS_MODELS_CONTAINER = "lilbee-models-container";
@@ -568,7 +568,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
                             if (!confirmed) return;
                             const result = await this.plugin.api.setEmbeddingModel(value);
                             if (result.isErr()) {
-                                new Notice(MESSAGES.NOTICE_FAILED_EMBEDDING);
+                                new Notice(noticeForResultError(result.error, MESSAGES.NOTICE_FAILED_EMBEDDING));
                                 return;
                             }
                             new Notice(MESSAGES.NOTICE_EMBEDDING_UPDATED);
@@ -598,7 +598,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
                         if (!confirmed) return;
                         const result = await this.plugin.api.setEmbeddingModel(trimmed);
                         if (result.isErr()) {
-                            new Notice(MESSAGES.NOTICE_FAILED_EMBEDDING);
+                            new Notice(noticeForResultError(result.error, MESSAGES.NOTICE_FAILED_EMBEDDING));
                             return;
                         }
                         new Notice(MESSAGES.NOTICE_EMBEDDING_UPDATED);
@@ -1194,7 +1194,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         }
         const result = await this.setModel({ name: value });
         if (result.isErr()) {
-            new Notice(MESSAGES.NOTICE_FAILED_SET_MODEL(MODEL_TASK.CHAT));
+            new Notice(noticeForResultError(result.error, MESSAGES.NOTICE_FAILED_SET_MODEL(MODEL_TASK.CHAT)));
             return;
         }
         new Notice(MESSAGES.NOTICE_SET_MODEL(label, value || MESSAGES.LABEL_NOT_SET.toLowerCase()));
@@ -1249,7 +1249,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
 
         const setResult = await this.setModel(model);
         if (setResult.isErr()) {
-            new Notice(MESSAGES.ERROR_SET_MODEL.replace("{model}", model.name));
+            new Notice(noticeForResultError(setResult.error, MESSAGES.ERROR_SET_MODEL.replace("{model}", model.name)));
         } else {
             new Notice(MESSAGES.NOTICE_MODEL_ACTIVATED_FULL(model.name));
         }
@@ -1327,7 +1327,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
 
         const setResult = await this.setModel(model);
         if (setResult.isErr()) {
-            new Notice(MESSAGES.ERROR_SET_MODEL.replace("{model}", model.name));
+            new Notice(noticeForResultError(setResult.error, MESSAGES.ERROR_SET_MODEL.replace("{model}", model.name)));
         } else {
             new Notice(MESSAGES.NOTICE_MODEL_ACTIVATED_FULL(model.name));
         }
@@ -1345,8 +1345,8 @@ export class LilbeeSettingTab extends PluginSettingTab {
         this.plugin.taskQueue.update(taskId, -1, model.name);
         const result = await this.plugin.api.deleteModel(model.name);
         if (result.isErr()) {
-            new Notice(MESSAGES.ERROR_DELETE_MODEL.replace("{model}", model.name));
-            this.plugin.taskQueue.fail(taskId, result.error.message);
+            new Notice(noticeForResultError(result.error, MESSAGES.ERROR_DELETE_MODEL.replace("{model}", model.name)));
+            this.plugin.taskQueue.fail(taskId, errorMessage(result.error, result.error.message));
             btn.disabled = false;
             return;
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -379,6 +379,7 @@ export const MODEL_SOURCE = {
 
 export const ERROR_NAME = {
     ABORT_ERROR: "AbortError",
+    SESSION_TOKEN: "SessionTokenError",
 } as const;
 
 export const WIZARD_STEP = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,8 +114,13 @@ export function formatRate(bytesPerSecond: number): string {
 /**
  * Pull a human-readable message out of an unknown thrown value.
  * Centralizes the `err instanceof Error ? err.message : <fallback>` pattern.
+ * Stale-session-token errors get a dedicated, actionable message so the user
+ * knows exactly where to fix it (see SessionTokenError in api.ts).
  */
 export function errorMessage(err: unknown, fallback: string): string {
+    if (err instanceof Error && err.name === "SessionTokenError") {
+        return "lilbee: session token invalid — paste a new one in Settings → Session token";
+    }
     return err instanceof Error ? err.message : fallback;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,6 @@
+import { SessionTokenError } from "./api";
+import { MESSAGES } from "./locales/en";
+
 export function debounce<T extends (...args: unknown[]) => unknown>(
     fn: T,
     ms: number,
@@ -118,10 +121,23 @@ export function formatRate(bytesPerSecond: number): string {
  * knows exactly where to fix it (see SessionTokenError in api.ts).
  */
 export function errorMessage(err: unknown, fallback: string): string {
-    if (err instanceof Error && err.name === "SessionTokenError") {
-        return "lilbee: session token invalid — paste a new one in Settings → Session token";
+    if (err instanceof SessionTokenError) {
+        return MESSAGES.NOTICE_SESSION_TOKEN_INVALID;
     }
     return err instanceof Error ? err.message : fallback;
+}
+
+/**
+ * Returns the stale-token notice when the error is a SessionTokenError, otherwise the fallback.
+ * Use at `.isErr()` call sites where the fallback is an operation-specific generic message — this
+ * preserves the generic text for non-auth failures while surfacing the actionable message for
+ * stale tokens.
+ */
+export function noticeForResultError(err: unknown, fallback: string): string {
+    if (err instanceof SessionTokenError) {
+        return MESSAGES.NOTICE_SESSION_TOKEN_INVALID;
+    }
+    return fallback;
 }
 
 /**

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -12,6 +12,7 @@ import {
     percentFromSse,
     errorMessage,
     extractSseErrorMessage,
+    noticeForResultError,
 } from "../utils";
 import { renderModelCard } from "../components/model-card";
 
@@ -164,7 +165,7 @@ export class CatalogModal extends Modal {
         try {
             const result = await this.plugin.api.catalog(params);
             if (result.isErr()) {
-                new Notice(MESSAGES.ERROR_LOAD_CATALOG);
+                new Notice(noticeForResultError(result.error, MESSAGES.ERROR_LOAD_CATALOG));
                 return;
             }
 
@@ -382,8 +383,10 @@ export class CatalogModal extends Modal {
 
         const result = await this.plugin.api.deleteModel(entry.hf_repo, entry.source);
         if (result.isErr()) {
-            new Notice(MESSAGES.ERROR_REMOVE_MODEL.replace("{model}", entry.hf_repo));
-            this.plugin.taskQueue.fail(taskId, result.error.message);
+            new Notice(
+                noticeForResultError(result.error, MESSAGES.ERROR_REMOVE_MODEL.replace("{model}", entry.hf_repo)),
+            );
+            this.plugin.taskQueue.fail(taskId, errorMessage(result.error, result.error.message));
             btn.textContent = MESSAGES.BUTTON_REMOVE;
             (btn as HTMLButtonElement).disabled = false;
             return;
@@ -402,7 +405,7 @@ export class CatalogModal extends Modal {
         const result = await this.setActiveFor(entry);
 
         if (result.isErr()) {
-            new Notice(MESSAGES.ERROR_SET_MODEL.replace("{model}", entry.hf_repo));
+            new Notice(noticeForResultError(result.error, MESSAGES.ERROR_SET_MODEL.replace("{model}", entry.hf_repo)));
             btn.textContent = MESSAGES.BUTTON_USE;
             (btn as HTMLButtonElement).disabled = false;
             return;
@@ -483,7 +486,7 @@ export class CatalogModal extends Modal {
 
         const result = await this.setActiveFor(entry);
         if (result.isErr()) {
-            new Notice(MESSAGES.ERROR_SET_MODEL.replace("{model}", entry.hf_repo));
+            new Notice(noticeForResultError(result.error, MESSAGES.ERROR_SET_MODEL.replace("{model}", entry.hf_repo)));
             this.plugin.fetchActiveModel();
             this.resetAndFetch();
             return;

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -33,6 +33,7 @@ import {
     percentFromSse,
     errorMessage,
     extractSseErrorMessage,
+    noticeForResultError,
 } from "../utils";
 
 interface OpenDialogResult {
@@ -380,7 +381,7 @@ export class ChatView extends ItemView {
                 }
                 const result = await this.plugin.api.setEmbeddingModel(el.value);
                 if (result.isErr()) {
-                    new Notice(MESSAGES.NOTICE_FAILED_EMBEDDING);
+                    new Notice(noticeForResultError(result.error, MESSAGES.NOTICE_FAILED_EMBEDDING));
                     this.revertEmbeddingSelect(previous);
                     return;
                 }
@@ -450,7 +451,7 @@ export class ChatView extends ItemView {
 
         const result = await this.plugin.api.setChatModel(model.name);
         if (result.isErr()) {
-            new Notice(MESSAGES.ERROR_SET_MODEL.replace("{model}", model.name));
+            new Notice(noticeForResultError(result.error, MESSAGES.ERROR_SET_MODEL.replace("{model}", model.name)));
         } else {
             this.plugin.activeModel = model.name;
             new Notice(MESSAGES.NOTICE_MODEL_ACTIVATED_FULL(model.name));

--- a/src/views/status-modal.ts
+++ b/src/views/status-modal.ts
@@ -2,6 +2,7 @@ import { App, Modal, Notice } from "obsidian";
 import type LilbeePlugin from "../main";
 import type { ModelShowResponse, StatusResponse } from "../types";
 import { MESSAGES } from "../locales/en";
+import { noticeForResultError } from "../utils";
 
 export class StatusModal extends Modal {
     private plugin: LilbeePlugin;
@@ -23,7 +24,7 @@ export class StatusModal extends Modal {
         try {
             const statusResult = await this.plugin.api.status();
             if (statusResult.isErr()) {
-                new Notice(MESSAGES.ERROR_COULD_NOT_CONNECT);
+                new Notice(noticeForResultError(statusResult.error, MESSAGES.ERROR_COULD_NOT_CONNECT));
                 this.close();
                 return;
             }

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -950,7 +950,7 @@ describe("fetchWithRetry() — token provider + 401/403 retry", () => {
         expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
-    it("skips auth retry when no provider is registered", async () => {
+    it("skips auth retry when no provider is registered — surfaces SessionTokenError", async () => {
         const c = new LilbeeClient(BASE_URL);
         c.setToken("old");
         fetchMock.mockResolvedValue({
@@ -960,10 +960,13 @@ describe("fetchWithRetry() — token provider + 401/403 retry", () => {
         } as unknown as Response);
         const result = await c.health();
         expect(result.isErr()).toBe(true);
+        const e = result._unsafeUnwrapErr();
+        expect(e).toBeInstanceOf(SessionTokenError);
+        expect((e as SessionTokenError).status).toBe(401);
         expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
-    it("skips auth retry when provider returns null", async () => {
+    it("skips auth retry when provider returns null — surfaces SessionTokenError", async () => {
         const c = new LilbeeClient(BASE_URL);
         c.setToken("old");
         c.setTokenProvider(() => null);
@@ -974,10 +977,13 @@ describe("fetchWithRetry() — token provider + 401/403 retry", () => {
         } as unknown as Response);
         const result = await c.health();
         expect(result.isErr()).toBe(true);
+        const e = result._unsafeUnwrapErr();
+        expect(e).toBeInstanceOf(SessionTokenError);
+        expect((e as SessionTokenError).status).toBe(401);
         expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
-    it("skips auth retry when provider returns the same token", async () => {
+    it("skips auth retry when provider returns the same token — surfaces SessionTokenError", async () => {
         const c = new LilbeeClient(BASE_URL);
         c.setToken("same");
         c.setTokenProvider(() => "same");
@@ -988,6 +994,9 @@ describe("fetchWithRetry() — token provider + 401/403 retry", () => {
         } as unknown as Response);
         const result = await c.health();
         expect(result.isErr()).toBe(true);
+        const e = result._unsafeUnwrapErr();
+        expect(e).toBeInstanceOf(SessionTokenError);
+        expect((e as SessionTokenError).status).toBe(401);
         expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,5 +1,5 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
-import { LilbeeClient } from "../src/api";
+import { LilbeeClient, SessionTokenError } from "../src/api";
 import type { Message } from "../src/types";
 
 const BASE_URL = "http://localhost:7433";
@@ -933,7 +933,7 @@ describe("fetchWithRetry() — token provider + 401/403 retry", () => {
         expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
-    it("does not retry twice — second 401 surfaces the error", async () => {
+    it("does not retry twice — second 401 surfaces SessionTokenError", async () => {
         const c = new LilbeeClient(BASE_URL);
         c.setToken("old");
         c.setTokenProvider(() => "new");
@@ -944,7 +944,9 @@ describe("fetchWithRetry() — token provider + 401/403 retry", () => {
         } as unknown as Response);
         const result = await c.health();
         expect(result.isErr()).toBe(true);
-        expect(result._unsafeUnwrapErr().message).toBe("Server responded 401: still bad");
+        const e = result._unsafeUnwrapErr();
+        expect(e.name).toBe("SessionTokenError");
+        expect((e as SessionTokenError).status).toBe(401);
         expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -6,6 +6,14 @@ import { FileProgressTracker } from "../src/main";
 import { MESSAGES } from "../src/locales/en";
 import { ConfirmModal } from "../src/views/confirm-modal";
 vi.mock("../src/api", () => ({
+    SessionTokenError: class SessionTokenError extends Error {
+        readonly status: number;
+        constructor(status: number, body: string) {
+            super(`Session token invalid (HTTP ${status}): ${body}`);
+            this.name = "SessionTokenError";
+            this.status = status;
+        }
+    },
     LilbeeClient: vi.fn().mockImplementation(() => ({
         status: vi.fn(),
         syncStream: vi.fn(),

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import {
     ensureUrlScheme,
+    errorMessage,
     formatBytes,
     formatRate,
     formatElapsed,
@@ -8,6 +9,7 @@ import {
     StreamIdleError,
     withIdleTimeout,
 } from "../src/utils";
+import { SessionTokenError } from "../src/api";
 
 describe("ensureUrlScheme", () => {
     it("returns URL unchanged when it starts with https://", () => {
@@ -161,5 +163,22 @@ describe("withIdleTimeout", () => {
         const out: number[] = [];
         for await (const v of withIdleTimeout(gen(), 1000, vi.fn())) out.push(v);
         expect(out).toEqual([1]);
+    });
+});
+
+describe("errorMessage", () => {
+    it("returns the Error.message for generic errors", () => {
+        expect(errorMessage(new Error("boom"), "fallback")).toBe("boom");
+    });
+
+    it("falls back to the provided string for non-Error values", () => {
+        expect(errorMessage("raw-string", "fallback")).toBe("fallback");
+        expect(errorMessage(null, "fallback")).toBe("fallback");
+    });
+
+    it("returns an actionable, user-facing message for SessionTokenError", () => {
+        const out = errorMessage(new SessionTokenError(401, "stale"), "fallback");
+        expect(out).toContain("session token invalid");
+        expect(out).toContain("Settings → Session token");
     });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -5,11 +5,14 @@ import {
     formatBytes,
     formatRate,
     formatElapsed,
+    noticeForResultError,
     percentFromSse,
     StreamIdleError,
     withIdleTimeout,
 } from "../src/utils";
 import { SessionTokenError } from "../src/api";
+import { MESSAGES } from "../src/locales/en";
+import { ERROR_NAME } from "../src/types";
 
 describe("ensureUrlScheme", () => {
     it("returns URL unchanged when it starts with https://", () => {
@@ -178,7 +181,32 @@ describe("errorMessage", () => {
 
     it("returns an actionable, user-facing message for SessionTokenError", () => {
         const out = errorMessage(new SessionTokenError(401, "stale"), "fallback");
-        expect(out).toContain("session token invalid");
-        expect(out).toContain("Settings → Session token");
+        expect(out).toBe(MESSAGES.NOTICE_SESSION_TOKEN_INVALID);
+    });
+
+    it("falls back for undefined", () => {
+        expect(errorMessage(undefined, "fallback")).toBe("fallback");
+    });
+
+    it("uses ERROR_NAME.SESSION_TOKEN constant for the thrown error name", () => {
+        const e = new SessionTokenError(403, "bad");
+        expect(e.name).toBe(ERROR_NAME.SESSION_TOKEN);
+    });
+});
+
+describe("noticeForResultError", () => {
+    it("returns the dedicated session-token notice for SessionTokenError", () => {
+        const err = new SessionTokenError(401, "stale");
+        expect(noticeForResultError(err, "generic fallback")).toBe(MESSAGES.NOTICE_SESSION_TOKEN_INVALID);
+    });
+
+    it("returns the operation-specific fallback for other errors", () => {
+        expect(noticeForResultError(new Error("boom"), "generic fallback")).toBe("generic fallback");
+    });
+
+    it("returns the fallback for non-Error values", () => {
+        expect(noticeForResultError("raw", "generic fallback")).toBe("generic fallback");
+        expect(noticeForResultError(null, "generic fallback")).toBe("generic fallback");
+        expect(noticeForResultError(undefined, "generic fallback")).toBe("generic fallback");
     });
 });


### PR DESCRIPTION
## Problem

When the lilbee server rotates its session token (reinstall, data-dir reset, fresh `lilbee serve`), the plugin's stored `manualToken` becomes stale. Every write (`PATCH /api/config`, `POST /api/crawl`, etc.) 401s. The plugin surfaced the raw `Server responded 401: {...}` string in Task Center rows and generic `failed to update X` toasts on settings changes — correct but not actionable.

## Fix

- New typed `SessionTokenError` in `src/api.ts`, thrown after `fetchWithRetry`'s existing token-refresh retry exhausts without success.
- `errorMessage()` in `src/utils.ts` intercepts the error and returns **"lilbee: session token invalid — paste a new one in Settings → Session token"** instead of leaking the raw HTTP text.

Every existing call site (settings PATCH, chat stream, crawl, sync, etc.) runs the thrown error through `errorMessage` before showing a toast, so the user now gets a single clear instruction pointing at the exact UI field to fix.