### PR TITLE
Add optional Vision step to setup wizard and decouple picks from server source field

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -397,6 +397,14 @@ export class LilbeeClient {
         });
     }
 
+    async setVisionModel(model: string): Promise<Result<void, Error>> {
+        return this.fetchResult<void>(`${this.baseUrl}/api/models/vision`, {
+            method: "PUT",
+            headers: { ...JSON_HEADERS, ...this.authHeaders() },
+            body: JSON.stringify({ model }),
+        });
+    }
+
     async wikiList(): Promise<WikiPage[]> {
         const res = await this.fetchWithRetry(`${this.baseUrl}/api/wiki`, { headers: this.authHeaders() });
         return res.json();

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -585,8 +585,9 @@ export const MESSAGES = {
     // Vision wizard step
     TITLE_PICK_VISION: "Vision model (optional)",
     WIZARD_VISION_HELP:
-        "Vision models let lilbee read scanned PDFs, handwritten notes, diagrams, and image-only pages. If your documents are already text, you can skip this.",
+        "Vision models help lilbee read scanned PDFs, handwritten notes, diagrams, and image-only pages — useful when standard OCR fails or returns garbled text. These models are only used for indexing images in your documents; your chat model is separate and won't change. Skip this step if your documents are already plain text.",
     WIZARD_VISION_RECOMMENDED: "Featured vision models",
+    NOTICE_VISION_SET: "Vision model set: {model}. Used for indexing scanned PDFs — your chat model is unchanged.",
     BUTTON_SKIP_STEP: "Skip",
 
     WIZARD_FILE_PICKER_VAULT: "From vault",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -582,6 +582,13 @@ export const MESSAGES = {
         "The embedding model converts your documents into searchable vectors. The default works well for most users.",
     WIZARD_EMBEDDING_RECOMMENDED: "Recommended",
 
+    // Vision wizard step
+    TITLE_PICK_VISION: "Vision model (optional)",
+    WIZARD_VISION_HELP:
+        "Vision models let lilbee read scanned PDFs, handwritten notes, diagrams, and image-only pages. If your documents are already text, you can skip this.",
+    WIZARD_VISION_RECOMMENDED: "Featured vision models",
+    BUTTON_SKIP_STEP: "Skip",
+
     WIZARD_FILE_PICKER_VAULT: "From vault",
     WIZARD_FILE_PICKER_DISK: "Files from disk",
     WIZARD_FOLDER_PICKER_DISK: "Folder from disk",

--- a/src/types.ts
+++ b/src/types.ts
@@ -409,9 +409,10 @@ export const WIZARD_STEP = {
     SERVER_MODE: 1,
     MODEL_PICKER: 2,
     EMBEDDING_PICKER: 3,
-    SYNC: 4,
-    WIKI: 5,
-    DONE: 6,
+    VISION_PICKER: 4,
+    SYNC: 5,
+    WIKI: 6,
+    DONE: 7,
 } as const satisfies Record<string, number>;
 
 export const DOWNLOAD_PANEL = {

--- a/src/utils/source-click.ts
+++ b/src/utils/source-click.ts
@@ -32,31 +32,39 @@ function isMarkdownish(contentType: string): boolean {
     return contentType === CONTENT_TYPE.MARKDOWN || contentType === CONTENT_TYPE.HTML;
 }
 
+function vaultAction(source: Source, path: string): SourceClickAction {
+    if (source.content_type === CONTENT_TYPE.PDF) {
+        return {
+            kind: SOURCE_ACTION.VAULT_PDF,
+            path,
+            page: source.page_start ?? DEFAULT_PDF_PAGE,
+        };
+    }
+    if (isMarkdownish(source.content_type) && source.line_start !== null) {
+        return {
+            kind: SOURCE_ACTION.VAULT_MARKDOWN,
+            path,
+            line: source.line_start,
+        };
+    }
+    return { kind: SOURCE_ACTION.VAULT_NOTE, path };
+}
+
 /**
  * Resolve what should happen when the user clicks a source reference.
  *
- * A vault-side file takes precedence: if the server returned a `vault_path`
- * and the file exists in the vault, deep-link into Obsidian. Otherwise fall
- * back to a preview modal that fetches the content from the server.
+ * Prefer the server-supplied `vault_path`. If absent (older server builds,
+ * or external-server mode), fall back to `source.source` — sources ingested
+ * via a vault-native flow often match a vault-relative path directly. Only
+ * fall through to the preview modal when no vault file can be resolved.
  */
 export function sourceClickAction(source: Source, vault: Vault): SourceClickAction {
-    const path = source.vault_path;
-    if (path && vault.getAbstractFileByPath(path)) {
-        if (source.content_type === CONTENT_TYPE.PDF) {
-            return {
-                kind: SOURCE_ACTION.VAULT_PDF,
-                path,
-                page: source.page_start ?? DEFAULT_PDF_PAGE,
-            };
-        }
-        if (isMarkdownish(source.content_type) && source.line_start !== null) {
-            return {
-                kind: SOURCE_ACTION.VAULT_MARKDOWN,
-                path,
-                line: source.line_start,
-            };
-        }
-        return { kind: SOURCE_ACTION.VAULT_NOTE, path };
+    const vaultPath = source.vault_path;
+    if (vaultPath && vault.getAbstractFileByPath(vaultPath)) {
+        return vaultAction(source, vaultPath);
+    }
+    if (source.source && vault.getAbstractFileByPath(source.source)) {
+        return vaultAction(source, source.source);
     }
     return { kind: SOURCE_ACTION.PREVIEW, source };
 }

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -47,9 +47,15 @@ export class CatalogModal extends Modal {
     private debouncedSearch: () => void;
     private cancelDebouncedSearch: () => void;
 
-    constructor(app: App, plugin: LilbeePlugin) {
+    /**
+     * @param initialTaskFilter Pre-select a task tab when opening (e.g.
+     * from the wizard's Vision step so users land on vision-only results).
+     * Defaults to "" which shows all tasks.
+     */
+    constructor(app: App, plugin: LilbeePlugin, initialTaskFilter: TaskFilter = "") {
         super(app);
         this.plugin = plugin;
+        this.filterTask = initialTaskFilter;
         const searchDebounced = debounce(() => this.resetAndFetch(), DEBOUNCE_MS);
         this.debouncedSearch = searchDebounced.run;
         this.cancelDebouncedSearch = searchDebounced.cancel;
@@ -85,10 +91,16 @@ export class CatalogModal extends Modal {
     private renderFilterBar(parent: HTMLElement): void {
         const filters = parent.createDiv({ cls: "lilbee-catalog-filters" });
 
-        this.renderSelect(filters, "lilbee-catalog-filter-task", CATALOG_FILTERS.TASK, (v) => {
-            this.filterTask = v as TaskFilter;
-            this.resetAndFetch();
-        });
+        this.renderSelect(
+            filters,
+            "lilbee-catalog-filter-task",
+            CATALOG_FILTERS.TASK,
+            (v) => {
+                this.filterTask = v as TaskFilter;
+                this.resetAndFetch();
+            },
+            this.filterTask,
+        );
 
         this.renderSelect(filters, "lilbee-catalog-filter-size", CATALOG_FILTERS.SIZE, (v) => {
             this.filterSize = v as SizeFilter;
@@ -122,12 +134,14 @@ export class CatalogModal extends Modal {
         cls: string,
         options: ReadonlyArray<readonly [string, string]>,
         onChange: (value: string) => void,
+        initialValue?: string,
     ): void {
         const select = parent.createEl("select", { cls }) as HTMLSelectElement;
         for (const [value, label] of options) {
             const opt = select.createEl("option", { text: label });
             opt.value = value;
         }
+        if (initialValue !== undefined && initialValue !== "") select.value = initialValue;
         select.addEventListener("change", () => onChange(select.value));
     }
 

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -1,7 +1,7 @@
 import { App, Modal, Notice } from "obsidian";
 import type LilbeePlugin from "../main";
 import type { CatalogEntry, CatalogViewMode, ModelTask, ModelSize } from "../types";
-import { MODEL_TASK, SSE_EVENT, TASK_TYPE, CATALOG_VIEW_MODE, ERROR_NAME } from "../types";
+import { MODEL_TASK, SSE_EVENT, TASK_TYPE, CATALOG_VIEW_MODE, ERROR_NAME, MODEL_SOURCE } from "../types";
 import { MESSAGES, FILTERS, CATALOG_FILTERS } from "../locales/en";
 import { ConfirmModal } from "./confirm-modal";
 import { ConfirmPullModal } from "./confirm-pull-modal";
@@ -466,7 +466,11 @@ export class CatalogModal extends Modal {
         const pullErrorPrefix = MESSAGES.ERROR_PULL_MODEL.replace("{model}", entry.hf_repo);
 
         try {
-            for await (const event of this.plugin.api.pullModel(entry.hf_repo, entry.source, controller.signal)) {
+            for await (const event of this.plugin.api.pullModel(
+                entry.hf_repo,
+                MODEL_SOURCE.NATIVE,
+                controller.signal,
+            )) {
                 if (event.event === SSE_EVENT.PROGRESS) {
                     const d = event.data as { percent?: number; current?: number; total?: number };
                     const pct = percentFromSse(d);

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -837,6 +837,7 @@ export class SetupWizard extends Modal {
                         new Notice(MESSAGES.ERROR_SET_MODEL.replace("{model}", repo));
                         return;
                     }
+                    new Notice(MESSAGES.NOTICE_VISION_SET.replace("{model}", repo));
                     this.step = WIZARD_STEP.SYNC;
                     this.renderStep();
                 })();
@@ -946,6 +947,7 @@ export class SetupWizard extends Modal {
                 (downloadBtn as HTMLButtonElement).disabled = false;
                 return;
             }
+            new Notice(MESSAGES.NOTICE_VISION_SET.replace("{model}", model.hf_repo));
             this.step = WIZARD_STEP.SYNC;
             this.renderStep();
         } catch (err) {

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -9,16 +9,18 @@ import { percentFromSse, extractSseErrorMessage } from "../utils";
 
 type FeaturedModel = CatalogEntry;
 type EmbeddingModel = CatalogEntry;
+type VisionModel = CatalogEntry;
 
 /**
- * Ordered, visible-in-indicator steps. The indicator labels these 1..6 so the
- * user has a clear sense of "Step N of 6" while moving through setup. Welcome
+ * Ordered, visible-in-indicator steps. The indicator labels these 1..7 so the
+ * user has a clear sense of "Step N of 7" while moving through setup. Welcome
  * is not in the numbered sequence (it's the intro splash).
  */
 const INDICATOR_STEPS: { step: number; key: string; label: string }[] = [
     { step: WIZARD_STEP.SERVER_MODE, key: "server", label: "Server" },
     { step: WIZARD_STEP.MODEL_PICKER, key: "model", label: "Model" },
     { step: WIZARD_STEP.EMBEDDING_PICKER, key: "embedding", label: "Embed" },
+    { step: WIZARD_STEP.VISION_PICKER, key: "vision", label: "Vision" },
     { step: WIZARD_STEP.SYNC, key: "sync", label: "Sync" },
     { step: WIZARD_STEP.WIKI, key: "wiki", label: "Wiki" },
     { step: WIZARD_STEP.DONE, key: "done", label: "Done" },
@@ -34,6 +36,7 @@ const STEP_KEY: Record<number, string> = {
     [WIZARD_STEP.SERVER_MODE]: "server",
     [WIZARD_STEP.MODEL_PICKER]: "model",
     [WIZARD_STEP.EMBEDDING_PICKER]: "embedding",
+    [WIZARD_STEP.VISION_PICKER]: "vision",
     [WIZARD_STEP.SYNC]: "sync",
     [WIZARD_STEP.WIKI]: "wiki",
     [WIZARD_STEP.DONE]: "done",
@@ -69,20 +72,30 @@ export function recommendedIndex(models: FeaturedModel[], memGB: number | null):
  * native models outside these families backfill after.
  */
 const PREFERRED_FAMILIES = ["gemma-4", "gemma-3", "gemma-2", "qwen3", "qwen2", "llama-3", "phi-3"];
-const MAX_FEATURED_PICKS = 4;
+const MAX_FEATURED_PICKS = 8;
 
 /**
- * Rank the catalog's native chat entries into the wizard's "Our picks" row.
- * Filters out litellm (requires an API key — wrong first-run default), then
- * prefers entries whose name starts with one of {@link PREFERRED_FAMILIES}
- * before falling back to remaining natives.
+ * Rank the server's featured chat entries into the wizard's "Our picks" row.
+ *
+ * Deliberately does NOT filter by `source`. When a server is mis-configured
+ * and tags every featured model as `source="litellm"` (a known transient bug
+ * in older builds), filtering on source emptied the wizard grid. The featured
+ * list itself is the source of truth — the server has already decided these
+ * are the models a fresh user should see. We just reorder them so recognised
+ * open-weight families (Gemma, Qwen, Llama, Phi) lead.
+ *
+ * Callers that genuinely need to hide a subset (e.g. API-only entries in a
+ * different UI) can pass a custom `filter` predicate.
  */
-export function pickNativeChatModels(models: FeaturedModel[]): FeaturedModel[] {
-    const natives = models.filter((m) => m.source !== "litellm");
+export function pickNativeChatModels(
+    models: FeaturedModel[],
+    filter: (m: FeaturedModel) => boolean = () => true,
+): FeaturedModel[] {
+    const eligible = models.filter(filter);
     const seen = new Set<string>();
     const ordered: FeaturedModel[] = [];
     for (const prefix of PREFERRED_FAMILIES) {
-        for (const m of natives) {
+        for (const m of eligible) {
             if (m.name.startsWith(prefix) && !seen.has(m.hf_repo)) {
                 ordered.push(m);
                 seen.add(m.hf_repo);
@@ -90,7 +103,7 @@ export function pickNativeChatModels(models: FeaturedModel[]): FeaturedModel[] {
             }
         }
     }
-    for (const m of natives) {
+    for (const m of eligible) {
         if (!seen.has(m.hf_repo)) {
             ordered.push(m);
             seen.add(m.hf_repo);
@@ -111,6 +124,8 @@ export class SetupWizard extends Modal {
     private pulledModelName = "";
     private selectedEmbedding: EmbeddingModel | null = null;
     private embeddingModels: EmbeddingModel[] = [];
+    private selectedVision: VisionModel | null = null;
+    private visionModels: VisionModel[] = [];
 
     constructor(app: App, plugin: LilbeePlugin) {
         super(app);
@@ -145,6 +160,9 @@ export class SetupWizard extends Modal {
                 break;
             case WIZARD_STEP.EMBEDDING_PICKER:
                 this.renderEmbeddingPicker();
+                break;
+            case WIZARD_STEP.VISION_PICKER:
+                this.renderVisionPicker();
                 break;
             case WIZARD_STEP.SYNC:
                 this.renderSync();
@@ -493,14 +511,15 @@ export class SetupWizard extends Modal {
         statusEl: HTMLElement,
     ): Promise<void> {
         try {
-            // Wizard picks = local/native models only, not litellm. The server
-            // marks litellm models as featured=true but those require an API
-            // key; surfacing them as the first-run "picks" was misleading. We
-            // query by downloads and take the top native entries, preferring
-            // well-known open-weight families (Gemma, Qwen, Llama) when
-            // available.
+            // The server's featured list is the source of truth for the
+            // wizard's "Our picks" row. Do NOT filter by `source` here — a
+            // mis-configured server can tag every featured model as
+            // `source="litellm"`, which would empty the grid and leave the
+            // user stuck. `pickNativeChatModels` just reorders so recognised
+            // open-weight families (Gemma, Qwen, Llama) lead.
             const result = await this.plugin.api.catalog({
                 task: MODEL_TASK.CHAT,
+                featured: true,
                 sort: FILTERS.SORT.DOWNLOADS,
                 limit: 40,
             });
@@ -632,7 +651,7 @@ export class SetupWizard extends Modal {
         const downloadBtn = actions.createEl("button", { text: MESSAGES.BUTTON_DOWNLOAD_CONTINUE, cls: "mod-cta" });
         downloadBtn.addEventListener("click", () => {
             if (!this.selectedEmbedding) {
-                this.step = WIZARD_STEP.SYNC;
+                this.step = WIZARD_STEP.VISION_PICKER;
                 this.renderStep();
                 return;
             }
@@ -644,7 +663,7 @@ export class SetupWizard extends Modal {
                         new Notice(MESSAGES.ERROR_SET_MODEL.replace("{model}", name));
                         return;
                     }
-                    this.step = WIZARD_STEP.SYNC;
+                    this.step = WIZARD_STEP.VISION_PICKER;
                     this.renderStep();
                 })();
                 return;
@@ -661,6 +680,7 @@ export class SetupWizard extends Modal {
         try {
             const result = await this.plugin.api.catalog({
                 task: MODEL_TASK.EMBEDDING,
+                featured: true,
                 sort: FILTERS.SORT.DOWNLOADS,
                 limit: 20,
             });
@@ -668,11 +688,10 @@ export class SetupWizard extends Modal {
                 this.embeddingModels = [];
                 return;
             }
-            // Same rule as chat picks: skip litellm entries so the wizard never
-            // offers a default that silently needs an API key.
-            this.embeddingModels = result.value.models
-                .filter((m) => m.source !== "litellm")
-                .slice(0, MAX_FEATURED_PICKS);
+            // Trust the server's featured list — don't filter by source.
+            // Mis-configured builds can stamp every featured embedding as
+            // source="litellm", which would leave the picker empty.
+            this.embeddingModels = result.value.models.slice(0, MAX_FEATURED_PICKS);
         } catch {
             this.embeddingModels = [];
             statusEl.textContent = MESSAGES.ERROR_LOAD_MODELS;
@@ -748,6 +767,178 @@ export class SetupWizard extends Modal {
             }
 
             const setResult = await this.plugin.api.setEmbeddingModel(model.hf_repo);
+            if (setResult.isErr()) {
+                new Notice(MESSAGES.ERROR_SET_MODEL.replace("{model}", model.hf_repo));
+                statusEl.textContent = setResult.error.message;
+                progressEl.style.display = "none";
+                (downloadBtn as HTMLButtonElement).disabled = false;
+                return;
+            }
+            this.step = WIZARD_STEP.VISION_PICKER;
+            this.renderStep();
+        } catch (err) {
+            if (err instanceof Error && err.name === ERROR_NAME.ABORT_ERROR) {
+                new Notice(MESSAGES.NOTICE_DOWNLOAD_CANCELLED);
+            } else {
+                statusEl.textContent = MESSAGES.ERROR_DOWNLOAD_FAILED;
+            }
+            progressEl.style.display = "none";
+            (downloadBtn as HTMLButtonElement).disabled = false;
+        } finally {
+            this.pullController = null;
+        }
+    }
+
+    private renderVisionPicker(): void {
+        const step = this.beginStep();
+        this.renderStepHeader(step, MESSAGES.TITLE_PICK_VISION);
+        step.createEl("p", { text: MESSAGES.WIZARD_VISION_HELP });
+
+        const modelsContainer = step.createDiv({ cls: "lilbee-wizard-models" });
+        const statusEl = step.createDiv({ cls: "lilbee-wizard-status" });
+        const { progressEl, progressFill, progressLabel } = this.renderProgressPanel(step);
+
+        const actions = step.createDiv({ cls: "lilbee-wizard-actions" });
+        const backBtn = actions.createEl("button", { text: MESSAGES.BUTTON_BACK });
+        backBtn.addEventListener("click", () => {
+            this.pullController?.abort();
+            this.back();
+        });
+        // Skip-step advances past Vision without configuring a vision model.
+        // Prominent next to "Download & continue" — vision is genuinely
+        // optional; most text-only vaults never need it.
+        const skipStepBtn = actions.createEl("button", { text: MESSAGES.BUTTON_SKIP_STEP });
+        skipStepBtn.addEventListener("click", () => {
+            this.pullController?.abort();
+            this.step = WIZARD_STEP.SYNC;
+            this.renderStep();
+        });
+
+        const catalogBtn = actions.createEl("button", { text: MESSAGES.BUTTON_BROWSE_FULL_CATALOG });
+        catalogBtn.addEventListener("click", () => {
+            // Open the catalog pre-filtered to vision-capable models so the
+            // user lands on the right tab instead of scrolling past chat/
+            // embedding entries.
+            new CatalogModal(this.app, this.plugin, FILTERS.TASK.VISION).open();
+        });
+
+        const downloadBtn = actions.createEl("button", { text: MESSAGES.BUTTON_DOWNLOAD_CONTINUE, cls: "mod-cta" });
+        downloadBtn.addEventListener("click", () => {
+            if (!this.selectedVision) {
+                this.step = WIZARD_STEP.SYNC;
+                this.renderStep();
+                return;
+            }
+            if (this.selectedVision.installed) {
+                const repo = this.selectedVision.hf_repo;
+                void (async () => {
+                    const result = await this.plugin.api.setVisionModel(repo);
+                    if (result.isErr()) {
+                        new Notice(MESSAGES.ERROR_SET_MODEL.replace("{model}", repo));
+                        return;
+                    }
+                    this.step = WIZARD_STEP.SYNC;
+                    this.renderStep();
+                })();
+                return;
+            }
+            downloadBtn.disabled = true;
+            statusEl.textContent = "";
+            void this.pullVisionModel(downloadBtn, progressEl, progressFill, progressLabel, statusEl, step);
+        });
+
+        void this.loadVisionModels(modelsContainer, statusEl);
+    }
+
+    private async loadVisionModels(container: HTMLElement, statusEl: HTMLElement): Promise<void> {
+        try {
+            const result = await this.plugin.api.catalog({
+                task: MODEL_TASK.VISION,
+                featured: true,
+                sort: FILTERS.SORT.DOWNLOADS,
+                limit: 20,
+            });
+            if (result.isErr()) {
+                this.visionModels = [];
+                return;
+            }
+            // Trust the server's featured list. No source filtering — same
+            // reasoning as chat/embedding: a mis-tagged server would empty
+            // the grid and strand the user.
+            this.visionModels = result.value.models.slice(0, MAX_FEATURED_PICKS);
+        } catch {
+            this.visionModels = [];
+            statusEl.textContent = MESSAGES.ERROR_LOAD_MODELS;
+            return;
+        }
+
+        this.selectedVision = this.visionModels[0] ?? null;
+
+        this.renderSectionHeading(container, MESSAGES.WIZARD_VISION_RECOMMENDED);
+        const grid = container.createDiv({ cls: "lilbee-catalog-grid" });
+
+        for (let i = 0; i < this.visionModels.length; i++) {
+            const entry = this.visionModels[i];
+            renderModelCard(grid, entry, {
+                isActive: i === 0,
+                onClick: () => this.selectVision(grid, entry),
+            });
+        }
+    }
+
+    private selectVision(grid: HTMLElement, model: VisionModel): void {
+        this.selectedVision = model;
+        for (const child of Array.from(grid.children)) {
+            const el = child as HTMLElement;
+            if (el.dataset.repo === model.hf_repo) {
+                el.classList.add("is-selected");
+            } else {
+                el.classList.remove("is-selected");
+            }
+        }
+    }
+
+    private async pullVisionModel(
+        downloadBtn: HTMLElement,
+        progressEl: HTMLElement,
+        progressFill: HTMLElement,
+        progressLabel: HTMLElement,
+        statusEl: HTMLElement,
+        step: HTMLElement,
+    ): Promise<void> {
+        if (!this.selectedVision) return;
+        const model = this.selectedVision;
+        progressEl.style.display = "";
+        progressLabel.textContent = MESSAGES.STATUS_DOWNLOADING_MODEL.replace("{model}", model.hf_repo);
+        this.pullController = new AbortController();
+        this.updateProgress(step, progressFill, undefined);
+
+        try {
+            for await (const event of this.plugin.api.pullModel(
+                model.hf_repo,
+                model.source,
+                this.pullController.signal,
+            )) {
+                if (event.event === SSE_EVENT.PROGRESS) {
+                    const d = event.data as { percent?: number; current?: number; total?: number };
+                    const pct = percentFromSse(d);
+                    if (pct !== undefined) {
+                        this.updateProgress(step, progressFill, pct);
+                        progressLabel.textContent = MESSAGES.STATUS_DOWNLOADING_MODEL_PCT.replace(
+                            "{model}",
+                            model.hf_repo,
+                        ).replace("{pct}", String(pct));
+                    }
+                } else if (event.event === SSE_EVENT.ERROR) {
+                    const d = event.data as { message?: string } | string;
+                    const msg = extractSseErrorMessage(d, MESSAGES.ERROR_UNKNOWN);
+                    new Notice(MESSAGES.ERROR_DOWNLOAD_FAILED);
+                    statusEl.textContent = msg;
+                    break;
+                }
+            }
+
+            const setResult = await this.plugin.api.setVisionModel(model.hf_repo);
             if (setResult.isErr()) {
                 new Notice(MESSAGES.ERROR_SET_MODEL.replace("{model}", model.hf_repo));
                 statusEl.textContent = setResult.error.message;

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -1,7 +1,7 @@
 import { App, Modal, Notice } from "obsidian";
 import type LilbeePlugin from "../main";
 import type { CatalogEntry, SSEEvent, SyncDone } from "../types";
-import { SERVER_MODE, SERVER_STATE, SSE_EVENT, WIZARD_STEP, ERROR_NAME, MODEL_TASK } from "../types";
+import { SERVER_MODE, SERVER_STATE, SSE_EVENT, WIZARD_STEP, ERROR_NAME, MODEL_TASK, MODEL_SOURCE } from "../types";
 import { CatalogModal } from "./catalog-modal";
 import { MESSAGES, FILTERS } from "../locales/en";
 import { renderModelCard } from "../components/model-card";
@@ -579,7 +579,7 @@ export class SetupWizard extends Modal {
         try {
             for await (const event of this.plugin.api.pullModel(
                 model.hf_repo,
-                model.source,
+                MODEL_SOURCE.NATIVE,
                 this.pullController.signal,
             )) {
                 if (event.event === SSE_EVENT.PROGRESS) {
@@ -744,7 +744,7 @@ export class SetupWizard extends Modal {
         try {
             for await (const event of this.plugin.api.pullModel(
                 model.hf_repo,
-                model.source,
+                MODEL_SOURCE.NATIVE,
                 this.pullController.signal,
             )) {
                 if (event.event === SSE_EVENT.PROGRESS) {
@@ -916,7 +916,7 @@ export class SetupWizard extends Modal {
         try {
             for await (const event of this.plugin.api.pullModel(
                 model.hf_repo,
-                model.source,
+                MODEL_SOURCE.NATIVE,
                 this.pullController.signal,
             )) {
                 if (event.event === SSE_EVENT.PROGRESS) {

--- a/styles.css
+++ b/styles.css
@@ -11,6 +11,7 @@
     --lilbee-color-wiki: #10b981;
     --lilbee-color-delete: #ef4444;
     --lilbee-color-setup: #8b5cf6;
+    --lilbee-color-vision: #ec4899;
 }
 
 .lilbee-document-card {
@@ -1378,6 +1379,7 @@
 .lilbee-wizard-step[data-step="server"]    { --wizard-step-color: var(--interactive-accent); }
 .lilbee-wizard-step[data-step="model"]     { --wizard-step-color: var(--lilbee-color-pull); }
 .lilbee-wizard-step[data-step="embedding"] { --wizard-step-color: var(--lilbee-color-download); }
+.lilbee-wizard-step[data-step="vision"]    { --wizard-step-color: var(--lilbee-color-vision); }
 .lilbee-wizard-step[data-step="sync"]      { --wizard-step-color: var(--lilbee-color-sync); }
 .lilbee-wizard-step[data-step="wiki"]      { --wizard-step-color: var(--lilbee-color-wiki); }
 .lilbee-wizard-step[data-step="done"]      { --wizard-step-color: var(--text-success, #22c55e); }
@@ -1440,6 +1442,7 @@
 .lilbee-wizard-step-slot[data-step="server"]    .lilbee-wizard-step-circle.is-active { --wizard-step-color: var(--interactive-accent); }
 .lilbee-wizard-step-slot[data-step="model"]     .lilbee-wizard-step-circle.is-active { --wizard-step-color: var(--lilbee-color-pull); }
 .lilbee-wizard-step-slot[data-step="embedding"] .lilbee-wizard-step-circle.is-active { --wizard-step-color: var(--lilbee-color-download); }
+.lilbee-wizard-step-slot[data-step="vision"]    .lilbee-wizard-step-circle.is-active { --wizard-step-color: var(--lilbee-color-vision); }
 .lilbee-wizard-step-slot[data-step="sync"]      .lilbee-wizard-step-circle.is-active { --wizard-step-color: var(--lilbee-color-sync); }
 .lilbee-wizard-step-slot[data-step="wiki"]      .lilbee-wizard-step-circle.is-active { --wizard-step-color: var(--lilbee-color-wiki); }
 .lilbee-wizard-step-slot[data-step="done"]      .lilbee-wizard-step-circle.is-active { --wizard-step-color: var(--text-success, #22c55e); }

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -682,6 +682,37 @@ describe("pullModel()", () => {
             expect(result._unsafeUnwrapErr().message).toBe("Server responded 400: ");
         });
     });
+
+    describe("setVisionModel()", () => {
+        it("PUTs to /api/models/vision", async () => {
+            fetchMock.mockResolvedValue(jsonResponse({ model: "ibm/granite-vision-3.2-2b" }));
+
+            const result = await client.setVisionModel("ibm/granite-vision-3.2-2b");
+
+            expect(fetchMock).toHaveBeenCalledWith(
+                `${BASE_URL}/api/models/vision`,
+                expect.objectContaining({
+                    method: "PUT",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ model: "ibm/granite-vision-3.2-2b" }),
+                }),
+            );
+            expect(result.isOk()).toBe(true);
+        });
+
+        it("returns error when response is not ok", async () => {
+            fetchMock.mockResolvedValue({
+                ok: false,
+                status: 400,
+                statusText: "Bad Request",
+                text: () => Promise.resolve(""),
+            } as unknown as Response);
+
+            const result = await client.setVisionModel("ibm/granite-vision-3.2-2b");
+            expect(result.isErr()).toBe(true);
+            expect(result._unsafeUnwrapErr().message).toBe("Server responded 400: ");
+        });
+    });
 });
 
 describe("setChatModel()", () => {

--- a/tests/utils/source-click.test.ts
+++ b/tests/utils/source-click.test.ts
@@ -38,6 +38,15 @@ function makeVault(fileExists: boolean): App["vault"] {
     return app.vault;
 }
 
+function makeVaultWithPaths(existingPaths: string[]): App["vault"] {
+    const app = new App();
+    const set = new Set(existingPaths);
+    app.vault.getAbstractFileByPath = vi.fn((path: string) =>
+        set.has(path) ? ({ path, name: path.split("/").pop() ?? path } as unknown as null) : null,
+    ) as ReturnType<typeof vi.fn>;
+    return app.vault;
+}
+
 beforeEach(() => {
     previewInstances.length = 0;
 });
@@ -132,24 +141,96 @@ describe("sourceClickAction — vault resolution", () => {
     });
 });
 
+describe("sourceClickAction — source fallback", () => {
+    it("falls back to source.source for PDFs when vault_path is null", () => {
+        const vault = makeVaultWithPaths(["cv-manual.pdf"]);
+        const source = makeSource({
+            source: "cv-manual.pdf",
+            vault_path: null,
+            content_type: CONTENT_TYPE.PDF,
+            page_start: 235,
+        });
+        const action = sourceClickAction(source, vault as never);
+        expect(action).toEqual({ kind: SOURCE_ACTION.VAULT_PDF, path: "cv-manual.pdf", page: 235 });
+    });
+
+    it("falls back to source.source for markdown with line deep-link", () => {
+        const vault = makeVaultWithPaths(["lilbee/crawled/example.com/page.md"]);
+        const source = makeSource({
+            source: "lilbee/crawled/example.com/page.md",
+            vault_path: undefined,
+            content_type: CONTENT_TYPE.MARKDOWN,
+            line_start: 12,
+        });
+        const action = sourceClickAction(source, vault as never);
+        expect(action).toEqual({
+            kind: SOURCE_ACTION.VAULT_MARKDOWN,
+            path: "lilbee/crawled/example.com/page.md",
+            line: 12,
+        });
+    });
+
+    it("falls back to source.source as vault-note for other content types", () => {
+        const vault = makeVaultWithPaths(["lilbee/imported/data.csv"]);
+        const source = makeSource({
+            source: "lilbee/imported/data.csv",
+            vault_path: null,
+            content_type: "text/csv",
+        });
+        const action = sourceClickAction(source, vault as never);
+        expect(action).toEqual({ kind: SOURCE_ACTION.VAULT_NOTE, path: "lilbee/imported/data.csv" });
+    });
+
+    it("uses vault_path in preference to source.source when both resolve", () => {
+        const vault = makeVaultWithPaths(["lilbee/alias/book.pdf", "cv-manual.pdf"]);
+        const source = makeSource({
+            source: "cv-manual.pdf",
+            vault_path: "lilbee/alias/book.pdf",
+            content_type: CONTENT_TYPE.PDF,
+            page_start: 3,
+        });
+        const action = sourceClickAction(source, vault as never);
+        expect(action).toEqual({ kind: SOURCE_ACTION.VAULT_PDF, path: "lilbee/alias/book.pdf", page: 3 });
+    });
+
+    it("falls back to source.source when vault_path is set but file is missing", () => {
+        const vault = makeVaultWithPaths(["cv-manual.pdf"]);
+        const source = makeSource({
+            source: "cv-manual.pdf",
+            vault_path: "lilbee/stale/book.pdf",
+            content_type: CONTENT_TYPE.PDF,
+            page_start: 7,
+        });
+        const action = sourceClickAction(source, vault as never);
+        expect(action).toEqual({ kind: SOURCE_ACTION.VAULT_PDF, path: "cv-manual.pdf", page: 7 });
+    });
+});
+
 describe("sourceClickAction — preview fallback", () => {
-    it("returns preview when vault_path is undefined", () => {
-        const vault = makeVault(true);
-        const source = makeSource({ vault_path: undefined });
-        const action = sourceClickAction(source, vault as never);
-        expect(action).toEqual({ kind: SOURCE_ACTION.PREVIEW, source });
-    });
-
-    it("returns preview when vault_path is null", () => {
-        const vault = makeVault(true);
-        const source = makeSource({ vault_path: null });
-        const action = sourceClickAction(source, vault as never);
-        expect(action).toEqual({ kind: SOURCE_ACTION.PREVIEW, source });
-    });
-
-    it("returns preview when vault_path is set but file missing from vault", () => {
+    it("returns preview when vault_path is undefined and source.source does not match", () => {
         const vault = makeVault(false);
-        const source = makeSource({ vault_path: "lilbee/deleted.md" });
+        const source = makeSource({ source: "external/only.md", vault_path: undefined });
+        const action = sourceClickAction(source, vault as never);
+        expect(action).toEqual({ kind: SOURCE_ACTION.PREVIEW, source });
+    });
+
+    it("returns preview when vault_path is null and source.source does not match", () => {
+        const vault = makeVault(false);
+        const source = makeSource({ source: "external/only.md", vault_path: null });
+        const action = sourceClickAction(source, vault as never);
+        expect(action).toEqual({ kind: SOURCE_ACTION.PREVIEW, source });
+    });
+
+    it("returns preview when both vault_path and source.source miss the vault", () => {
+        const vault = makeVault(false);
+        const source = makeSource({ source: "external/gone.md", vault_path: "lilbee/deleted.md" });
+        const action = sourceClickAction(source, vault as never);
+        expect(action).toEqual({ kind: SOURCE_ACTION.PREVIEW, source });
+    });
+
+    it("returns preview when source.source is an empty string", () => {
+        const vault = makeVaultWithPaths([""]);
+        const source = makeSource({ source: "", vault_path: null });
         const action = sourceClickAction(source, vault as never);
         expect(action).toEqual({ kind: SOURCE_ACTION.PREVIEW, source });
     });

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -144,6 +144,18 @@ describe("CatalogModal", () => {
             await openModal(plugin);
             expect(Notice.instances.map((n) => n.message)).toContain(MESSAGES.ERROR_LOAD_CATALOG);
         });
+
+        it("honors initialTaskFilter by pre-selecting the dropdown and fetching with task param", async () => {
+            const plugin = makePlugin();
+            const modal = new CatalogModal(new App() as any, plugin as any, "vision");
+            modal.open();
+            await tick();
+            await tick();
+            const content = contentEl(modal);
+            const taskSelect = content.find("lilbee-catalog-filter-task")! as unknown as { value: string };
+            expect(taskSelect.value).toBe("vision");
+            expect(plugin.api.catalog).toHaveBeenCalledWith(expect.objectContaining({ task: "vision" }));
+        });
     });
 
     describe("grid view", () => {

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -1,7 +1,7 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { App, Notice } from "obsidian";
 import { MockElement } from "../__mocks__/obsidian";
-import { SetupWizard, getSystemMemoryGB, recommendedIndex } from "../../src/views/setup-wizard";
+import { SetupWizard, getSystemMemoryGB, pickNativeChatModels, recommendedIndex } from "../../src/views/setup-wizard";
 import { SSE_EVENT, WIZARD_STEP } from "../../src/types";
 import { ok, err } from "neverthrow";
 import { MESSAGES } from "../../src/locales/en";
@@ -65,6 +65,7 @@ function makePlugin(overrides: Record<string, unknown> = {}) {
                 chat: { active: "", catalog: [], installed: [] },
             }),
             setEmbeddingModel: vi.fn().mockResolvedValue(ok(undefined)),
+            setVisionModel: vi.fn().mockResolvedValue(ok(undefined)),
             setBaseUrl: vi.fn(),
             setToken: vi.fn(),
             setTokenProvider: vi.fn(),
@@ -123,8 +124,8 @@ describe("SetupWizard", () => {
             expect(indicator).not.toBeNull();
             const dots = indicator!.findAll("lilbee-wizard-step-circle");
             const lines = indicator!.findAll("lilbee-wizard-step-line");
-            expect(dots.length).toBe(6);
-            expect(lines.length).toBe(5);
+            expect(dots.length).toBe(7);
+            expect(lines.length).toBe(6);
         });
 
         it("marks no slot as active on welcome (step 0)", () => {
@@ -158,29 +159,30 @@ describe("SetupWizard", () => {
             expect(dots[1].classList.contains("is-active")).toBe(true);
             expect(dots[2].classList.contains("is-active")).toBe(false);
             expect(dots[2].classList.contains("is-done")).toBe(false);
-            expect(dots[5].classList.contains("is-active")).toBe(false);
-            expect(dots[5].classList.contains("is-done")).toBe(false);
+            // slot[6] = Done (step=7) — untouched while we're on Model.
+            expect(dots[6].classList.contains("is-active")).toBe(false);
+            expect(dots[6].classList.contains("is-done")).toBe(false);
             // line[0] is between slot[0] (step=1) and slot[1] (step=2) — done.
             expect(lines[0].classList.contains("is-done")).toBe(true);
             expect(lines[1].classList.contains("is-done")).toBe(false);
-            expect(lines[4].classList.contains("is-done")).toBe(false);
+            expect(lines[5].classList.contains("is-done")).toBe(false);
         });
 
-        it("marks prior slots done and last slot active on done step (step 6)", () => {
+        it("marks prior slots done and last slot active on done step (step 7)", () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 6;
+            (wizard as any).step = 7;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
             const dots = el.find("lilbee-wizard-step-indicator")!.findAll("lilbee-wizard-step-circle");
             const lines = el.find("lilbee-wizard-step-indicator")!.findAll("lilbee-wizard-step-line");
-            // slots[0..4] correspond to steps 1..5 — all done. slot[5] = step 6 = active.
-            for (let i = 0; i < 5; i++) {
+            // slots[0..5] correspond to steps 1..6 — all done. slot[6] = step 7 = active.
+            for (let i = 0; i < 6; i++) {
                 expect(dots[i].classList.contains("is-done")).toBe(true);
             }
-            expect(dots[5].classList.contains("is-active")).toBe(true);
+            expect(dots[6].classList.contains("is-active")).toBe(true);
             for (const line of lines) {
                 expect(line.classList.contains("is-done")).toBe(true);
             }
@@ -559,12 +561,14 @@ describe("SetupWizard", () => {
             const entries = [
                 makeEntry({
                     name: "qwen/qwen3-0.6B",
+                    hf_repo: "qwen/qwen3-0.6B",
                     size_gb: 0.5,
                     min_ram_gb: 4,
                     display_name: "Qwen3 0.6B",
                 }),
                 makeEntry({
                     name: "qwen/qwen3-4B",
+                    hf_repo: "qwen/qwen3-4B",
                     size_gb: 2.5,
                     min_ram_gb: 8,
                     display_name: "Qwen3 4B",
@@ -1062,7 +1066,7 @@ describe("SetupWizard", () => {
             );
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 4;
+            (wizard as any).step = 5;
             (wizard as any).renderStep();
             await tick();
             await tick();
@@ -1083,7 +1087,7 @@ describe("SetupWizard", () => {
             );
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 4;
+            (wizard as any).step = 5;
             (wizard as any).renderStep();
             await tick();
             await tick();
@@ -1100,7 +1104,7 @@ describe("SetupWizard", () => {
             );
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 4;
+            (wizard as any).step = 5;
             (wizard as any).renderStep();
             await tick();
             await tick();
@@ -1118,7 +1122,7 @@ describe("SetupWizard", () => {
             );
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 4;
+            (wizard as any).step = 5;
             (wizard as any).renderStep();
             await tick();
             await tick();
@@ -1136,7 +1140,7 @@ describe("SetupWizard", () => {
             );
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 4;
+            (wizard as any).step = 5;
             (wizard as any).renderStep();
             await tick();
             await tick();
@@ -1154,7 +1158,7 @@ describe("SetupWizard", () => {
             );
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 4;
+            (wizard as any).step = 5;
             (wizard as any).renderStep();
             await tick();
             await tick();
@@ -1175,7 +1179,7 @@ describe("SetupWizard", () => {
             });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 4;
+            (wizard as any).step = 5;
             (wizard as any).renderStep();
             await tick();
 
@@ -1199,7 +1203,7 @@ describe("SetupWizard", () => {
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             const closeSpy = vi.spyOn(wizard, "close");
             wizard.open();
-            (wizard as any).step = 4;
+            (wizard as any).step = 5;
             (wizard as any).renderStep();
             await tick();
 
@@ -1215,7 +1219,7 @@ describe("SetupWizard", () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 5;
+            (wizard as any).step = 6;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -1234,7 +1238,7 @@ describe("SetupWizard", () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 5;
+            (wizard as any).step = 6;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -1249,7 +1253,7 @@ describe("SetupWizard", () => {
             const plugin = makePlugin({ settings: { serverMode: "external", wikiEnabled: false } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 5;
+            (wizard as any).step = 6;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -1263,7 +1267,7 @@ describe("SetupWizard", () => {
             const plugin = makePlugin({ settings: { serverMode: "external", wikiEnabled: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 5;
+            (wizard as any).step = 6;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -1277,7 +1281,7 @@ describe("SetupWizard", () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 5;
+            (wizard as any).step = 6;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -1291,7 +1295,7 @@ describe("SetupWizard", () => {
             const plugin = makePlugin({ settings: { serverMode: "external", wikiEnabled: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 5;
+            (wizard as any).step = 6;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -1305,7 +1309,7 @@ describe("SetupWizard", () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 5;
+            (wizard as any).step = 6;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -1328,7 +1332,7 @@ describe("SetupWizard", () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 5;
+            (wizard as any).step = 6;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -1349,7 +1353,7 @@ describe("SetupWizard", () => {
             );
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 5;
+            (wizard as any).step = 6;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -1365,7 +1369,7 @@ describe("SetupWizard", () => {
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             const closeSpy = vi.spyOn(wizard, "close");
             wizard.open();
-            (wizard as any).step = 5;
+            (wizard as any).step = 6;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -1378,21 +1382,21 @@ describe("SetupWizard", () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 5;
+            (wizard as any).step = 6;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
             const indicator = el.find("lilbee-wizard-step-indicator");
             expect(indicator).not.toBeNull();
             const dots = indicator!.findAll("lilbee-wizard-step-circle");
-            expect(dots.length).toBe(6);
+            expect(dots.length).toBe(7);
         });
 
         it("renders pros list items", () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 5;
+            (wizard as any).step = 6;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -1404,7 +1408,7 @@ describe("SetupWizard", () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 5;
+            (wizard as any).step = 6;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -1427,7 +1431,7 @@ describe("SetupWizard", () => {
                 unchanged: 8,
                 failed: [],
             };
-            (wizard as any).step = 6;
+            (wizard as any).step = 7;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -1442,7 +1446,7 @@ describe("SetupWizard", () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 6;
+            (wizard as any).step = 7;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -1455,7 +1459,7 @@ describe("SetupWizard", () => {
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             const closeSpy = vi.spyOn(wizard, "close");
             wizard.open();
-            (wizard as any).step = 6;
+            (wizard as any).step = 7;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -1473,7 +1477,7 @@ describe("SetupWizard", () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 6;
+            (wizard as any).step = 7;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -1486,7 +1490,7 @@ describe("SetupWizard", () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 6;
+            (wizard as any).step = 7;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -1502,7 +1506,7 @@ describe("SetupWizard", () => {
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).pulledModelName = "test-model";
-            (wizard as any).step = 6;
+            (wizard as any).step = 7;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -1514,7 +1518,7 @@ describe("SetupWizard", () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 6;
+            (wizard as any).step = 7;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -1557,29 +1561,35 @@ describe("SetupWizard", () => {
             expect(texts.some((t) => t.includes("Welcome to lilbee"))).toBe(true);
         });
 
-        it("back() at step 3 goes to step 2", () => {
+        it("back() at step 4 (vision) goes to step 3 (embedding picker)", () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
-            plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse([]));
-            plugin.api.syncStream = vi.fn().mockReturnValue(
-                (async function* () {
-                    await new Promise(() => {});
-                })(),
-            );
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 4;
             wizard.back();
 
             const texts = collectTexts(wizard.contentEl as unknown as MockElement);
-            // From step 4 (sync), back() goes to step 3 (embedding picker)
             expect(texts.some((t) => t.includes("Pick an embedding model"))).toBe(true);
         });
 
-        it("back() at step 5 goes to step 4 (wiki)", () => {
+        it("back() at step 5 (sync) goes to step 4 (vision)", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 5;
+            wizard.back();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some((t) => t.includes("Vision model (optional)"))).toBe(true);
+        });
+
+        it("back() at step 7 (done) goes to step 6 (wiki)", () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 6;
+            (wizard as any).step = 7;
             wizard.back();
 
             const texts = collectTexts(wizard.contentEl as unknown as MockElement);
@@ -1628,7 +1638,7 @@ describe("SetupWizard", () => {
             });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 4;
+            (wizard as any).step = 5;
             (wizard as any).renderStep();
             await tick();
 
@@ -1658,7 +1668,7 @@ describe("SetupWizard", () => {
     });
 
     describe("Full flow integration", () => {
-        it("complete flow: welcome -> model -> sync -> wiki -> done", async () => {
+        it("complete flow: welcome -> model -> embed -> vision -> sync -> wiki -> done", async () => {
             const entries = [makeEntry({ name: "qwen/qwen3-0.6B" })];
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
@@ -1696,7 +1706,7 @@ describe("SetupWizard", () => {
             await tick();
             await tick();
 
-            // Step 3: Embedding picker -> Download & continue (skips to sync when no selection)
+            // Step 3: Embedding picker -> Download & continue (skips to vision when no selection)
             el = wizard.contentEl as unknown as MockElement;
             findButtons(el)
                 .find((b) => b.textContent === "Download & continue")!
@@ -1704,11 +1714,19 @@ describe("SetupWizard", () => {
             await tick();
             await tick();
 
-            // Step 4: Sync (auto-starts, should auto-advance to wiki)
+            // Step 4: Vision picker -> Skip
+            el = wizard.contentEl as unknown as MockElement;
+            expect(collectTexts(el).some((t) => t.includes("Vision model (optional)"))).toBe(true);
+            findButtons(el)
+                .find((b) => b.textContent === "Skip")!
+                .trigger("click");
+            await tick();
+
+            // Step 5: Sync (auto-starts, should auto-advance to wiki)
             await tick();
             await tick();
 
-            // Step 5: Wiki -> Next (keep disabled)
+            // Step 6: Wiki -> Next (keep disabled)
             el = wizard.contentEl as unknown as MockElement;
             expect(collectTexts(el).some((t) => t.includes("Wiki (optional, experimental)"))).toBe(true);
             findButtons(el)
@@ -1716,7 +1734,7 @@ describe("SetupWizard", () => {
                 .trigger("click");
             await tick();
 
-            // Step 6: Done -> Open chat
+            // Step 7: Done -> Open chat
             el = wizard.contentEl as unknown as MockElement;
             expect(collectTexts(el).some((t) => t.includes("You're all set!"))).toBe(true);
 
@@ -1727,6 +1745,65 @@ describe("SetupWizard", () => {
 
             expect(plugin.settings.setupCompleted).toBe(true);
             expect(plugin.activateChatView).toHaveBeenCalled();
+        });
+    });
+
+    describe("pickNativeChatModels", () => {
+        // Regression test for the "buggy server" path: all featured models
+        // come back labeled source="litellm". Previous behavior filtered
+        // those out and emptied the wizard grid; new behavior keeps them.
+        it("does not drop entries even when every model is labeled litellm", () => {
+            const models = [
+                makeEntry({ name: "qwen3-0.6b", hf_repo: "q/a", source: "litellm" }),
+                makeEntry({ name: "gemma-3-4b", hf_repo: "g/b", source: "litellm" }),
+                makeEntry({ name: "mistral-7b", hf_repo: "m/c", source: "litellm" }),
+            ];
+            const picks = pickNativeChatModels(models);
+            expect(picks.length).toBe(3);
+        });
+
+        it("orders recognised families before others", () => {
+            const models = [
+                makeEntry({ name: "smollm2", hf_repo: "a/a" }),
+                makeEntry({ name: "qwen3-0.6b", hf_repo: "b/b" }),
+                makeEntry({ name: "gemma-3-1b", hf_repo: "c/c" }),
+            ];
+            const picks = pickNativeChatModels(models);
+            // Gemma family comes first in PREFERRED_FAMILIES order.
+            expect(picks[0].name).toBe("gemma-3-1b");
+            expect(picks[1].name).toBe("qwen3-0.6b");
+            expect(picks[2].name).toBe("smollm2");
+        });
+
+        it("dedupes entries sharing the same hf_repo", () => {
+            const dup = makeEntry({ name: "qwen3-0.6b", hf_repo: "q/a" });
+            const picks = pickNativeChatModels([dup, dup]);
+            expect(picks.length).toBe(1);
+        });
+
+        it("caps at MAX_FEATURED_PICKS even after preferred-family and backfill rounds", () => {
+            const models = Array.from({ length: 20 }, (_, i) => makeEntry({ name: `other-${i}`, hf_repo: `x/${i}` }));
+            const picks = pickNativeChatModels(models);
+            expect(picks.length).toBe(8);
+        });
+
+        it("caps MID-preferred-family iteration when max is reached", () => {
+            // Exercise the early-return inside the preferred-families loop.
+            const models = Array.from({ length: 10 }, (_, i) =>
+                makeEntry({ name: `gemma-3-${i}b`, hf_repo: `g/${i}` }),
+            );
+            const picks = pickNativeChatModels(models);
+            expect(picks.length).toBe(8);
+        });
+
+        it("applies a custom filter predicate when provided", () => {
+            const models = [
+                makeEntry({ name: "qwen3-0.6b", hf_repo: "q/a", source: "litellm" }),
+                makeEntry({ name: "gemma-3-1b", hf_repo: "g/b", source: "native" }),
+            ];
+            const picks = pickNativeChatModels(models, (m) => m.source !== "litellm");
+            expect(picks.length).toBe(1);
+            expect(picks[0].source).toBe("native");
         });
     });
 
@@ -1778,7 +1855,7 @@ describe("SetupWizard", () => {
             );
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 4;
+            (wizard as any).step = 5;
             (wizard as any).renderStep();
             await tick();
             await tick();
@@ -1883,14 +1960,9 @@ describe("SetupWizard", () => {
             expect(mockAbort).toHaveBeenCalled();
         });
 
-        it("download & continue with no selection skips to sync", async () => {
+        it("download & continue with no selection skips to vision picker", async () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
-            plugin.api.syncStream = vi.fn().mockReturnValue(
-                (async function* () {
-                    await new Promise(() => {});
-                })(),
-            );
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 3;
@@ -1904,10 +1976,10 @@ describe("SetupWizard", () => {
             await tick();
 
             const texts = collectTexts(wizard.contentEl as unknown as MockElement);
-            expect(texts.some((t) => t.includes("Index your vault"))).toBe(true);
+            expect(texts.some((t) => t.includes("Vision model (optional)"))).toBe(true);
         });
 
-        it("download & continue with installed model sets embedding and skips to sync", async () => {
+        it("download & continue with installed model sets embedding and advances to vision picker", async () => {
             const entries = [
                 makeEntry({
                     name: "nomic-embed-text",
@@ -1918,11 +1990,6 @@ describe("SetupWizard", () => {
             ];
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
-            plugin.api.syncStream = vi.fn().mockReturnValue(
-                (async function* () {
-                    await new Promise(() => {});
-                })(),
-            );
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 3;
@@ -1937,7 +2004,7 @@ describe("SetupWizard", () => {
 
             expect(plugin.api.setEmbeddingModel).toHaveBeenCalledWith("nomic-embed-text");
             const texts = collectTexts(wizard.contentEl as unknown as MockElement);
-            expect(texts.some((t) => t.includes("Index your vault"))).toBe(true);
+            expect(texts.some((t) => t.includes("Vision model (optional)"))).toBe(true);
         });
 
         it("installed-embedding click surfaces notice when setEmbeddingModel returns err", async () => {
@@ -2077,7 +2144,7 @@ describe("SetupWizard", () => {
             await (wizard as any).pullEmbeddingModel(btn, el, el, el, el, el);
             const setFailed = MESSAGES.ERROR_SET_MODEL.replace("{model}", "nomic/nomic-embed-text");
             expect(Notice.instances.some((n: any) => n.message === setFailed)).toBe(true);
-            expect((wizard as any).step).not.toBe(WIZARD_STEP.SYNC);
+            expect((wizard as any).step).not.toBe(WIZARD_STEP.VISION_PICKER);
         });
 
         it("pullEmbeddingModel handles progress with current/total", async () => {
@@ -2296,6 +2363,537 @@ describe("SetupWizard", () => {
         });
     });
 
+    describe("Step 4: Vision Picker", () => {
+        function visionEntry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
+            return makeEntry({
+                name: "granite-vision",
+                hf_repo: "ibm/granite-vision-3.2-2b",
+                task: "vision",
+                display_name: "Granite Vision 3.2B",
+                ...overrides,
+            });
+        }
+
+        it("renders vision picker step with optional framing", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([visionEntry()])));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+            await tick();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            // Optional framing must be explicit in the step header.
+            expect(texts.some((t) => t.includes("Vision model (optional)"))).toBe(true);
+            // Plain-English context is required.
+            expect(texts.some((t) => t.includes("scanned PDFs"))).toBe(true);
+            expect(texts.some((t) => t.includes("can skip this"))).toBe(true);
+        });
+
+        it("renders Step 04 · VISION header badge", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const badge = el.find("lilbee-wizard-step-badge");
+            expect(badge).not.toBeNull();
+            expect(badge!.textContent).toBe("Step 04 · VISION");
+        });
+
+        it("renders model cards and a prominent Skip button", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([visionEntry()])));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            // Grid + one card for the single featured vision entry.
+            expect(el.find("lilbee-catalog-grid")).not.toBeNull();
+            expect(el.findAll("lilbee-model-card").length).toBe(1);
+            // Skip button lives in the actions footer.
+            const buttons = findButtons(el);
+            expect(buttons.some((b) => b.textContent === "Skip")).toBe(true);
+            expect(buttons.some((b) => b.textContent === "Download & continue")).toBe(true);
+        });
+
+        it("exposes a Browse full catalog button that opens CatalogModal pre-filtered to vision", async () => {
+            const { CatalogModal } = await import("../../src/views/catalog-modal");
+            const mockCatalog = CatalogModal as unknown as ReturnType<typeof vi.fn>;
+            mockCatalog.mockClear();
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const catalogBtn = findButtons(el).find((b) => b.textContent === "Browse full catalog");
+            expect(catalogBtn).toBeDefined();
+            catalogBtn!.trigger("click");
+            expect(mockCatalog).toHaveBeenCalled();
+            // Third arg is the initial task filter — should be "vision".
+            const callArgs = mockCatalog.mock.calls.at(-1);
+            expect(callArgs?.[2]).toBe("vision");
+        });
+
+        it("Skip advances to sync without selecting or pulling a vision model", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([visionEntry()])));
+            plugin.api.syncStream = vi.fn().mockReturnValue(
+                (async function* () {
+                    await new Promise(() => {});
+                })(),
+            );
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const skipBtn = findButtons(el).find((b) => b.textContent === "Skip")!;
+            skipBtn.trigger("click");
+            await tick();
+
+            expect(plugin.api.pullModel).not.toHaveBeenCalled();
+            expect(plugin.api.setVisionModel).not.toHaveBeenCalled();
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some((t) => t.includes("Index your vault"))).toBe(true);
+        });
+
+        it("Skip also aborts any ongoing pull before advancing", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
+            plugin.api.syncStream = vi.fn().mockReturnValue(
+                (async function* () {
+                    await new Promise(() => {});
+                })(),
+            );
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+
+            const mockAbort = vi.fn();
+            (wizard as any).pullController = { abort: mockAbort };
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const skipBtn = findButtons(el).find((b) => b.textContent === "Skip")!;
+            skipBtn.trigger("click");
+            expect(mockAbort).toHaveBeenCalled();
+        });
+
+        it("Back returns to embedding picker and aborts ongoing pull", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+
+            const mockAbort = vi.fn();
+            (wizard as any).pullController = { abort: mockAbort };
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const backBtn = findButtons(el).find((b) => b.textContent === "Back")!;
+            backBtn.trigger("click");
+            expect(mockAbort).toHaveBeenCalled();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some((t) => t.includes("Pick an embedding model"))).toBe(true);
+        });
+
+        it("Download & continue with no selection skips to sync", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
+            plugin.api.syncStream = vi.fn().mockReturnValue(
+                (async function* () {
+                    await new Promise(() => {});
+                })(),
+            );
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            findButtons(el)
+                .find((b) => b.textContent === "Download & continue")!
+                .trigger("click");
+            await tick();
+
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some((t) => t.includes("Index your vault"))).toBe(true);
+        });
+
+        it("Download & continue with a non-installed selected vision model triggers pullVisionModel", async () => {
+            const entries = [visionEntry({ installed: false })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
+            plugin.api.pullModel = vi.fn().mockReturnValue(
+                (async function* () {
+                    yield { event: SSE_EVENT.PROGRESS, data: { percent: 100 } };
+                })(),
+            );
+            plugin.api.syncStream = vi.fn().mockReturnValue(
+                (async function* () {
+                    await new Promise(() => {});
+                })(),
+            );
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            findButtons(el)
+                .find((b) => b.textContent === "Download & continue")!
+                .trigger("click");
+            await tick();
+            await tick();
+
+            expect(plugin.api.pullModel).toHaveBeenCalledWith(
+                "ibm/granite-vision-3.2-2b",
+                "native",
+                expect.any(AbortSignal),
+            );
+            expect(plugin.api.setVisionModel).toHaveBeenCalledWith("ibm/granite-vision-3.2-2b");
+        });
+
+        it("Download & continue with installed model sets vision and advances to sync", async () => {
+            const entries = [visionEntry({ installed: true })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
+            plugin.api.syncStream = vi.fn().mockReturnValue(
+                (async function* () {
+                    await new Promise(() => {});
+                })(),
+            );
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            findButtons(el)
+                .find((b) => b.textContent === "Download & continue")!
+                .trigger("click");
+            await tick();
+
+            expect(plugin.api.setVisionModel).toHaveBeenCalledWith("ibm/granite-vision-3.2-2b");
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some((t) => t.includes("Index your vault"))).toBe(true);
+        });
+
+        it("installed-vision click surfaces notice when setVisionModel returns err", async () => {
+            Notice.clear();
+            const entries = [visionEntry({ installed: true })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
+            plugin.api.setVisionModel = vi.fn().mockResolvedValue(err(new Error("activate fail")));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            findButtons(el)
+                .find((b) => b.textContent === "Download & continue")!
+                .trigger("click");
+            await tick();
+            await tick();
+
+            const setFailed = MESSAGES.ERROR_SET_MODEL.replace("{model}", "ibm/granite-vision-3.2-2b");
+            expect(Notice.instances.some((n: any) => n.message === setFailed)).toBe(true);
+        });
+
+        it("pullVisionModel early return when selectedVision is null", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).selectedVision = null;
+            const el = new MockElement("div");
+            await (wizard as any).pullVisionModel(el, el, el, el, el, el);
+            expect(plugin.api.pullModel).not.toHaveBeenCalled();
+        });
+
+        it("pullVisionModel handles pull failure and re-enables button", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.pullModel = vi.fn().mockReturnValue(
+                (async function* () {
+                    throw new Error("network error");
+                })(),
+            );
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).selectedVision = visionEntry();
+            const el = new MockElement("div") as unknown as HTMLElement;
+            const btn = new MockElement("button") as unknown as HTMLElement;
+            await (wizard as any).pullVisionModel(btn, el, el, el, el, el);
+            expect((btn as unknown as MockElement).disabled).toBe(false);
+        });
+
+        it("pullVisionModel handles AbortError with cancelled notice", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.pullModel = vi.fn().mockReturnValue(
+                (async function* () {
+                    const e = new Error("abort");
+                    e.name = "AbortError";
+                    throw e;
+                })(),
+            );
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).selectedVision = visionEntry();
+            const el = new MockElement("div") as unknown as HTMLElement;
+            const btn = new MockElement("button") as unknown as HTMLElement;
+            await (wizard as any).pullVisionModel(btn, el, el, el, el, el);
+            expect(Notice.instances.some((n) => n.message.includes("download cancelled"))).toBe(true);
+        });
+
+        it("pullVisionModel succeeds, sets vision model, and advances to sync", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.pullModel = vi.fn().mockReturnValue(
+                (async function* () {
+                    yield { event: SSE_EVENT.PROGRESS, data: { percent: 50 } };
+                })(),
+            );
+            plugin.api.syncStream = vi.fn().mockReturnValue(
+                (async function* () {
+                    await new Promise(() => {});
+                })(),
+            );
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).selectedVision = visionEntry();
+            const el = new MockElement("div") as unknown as HTMLElement;
+            const btn = new MockElement("button") as unknown as HTMLElement;
+            await (wizard as any).pullVisionModel(btn, el, el, el, el, el);
+            expect(plugin.api.setVisionModel).toHaveBeenCalledWith("ibm/granite-vision-3.2-2b");
+            expect((wizard as any).step).toBe(WIZARD_STEP.SYNC);
+        });
+
+        it("pullVisionModel surfaces notice and keeps step when setVisionModel returns err", async () => {
+            Notice.clear();
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.pullModel = vi.fn().mockReturnValue(
+                (async function* () {
+                    yield { event: SSE_EVENT.PROGRESS, data: { percent: 100 } };
+                })(),
+            );
+            plugin.api.setVisionModel = vi.fn().mockResolvedValue(err(new Error("activate fail")));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).selectedVision = visionEntry();
+            const el = new MockElement("div") as unknown as HTMLElement;
+            const btn = new MockElement("button") as unknown as HTMLElement;
+            await (wizard as any).pullVisionModel(btn, el, el, el, el, el);
+            const setFailed = MESSAGES.ERROR_SET_MODEL.replace("{model}", "ibm/granite-vision-3.2-2b");
+            expect(Notice.instances.some((n: any) => n.message === setFailed)).toBe(true);
+            expect((wizard as any).step).not.toBe(WIZARD_STEP.SYNC);
+        });
+
+        it("pullVisionModel handles progress with current/total", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.pullModel = vi.fn().mockReturnValue(
+                (async function* () {
+                    yield { event: SSE_EVENT.PROGRESS, data: { current: 25, total: 100 } };
+                })(),
+            );
+            plugin.api.syncStream = vi.fn().mockReturnValue(
+                (async function* () {
+                    await new Promise(() => {});
+                })(),
+            );
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).selectedVision = visionEntry();
+            const el = new MockElement("div") as unknown as HTMLElement;
+            const btn = new MockElement("button") as unknown as HTMLElement;
+            await (wizard as any).pullVisionModel(btn, el, el, el, el, el);
+            expect(plugin.api.setVisionModel).toHaveBeenCalledWith("ibm/granite-vision-3.2-2b");
+        });
+
+        it("pullVisionModel handles progress with no percent and no total", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.pullModel = vi.fn().mockReturnValue(
+                (async function* () {
+                    yield { event: SSE_EVENT.PROGRESS, data: {} };
+                })(),
+            );
+            plugin.api.syncStream = vi.fn().mockReturnValue(
+                (async function* () {
+                    await new Promise(() => {});
+                })(),
+            );
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).selectedVision = visionEntry();
+            const el = new MockElement("div") as unknown as HTMLElement;
+            const btn = new MockElement("button") as unknown as HTMLElement;
+            await (wizard as any).pullVisionModel(btn, el, el, el, el, el);
+            expect(plugin.api.setVisionModel).toHaveBeenCalledWith("ibm/granite-vision-3.2-2b");
+        });
+
+        it("pullVisionModel handles SSE error with string data", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.pullModel = vi.fn().mockReturnValue(
+                (async function* () {
+                    yield { event: SSE_EVENT.ERROR, data: "raw string error" };
+                })(),
+            );
+            plugin.api.syncStream = vi.fn().mockReturnValue(
+                (async function* () {
+                    await new Promise(() => {});
+                })(),
+            );
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).selectedVision = visionEntry();
+            const el = new MockElement("div") as unknown as HTMLElement;
+            const btn = new MockElement("button") as unknown as HTMLElement;
+            await (wizard as any).pullVisionModel(btn, el, el, el, el, el);
+            expect(Notice.instances.some((n) => n.message.includes("Download failed"))).toBe(true);
+        });
+
+        it("pullVisionModel handles SSE error event with message", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.pullModel = vi.fn().mockReturnValue(
+                (async function* () {
+                    yield { event: SSE_EVENT.ERROR, data: { message: "pull failed" } };
+                })(),
+            );
+            plugin.api.syncStream = vi.fn().mockReturnValue(
+                (async function* () {
+                    await new Promise(() => {});
+                })(),
+            );
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).selectedVision = visionEntry();
+            const el = new MockElement("div") as unknown as HTMLElement;
+            const btn = new MockElement("button") as unknown as HTMLElement;
+            await (wizard as any).pullVisionModel(btn, el, el, el, el, el);
+            expect(Notice.instances.some((n) => n.message.includes("Download failed"))).toBe(true);
+        });
+
+        it("pullVisionModel handles SSE error with empty object", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.pullModel = vi.fn().mockReturnValue(
+                (async function* () {
+                    yield { event: SSE_EVENT.ERROR, data: {} };
+                })(),
+            );
+            plugin.api.syncStream = vi.fn().mockReturnValue(
+                (async function* () {
+                    await new Promise(() => {});
+                })(),
+            );
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).selectedVision = visionEntry();
+            const el = new MockElement("div") as unknown as HTMLElement;
+            const btn = new MockElement("button") as unknown as HTMLElement;
+            await (wizard as any).pullVisionModel(btn, el, el, el, el, el);
+            expect(Notice.instances.some((n) => n.message.includes("Download failed"))).toBe(true);
+        });
+
+        it("selectVision updates selection on grid", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            const grid = new MockElement("div") as unknown as HTMLElement;
+            const child = (grid as unknown as MockElement).createDiv();
+            child.dataset.repo = "ibm/granite-vision-3.2-2b";
+            const other = (grid as unknown as MockElement).createDiv();
+            other.dataset.repo = "other/vision";
+            other.classList.add("is-selected");
+            const model = visionEntry();
+            (wizard as any).selectVision(grid, model);
+            expect((wizard as any).selectedVision).toBe(model);
+            expect(child.classList.contains("is-selected")).toBe(true);
+            expect(other.classList.contains("is-selected")).toBe(false);
+        });
+
+        it("loadVisionModels handles catalog error (thrown)", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockRejectedValue(new Error("fail"));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const statusEl = new MockElement("div") as unknown as HTMLElement;
+            await (wizard as any).loadVisionModels(container, statusEl);
+            expect((wizard as any).visionModels).toEqual([]);
+            expect((statusEl as unknown as MockElement).textContent).toContain("Could not load models");
+        });
+
+        it("loadVisionModels handles catalog isErr result", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(err(new Error("fail")));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const statusEl = new MockElement("div") as unknown as HTMLElement;
+            await (wizard as any).loadVisionModels(container, statusEl);
+            expect((wizard as any).visionModels).toEqual([]);
+        });
+
+        it("loadVisionModels queries catalog with featured=true and task=vision", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([visionEntry()])));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const statusEl = new MockElement("div") as unknown as HTMLElement;
+            await (wizard as any).loadVisionModels(container, statusEl);
+            expect(plugin.api.catalog).toHaveBeenCalledWith(
+                expect.objectContaining({ task: "vision", featured: true }),
+            );
+            expect((wizard as any).selectedVision?.name).toBe("granite-vision");
+        });
+
+        it("loadVisionModels renders model cards with onClick that calls selectVision", async () => {
+            const entries = [
+                visionEntry({ name: "granite-vision", hf_repo: "ibm/granite-vision-3.2-2b" }),
+                visionEntry({ name: "moondream", hf_repo: "vikhyatk/moondream2" }),
+            ];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const statusEl = new MockElement("div") as unknown as HTMLElement;
+
+            const onClicks: Array<() => void> = [];
+            const origRender = (await import("../../src/components/model-card")).renderModelCard;
+            vi.spyOn(await import("../../src/components/model-card"), "renderModelCard").mockImplementation(
+                (c, e, opts) => {
+                    if (opts?.onClick) onClicks.push(() => opts.onClick!(e));
+                    return origRender(c, e, opts);
+                },
+            );
+            await (wizard as any).loadVisionModels(container, statusEl);
+
+            expect(onClicks.length).toBe(2);
+            onClicks[1]();
+            expect((wizard as any).selectedVision?.name).toBe("moondream");
+        });
+    });
+
     describe("back from step 2 with ready server manager", () => {
         it("goes to step 0 when serverManager is ready", () => {
             const plugin = makePlugin({
@@ -2328,7 +2926,7 @@ describe("SetupWizard", () => {
             );
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 4;
+            (wizard as any).step = 5;
             (wizard as any).renderStep();
             await tick();
             await tick();
@@ -2352,7 +2950,7 @@ describe("SetupWizard", () => {
                 unchanged: 6,
                 failed: [],
             };
-            (wizard as any).step = 6;
+            (wizard as any).step = 7;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -2372,7 +2970,7 @@ describe("SetupWizard", () => {
                 unchanged: 10,
                 failed: [],
             };
-            (wizard as any).step = 6;
+            (wizard as any).step = 7;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -2388,6 +2986,11 @@ describe("SetupWizard", () => {
         it("tags the step container with its semantic data-step key", async () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
+            plugin.api.syncStream = vi.fn().mockReturnValue(
+                (async function* () {
+                    await new Promise(() => {});
+                })(),
+            );
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
 
@@ -2396,8 +2999,10 @@ describe("SetupWizard", () => {
                 [1, "server"],
                 [2, "model"],
                 [3, "embedding"],
-                [5, "wiki"],
-                [6, "done"],
+                [4, "vision"],
+                [5, "sync"],
+                [6, "wiki"],
+                [7, "done"],
             ];
             for (const [step, key] of cases) {
                 (wizard as any).step = step;
@@ -2438,10 +3043,15 @@ describe("SetupWizard", () => {
         it("adds the hero rail to every rendered step", async () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
+            plugin.api.syncStream = vi.fn().mockReturnValue(
+                (async function* () {
+                    await new Promise(() => {});
+                })(),
+            );
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
 
-            for (const step of [0, 1, 2, 5, 6]) {
+            for (const step of [0, 1, 2, 4, 6, 7]) {
                 (wizard as any).step = step;
                 (wizard as any).renderStep();
                 await tick();
@@ -2562,7 +3172,7 @@ describe("SetupWizard", () => {
             });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 4;
+            (wizard as any).step = 5;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -2577,7 +3187,7 @@ describe("SetupWizard", () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 5;
+            (wizard as any).step = 6;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;
@@ -2592,7 +3202,7 @@ describe("SetupWizard", () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
-            (wizard as any).step = 5;
+            (wizard as any).step = 6;
             (wizard as any).renderStep();
 
             const el = wizard.contentEl as unknown as MockElement;

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -2388,7 +2388,10 @@ describe("SetupWizard", () => {
             expect(texts.some((t) => t.includes("Vision model (optional)"))).toBe(true);
             // Plain-English context is required.
             expect(texts.some((t) => t.includes("scanned PDFs"))).toBe(true);
-            expect(texts.some((t) => t.includes("can skip this"))).toBe(true);
+            expect(texts.some((t) => t.includes("Skip this step"))).toBe(true);
+            // Role clarity: vision picks must not imply chat model changes.
+            expect(texts.some((t) => t.includes("OCR fails"))).toBe(true);
+            expect(texts.some((t) => t.includes("chat model is separate"))).toBe(true);
         });
 
         it("renders Step 04 · VISION header badge", () => {
@@ -2594,6 +2597,8 @@ describe("SetupWizard", () => {
             await tick();
 
             expect(plugin.api.setVisionModel).toHaveBeenCalledWith("ibm/granite-vision-3.2-2b");
+            const visionSet = MESSAGES.NOTICE_VISION_SET.replace("{model}", "ibm/granite-vision-3.2-2b");
+            expect(Notice.instances.some((n: any) => n.message === visionSet)).toBe(true);
             const texts = collectTexts(wizard.contentEl as unknown as MockElement);
             expect(texts.some((t) => t.includes("Index your vault"))).toBe(true);
         });
@@ -2684,6 +2689,8 @@ describe("SetupWizard", () => {
             const btn = new MockElement("button") as unknown as HTMLElement;
             await (wizard as any).pullVisionModel(btn, el, el, el, el, el);
             expect(plugin.api.setVisionModel).toHaveBeenCalledWith("ibm/granite-vision-3.2-2b");
+            const visionSet = MESSAGES.NOTICE_VISION_SET.replace("{model}", "ibm/granite-vision-3.2-2b");
+            expect(Notice.instances.some((n: any) => n.message === visionSet)).toBe(true);
             expect((wizard as any).step).toBe(WIZARD_STEP.SYNC);
         });
 


### PR DESCRIPTION
Adds an optional **Vision** step to the setup wizard between Embedding and Sync. Clearly marked optional, with a Skip button and copy explaining when you'd want one (scanned PDFs, handwritten notes, diagrams). Includes a **Browse full catalog** button pre-filtered to vision models.

Also fixes a regression where the wizard's picks grid went empty on servers that mis-label featured models as LiteLLM (fixed in parallel in lilbee #149, but plugin has to work against older servers). Picks are now ordered by family preference (Gemma/Qwen/Llama/Phi) without depending on the `source` field. Cap bumped 4→8.

Indicator is now 7 slots: Server · Model · Embed · Vision · Sync · Wiki · Done. 1610 tests, 100% coverage.