### PR TITLE
DocumentsModal: use has_more as pagination stop signal

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -293,6 +293,7 @@ export interface DocumentsResponse {
     total: number;
     limit: number;
     offset: number;
+    has_more?: boolean;
 }
 
 export interface ConfigUpdateResponse {

--- a/src/views/documents-modal.ts
+++ b/src/views/documents-modal.ts
@@ -12,6 +12,7 @@ export class DocumentsModal extends Modal {
     private plugin: LilbeePlugin;
     private offset = 0;
     private total = 0;
+    private hasMore = true;
     private isFetching = false;
     private documents: DocumentEntry[] = [];
     private selected = new Set<string>();
@@ -65,7 +66,7 @@ export class DocumentsModal extends Modal {
     }
 
     private onScroll = (): void => {
-        if (!this.resultsEl || this.isFetching || this.offset >= this.total) return;
+        if (!this.resultsEl || this.isFetching || !this.hasMore) return;
         const { scrollTop, clientHeight, scrollHeight } = this.resultsEl;
         if (scrollTop + clientHeight >= scrollHeight - SCROLL_BOTTOM_THRESHOLD_PX) {
             void this.fetchPage();
@@ -74,6 +75,7 @@ export class DocumentsModal extends Modal {
 
     private resetAndFetch(): void {
         this.offset = 0;
+        this.hasMore = true;
         this.documents = [];
         this.selected.clear();
         if (this.resultsEl) this.resultsEl.empty();
@@ -93,6 +95,10 @@ export class DocumentsModal extends Modal {
             this.total = response.total;
             this.documents.push(...response.documents);
             this.offset += response.documents.length;
+            this.hasMore =
+                response.has_more !== undefined
+                    ? response.has_more
+                    : response.documents.length > 0 && this.offset < response.total;
 
             for (const doc of response.documents) {
                 this.renderRow(doc);

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -537,6 +537,31 @@ describe("pullModel()", () => {
             expect(url.searchParams.get("limit")).toBe("10");
             expect(url.searchParams.get("offset")).toBe("5");
         });
+
+        describe("contract", () => {
+            it("round-trips has_more: true", async () => {
+                const data = { documents: [], total: 50, limit: 20, offset: 0, has_more: true };
+                fetchMock.mockResolvedValue(jsonResponse(data));
+                const result = await client.listDocuments();
+                expect(result.has_more).toBe(true);
+                expect(result).toEqual(data);
+            });
+
+            it("round-trips has_more: false", async () => {
+                const data = { documents: [], total: 50, limit: 20, offset: 40, has_more: false };
+                fetchMock.mockResolvedValue(jsonResponse(data));
+                const result = await client.listDocuments(undefined, 20, 40);
+                expect(result.has_more).toBe(false);
+                expect(result).toEqual(data);
+            });
+
+            it("legacy response without has_more leaves the field undefined", async () => {
+                const data = { documents: [], total: 0, limit: 20, offset: 0 };
+                fetchMock.mockResolvedValue(jsonResponse(data));
+                const result = await client.listDocuments();
+                expect(result.has_more).toBeUndefined();
+            });
+        });
     });
 
     describe("removeDocuments()", () => {

--- a/tests/views/documents-modal.test.ts
+++ b/tests/views/documents-modal.test.ts
@@ -479,6 +479,129 @@ describe("DocumentsModal", () => {
         // Should not throw
     });
 
+    it("stops paginating when has_more is false, even with offset < total", async () => {
+        const page1 = Array.from({ length: 20 }, (_, i) => makeDoc({ filename: `f${i}.md` }));
+        const plugin = makePlugin();
+        plugin.api.listDocuments.mockResolvedValue({
+            documents: page1,
+            total: 999,
+            limit: 20,
+            offset: 0,
+            has_more: false,
+        });
+        const app = new App();
+        const modal = new DocumentsModal(app as any, plugin as any);
+        modal.open();
+        await vi.runAllTimersAsync();
+        plugin.api.listDocuments.mockClear();
+
+        const el = (modal as any).resultsEl as MockElement;
+        Object.assign(el, { scrollTop: 800, clientHeight: 400, scrollHeight: 1100 });
+        (modal as any).onScroll();
+        await vi.runAllTimersAsync();
+
+        expect(plugin.api.listDocuments).not.toHaveBeenCalled();
+    });
+
+    it("keeps paginating when has_more is true, even if offset equals total", async () => {
+        const page1 = Array.from({ length: 20 }, (_, i) => makeDoc({ filename: `f${i}.md` }));
+        const page2 = [makeDoc({ filename: "f20.md" })];
+        const plugin = makePlugin();
+        plugin.api.listDocuments
+            .mockResolvedValueOnce({
+                documents: page1,
+                total: 20,
+                limit: 20,
+                offset: 0,
+                has_more: true,
+            })
+            .mockResolvedValueOnce({
+                documents: page2,
+                total: 20,
+                limit: 20,
+                offset: 20,
+                has_more: false,
+            });
+        const app = new App();
+        const modal = new DocumentsModal(app as any, plugin as any);
+        modal.open();
+        await vi.runAllTimersAsync();
+
+        const el = (modal as any).resultsEl as MockElement;
+        Object.assign(el, { scrollTop: 800, clientHeight: 400, scrollHeight: 1100 });
+        (modal as any).onScroll();
+        await vi.runAllTimersAsync();
+
+        expect(plugin.api.listDocuments).toHaveBeenCalledTimes(2);
+        expect(plugin.api.listDocuments).toHaveBeenLastCalledWith(undefined, 20, 20);
+    });
+
+    it("falls back to offset>=total when has_more is absent (legacy server)", async () => {
+        const docs = [makeDoc({ filename: "only.md" })];
+        const plugin = makePlugin();
+        plugin.api.listDocuments.mockResolvedValue(makeDocsResponse(docs, 1));
+        const app = new App();
+        const modal = new DocumentsModal(app as any, plugin as any);
+        modal.open();
+        await vi.runAllTimersAsync();
+        plugin.api.listDocuments.mockClear();
+
+        const el = (modal as any).resultsEl as MockElement;
+        Object.assign(el, { scrollTop: 800, clientHeight: 400, scrollHeight: 1100 });
+        (modal as any).onScroll();
+        await vi.runAllTimersAsync();
+
+        expect(plugin.api.listDocuments).not.toHaveBeenCalled();
+    });
+
+    it("legacy server: stops when response returns zero rows", async () => {
+        const page1 = Array.from({ length: 20 }, (_, i) => makeDoc({ filename: `f${i}.md` }));
+        const plugin = makePlugin();
+        plugin.api.listDocuments
+            .mockResolvedValueOnce(makeDocsResponse(page1, 999))
+            .mockResolvedValueOnce(makeDocsResponse([], 999));
+        const app = new App();
+        const modal = new DocumentsModal(app as any, plugin as any);
+        modal.open();
+        await vi.runAllTimersAsync();
+
+        const el = (modal as any).resultsEl as MockElement;
+        Object.assign(el, { scrollTop: 800, clientHeight: 400, scrollHeight: 1100 });
+        (modal as any).onScroll();
+        await vi.runAllTimersAsync();
+        plugin.api.listDocuments.mockClear();
+        (modal as any).onScroll();
+        await vi.runAllTimersAsync();
+
+        expect(plugin.api.listDocuments).not.toHaveBeenCalled();
+    });
+
+    it("resetAndFetch re-enables pagination after a terminal page", async () => {
+        const plugin = makePlugin();
+        plugin.api.listDocuments.mockResolvedValue({
+            documents: [makeDoc()],
+            total: 1,
+            limit: 20,
+            offset: 0,
+            has_more: false,
+        });
+        const app = new App();
+        const modal = new DocumentsModal(app as any, plugin as any);
+        modal.open();
+        await vi.runAllTimersAsync();
+        expect((modal as any).hasMore).toBe(false);
+
+        const el = modal.contentEl as unknown as MockElement;
+        const searchInput = el.find("lilbee-documents-search")!;
+        (searchInput as any).value = "query";
+        searchInput.trigger("input");
+        await vi.advanceTimersByTimeAsync(300);
+        await vi.runAllTimersAsync();
+
+        // hasMore resets to the new response's has_more, but was true between reset and fetch
+        expect(plugin.api.listDocuments).toHaveBeenLastCalledWith("query", 20, 0);
+    });
+
     it("does not call removeDocuments when nothing selected", async () => {
         vi.useRealTimers();
         const plugin = makePlugin();


### PR DESCRIPTION
## What

Hardens the plugin's `DocumentsModal` pagination against an upstream server change that moves `/api/documents` pagination into the DB layer and adds a `has_more` field to the response. Target branch is `feature/server-api-parity` (the 0.2 integration branch).

## Why

The modal's only stop signal was `this.offset >= this.total`. That breaks on the new server if `total` semantics shift, and it can't recover from a short non-final page — the loop would either spin, duplicate rows, or truncate the list. The change is small, but the failure mode is invisible (the user just sees a partial list), so it's worth locking down before the server-side change lands.

## What changed

- **`src/types.ts`** — `DocumentsResponse` picks up an optional `has_more?: boolean`. Optional so the plugin still works against older servers during the rollout window.
- **`src/views/documents-modal.ts`** — adds a `hasMore` field, uses it as the bail condition in `onScroll`, and updates it per response: `has_more` from the server when present, otherwise falls back to the equivalent `documents.length > 0 && offset < total` check. `resetAndFetch` re-enables it alongside `offset = 0`.
- **`tests/views/documents-modal.test.ts`** — new tests covering: `has_more: false` stops pagination even when `offset < total`; `has_more: true` keeps fetching even when `offset === total`; legacy-response (no `has_more`) fallback behavior; legacy zero-row termination; reset-on-search re-enabling the fetch loop.
- **`tests/api.test.ts`** — new `listDocuments() contract` block that round-trips `has_more: true`, `has_more: false`, and the legacy (absent) shape through the typed client.

Behavior against today's server is unchanged — the legacy branch preserves the old semantics expressed through the new field.

## Follow-up (separate PR)

Once the plugin's pinned server version crosses this change, drop the `?` on `has_more` and remove the legacy fallback branch in the modal.