### PR TITLE
feat: reranker picker in settings with candidates control

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -4,6 +4,7 @@ import { ok, err, Result } from "neverthrow";
 import type {
     AskResponse,
     CatalogResponse,
+    ConfigResponse,
     ConfigUpdateResponse,
     DocumentResult,
     DocumentsResponse,
@@ -12,6 +13,7 @@ import type {
     Message,
     ModelShowResponse,
     ModelsResponse,
+    ModelTask,
     SearchChunkType,
     SSEEvent,
     StatusResponse,
@@ -276,7 +278,7 @@ export class LilbeeClient {
     }
 
     async catalog(params?: {
-        task?: "chat" | "embedding" | "vision";
+        task?: ModelTask;
         search?: string;
         size?: "small" | "medium" | "large";
         sort?: "featured" | "downloads" | "name" | "size_asc" | "size_desc";
@@ -296,8 +298,11 @@ export class LilbeeClient {
         return this.fetchResult<CatalogResponse>(`${this.baseUrl}/api/models/catalog${suffix}`);
     }
 
-    async installedModels(): Promise<InstalledResponse> {
-        const res = await this.fetchWithRetry(`${this.baseUrl}/api/models/installed`);
+    async installedModels(params?: { task?: ModelTask }): Promise<InstalledResponse> {
+        const qs = new URLSearchParams();
+        if (params?.task) qs.set("task", params.task);
+        const suffix = qs.toString() ? `?${qs}` : "";
+        const res = await this.fetchWithRetry(`${this.baseUrl}/api/models/installed${suffix}`);
         return res.json();
     }
 
@@ -363,7 +368,7 @@ export class LilbeeClient {
         yield* this.parseSSE(res);
     }
 
-    async config(): Promise<Record<string, unknown>> {
+    async config(): Promise<ConfigResponse> {
         const res = await this.fetchWithRetry(`${this.baseUrl}/api/config`);
         return res.json();
     }
@@ -384,6 +389,14 @@ export class LilbeeClient {
 
     async setEmbeddingModel(model: string): Promise<Result<void, Error>> {
         return this.fetchResult<void>(`${this.baseUrl}/api/models/embedding`, {
+            method: "PUT",
+            headers: { ...JSON_HEADERS, ...this.authHeaders() },
+            body: JSON.stringify({ model }),
+        });
+    }
+
+    async setRerankerModel(model: string): Promise<Result<void, Error>> {
+        return this.fetchResult<void>(`${this.baseUrl}/api/models/reranker`, {
             method: "PUT",
             headers: { ...JSON_HEADERS, ...this.authHeaders() },
             body: JSON.stringify({ model }),

--- a/src/components/pill.ts
+++ b/src/components/pill.ts
@@ -6,6 +6,7 @@ export const PILL_CLS = {
     TASK_CHAT: "lilbee-pill-task-chat",
     TASK_EMBEDDING: "lilbee-pill-task-embedding",
     TASK_VISION: "lilbee-pill-task-vision",
+    TASK_RERANK: "lilbee-pill-task-rerank",
     INSTALLED: "lilbee-pill-installed",
     ACTIVE: "lilbee-pill-active",
     PROVIDER: "lilbee-pill-provider",
@@ -15,6 +16,7 @@ const TASK_PILL_MAP: Record<string, string> = {
     [MODEL_TASK.CHAT]: PILL_CLS.TASK_CHAT,
     [MODEL_TASK.EMBEDDING]: PILL_CLS.TASK_EMBEDDING,
     [MODEL_TASK.VISION]: PILL_CLS.TASK_VISION,
+    [MODEL_TASK.RERANK]: PILL_CLS.TASK_RERANK,
 };
 
 export function renderPill(container: HTMLElement, text: string, cls: string): HTMLElement {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -113,6 +113,18 @@ export const MESSAGES = {
     BUTTON_RESET_ALL: "Reset all",
     LABEL_ADVANCED: "Advanced",
     LABEL_EMBEDDING_MODEL: "Embedding model",
+    LABEL_RERANKER_TITLE: "Reranker model",
+    LABEL_RERANKER_DISABLED: "(disabled)",
+    LABEL_RERANKER_HOSTED_GROUP: "Hosted via LiteLLM",
+    LABEL_RERANKER_CANDIDATES: "Rerank candidates",
+    DESC_RERANKER_MODEL: "Reorders search results for better relevance. Disabled by default.",
+    DESC_RERANKER_CANDIDATES: "How many candidate results to rerank (1-100). Higher = slower but more accurate.",
+    NOTICE_RERANKER_UNAVAILABLE: "Rerank is not supported by this server build. Update the server to enable.",
+    NOTICE_FAILED_RERANKER: "lilbee: failed to update reranker model",
+    NOTICE_RERANKER_UPDATED: "lilbee: reranker model updated",
+    NOTICE_RERANKER_NEEDS_KEY: "Configure the LiteLLM API key in the LLM provider settings to use this reranker.",
+    NOTICE_RERANKER_LOAD_FAILED: "lilbee: failed to load reranker options",
+    PLACEHOLDER_RERANK_CANDIDATES: "20",
     LABEL_LLM_PROVIDER: "AI backend",
     LABEL_API_KEY: "API key",
     LABEL_OPENAI_API_KEY: "OpenAI API key",
@@ -169,6 +181,7 @@ export const MESSAGES = {
     LABEL_SECTION_CHAT: "Chat",
     LABEL_SECTION_EMBEDDING: "Embedding",
     LABEL_SECTION_VISION: "Vision",
+    LABEL_SECTION_RERANK: "Rerank",
     LABEL_PICK: "pick",
     LABEL_SWITCH_TO_LIST: "Switch to list view",
     LABEL_SWITCH_TO_GRID: "Switch to grid view",
@@ -562,6 +575,7 @@ export const FILTERS = {
         CHAT: "chat",
         EMBEDDING: "embedding",
         VISION: "vision",
+        RERANK: "rerank",
     } as const,
     SIZE: {
         ALL: "",
@@ -582,6 +596,7 @@ export const TASK_LABELS = {
     [MODEL_TASK.CHAT]: "Chat",
     [MODEL_TASK.VISION]: "Vision",
     [MODEL_TASK.EMBEDDING]: "Embedding",
+    [MODEL_TASK.RERANK]: "Rerank",
 } as const;
 
 export const CATALOG_FILTERS = {
@@ -590,6 +605,7 @@ export const CATALOG_FILTERS = {
         [FILTERS.TASK.CHAT, TASK_LABELS[MODEL_TASK.CHAT]],
         [FILTERS.TASK.EMBEDDING, TASK_LABELS[MODEL_TASK.EMBEDDING]],
         [FILTERS.TASK.VISION, TASK_LABELS[MODEL_TASK.VISION]],
+        [FILTERS.TASK.RERANK, TASK_LABELS[MODEL_TASK.RERANK]],
     ] as const,
     SIZE: [
         [FILTERS.SIZE.ALL, MESSAGES.LABEL_ALL_SIZES],

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,16 +12,35 @@ import {
     TASK_TYPE,
     ERROR_NAME,
 } from "./types";
-import type { LilbeeSettings, ModelCatalog, ModelInfo, ModelsResponse, ServerMode } from "./types";
+import type {
+    CatalogEntry,
+    ConfigResponse,
+    InstalledModel,
+    LilbeeSettings,
+    ModelCatalog,
+    ModelInfo,
+    ModelsResponse,
+    ServerMode,
+} from "./types";
 import { MESSAGES } from "./locales/en";
 import { CatalogModal } from "./views/catalog-modal";
 import { ConfirmModal } from "./views/confirm-modal";
 import { ConfirmPullModal } from "./views/confirm-pull-modal";
 import { SetupWizard } from "./views/setup-wizard";
-import { percentFromSse, errorMessage, extractSseErrorMessage, noticeForResultError } from "./utils";
+import {
+    debounce,
+    DEBOUNCE_MS,
+    percentFromSse,
+    errorMessage,
+    extractSseErrorMessage,
+    noticeForResultError,
+} from "./utils";
 
 const CHECK_TIMEOUT_MS = 5000;
 const CLS_MODELS_CONTAINER = "lilbee-models-container";
+const RERANKER_DISABLED_KEY = "";
+const RERANK_CANDIDATES_MIN = 1;
+const RERANK_CANDIDATES_MAX = 100;
 const SEPARATOR_KEY = "__separator__";
 const SEPARATOR_LABEL = "\u2500\u2500 Other... \u2500\u2500";
 const ICON_RESET = "rotate-ccw";
@@ -411,7 +430,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
     private loadServerDefaults(): void {
         this.plugin.api
             .config()
-            .then((cfg: Record<string, unknown>) => {
+            .then((cfg: ConfigResponse) => {
                 // Populate editable server-config inputs with the current server values.
                 for (const [key, inputEl] of this.serverConfigInputs) {
                     const v = cfg[key];
@@ -661,6 +680,166 @@ export class LilbeeSettingTab extends PluginSettingTab {
             .catch(() => {
                 this.renderEmbeddingFallback(container);
             });
+    }
+
+    private renderRerankerSection(container: HTMLElement): void {
+        Promise.all([
+            this.plugin.api.config(),
+            this.plugin.api.catalog({ task: MODEL_TASK.RERANK }),
+            this.plugin.api.installedModels({ task: MODEL_TASK.RERANK }).catch(() => ({ models: [] })),
+        ])
+            .then(([cfg, catalogResult, installedResp]) => {
+                const active = typeof cfg.reranker_model === "string" ? cfg.reranker_model : RERANKER_DISABLED_KEY;
+                const available = cfg.reranker_available === true;
+                if (!available) {
+                    this.renderRerankerUnavailable(container);
+                    return;
+                }
+                const catalogEntries = catalogResult.isOk() ? catalogResult.value.models : [];
+                this.renderRerankerDropdown(container, active, catalogEntries, installedResp.models);
+            })
+            .catch(() => {
+                new Notice(MESSAGES.NOTICE_RERANKER_LOAD_FAILED);
+            });
+    }
+
+    private renderRerankerUnavailable(container: HTMLElement): void {
+        new Setting(container)
+            .setName(MESSAGES.LABEL_RERANKER_TITLE)
+            .setDesc(MESSAGES.NOTICE_RERANKER_UNAVAILABLE)
+            .setDisabled(true)
+            .addDropdown((dropdown) => {
+                dropdown.addOption(RERANKER_DISABLED_KEY, MESSAGES.LABEL_RERANKER_DISABLED);
+                dropdown.setValue(RERANKER_DISABLED_KEY);
+            });
+    }
+
+    private renderRerankerDropdown(
+        container: HTMLElement,
+        active: string,
+        catalogEntries: CatalogEntry[],
+        installed: InstalledModel[],
+    ): void {
+        const options = this.buildRerankerOptions(catalogEntries, installed);
+        new Setting(container)
+            .setName(MESSAGES.LABEL_RERANKER_TITLE)
+            .setDesc(MESSAGES.DESC_RERANKER_MODEL)
+            .addDropdown((dropdown) => {
+                for (const [value, label] of options) {
+                    dropdown.addOption(value, label);
+                }
+                dropdown.setValue(active || RERANKER_DISABLED_KEY);
+                dropdown.onChange(async (value) => {
+                    await this.handleRerankerChange(value, catalogEntries, installed);
+                });
+            });
+    }
+
+    private buildRerankerOptions(catalogEntries: CatalogEntry[], installed: InstalledModel[]): Array<[string, string]> {
+        const installedNames = new Set(installed.map((m) => m.name));
+        const opts: Array<[string, string]> = [[RERANKER_DISABLED_KEY, MESSAGES.LABEL_RERANKER_DISABLED]];
+        const localInstalled = catalogEntries.filter(
+            (e) => e.source !== MODEL_SOURCE.LITELLM && installedNames.has(e.hf_repo),
+        );
+        const localNotInstalled = catalogEntries.filter(
+            (e) => e.source !== MODEL_SOURCE.LITELLM && !installedNames.has(e.hf_repo),
+        );
+        const hosted = catalogEntries.filter((e) => e.source === MODEL_SOURCE.LITELLM);
+        for (const e of localInstalled) opts.push([e.hf_repo, e.hf_repo]);
+        for (const e of localNotInstalled) opts.push([e.hf_repo, `${e.hf_repo}${MESSAGES.LABEL_NOT_INSTALLED}`]);
+        if (hosted.length > 0) {
+            for (const e of hosted) opts.push([e.hf_repo, `${e.hf_repo} — ${MESSAGES.LABEL_RERANKER_HOSTED_GROUP}`]);
+        }
+        return opts;
+    }
+
+    private async handleRerankerChange(
+        value: string,
+        catalogEntries: CatalogEntry[],
+        installed: InstalledModel[],
+    ): Promise<void> {
+        const installedNames = new Set(installed.map((m) => m.name));
+        const catalogEntry = catalogEntries.find((e) => e.hf_repo === value);
+        if (
+            value === RERANKER_DISABLED_KEY ||
+            installedNames.has(value) ||
+            catalogEntry?.source === MODEL_SOURCE.LITELLM
+        ) {
+            await this.applyRerankerSelection(value);
+            return;
+        }
+        if (catalogEntry) {
+            await this.pullAndSetReranker(catalogEntry);
+        }
+    }
+
+    private async applyRerankerSelection(value: string): Promise<void> {
+        const result = await this.plugin.api.setRerankerModel(value);
+        if (result.isErr()) {
+            if (result.error.message.includes("422")) {
+                new Notice(MESSAGES.NOTICE_RERANKER_NEEDS_KEY);
+            } else {
+                new Notice(MESSAGES.NOTICE_FAILED_RERANKER);
+            }
+            return;
+        }
+        new Notice(MESSAGES.NOTICE_RERANKER_UPDATED);
+    }
+
+    private async pullAndSetReranker(entry: CatalogEntry): Promise<void> {
+        const taskId = this.plugin.taskQueue.enqueue(`Pull ${entry.hf_repo}`, TASK_TYPE.PULL);
+        if (taskId === null) {
+            new Notice(MESSAGES.NOTICE_QUEUE_FULL);
+            return;
+        }
+        const controller = new AbortController();
+        this.plugin.taskQueue.registerAbort(taskId, controller);
+        const ok = await this.streamRerankerPull(taskId, entry, controller.signal);
+        if (!ok) return;
+        this.plugin.taskQueue.complete(taskId);
+        await this.applyRerankerSelection(entry.hf_repo);
+    }
+
+    private async streamRerankerPull(taskId: string, entry: CatalogEntry, signal: AbortSignal): Promise<boolean> {
+        try {
+            for await (const event of this.plugin.api.pullModel(entry.hf_repo, MODEL_SOURCE.NATIVE, signal)) {
+                if (event.event === SSE_EVENT.PROGRESS) {
+                    this.handleRerankerPullProgress(taskId, entry, event.data);
+                } else if (event.event === SSE_EVENT.ERROR) {
+                    this.handleRerankerPullSseError(taskId, entry, event.data);
+                    return false;
+                }
+            }
+        } catch (err) {
+            this.handleRerankerPullException(taskId, entry, err);
+            return false;
+        }
+        return true;
+    }
+
+    private handleRerankerPullProgress(taskId: string, entry: CatalogEntry, data: unknown): void {
+        const d = data as { percent?: number; current?: number; total?: number };
+        const pct = percentFromSse(d);
+        if (pct !== undefined) {
+            this.plugin.taskQueue.update(taskId, pct, entry.hf_repo, { current: d.current, total: d.total });
+        }
+    }
+
+    private handleRerankerPullSseError(taskId: string, entry: CatalogEntry, data: unknown): void {
+        const msg = extractSseErrorMessage(data as { message?: string } | string, MESSAGES.ERROR_UNKNOWN);
+        new Notice(`${MESSAGES.ERROR_PULL_MODEL.replace("{model}", entry.hf_repo)}: ${msg}`);
+        this.plugin.taskQueue.fail(taskId, msg);
+    }
+
+    private handleRerankerPullException(taskId: string, entry: CatalogEntry, err: unknown): void {
+        if (err instanceof Error && err.name === ERROR_NAME.ABORT_ERROR) {
+            new Notice(MESSAGES.NOTICE_PULL_CANCELLED);
+            this.plugin.taskQueue.cancel(taskId);
+            return;
+        }
+        const reason = errorMessage(err, MESSAGES.ERROR_UNKNOWN);
+        new Notice(`${MESSAGES.ERROR_PULL_MODEL.replace("{model}", entry.hf_repo)}: ${reason}`);
+        this.plugin.taskQueue.fail(taskId, reason);
     }
 
     private renderEmbeddingFallback(container: HTMLElement): void {
@@ -1130,6 +1309,8 @@ export class LilbeeSettingTab extends PluginSettingTab {
             this.appendResetAffordance(advancedSetting, field.key, field.name);
         }
 
+        this.renderRerankCandidatesField(details);
+
         const litellmContainer = details.createDiv({ cls: "lilbee-litellm-container" });
 
         const llmSetting = new Setting(details)
@@ -1288,6 +1469,8 @@ export class LilbeeSettingTab extends PluginSettingTab {
         }
         const embeddingContainer = container.createDiv({ cls: "lilbee-embedding-container" });
         this.loadEmbeddingDropdown(embeddingContainer);
+        const rerankerContainer = container.createDiv({ cls: "lilbee-reranker-container" });
+        this.renderRerankerSection(rerankerContainer);
     }
 
     private renderModelSection(container: HTMLElement, label: string, catalog: ModelsResponse["chat"]): void {
@@ -1512,6 +1695,38 @@ export class LilbeeSettingTab extends PluginSettingTab {
         const modelsContainer = this.containerEl.querySelector(`.${CLS_MODELS_CONTAINER}`);
         if (modelsContainer) {
             await this.loadModels(modelsContainer as HTMLElement);
+        }
+    }
+
+    private renderRerankCandidatesField(container: HTMLElement): void {
+        const patch = debounce((...args: unknown[]) => {
+            const num = args[0] as number;
+            void this.patchRerankCandidates(num);
+        }, DEBOUNCE_MS);
+
+        new Setting(container)
+            .setName(MESSAGES.LABEL_RERANKER_CANDIDATES)
+            .setDesc(MESSAGES.DESC_RERANKER_CANDIDATES)
+            .addText((text) => {
+                text.setPlaceholder(MESSAGES.PLACEHOLDER_RERANK_CANDIDATES)
+                    .setValue("")
+                    .onChange((value) => {
+                        const trimmed = value.trim();
+                        if (trimmed === "") return;
+                        const num = parseInt(trimmed, 10);
+                        if (isNaN(num) || num < RERANK_CANDIDATES_MIN || num > RERANK_CANDIDATES_MAX) return;
+                        patch.run(num);
+                    });
+                this.serverConfigInputs.set("rerank_candidates", text.inputEl as unknown as HTMLInputElement);
+            });
+    }
+
+    private async patchRerankCandidates(num: number): Promise<void> {
+        try {
+            await this.plugin.api.updateConfig({ rerank_candidates: num });
+            new Notice(MESSAGES.NOTICE_FIELD_UPDATED(MESSAGES.LABEL_RERANKER_CANDIDATES));
+        } catch {
+            new Notice(MESSAGES.NOTICE_FAILED_UPDATE(MESSAGES.LABEL_RERANKER_CANDIDATES));
         }
     }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -736,19 +736,21 @@ export class LilbeeSettingTab extends PluginSettingTab {
     }
 
     private buildRerankerOptions(catalogEntries: CatalogEntry[], installed: InstalledModel[]): Array<[string, string]> {
-        const installedNames = new Set(installed.map((m) => m.name));
+        // ``installed`` carries the server's canonical ``name:tag`` ref, while
+        // catalog entries expose ``name`` and ``tag`` separately. Compare via the
+        // same ``name:tag`` form so an installed reranker isn't mislabelled
+        // ``(not installed)`` just because the catalog exposes the hf_repo.
+        const installedRefs = new Set(installed.map((m) => m.name));
+        const ref = (e: CatalogEntry): string => `${e.name}:${e.tag}`;
+        const isInstalled = (e: CatalogEntry): boolean => installedRefs.has(ref(e));
         const opts: Array<[string, string]> = [[RERANKER_DISABLED_KEY, MESSAGES.LABEL_RERANKER_DISABLED]];
-        const localInstalled = catalogEntries.filter(
-            (e) => e.source !== MODEL_SOURCE.LITELLM && installedNames.has(e.hf_repo),
-        );
-        const localNotInstalled = catalogEntries.filter(
-            (e) => e.source !== MODEL_SOURCE.LITELLM && !installedNames.has(e.hf_repo),
-        );
+        const localInstalled = catalogEntries.filter((e) => e.source !== MODEL_SOURCE.LITELLM && isInstalled(e));
+        const localNotInstalled = catalogEntries.filter((e) => e.source !== MODEL_SOURCE.LITELLM && !isInstalled(e));
         const hosted = catalogEntries.filter((e) => e.source === MODEL_SOURCE.LITELLM);
-        for (const e of localInstalled) opts.push([e.hf_repo, e.hf_repo]);
-        for (const e of localNotInstalled) opts.push([e.hf_repo, `${e.hf_repo}${MESSAGES.LABEL_NOT_INSTALLED}`]);
+        for (const e of localInstalled) opts.push([ref(e), e.hf_repo]);
+        for (const e of localNotInstalled) opts.push([ref(e), `${e.hf_repo}${MESSAGES.LABEL_NOT_INSTALLED}`]);
         if (hosted.length > 0) {
-            for (const e of hosted) opts.push([e.hf_repo, `${e.hf_repo} — ${MESSAGES.LABEL_RERANKER_HOSTED_GROUP}`]);
+            for (const e of hosted) opts.push([ref(e), `${e.hf_repo} — ${MESSAGES.LABEL_RERANKER_HOSTED_GROUP}`]);
         }
         return opts;
     }
@@ -758,11 +760,11 @@ export class LilbeeSettingTab extends PluginSettingTab {
         catalogEntries: CatalogEntry[],
         installed: InstalledModel[],
     ): Promise<void> {
-        const installedNames = new Set(installed.map((m) => m.name));
-        const catalogEntry = catalogEntries.find((e) => e.hf_repo === value);
+        const installedRefs = new Set(installed.map((m) => m.name));
+        const catalogEntry = catalogEntries.find((e) => `${e.name}:${e.tag}` === value);
         if (
             value === RERANKER_DISABLED_KEY ||
-            installedNames.has(value) ||
+            installedRefs.has(value) ||
             catalogEntry?.source === MODEL_SOURCE.LITELLM
         ) {
             await this.applyRerankerSelection(value);
@@ -797,7 +799,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         const ok = await this.streamRerankerPull(taskId, entry, controller.signal);
         if (!ok) return;
         this.plugin.taskQueue.complete(taskId);
-        await this.applyRerankerSelection(entry.hf_repo);
+        await this.applyRerankerSelection(`${entry.name}:${entry.tag}`);
     }
 
     private async streamRerankerPull(taskId: string, entry: CatalogEntry, signal: AbortSignal): Promise<boolean> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,14 @@ export interface ModelCatalog {
 
 export interface ModelsResponse {
     chat: ModelCatalog;
+    reranker?: ModelCatalog;
+}
+
+export interface ConfigResponse {
+    reranker_model: string;
+    rerank_candidates: number;
+    reranker_available: boolean;
+    [key: string]: unknown;
 }
 
 export interface StatusResponse {
@@ -353,16 +361,18 @@ export const SYNC_MODE = {
     AUTO: "auto",
 } as const satisfies Record<string, SyncMode>;
 
-export type ModelTask = "chat" | "vision" | "embedding";
+export type ModelTask = "chat" | "vision" | "embedding" | "rerank";
 
 export const MODEL_TASK = {
     CHAT: "chat",
     VISION: "vision",
     EMBEDDING: "embedding",
+    RERANK: "rerank",
 } as const satisfies Record<string, ModelTask>;
 
 export const MODEL_SOURCE = {
     NATIVE: "native",
+    LITELLM: "litellm",
 } as const;
 
 export const ERROR_NAME = {

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -27,6 +27,7 @@ const TASK_SECTION_LABEL: Record<ModelTask, string> = {
     [MODEL_TASK.CHAT]: MESSAGES.LABEL_SECTION_CHAT,
     [MODEL_TASK.VISION]: MESSAGES.LABEL_SECTION_VISION,
     [MODEL_TASK.EMBEDDING]: MESSAGES.LABEL_SECTION_EMBEDDING,
+    [MODEL_TASK.RERANK]: MESSAGES.LABEL_SECTION_RERANK,
 };
 
 export class CatalogModal extends Modal {
@@ -419,6 +420,9 @@ export class CatalogModal extends Modal {
     private async setActiveFor(entry: CatalogEntry): ReturnType<typeof this.plugin.api.setChatModel> {
         if (entry.task === MODEL_TASK.EMBEDDING) {
             return this.plugin.api.setEmbeddingModel(entry.hf_repo);
+        }
+        if (entry.task === MODEL_TASK.RERANK) {
+            return this.plugin.api.setRerankerModel(entry.hf_repo);
         }
         const result = await this.plugin.api.setChatModel(entry.hf_repo);
         if (result.isOk()) this.plugin.activeModel = entry.hf_repo;

--- a/styles.css
+++ b/styles.css
@@ -905,6 +905,11 @@
     color: var(--text-muted);
 }
 
+.lilbee-pill-task-rerank {
+    background: rgba(56, 139, 176, 0.15);
+    color: rgb(56, 139, 176);
+}
+
 .lilbee-pill-installed {
     background: var(--background-modifier-success);
     color: var(--text-on-accent);

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -645,6 +645,113 @@ describe("pullModel()", () => {
         });
     });
 
+    describe("setRerankerModel()", () => {
+        it("PUTs to /api/models/reranker", async () => {
+            fetchMock.mockResolvedValue(jsonResponse({ model: "bge-reranker-v2-m3" }));
+
+            const result = await client.setRerankerModel("bge-reranker-v2-m3");
+
+            expect(fetchMock).toHaveBeenCalledWith(
+                `${BASE_URL}/api/models/reranker`,
+                expect.objectContaining({
+                    method: "PUT",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ model: "bge-reranker-v2-m3" }),
+                }),
+            );
+            expect(result.isOk()).toBe(true);
+        });
+
+        it("accepts empty string to disable the reranker", async () => {
+            fetchMock.mockResolvedValue(jsonResponse({ model: "" }));
+
+            const result = await client.setRerankerModel("");
+
+            expect(fetchMock).toHaveBeenCalledWith(
+                `${BASE_URL}/api/models/reranker`,
+                expect.objectContaining({
+                    method: "PUT",
+                    body: JSON.stringify({ model: "" }),
+                }),
+            );
+            expect(result.isOk()).toBe(true);
+        });
+
+        it("returns error when server returns 422", async () => {
+            fetchMock.mockResolvedValue({
+                ok: false,
+                status: 422,
+                statusText: "Unprocessable",
+                text: () => Promise.resolve("Unknown reranker model"),
+            } as unknown as Response);
+
+            const result = await client.setRerankerModel("not-a-model");
+            expect(result.isErr()).toBe(true);
+            expect(result._unsafeUnwrapErr().message).toContain("422");
+        });
+
+        it("propagates AbortError as err()", async () => {
+            fetchMock.mockImplementation(() => {
+                const err = new Error("aborted");
+                err.name = "AbortError";
+                return Promise.reject(err);
+            });
+
+            const result = await client.setRerankerModel("bge-reranker-v2-m3");
+            expect(result.isErr()).toBe(true);
+            expect(result._unsafeUnwrapErr().name).toBe("AbortError");
+        });
+    });
+
+    describe("catalog() with task=rerank", () => {
+        it("appends task=rerank to the query string", async () => {
+            fetchMock.mockResolvedValue(jsonResponse({ total: 0, limit: 20, offset: 0, models: [], has_more: false }));
+
+            await client.catalog({ task: "rerank" });
+
+            const url = new URL(fetchMock.mock.calls[0][0]);
+            expect(url.searchParams.get("task")).toBe("rerank");
+        });
+    });
+
+    describe("installedModels() with task filter", () => {
+        it("omits task query param when not provided", async () => {
+            fetchMock.mockResolvedValue(jsonResponse({ models: [] }));
+
+            await client.installedModels();
+
+            expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/api/models/installed`, expect.objectContaining({}));
+        });
+
+        it("forwards task=rerank when provided", async () => {
+            fetchMock.mockResolvedValue(jsonResponse({ models: [] }));
+
+            await client.installedModels({ task: "rerank" });
+
+            const url = new URL(fetchMock.mock.calls[0][0]);
+            expect(url.pathname).toBe("/api/models/installed");
+            expect(url.searchParams.get("task")).toBe("rerank");
+        });
+    });
+
+    describe("config() with reranker fields", () => {
+        it("parses reranker_model, rerank_candidates, and reranker_available", async () => {
+            const data = {
+                reranker_model: "bge-reranker-v2-m3",
+                rerank_candidates: 25,
+                reranker_available: true,
+                chat_model: "qwen3:8b",
+            };
+            fetchMock.mockResolvedValue(jsonResponse(data));
+
+            const result = await client.config();
+
+            expect(result.reranker_model).toBe("bge-reranker-v2-m3");
+            expect(result.rerank_candidates).toBe(25);
+            expect(result.reranker_available).toBe(true);
+        });
+    });
+
     describe("setEmbeddingModel()", () => {
         it("PUTs to /api/models/embedding", async () => {
             fetchMock.mockResolvedValue(jsonResponse({ model: "nomic-embed-text-v1.5" }));

--- a/tests/locales/en.test.ts
+++ b/tests/locales/en.test.ts
@@ -386,6 +386,7 @@ describe("FILTERS", () => {
             expect(FILTERS.TASK.CHAT).toBe("chat");
             expect(FILTERS.TASK.EMBEDDING).toBe("embedding");
             expect(FILTERS.TASK.VISION).toBe("vision");
+            expect(FILTERS.TASK.RERANK).toBe("rerank");
         });
     });
 
@@ -414,6 +415,7 @@ describe("TASK_LABELS", () => {
         expect(TASK_LABELS[MODEL_TASK.CHAT]).toBe("Chat");
         expect(TASK_LABELS[MODEL_TASK.VISION]).toBe("Vision");
         expect(TASK_LABELS[MODEL_TASK.EMBEDDING]).toBe("Embedding");
+        expect(TASK_LABELS[MODEL_TASK.RERANK]).toBe("Rerank");
     });
 });
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -4138,6 +4138,7 @@ describe("managed mode settings", () => {
                     models: [
                         {
                             name: "bge-reranker-v2-m3",
+                            tag: "latest",
                             hf_repo: "BAAI/bge-reranker-v2-m3",
                             display_name: "BGE v2",
                             size_gb: 1,
@@ -4153,7 +4154,7 @@ describe("managed mode settings", () => {
                 }),
             );
             (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({
-                models: [{ name: "BAAI/bge-reranker-v2-m3", source: "native" }],
+                models: [{ name: "bge-reranker-v2-m3:latest", source: "native" }],
             });
             const container = new MockElement("div") as unknown as HTMLElement;
             const tab = makeTab(plugin);
@@ -4165,7 +4166,7 @@ describe("managed mode settings", () => {
 
             expect(options[0][""]).toBe(MESSAGES.LABEL_RERANKER_DISABLED);
             // Dropdown option keys use hf_repo (canonical id), not display name
-            expect(options[0]["BAAI/bge-reranker-v2-m3"]).toBe("BAAI/bge-reranker-v2-m3");
+            expect(options[0]["bge-reranker-v2-m3:latest"]).toBe("BAAI/bge-reranker-v2-m3");
             expect(values[0]).toBe("");
         });
 
@@ -4184,6 +4185,7 @@ describe("managed mode settings", () => {
                     models: [
                         {
                             name: "bge-reranker-v2-m3",
+                            tag: "latest",
                             hf_repo: "BAAI/bge-reranker-v2-m3",
                             display_name: "BGE",
                             size_gb: 1,
@@ -4199,7 +4201,7 @@ describe("managed mode settings", () => {
                 }),
             );
             (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({
-                models: [{ name: "BAAI/bge-reranker-v2-m3", source: "native" }],
+                models: [{ name: "bge-reranker-v2-m3:latest", source: "native" }],
             });
             const container = new MockElement("div") as unknown as HTMLElement;
             const tab = makeTab(plugin);
@@ -4210,8 +4212,8 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
 
             // The dropdown value is hf_repo (canonical id), not the display name
-            await dropdowns[0]("BAAI/bge-reranker-v2-m3");
-            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("BAAI/bge-reranker-v2-m3");
+            await dropdowns[0]("bge-reranker-v2-m3:latest");
+            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("bge-reranker-v2-m3:latest");
             expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_RERANKER_UPDATED)).toBe(true);
         });
 
@@ -4256,6 +4258,7 @@ describe("managed mode settings", () => {
                     models: [
                         {
                             name: "bge",
+                            tag: "latest",
                             hf_repo: "BAAI/bge",
                             display_name: "",
                             size_gb: 1,
@@ -4271,7 +4274,7 @@ describe("managed mode settings", () => {
                 }),
             );
             (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({
-                models: [{ name: "BAAI/bge", source: "native" }],
+                models: [{ name: "bge:latest", source: "native" }],
             });
             const container = new MockElement("div") as unknown as HTMLElement;
             const tab = makeTab(plugin);
@@ -4281,7 +4284,7 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            await dropdowns[0]("BAAI/bge");
+            await dropdowns[0]("bge:latest");
             expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_FAILED_RERANKER)).toBe(true);
         });
 
@@ -4304,6 +4307,7 @@ describe("managed mode settings", () => {
                     models: [
                         {
                             name: "bge-reranker-large",
+                            tag: "latest",
                             hf_repo: "BAAI/bge-reranker-large",
                             display_name: "",
                             size_gb: 2,
@@ -4328,13 +4332,13 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
 
             // pullModel and setRerankerModel must use hf_repo (canonical id), not display name
-            await dropdowns[0]("BAAI/bge-reranker-large");
+            await dropdowns[0]("bge-reranker-large:latest");
             expect(plugin.api.pullModel).toHaveBeenCalledWith(
                 "BAAI/bge-reranker-large",
                 "native",
                 expect.any(AbortSignal),
             );
-            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("BAAI/bge-reranker-large");
+            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("bge-reranker-large:latest");
         });
 
         it("hosted litellm entry skips pull and calls setRerankerModel directly", async () => {
@@ -4352,6 +4356,7 @@ describe("managed mode settings", () => {
                     models: [
                         {
                             name: "rerank-english-v3.0",
+                            tag: "latest",
                             hf_repo: "cohere/rerank-english-v3.0",
                             display_name: "Cohere",
                             size_gb: 0,
@@ -4375,9 +4380,9 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            await dropdowns[0]("cohere/rerank-english-v3.0");
+            await dropdowns[0]("rerank-english-v3.0:latest");
             expect(plugin.api.pullModel).not.toHaveBeenCalled();
-            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("cohere/rerank-english-v3.0");
+            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("rerank-english-v3.0:latest");
         });
 
         it("hosted litellm entry with 422 response surfaces API-key notice", async () => {
@@ -4398,6 +4403,7 @@ describe("managed mode settings", () => {
                     models: [
                         {
                             name: "rerank",
+                            tag: "latest",
                             hf_repo: "cohere/rerank",
                             display_name: "",
                             size_gb: 0,
@@ -4421,7 +4427,7 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            await dropdowns[0]("cohere/rerank");
+            await dropdowns[0]("rerank:latest");
             expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_RERANKER_NEEDS_KEY)).toBe(true);
         });
 
@@ -4501,6 +4507,7 @@ describe("managed mode settings", () => {
                     models: [
                         {
                             name: "bge",
+                            tag: "latest",
                             hf_repo: "BAAI/bge",
                             display_name: "",
                             size_gb: 1,
@@ -4524,7 +4531,7 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            await dropdowns[0]("BAAI/bge");
+            await dropdowns[0]("bge:latest");
             expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_QUEUE_FULL)).toBe(true);
             expect(plugin.api.pullModel).not.toHaveBeenCalled();
         });
@@ -4548,6 +4555,7 @@ describe("managed mode settings", () => {
                     models: [
                         {
                             name: "bge",
+                            tag: "latest",
                             hf_repo: "BAAI/bge",
                             display_name: "",
                             size_gb: 1,
@@ -4571,7 +4579,7 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            await dropdowns[0]("BAAI/bge");
+            await dropdowns[0]("bge:latest");
             expect(Notice.instances.some((n) => n.message.includes("failed to pull"))).toBe(true);
             expect(plugin.api.setRerankerModel).not.toHaveBeenCalled();
         });
@@ -4597,6 +4605,7 @@ describe("managed mode settings", () => {
                     models: [
                         {
                             name: "bge",
+                            tag: "latest",
                             hf_repo: "BAAI/bge",
                             display_name: "",
                             size_gb: 1,
@@ -4620,7 +4629,7 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            await dropdowns[0]("BAAI/bge");
+            await dropdowns[0]("bge:latest");
             expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_PULL_CANCELLED)).toBe(true);
         });
 
@@ -4643,6 +4652,7 @@ describe("managed mode settings", () => {
                     models: [
                         {
                             name: "bge",
+                            tag: "latest",
                             hf_repo: "BAAI/bge",
                             display_name: "",
                             size_gb: 1,
@@ -4666,7 +4676,7 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            await dropdowns[0]("BAAI/bge");
+            await dropdowns[0]("bge:latest");
             const failed = plugin.taskQueue.completed.find((t: any) => t.status === "failed");
             expect(failed).toBeDefined();
             expect(failed!.error).toBe("unknown error");
@@ -4691,6 +4701,7 @@ describe("managed mode settings", () => {
                     models: [
                         {
                             name: "bge",
+                            tag: "latest",
                             hf_repo: "BAAI/bge",
                             display_name: "",
                             size_gb: 1,
@@ -4714,8 +4725,8 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            await expect(dropdowns[0]("BAAI/bge")).resolves.not.toThrow();
-            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("BAAI/bge");
+            await expect(dropdowns[0]("bge:latest")).resolves.not.toThrow();
+            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("bge:latest");
         });
 
         it("buildRerankerOptions includes only installed-first then not-installed then hosted", async () => {
@@ -4733,6 +4744,7 @@ describe("managed mode settings", () => {
                     models: [
                         {
                             name: "bge-installed",
+                            tag: "latest",
                             hf_repo: "BAAI/bge-installed",
                             display_name: "",
                             size_gb: 1,
@@ -4745,6 +4757,7 @@ describe("managed mode settings", () => {
                         },
                         {
                             name: "bge-not-installed",
+                            tag: "latest",
                             hf_repo: "BAAI/bge-not-installed",
                             display_name: "",
                             size_gb: 1,
@@ -4757,6 +4770,7 @@ describe("managed mode settings", () => {
                         },
                         {
                             name: "rerank",
+                            tag: "latest",
                             hf_repo: "cohere/rerank",
                             display_name: "",
                             size_gb: 0,
@@ -4772,7 +4786,7 @@ describe("managed mode settings", () => {
                 }),
             );
             (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({
-                models: [{ name: "BAAI/bge-installed", source: "native" }],
+                models: [{ name: "bge-installed:latest", source: "native" }],
             });
             const container = new MockElement("div") as unknown as HTMLElement;
             const tab = makeTab(plugin);
@@ -4782,11 +4796,67 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            // Dropdown values must be hf_repo (canonical id), not display name
+            // Dropdown VALUES use the canonical ``name:tag`` ref so the
+            // server's active-reranker string (returned in name:tag form)
+            // matches an option and setValue resolves. Display labels still
+            // show hf_repo so the UI stays human-readable.
             const keys = Object.keys(options[0]);
-            expect(keys).toEqual(["", "BAAI/bge-installed", "BAAI/bge-not-installed", "cohere/rerank"]);
-            expect(options[0]["BAAI/bge-not-installed"]).toContain(MESSAGES.LABEL_NOT_INSTALLED);
-            expect(options[0]["cohere/rerank"]).toContain(MESSAGES.LABEL_RERANKER_HOSTED_GROUP);
+            expect(keys).toEqual(["", "bge-installed:latest", "bge-not-installed:latest", "rerank:latest"]);
+            expect(options[0]["bge-installed:latest"]).toBe("BAAI/bge-installed");
+            expect(options[0]["bge-not-installed:latest"]).toContain(MESSAGES.LABEL_NOT_INSTALLED);
+            expect(options[0]["rerank:latest"]).toContain(MESSAGES.LABEL_RERANKER_HOSTED_GROUP);
+        });
+
+        it("installed reranker with server's name:tag ref is NOT labelled (not installed)", async () => {
+            // Regression: buildRerankerOptions used to compare against
+            // ``entry.hf_repo`` but the server's ``/api/models/installed``
+            // returns the canonical ``name:tag`` ref. That mismatch made
+            // installed rerankers render as "(not installed)" and the
+            // dropdown fall back to "(disabled)" even when the server had
+            // an active reranker set. Guard the both forms here.
+            const plugin = makePlugin();
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                reranker_model: "bge-reranker-v2-m3:latest",
+                rerank_candidates: 20,
+                reranker_available: true,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({
+                    total: 1,
+                    limit: 20,
+                    offset: 0,
+                    models: [
+                        {
+                            name: "bge-reranker-v2-m3",
+                            tag: "latest",
+                            hf_repo: "gpustack/bge-reranker-v2-m3-GGUF",
+                            display_name: "BGE",
+                            size_gb: 0.4,
+                            min_ram_gb: 2,
+                            description: "",
+                            quality_tier: "balanced",
+                            installed: true,
+                            source: "native",
+                            task: "rerank",
+                        },
+                    ],
+                    has_more: false,
+                }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({
+                models: [{ name: "bge-reranker-v2-m3:latest", source: "native" }],
+            });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { options, values } = captureRerankerDropdown();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(options[0]["bge-reranker-v2-m3:latest"]).toBe("gpustack/bge-reranker-v2-m3-GGUF");
+            expect(options[0]["bge-reranker-v2-m3:latest"]).not.toContain(MESSAGES.LABEL_NOT_INSTALLED);
+            expect(values[0]).toBe("bge-reranker-v2-m3:latest");
         });
 
         it("parses reranker_model as empty when config lacks the field", async () => {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -72,6 +72,8 @@ function makePlugin(overrides: Partial<LilbeeSettings> = {}) {
         configDefaults: vi.fn().mockRejectedValue(new Error("unreachable")),
         updateConfig: vi.fn().mockResolvedValue({ updated: [], reindex_required: false }),
         setEmbeddingModel: vi.fn().mockResolvedValue(ok(undefined)),
+        setRerankerModel: vi.fn().mockResolvedValue(ok(undefined)),
+        installedModels: vi.fn().mockResolvedValue({ models: [] }),
         catalog: vi.fn().mockResolvedValue(err(new Error("unreachable"))),
     };
     const saveSettings = vi.fn().mockResolvedValue(undefined);
@@ -374,8 +376,8 @@ describe("LilbeeSettingTab", () => {
             (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
-            // serverPort + 6 generation + syncDebounce + 10 crawling (3 existing + 7 new text) + wikiVaultFolder + 2 chunks + hfToken + litellm = 23
-            expect(textOnChanges.length).toBe(23);
+            // serverPort + 6 generation + syncDebounce + 10 crawling + wikiVaultFolder + 2 chunks + rerank_candidates + hfToken + litellm = 24
+            expect(textOnChanges.length).toBe(24);
         });
 
         it("does NOT show sync-debounce when syncMode is 'manual'", () => {
@@ -383,8 +385,8 @@ describe("LilbeeSettingTab", () => {
             (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
-            // serverPort + 6 generation + 10 crawling + wikiVaultFolder + 2 chunks + hfToken + litellm = 22
-            expect(textOnChanges.length).toBe(22);
+            // serverPort + 6 generation + 10 crawling + wikiVaultFolder + 2 chunks + rerank_candidates + hfToken + litellm = 23
+            expect(textOnChanges.length).toBe(23);
         });
     });
 
@@ -3481,8 +3483,8 @@ describe("managed mode settings", () => {
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
-            // Index 13: HF token (0=port, 1-6=gen, 7-9=crawl, 10=wikiVaultFolder, 11-12=chunks, 13=hfToken)
-            await textOnChanges[20]("hf_test123");
+            // Index 21: HF token (0=port, 1-6=gen, 7-16=crawl, 17=wikiVaultFolder, 18-19=chunks, 20=rerank_candidates, 21=hfToken)
+            await textOnChanges[21]("hf_test123");
             expect(plugin.api.updateConfig).toHaveBeenCalledWith({ hf_token: "hf_test123" });
             expect(plugin.settings.hfToken).toBe("hf_test123");
             expect(Notice.instances.some((n: any) => n.message.includes("HuggingFace token saved"))).toBe(true);
@@ -3494,7 +3496,7 @@ describe("managed mode settings", () => {
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
-            await textOnChanges[20]("");
+            await textOnChanges[21]("");
             expect(plugin.settings.hfToken).toBe("");
         });
 
@@ -3505,7 +3507,7 @@ describe("managed mode settings", () => {
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
-            await textOnChanges[20]("hf_test123");
+            await textOnChanges[21]("hf_test123");
             expect(Notice.instances.some((n: any) => n.message.includes("failed to save HuggingFace token"))).toBe(
                 true,
             );
@@ -3637,7 +3639,7 @@ describe("managed mode settings", () => {
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
             // Index 14: LiteLLM base URL (after hfToken at 13)
-            await textOnChanges[21]("http://localhost:4000");
+            await textOnChanges[22]("http://localhost:4000");
             expect(plugin.api.updateConfig).toHaveBeenCalledWith({ litellm_base_url: "http://localhost:4000" });
         });
 
@@ -3647,7 +3649,7 @@ describe("managed mode settings", () => {
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
-            await textOnChanges[21]("  ");
+            await textOnChanges[22]("  ");
             expect(plugin.api.updateConfig).not.toHaveBeenCalled();
         });
 
@@ -3658,7 +3660,7 @@ describe("managed mode settings", () => {
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
-            await textOnChanges[21]("http://localhost:4000");
+            await textOnChanges[22]("http://localhost:4000");
             expect(Notice.instances.some((n: any) => n.message.includes("failed to update LiteLLM URL"))).toBe(true);
         });
     });
@@ -4027,10 +4029,10 @@ describe("managed mode settings", () => {
             tab.display();
             Setting.prototype.addText = origAddText;
 
-            // 3 API keys at indices 20-22 (0=port, 1-6=gen, 7-16=crawl, 17=wikiVaultFolder, 18-19=chunks, 20-22=apiKeys)
-            expect(inputs[20].type).toBe("password");
+            // 3 API keys at indices 21-23 (0=port, 1-6=gen, 7-16=crawl, 17=wikiVaultFolder, 18-19=chunks, 20=rerank_candidates, 21-23=apiKeys)
             expect(inputs[21].type).toBe("password");
             expect(inputs[22].type).toBe("password");
+            expect(inputs[23].type).toBe("password");
         });
 
         it("sets HF token input type to password", () => {
@@ -4053,8 +4055,877 @@ describe("managed mode settings", () => {
             tab.display();
             Setting.prototype.addText = origAddText;
 
-            // HF token is index 23 (after 3 API keys at 20-22)
-            expect(inputs[23].type).toBe("password");
+            // HF token is index 24 (after rerank_candidates at 20 and 3 API keys at 21-23)
+            expect(inputs[24].type).toBe("password");
+        });
+    });
+
+    describe("Reranker section", () => {
+        let origAddDropdown: typeof Setting.prototype.addDropdown;
+
+        function captureRerankerDropdown(): {
+            dropdowns: DropdownOnChange[];
+            options: Array<Record<string, string>>;
+            values: string[];
+        } {
+            const dropdowns: DropdownOnChange[] = [];
+            const options: Array<Record<string, string>> = [];
+            const values: string[] = [];
+            Setting.prototype.addDropdown = function (cb: (dropdown: any) => void) {
+                const opts: Record<string, string> = {};
+                const fakeDropdown = {
+                    addOption: (v: string, l: string) => {
+                        opts[v] = l;
+                        return fakeDropdown;
+                    },
+                    setValue: (v: string) => {
+                        values.push(v);
+                        return fakeDropdown;
+                    },
+                    onChange: (handler: DropdownOnChange) => {
+                        dropdowns.push(handler);
+                        return fakeDropdown;
+                    },
+                };
+                cb(fakeDropdown);
+                options.push(opts);
+                return this;
+            };
+            return { dropdowns, options, values };
+        }
+
+        beforeEach(() => {
+            origAddDropdown = Setting.prototype.addDropdown;
+        });
+        afterEach(() => {
+            Setting.prototype.addDropdown = origAddDropdown;
+        });
+
+        it("renders unavailable notice and disabled dropdown when reranker_available is false", async () => {
+            const plugin = makePlugin();
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                reranker_model: "",
+                rerank_candidates: 20,
+                reranker_available: false,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ total: 0, limit: 20, offset: 0, models: [], has_more: false }),
+            );
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { options } = captureRerankerDropdown();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(options.length).toBe(1);
+            expect(options[0][""]).toBe(MESSAGES.LABEL_RERANKER_DISABLED);
+        });
+
+        it("renders dropdown with (disabled) selected when active is empty", async () => {
+            const plugin = makePlugin();
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                reranker_model: "",
+                rerank_candidates: 20,
+                reranker_available: true,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({
+                    total: 1,
+                    limit: 20,
+                    offset: 0,
+                    models: [
+                        {
+                            name: "bge-reranker-v2-m3",
+                            hf_repo: "BAAI/bge-reranker-v2-m3",
+                            display_name: "BGE v2",
+                            size_gb: 1,
+                            min_ram_gb: 4,
+                            description: "multilingual",
+                            quality_tier: "balanced",
+                            installed: true,
+                            source: "native",
+                            task: "rerank",
+                        },
+                    ],
+                    has_more: false,
+                }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({
+                models: [{ name: "BAAI/bge-reranker-v2-m3", source: "native" }],
+            });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { options, values } = captureRerankerDropdown();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(options[0][""]).toBe(MESSAGES.LABEL_RERANKER_DISABLED);
+            // Dropdown option keys use hf_repo (canonical id), not display name
+            expect(options[0]["BAAI/bge-reranker-v2-m3"]).toBe("BAAI/bge-reranker-v2-m3");
+            expect(values[0]).toBe("");
+        });
+
+        it("selecting installed reranker calls setRerankerModel", async () => {
+            const plugin = makePlugin();
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                reranker_model: "",
+                rerank_candidates: 20,
+                reranker_available: true,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({
+                    total: 1,
+                    limit: 20,
+                    offset: 0,
+                    models: [
+                        {
+                            name: "bge-reranker-v2-m3",
+                            hf_repo: "BAAI/bge-reranker-v2-m3",
+                            display_name: "BGE",
+                            size_gb: 1,
+                            min_ram_gb: 4,
+                            description: "",
+                            quality_tier: "balanced",
+                            installed: true,
+                            source: "native",
+                            task: "rerank",
+                        },
+                    ],
+                    has_more: false,
+                }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({
+                models: [{ name: "BAAI/bge-reranker-v2-m3", source: "native" }],
+            });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { dropdowns } = captureRerankerDropdown();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            // The dropdown value is hf_repo (canonical id), not the display name
+            await dropdowns[0]("BAAI/bge-reranker-v2-m3");
+            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("BAAI/bge-reranker-v2-m3");
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_RERANKER_UPDATED)).toBe(true);
+        });
+
+        it("selecting disabled calls setRerankerModel('')", async () => {
+            const plugin = makePlugin();
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                reranker_model: "bge-reranker-v2-m3",
+                rerank_candidates: 20,
+                reranker_available: true,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ total: 0, limit: 20, offset: 0, models: [], has_more: false }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({ models: [] });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { dropdowns } = captureRerankerDropdown();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            await dropdowns[0]("");
+            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("");
+        });
+
+        it("shows failure notice when setRerankerModel returns non-422 error", async () => {
+            const plugin = makePlugin();
+            (plugin.api.setRerankerModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                err(new Error("Server responded 500: ")),
+            );
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                reranker_model: "",
+                rerank_candidates: 20,
+                reranker_available: true,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({
+                    total: 1,
+                    limit: 20,
+                    offset: 0,
+                    models: [
+                        {
+                            name: "bge",
+                            hf_repo: "BAAI/bge",
+                            display_name: "",
+                            size_gb: 1,
+                            min_ram_gb: 4,
+                            description: "",
+                            quality_tier: "",
+                            installed: true,
+                            source: "native",
+                            task: "rerank",
+                        },
+                    ],
+                    has_more: false,
+                }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({
+                models: [{ name: "BAAI/bge", source: "native" }],
+            });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { dropdowns } = captureRerankerDropdown();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            await dropdowns[0]("BAAI/bge");
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_FAILED_RERANKER)).toBe(true);
+        });
+
+        it("selecting not-installed local catalog entry triggers pull then set", async () => {
+            const plugin = makePlugin();
+            async function* fakePull() {
+                yield { event: SSE_EVENT.PROGRESS, data: { percent: 50 } };
+            }
+            (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                reranker_model: "",
+                rerank_candidates: 20,
+                reranker_available: true,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({
+                    total: 1,
+                    limit: 20,
+                    offset: 0,
+                    models: [
+                        {
+                            name: "bge-reranker-large",
+                            hf_repo: "BAAI/bge-reranker-large",
+                            display_name: "",
+                            size_gb: 2,
+                            min_ram_gb: 4,
+                            description: "",
+                            quality_tier: "",
+                            installed: false,
+                            source: "native",
+                            task: "rerank",
+                        },
+                    ],
+                    has_more: false,
+                }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({ models: [] });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { dropdowns } = captureRerankerDropdown();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            // pullModel and setRerankerModel must use hf_repo (canonical id), not display name
+            await dropdowns[0]("BAAI/bge-reranker-large");
+            expect(plugin.api.pullModel).toHaveBeenCalledWith(
+                "BAAI/bge-reranker-large",
+                "native",
+                expect.any(AbortSignal),
+            );
+            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("BAAI/bge-reranker-large");
+        });
+
+        it("hosted litellm entry skips pull and calls setRerankerModel directly", async () => {
+            const plugin = makePlugin();
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                reranker_model: "",
+                rerank_candidates: 20,
+                reranker_available: true,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({
+                    total: 1,
+                    limit: 20,
+                    offset: 0,
+                    models: [
+                        {
+                            name: "rerank-english-v3.0",
+                            hf_repo: "cohere/rerank-english-v3.0",
+                            display_name: "Cohere",
+                            size_gb: 0,
+                            min_ram_gb: 0,
+                            description: "",
+                            quality_tier: "",
+                            installed: false,
+                            source: "litellm",
+                            task: "rerank",
+                        },
+                    ],
+                    has_more: false,
+                }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({ models: [] });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { dropdowns } = captureRerankerDropdown();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            await dropdowns[0]("cohere/rerank-english-v3.0");
+            expect(plugin.api.pullModel).not.toHaveBeenCalled();
+            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("cohere/rerank-english-v3.0");
+        });
+
+        it("hosted litellm entry with 422 response surfaces API-key notice", async () => {
+            const plugin = makePlugin();
+            (plugin.api.setRerankerModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                err(new Error("Server responded 422: key missing")),
+            );
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                reranker_model: "",
+                rerank_candidates: 20,
+                reranker_available: true,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({
+                    total: 1,
+                    limit: 20,
+                    offset: 0,
+                    models: [
+                        {
+                            name: "rerank",
+                            hf_repo: "cohere/rerank",
+                            display_name: "",
+                            size_gb: 0,
+                            min_ram_gb: 0,
+                            description: "",
+                            quality_tier: "",
+                            installed: false,
+                            source: "litellm",
+                            task: "rerank",
+                        },
+                    ],
+                    has_more: false,
+                }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({ models: [] });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { dropdowns } = captureRerankerDropdown();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            await dropdowns[0]("cohere/rerank");
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_RERANKER_NEEDS_KEY)).toBe(true);
+        });
+
+        it("falls back to notice when initial load fails", async () => {
+            const plugin = makePlugin();
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("unreachable"));
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ total: 0, limit: 20, offset: 0, models: [], has_more: false }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({ models: [] });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_RERANKER_LOAD_FAILED)).toBe(true);
+        });
+
+        it("falls back to notice when installedModels rejects (caught by inner catch)", async () => {
+            const plugin = makePlugin();
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                reranker_model: "",
+                rerank_candidates: 20,
+                reranker_available: true,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ total: 0, limit: 20, offset: 0, models: [], has_more: false }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("boom"));
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { options } = captureRerankerDropdown();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            // installed catch fallback returns empty models — dropdown still renders with just (disabled)
+            expect(options[0][""]).toBe(MESSAGES.LABEL_RERANKER_DISABLED);
+        });
+
+        it("falls back when catalog returns err() — shows empty dropdown with just (disabled)", async () => {
+            const plugin = makePlugin();
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                reranker_model: "",
+                rerank_candidates: 20,
+                reranker_available: true,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(err(new Error("fail")));
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({ models: [] });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { options } = captureRerankerDropdown();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(Object.keys(options[0])).toEqual([""]);
+        });
+
+        it("pull flow surfaces queue-full notice when enqueue fails", async () => {
+            const plugin = makePlugin();
+            plugin.taskQueue.enqueue = vi.fn(() => null) as any;
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                reranker_model: "",
+                rerank_candidates: 20,
+                reranker_available: true,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({
+                    total: 1,
+                    limit: 20,
+                    offset: 0,
+                    models: [
+                        {
+                            name: "bge",
+                            hf_repo: "BAAI/bge",
+                            display_name: "",
+                            size_gb: 1,
+                            min_ram_gb: 4,
+                            description: "",
+                            quality_tier: "",
+                            installed: false,
+                            source: "native",
+                            task: "rerank",
+                        },
+                    ],
+                    has_more: false,
+                }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({ models: [] });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { dropdowns } = captureRerankerDropdown();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            await dropdowns[0]("BAAI/bge");
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_QUEUE_FULL)).toBe(true);
+            expect(plugin.api.pullModel).not.toHaveBeenCalled();
+        });
+
+        it("pull SSE error fails the task and surfaces notice", async () => {
+            const plugin = makePlugin();
+            async function* failingPull() {
+                yield { event: SSE_EVENT.ERROR, data: { message: "boom" } };
+            }
+            (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(failingPull());
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                reranker_model: "",
+                rerank_candidates: 20,
+                reranker_available: true,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({
+                    total: 1,
+                    limit: 20,
+                    offset: 0,
+                    models: [
+                        {
+                            name: "bge",
+                            hf_repo: "BAAI/bge",
+                            display_name: "",
+                            size_gb: 1,
+                            min_ram_gb: 4,
+                            description: "",
+                            quality_tier: "",
+                            installed: false,
+                            source: "native",
+                            task: "rerank",
+                        },
+                    ],
+                    has_more: false,
+                }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({ models: [] });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { dropdowns } = captureRerankerDropdown();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            await dropdowns[0]("BAAI/bge");
+            expect(Notice.instances.some((n) => n.message.includes("failed to pull"))).toBe(true);
+            expect(plugin.api.setRerankerModel).not.toHaveBeenCalled();
+        });
+
+        it("pull AbortError cancels the task and surfaces cancel notice", async () => {
+            const plugin = makePlugin();
+            async function* aborting(): AsyncGenerator<never> {
+                const e = new Error("aborted");
+                e.name = "AbortError";
+                throw e;
+            }
+            (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(aborting());
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                reranker_model: "",
+                rerank_candidates: 20,
+                reranker_available: true,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({
+                    total: 1,
+                    limit: 20,
+                    offset: 0,
+                    models: [
+                        {
+                            name: "bge",
+                            hf_repo: "BAAI/bge",
+                            display_name: "",
+                            size_gb: 1,
+                            min_ram_gb: 4,
+                            description: "",
+                            quality_tier: "",
+                            installed: false,
+                            source: "native",
+                            task: "rerank",
+                        },
+                    ],
+                    has_more: false,
+                }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({ models: [] });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { dropdowns } = captureRerankerDropdown();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            await dropdowns[0]("BAAI/bge");
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_PULL_CANCELLED)).toBe(true);
+        });
+
+        it("pull non-Error throw uses 'unknown' as reason", async () => {
+            const plugin = makePlugin();
+            async function* failing(): AsyncGenerator<never> {
+                throw "string failure";
+            }
+            (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(failing());
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                reranker_model: "",
+                rerank_candidates: 20,
+                reranker_available: true,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({
+                    total: 1,
+                    limit: 20,
+                    offset: 0,
+                    models: [
+                        {
+                            name: "bge",
+                            hf_repo: "BAAI/bge",
+                            display_name: "",
+                            size_gb: 1,
+                            min_ram_gb: 4,
+                            description: "",
+                            quality_tier: "",
+                            installed: false,
+                            source: "native",
+                            task: "rerank",
+                        },
+                    ],
+                    has_more: false,
+                }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({ models: [] });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { dropdowns } = captureRerankerDropdown();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            await dropdowns[0]("BAAI/bge");
+            const failed = plugin.taskQueue.completed.find((t: any) => t.status === "failed");
+            expect(failed).toBeDefined();
+            expect(failed!.error).toBe("unknown error");
+        });
+
+        it("pull progress without percent or total is ignored", async () => {
+            const plugin = makePlugin();
+            async function* fakePull() {
+                yield { event: SSE_EVENT.PROGRESS, data: {} };
+            }
+            (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                reranker_model: "",
+                rerank_candidates: 20,
+                reranker_available: true,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({
+                    total: 1,
+                    limit: 20,
+                    offset: 0,
+                    models: [
+                        {
+                            name: "bge",
+                            hf_repo: "BAAI/bge",
+                            display_name: "",
+                            size_gb: 1,
+                            min_ram_gb: 4,
+                            description: "",
+                            quality_tier: "",
+                            installed: false,
+                            source: "native",
+                            task: "rerank",
+                        },
+                    ],
+                    has_more: false,
+                }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({ models: [] });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { dropdowns } = captureRerankerDropdown();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            await expect(dropdowns[0]("BAAI/bge")).resolves.not.toThrow();
+            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("BAAI/bge");
+        });
+
+        it("buildRerankerOptions includes only installed-first then not-installed then hosted", async () => {
+            const plugin = makePlugin();
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                reranker_model: "",
+                rerank_candidates: 20,
+                reranker_available: true,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({
+                    total: 3,
+                    limit: 20,
+                    offset: 0,
+                    models: [
+                        {
+                            name: "bge-installed",
+                            hf_repo: "BAAI/bge-installed",
+                            display_name: "",
+                            size_gb: 1,
+                            min_ram_gb: 4,
+                            description: "",
+                            quality_tier: "",
+                            installed: true,
+                            source: "native",
+                            task: "rerank",
+                        },
+                        {
+                            name: "bge-not-installed",
+                            hf_repo: "BAAI/bge-not-installed",
+                            display_name: "",
+                            size_gb: 1,
+                            min_ram_gb: 4,
+                            description: "",
+                            quality_tier: "",
+                            installed: false,
+                            source: "native",
+                            task: "rerank",
+                        },
+                        {
+                            name: "rerank",
+                            hf_repo: "cohere/rerank",
+                            display_name: "",
+                            size_gb: 0,
+                            min_ram_gb: 0,
+                            description: "",
+                            quality_tier: "",
+                            installed: false,
+                            source: "litellm",
+                            task: "rerank",
+                        },
+                    ],
+                    has_more: false,
+                }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({
+                models: [{ name: "BAAI/bge-installed", source: "native" }],
+            });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { options } = captureRerankerDropdown();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            // Dropdown values must be hf_repo (canonical id), not display name
+            const keys = Object.keys(options[0]);
+            expect(keys).toEqual(["", "BAAI/bge-installed", "BAAI/bge-not-installed", "cohere/rerank"]);
+            expect(options[0]["BAAI/bge-not-installed"]).toContain(MESSAGES.LABEL_NOT_INSTALLED);
+            expect(options[0]["cohere/rerank"]).toContain(MESSAGES.LABEL_RERANKER_HOSTED_GROUP);
+        });
+
+        it("parses reranker_model as empty when config lacks the field", async () => {
+            const plugin = makePlugin();
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                // no reranker_model key
+                reranker_available: true,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ total: 0, limit: 20, offset: 0, models: [], has_more: false }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({ models: [] });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { values } = captureRerankerDropdown();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(values[0]).toBe("");
+        });
+
+        it("unavailable branch resets dropdown to disabled regardless of stale active value", async () => {
+            const plugin = makePlugin();
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                reranker_model: "stale-value",
+                rerank_candidates: 20,
+                reranker_available: false,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ total: 0, limit: 20, offset: 0, models: [], has_more: false }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({ models: [] });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { values } = captureRerankerDropdown();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            // When unavailable, the stale active value is irrelevant — dropdown is always disabled.
+            expect(values[0]).toBe("");
+        });
+    });
+    describe("rerank_candidates advanced field", () => {
+        // In manual mode: [0]=port, [1-6]=gen, [7-9]=crawl, [10]=wikiVaultFolder, [11-12]=chunks, [13]=rerank_candidates
+        const RERANK_IDX = 20;
+
+        beforeEach(() => {
+            vi.useFakeTimers();
+        });
+        afterEach(() => {
+            vi.useRealTimers();
+        });
+
+        it("calls updateConfig with parsed number after debounce", async () => {
+            const plugin = makePlugin();
+            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            const tab = makeTab(plugin);
+            const { textOnChanges } = captureSettingCallbacks(() => tab.display());
+
+            await textOnChanges[RERANK_IDX]("40");
+            // Debounced: PATCH doesn't fire synchronously
+            expect(plugin.api.updateConfig).not.toHaveBeenCalled();
+            await vi.advanceTimersByTimeAsync(400);
+            expect(plugin.api.updateConfig).toHaveBeenCalledWith({ rerank_candidates: 40 });
+            expect(Notice.instances.some((n) => n.message.includes("Rerank candidates"))).toBe(true);
+        });
+
+        it("debounces rapid changes into a single PATCH", async () => {
+            const plugin = makePlugin();
+            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            const tab = makeTab(plugin);
+            const { textOnChanges } = captureSettingCallbacks(() => tab.display());
+
+            await textOnChanges[RERANK_IDX]("30");
+            await textOnChanges[RERANK_IDX]("35");
+            await textOnChanges[RERANK_IDX]("40");
+            await vi.advanceTimersByTimeAsync(400);
+            expect(plugin.api.updateConfig).toHaveBeenCalledTimes(1);
+            expect(plugin.api.updateConfig).toHaveBeenCalledWith({ rerank_candidates: 40 });
+        });
+
+        it("skips empty value", async () => {
+            const plugin = makePlugin();
+            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            const tab = makeTab(plugin);
+            const { textOnChanges } = captureSettingCallbacks(() => tab.display());
+
+            await textOnChanges[RERANK_IDX]("");
+            await vi.advanceTimersByTimeAsync(400);
+            expect(plugin.api.updateConfig).not.toHaveBeenCalled();
+        });
+
+        it("rejects NaN input", async () => {
+            const plugin = makePlugin();
+            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            const tab = makeTab(plugin);
+            const { textOnChanges } = captureSettingCallbacks(() => tab.display());
+
+            await textOnChanges[RERANK_IDX]("abc");
+            await vi.advanceTimersByTimeAsync(400);
+            expect(plugin.api.updateConfig).not.toHaveBeenCalled();
+        });
+
+        it("rejects out-of-range low value", async () => {
+            const plugin = makePlugin();
+            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            const tab = makeTab(plugin);
+            const { textOnChanges } = captureSettingCallbacks(() => tab.display());
+
+            await textOnChanges[RERANK_IDX]("0");
+            await vi.advanceTimersByTimeAsync(400);
+            expect(plugin.api.updateConfig).not.toHaveBeenCalled();
+        });
+
+        it("rejects out-of-range high value", async () => {
+            const plugin = makePlugin();
+            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            const tab = makeTab(plugin);
+            const { textOnChanges } = captureSettingCallbacks(() => tab.display());
+
+            await textOnChanges[RERANK_IDX]("101");
+            await vi.advanceTimersByTimeAsync(400);
+            expect(plugin.api.updateConfig).not.toHaveBeenCalled();
+        });
+
+        it("shows error notice on updateConfig failure", async () => {
+            const plugin = makePlugin();
+            (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("fail"));
+            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            const tab = makeTab(plugin);
+            const { textOnChanges } = captureSettingCallbacks(() => tab.display());
+
+            await textOnChanges[RERANK_IDX]("40");
+            await vi.advanceTimersByTimeAsync(400);
+            expect(Notice.instances.some((n) => n.message.includes("failed to update"))).toBe(true);
         });
     });
 });

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -63,6 +63,7 @@ function makePlugin(overrides: Record<string, unknown> = {}) {
             pullModel: vi.fn(),
             setChatModel: vi.fn().mockResolvedValue(ok(undefined)),
             setEmbeddingModel: vi.fn().mockResolvedValue(ok(undefined)),
+            setRerankerModel: vi.fn().mockResolvedValue(ok(undefined)),
             deleteModel: vi.fn().mockResolvedValue(ok({ deleted: true, model: "", freed_gb: 2.5 })),
         },
         activeModel: "",
@@ -720,6 +721,23 @@ describe("CatalogModal", () => {
             await tick();
             await tick();
             expect(plugin.api.setEmbeddingModel).toHaveBeenCalledWith("qwen/qwen3-8b");
+        });
+
+        it("uses setRerankerModel when the entry is a rerank task (and does not mutate activeModel)", async () => {
+            const plugin = makePlugin();
+            plugin.api.catalog.mockResolvedValue(
+                ok(makeCatalogResponse([makeEntry({ installed: true, task: "rerank" })])),
+            );
+            const modal = await openModal(plugin);
+            const content = contentEl(modal);
+            const useBtn = findButtons(content).find((b) => b.textContent === MESSAGES.BUTTON_USE)!;
+            useBtn.trigger("click");
+            await tick();
+            await tick();
+            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("qwen/qwen3-8b");
+            expect(plugin.api.setChatModel).not.toHaveBeenCalled();
+            // activeModel is the chat model and must NOT be mutated by the rerank branch
+            expect(plugin.activeModel).toBe("");
         });
 
         it("uses setChatModel by default", async () => {


### PR DESCRIPTION
## What

Adds a reranker model picker to the plugin's Settings tab, matching how chat and embedding models are configured. Users pick a model from a dropdown, pull new ones with progress feedback, or disable reranking with a single option — no more hunting through the generic config.

## How

New `renderRerankerSection` in `src/settings.ts` composes three existing API calls (`getConfig`, `catalog({task:"rerank"})`, `installedModels({task:"rerank"})`) to render:

- `(disabled)` option
- Installed rerank models
- Catalog entries not yet installed — clicking triggers the shared pull SSE flow, then sets as active
- Hosted LiteLLM rerankers if any appear in the catalog (grouped separately, no pull step)

`LilbeeClient.setRerankerModel(model)` wraps `PUT /api/models/reranker`. `catalog()` and `installedModels()` gain `task: ModelTask` support. `ConfigResponse` gains `reranker_model`, `rerank_candidates`, and `reranker_available`; `api.config()`'s return type is tightened to match.

## Advanced settings

`rerank_candidates` (top-N chunks to rerank) is a new field in the Advanced section, 1-100, with debounced PATCH.

## Catalog modal

`CatalogModal` now exposes a rerank filter in the task dropdown and routes rerank entries to `setRerankerModel` when activated. Without this dispatch, rerank catalog entries silently fell through to `setChatModel` and corrupted `plugin.activeModel`.

## Requires

Server-side PR (`lilbee/feature/reranker-parity` → `release/next`) merged first. This plugin calls `PUT /api/models/reranker` and expects `GET /api/config` to include `reranker_available`.

## Verification

- \`npm test\` — 1489 tests pass, 100% coverage
- \`npx tsc --noEmit\` clean
- \`npm run build\`, \`npm run format:check\`, \`npm run lint\` all clean