### PR TITLE
Forward the chat toolbar scope toggle to /api/chat/stream

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,4 @@
-import { JSON_HEADERS, SSE_EVENT, ERROR_NAME } from "./types";
+import { JSON_HEADERS, SEARCH_CHUNK_TYPE, SSE_EVENT, ERROR_NAME } from "./types";
 import { ok, err, Result } from "neverthrow";
 
 import type {
@@ -185,7 +185,7 @@ export class LilbeeClient {
     async search(query: string, topK?: number, chunkType?: SearchChunkType): Promise<DocumentResult[]> {
         const params = new URLSearchParams({ q: query });
         if (topK !== undefined) params.set("top_k", String(topK));
-        if (chunkType && chunkType !== "all") params.set("chunk_type", chunkType);
+        if (chunkType && chunkType !== SEARCH_CHUNK_TYPE.ALL) params.set("chunk_type", chunkType);
         const res = await this.fetchWithRetry(`${this.baseUrl}/api/search?${params}`);
         return res.json();
     }
@@ -209,8 +209,8 @@ export class LilbeeClient {
     ): AsyncGenerator<SSEEvent> {
         const body: Record<string, unknown> = { question, history, top_k: topK ?? 0 };
         if (options && Object.keys(options).length > 0) body.options = options;
-        // "all" is the UI-side label for no filter; the server expects null/omit.
-        if (chunkType && chunkType !== "all") body.chunk_type = chunkType;
+        // "all" is the UI-side label for no filter; the field is omitted on the wire.
+        if (chunkType && chunkType !== SEARCH_CHUNK_TYPE.ALL) body.chunk_type = chunkType;
         const res = await this.fetchWithRetry(
             `${this.baseUrl}/api/chat/stream`,
             {

--- a/src/api.ts
+++ b/src/api.ts
@@ -205,9 +205,12 @@ export class LilbeeClient {
         topK?: number,
         signal?: AbortSignal,
         options?: GenerationOptions,
+        chunkType?: SearchChunkType,
     ): AsyncGenerator<SSEEvent> {
         const body: Record<string, unknown> = { question, history, top_k: topK ?? 0 };
         if (options && Object.keys(options).length > 0) body.options = options;
+        // "all" is the UI-side label for no filter; the server expects null/omit.
+        if (chunkType && chunkType !== "all") body.chunk_type = chunkType;
         const res = await this.fetchWithRetry(
             `${this.baseUrl}/api/chat/stream`,
             {

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,6 +141,12 @@ export const SERVER_MODE = {
 
 export type SearchChunkType = "all" | "wiki" | "raw";
 
+export const SEARCH_CHUNK_TYPE = {
+    ALL: "all",
+    WIKI: "wiki",
+    RAW: "raw",
+} as const satisfies Record<string, SearchChunkType>;
+
 export interface LilbeeSettings {
     serverUrl: string;
     topK: number;

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -528,6 +528,8 @@ export class ChatView extends ItemView {
                 this.history.slice(0, -1),
                 this.plugin.settings.topK,
                 this.streamController.signal,
+                undefined,
+                this.plugin.settings.searchChunkType,
             )) {
                 this.handleStreamEvent(event, textEl, assistantBubble, state, revealContent, scheduleRender);
             }

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -208,6 +208,42 @@ describe("chatStream()", () => {
         const body = JSON.parse(fetchMock.mock.calls[0][1].body);
         expect(body.options).toBeUndefined();
     });
+
+    it("includes chunk_type when chunkType is 'wiki'", async () => {
+        fetchMock.mockResolvedValue(sseResponse([]));
+
+        await collect(client.chatStream("q", [], 0, undefined, undefined, "wiki"));
+
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.chunk_type).toBe("wiki");
+    });
+
+    it("includes chunk_type when chunkType is 'raw'", async () => {
+        fetchMock.mockResolvedValue(sseResponse([]));
+
+        await collect(client.chatStream("q", [], 0, undefined, undefined, "raw"));
+
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.chunk_type).toBe("raw");
+    });
+
+    it("omits chunk_type when chunkType is 'all'", async () => {
+        fetchMock.mockResolvedValue(sseResponse([]));
+
+        await collect(client.chatStream("q", [], 0, undefined, undefined, "all"));
+
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.chunk_type).toBeUndefined();
+    });
+
+    it("omits chunk_type when chunkType is undefined", async () => {
+        fetchMock.mockResolvedValue(sseResponse([]));
+
+        await collect(client.chatStream("q", []));
+
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.chunk_type).toBeUndefined();
+    });
 });
 
 describe("addFiles()", () => {

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -295,7 +295,14 @@ describe("ChatView.onOpen — send button triggers send", () => {
         container.find("lilbee-chat-send")!.trigger("click");
         await done;
 
-        expect(plugin.api.chatStream).toHaveBeenCalledWith("hello", [], 5, expect.any(AbortSignal));
+        expect(plugin.api.chatStream).toHaveBeenCalledWith(
+            "hello",
+            [],
+            5,
+            expect.any(AbortSignal),
+            undefined,
+            "all",
+        );
     });
 
     it("clears textarea value after send", async () => {
@@ -2126,7 +2133,63 @@ describe("ChatView.sendMessage — does not send generation overrides", () => {
         container.find("lilbee-chat-send")!.trigger("click");
         await done;
 
-        expect(plugin.api.chatStream).toHaveBeenCalledWith("hi", [], 5, expect.any(AbortSignal));
+        expect(plugin.api.chatStream).toHaveBeenCalledWith(
+            "hi",
+            [],
+            5,
+            expect.any(AbortSignal),
+            undefined,
+            "all",
+        );
+    });
+});
+
+
+describe("ChatView.sendMessage — forwards searchChunkType", () => {
+    it("passes 'wiki' when the setting is 'wiki'", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        plugin.settings.searchChunkType = "wiki";
+        const { mockFn, done } = makeStream([{ event: SSE_EVENT.DONE, data: {} }]);
+        plugin.api.chatStream = mockFn;
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const textarea = container.find("lilbee-chat-textarea")!;
+        textarea.value = "q";
+        container.find("lilbee-chat-send")!.trigger("click");
+        await done;
+        expect(plugin.api.chatStream).toHaveBeenCalledWith(
+            "q",
+            [],
+            5,
+            expect.any(AbortSignal),
+            undefined,
+            "wiki",
+        );
+    });
+
+    it("passes 'raw' when the setting is 'raw'", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        plugin.settings.searchChunkType = "raw";
+        const { mockFn, done } = makeStream([{ event: SSE_EVENT.DONE, data: {} }]);
+        plugin.api.chatStream = mockFn;
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const textarea = container.find("lilbee-chat-textarea")!;
+        textarea.value = "q";
+        container.find("lilbee-chat-send")!.trigger("click");
+        await done;
+        expect(plugin.api.chatStream).toHaveBeenCalledWith(
+            "q",
+            [],
+            5,
+            expect.any(AbortSignal),
+            undefined,
+            "raw",
+        );
     });
 });
 

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -295,14 +295,7 @@ describe("ChatView.onOpen — send button triggers send", () => {
         container.find("lilbee-chat-send")!.trigger("click");
         await done;
 
-        expect(plugin.api.chatStream).toHaveBeenCalledWith(
-            "hello",
-            [],
-            5,
-            expect.any(AbortSignal),
-            undefined,
-            "all",
-        );
+        expect(plugin.api.chatStream).toHaveBeenCalledWith("hello", [], 5, expect.any(AbortSignal), undefined, "all");
     });
 
     it("clears textarea value after send", async () => {
@@ -2133,17 +2126,9 @@ describe("ChatView.sendMessage — does not send generation overrides", () => {
         container.find("lilbee-chat-send")!.trigger("click");
         await done;
 
-        expect(plugin.api.chatStream).toHaveBeenCalledWith(
-            "hi",
-            [],
-            5,
-            expect.any(AbortSignal),
-            undefined,
-            "all",
-        );
+        expect(plugin.api.chatStream).toHaveBeenCalledWith("hi", [], 5, expect.any(AbortSignal), undefined, "all");
     });
 });
-
 
 describe("ChatView.sendMessage — forwards searchChunkType", () => {
     it("passes 'wiki' when the setting is 'wiki'", async () => {
@@ -2159,14 +2144,7 @@ describe("ChatView.sendMessage — forwards searchChunkType", () => {
         textarea.value = "q";
         container.find("lilbee-chat-send")!.trigger("click");
         await done;
-        expect(plugin.api.chatStream).toHaveBeenCalledWith(
-            "q",
-            [],
-            5,
-            expect.any(AbortSignal),
-            undefined,
-            "wiki",
-        );
+        expect(plugin.api.chatStream).toHaveBeenCalledWith("q", [], 5, expect.any(AbortSignal), undefined, "wiki");
     });
 
     it("passes 'raw' when the setting is 'raw'", async () => {
@@ -2182,14 +2160,7 @@ describe("ChatView.sendMessage — forwards searchChunkType", () => {
         textarea.value = "q";
         container.find("lilbee-chat-send")!.trigger("click");
         await done;
-        expect(plugin.api.chatStream).toHaveBeenCalledWith(
-            "q",
-            [],
-            5,
-            expect.any(AbortSignal),
-            undefined,
-            "raw",
-        );
+        expect(plugin.api.chatStream).toHaveBeenCalledWith("q", [], 5, expect.any(AbortSignal), undefined, "raw");
     });
 });
 


### PR DESCRIPTION
## What this fixes

The chat toolbar has an All / Wiki / Raw toggle. Before this PR, clicking it updated settings but had no effect on what chat actually saw — the toggle was cosmetic. Asking with "Wiki" selected still pulled from raw source chunks.

## What changes

### The toggle takes effect on the very next message

Picking **Wiki** narrows chat retrieval to wiki pages. Picking **Raw** narrows it to source documents. **All** searches across both. The choice applies from the next question onward, no reload needed.

### The Wiki option hides when wiki is off

If wiki generation isn't enabled on the server, the Wiki button disappears from the toolbar — you see only All and Raw, and the chat defaults to All. Nothing to pick between when there's nothing to pick.