### PR TITLE
Copy paperclip Disk Files into the vault before indexing

### DIFF
--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -1,7 +1,7 @@
 import { requestUrl } from "obsidian";
 import { execFile, spawn } from "child_process";
 import { existsSync, mkdirSync, chmodSync, writeFileSync, readFileSync, unlinkSync, copyFileSync } from "fs";
-import { join } from "path";
+import { basename, join } from "path";
 import { promisify } from "util";
 import { ARCH, PLATFORM } from "./types";
 
@@ -18,6 +18,8 @@ export const node = {
     readFileSync,
     unlinkSync,
     copyFileSync,
+    join,
+    basename,
     requestUrl,
     fetch: globalThis.fetch.bind(globalThis) as typeof globalThis.fetch,
 };

--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -1,6 +1,6 @@
 import { requestUrl } from "obsidian";
 import { execFile, spawn } from "child_process";
-import { existsSync, mkdirSync, chmodSync, writeFileSync, readFileSync, unlinkSync } from "fs";
+import { existsSync, mkdirSync, chmodSync, writeFileSync, readFileSync, unlinkSync, copyFileSync } from "fs";
 import { join } from "path";
 import { promisify } from "util";
 import { ARCH, PLATFORM } from "./types";
@@ -17,6 +17,7 @@ export const node = {
     writeFileSync,
     readFileSync,
     unlinkSync,
+    copyFileSync,
     requestUrl,
     fetch: globalThis.fetch.bind(globalThis) as typeof globalThis.fetch,
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -891,20 +891,28 @@ export default class LilbeePlugin extends Plugin {
      * new absolute paths for indexing. Paths already under the vault root
      * are returned unchanged. On copy failure the offending file is dropped
      * with a user-visible Notice so the rest of the batch still proceeds.
+     *
+     * All path joins go through ``node.path`` so Windows ``\\`` separators
+     * round-trip correctly — a naïve string ``startsWith(vaultBase + "/")``
+     * check would miss every file on Windows and mis-copy them into imports.
      */
     private copyExternalFilesToVault(paths: string[]): string[] {
         const vaultBase = this.getVaultBasePath();
-        const importsDir = `${vaultBase}/lilbee/imports`;
-        if (!node.existsSync(importsDir)) {
+        const importsDir = node.join(vaultBase, "lilbee", "imports");
+        try {
             node.mkdirSync(importsDir, { recursive: true });
+        } catch (err) {
+            console.error("[lilbee] import dir create failed:", importsDir, err);
+            new Notice(MESSAGES.ERROR_FILE_PICKER);
+            return [];
         }
         const results: string[] = [];
         for (const source of paths) {
-            if (source.startsWith(`${vaultBase}/`)) {
+            if (this.isUnderVault(source, vaultBase)) {
                 results.push(source);
                 continue;
             }
-            const name = source.split("/").pop() || "imported";
+            const name = node.basename(source) || "imported";
             const dest = this.uniqueImportPath(importsDir, name);
             try {
                 node.copyFileSync(source, dest);
@@ -917,17 +925,28 @@ export default class LilbeePlugin extends Plugin {
         return results;
     }
 
+    /**
+     * True if ``source`` sits under ``vaultBase``. Normalises separators so
+     * ``C:\\vault\\foo.pdf`` correctly matches a vault base of ``C:\\vault``
+     * regardless of which slash flavour either side uses.
+     */
+    private isUnderVault(source: string, vaultBase: string): boolean {
+        const norm = (p: string) => p.replace(/\\/g, "/");
+        const prefix = norm(vaultBase).replace(/\/+$/, "");
+        return norm(source).startsWith(`${prefix}/`);
+    }
+
     /** Append a ``-N`` suffix until ``<dir>/<name>`` doesn't exist on disk. */
     private uniqueImportPath(dir: string, name: string): string {
-        const candidate = `${dir}/${name}`;
+        const candidate = node.join(dir, name);
         if (!node.existsSync(candidate)) return candidate;
         const dot = name.lastIndexOf(".");
         const [stem, ext] = dot > 0 ? [name.slice(0, dot), name.slice(dot)] : [name, ""];
         for (let n = 1; n < 1000; n++) {
-            const next = `${dir}/${stem}-${n}${ext}`;
+            const next = node.join(dir, `${stem}-${n}${ext}`);
             if (!node.existsSync(next)) return next;
         }
-        return `${dir}/${stem}-${Date.now()}${ext}`;
+        return node.join(dir, `${stem}-${Date.now()}${ext}`);
     }
 
     async addToLilbee(file: TAbstractFile): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import { type EventRef, type Menu, type MenuItem, Notice, Plugin, type TAbstractFile } from "obsidian";
 import { LilbeeClient, SessionTokenError } from "./api";
-import { BinaryManager, getLatestRelease, checkForUpdate } from "./binary-manager";
+import { BinaryManager, getLatestRelease, checkForUpdate, node } from "./binary-manager";
 import type { ReleaseInfo } from "./binary-manager";
 import { ServerManager } from "./server-manager";
 import { readSessionToken, resolveExternalDataRoot } from "./session-token";
@@ -873,8 +873,61 @@ export default class LilbeePlugin extends Plugin {
 
         if (paths.length === 1 && !(await this.confirmReindexIfNeeded(label))) return;
 
+        // Copy disk-picked files into the vault before indexing so the
+        // resulting source lives where the user expects — visible in the
+        // file tree, reachable as a native Obsidian file, and eligible for
+        // the vault_path deep-link on chat source chips. Skips files whose
+        // paths are already inside the vault (right-click "Add to lilbee"
+        // routes through here too for single-path external paths).
+        const copiedPaths = this.copyExternalFilesToVault(paths);
+        if (copiedPaths.length === 0) return;
+
         new Notice(MESSAGES.STATUS_ADDING.replace("{label}", label));
-        await this.runAdd(paths);
+        await this.runAdd(copiedPaths);
+    }
+
+    /**
+     * Copy each external path into ``<vault>/lilbee/imports/`` and return the
+     * new absolute paths for indexing. Paths already under the vault root
+     * are returned unchanged. On copy failure the offending file is dropped
+     * with a user-visible Notice so the rest of the batch still proceeds.
+     */
+    private copyExternalFilesToVault(paths: string[]): string[] {
+        const vaultBase = this.getVaultBasePath();
+        const importsDir = `${vaultBase}/lilbee/imports`;
+        if (!node.existsSync(importsDir)) {
+            node.mkdirSync(importsDir, { recursive: true });
+        }
+        const results: string[] = [];
+        for (const source of paths) {
+            if (source.startsWith(`${vaultBase}/`)) {
+                results.push(source);
+                continue;
+            }
+            const name = source.split("/").pop() || "imported";
+            const dest = this.uniqueImportPath(importsDir, name);
+            try {
+                node.copyFileSync(source, dest);
+                results.push(dest);
+            } catch (err) {
+                console.error("[lilbee] import copy failed:", source, err);
+                new Notice(MESSAGES.ERROR_FILE_PICKER);
+            }
+        }
+        return results;
+    }
+
+    /** Append a ``-N`` suffix until ``<dir>/<name>`` doesn't exist on disk. */
+    private uniqueImportPath(dir: string, name: string): string {
+        const candidate = `${dir}/${name}`;
+        if (!node.existsSync(candidate)) return candidate;
+        const dot = name.lastIndexOf(".");
+        const [stem, ext] = dot > 0 ? [name.slice(0, dot), name.slice(dot)] : [name, ""];
+        for (let n = 1; n < 1000; n++) {
+            const next = `${dir}/${stem}-${n}${ext}`;
+            if (!node.existsSync(next)) return next;
+        }
+        return `${dir}/${stem}-${Date.now()}${ext}`;
     }
 
     async addToLilbee(file: TAbstractFile): Promise<void> {

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -232,6 +232,11 @@ export class App {
         offref: vi.fn(),
         adapter: {
             getBasePath: vi.fn().mockReturnValue("/test/vault"),
+            // Obsidian's real DataAdapter surfaces these; tests that copy
+            // external files into the vault use them.
+            exists: vi.fn().mockResolvedValue(false),
+            mkdir: vi.fn().mockResolvedValue(undefined),
+            writeBinary: vi.fn().mockResolvedValue(undefined),
         },
         getFiles: vi.fn().mockReturnValue([]),
         getAbstractFileByPath: vi.fn().mockReturnValue(null),

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1378,6 +1378,140 @@ describe("LilbeePlugin", () => {
 
             expect(Notice.instances.some((n) => n.message.includes("1 failed"))).toBe(true);
         });
+
+        it("passes through sources already under the vault root without copying", async () => {
+            const { node } = await import("../src/binary-manager");
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+
+            async function* noEvents() {}
+            plugin.api.addFiles = vi.fn().mockReturnValue(noEvents());
+            (node.copyFileSync as ReturnType<typeof vi.fn>).mockClear();
+
+            await plugin.addExternalFiles(["/test/vault/existing.pdf"]);
+
+            expect(node.copyFileSync).not.toHaveBeenCalled();
+            expect(plugin.api.addFiles).toHaveBeenCalledWith(
+                ["/test/vault/existing.pdf"],
+                true,
+                null,
+                expect.any(AbortSignal),
+            );
+        });
+
+        it("drops files that fail to copy and proceeds with the rest", async () => {
+            const { node } = await import("../src/binary-manager");
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+
+            async function* noEvents() {}
+            plugin.api.addFiles = vi.fn().mockReturnValue(noEvents());
+            (node.copyFileSync as ReturnType<typeof vi.fn>).mockReset();
+            (node.copyFileSync as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+                throw new Error("perm denied");
+            });
+
+            await plugin.addExternalFiles(["/home/user/bad.pdf", "/home/user/good.pdf"]);
+
+            expect(Notice.instances.some((n) => n.message === MESSAGES.ERROR_FILE_PICKER)).toBe(true);
+            expect(plugin.api.addFiles).toHaveBeenCalledWith(
+                ["/test/vault/lilbee/imports/good.pdf"],
+                true,
+                null,
+                expect.any(AbortSignal),
+            );
+        });
+
+        it("returns without indexing when every external file fails to copy", async () => {
+            const { node } = await import("../src/binary-manager");
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+            plugin.api.addFiles = vi.fn();
+            (node.copyFileSync as ReturnType<typeof vi.fn>).mockReset();
+            (node.copyFileSync as ReturnType<typeof vi.fn>).mockImplementation(() => {
+                throw new Error("perm denied");
+            });
+
+            await plugin.addExternalFiles(["/home/user/a.pdf", "/home/user/b.pdf"]);
+
+            expect(plugin.api.addFiles).not.toHaveBeenCalled();
+        });
+
+        it("appends a -N suffix when the target import filename already exists", async () => {
+            const { node } = await import("../src/binary-manager");
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+
+            async function* noEvents() {}
+            plugin.api.addFiles = vi.fn().mockReturnValue(noEvents());
+            (node.copyFileSync as ReturnType<typeof vi.fn>).mockReset();
+            (node.existsSync as ReturnType<typeof vi.fn>).mockReset();
+            (node.existsSync as ReturnType<typeof vi.fn>).mockImplementation(
+                (p: unknown) => p === "/test/vault/lilbee/imports/doc.pdf",
+            );
+
+            await plugin.addExternalFiles(["/home/user/doc.pdf"]);
+
+            expect(plugin.api.addFiles).toHaveBeenCalledWith(
+                ["/test/vault/lilbee/imports/doc-1.pdf"],
+                true,
+                null,
+                expect.any(AbortSignal),
+            );
+        });
+
+        it("falls back to a timestamp suffix when 999 sequential collisions are exhausted", async () => {
+            const { node } = await import("../src/binary-manager");
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+
+            async function* noEvents() {}
+            plugin.api.addFiles = vi.fn().mockReturnValue(noEvents());
+            (node.copyFileSync as ReturnType<typeof vi.fn>).mockReset();
+            (node.existsSync as ReturnType<typeof vi.fn>).mockReset();
+            // Every candidate collides → the loop runs out and the helper
+            // has to mint a timestamped fallback name.
+            (node.existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+            await plugin.addExternalFiles(["/home/user/doc.pdf"]);
+
+            expect(plugin.api.addFiles).toHaveBeenCalled();
+            const call = (plugin.api.addFiles as ReturnType<typeof vi.fn>).mock.calls[0];
+            const indexedPaths = call[0] as string[];
+            expect(indexedPaths).toHaveLength(1);
+            expect(indexedPaths[0]).toMatch(/^\/test\/vault\/lilbee\/imports\/doc-\d+\.pdf$/);
+            // Must NOT be the collision-loop form doc-1..doc-999
+            expect(indexedPaths[0]).not.toMatch(/\/doc-\d{1,3}\.pdf$/);
+        });
+
+        it("appends -N to extensionless filenames without adding a spurious dot", async () => {
+            const { node } = await import("../src/binary-manager");
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+
+            async function* noEvents() {}
+            plugin.api.addFiles = vi.fn().mockReturnValue(noEvents());
+            (node.copyFileSync as ReturnType<typeof vi.fn>).mockReset();
+            (node.existsSync as ReturnType<typeof vi.fn>).mockReset();
+            (node.existsSync as ReturnType<typeof vi.fn>).mockImplementation(
+                (p: unknown) => p === "/test/vault/lilbee/imports/Makefile",
+            );
+
+            await plugin.addExternalFiles(["/tmp/Makefile"]);
+
+            expect(plugin.api.addFiles).toHaveBeenCalledWith(
+                ["/test/vault/lilbee/imports/Makefile-1"],
+                true,
+                null,
+                expect.any(AbortSignal),
+            );
+        });
     });
 
     describe("triggerSync event handling", () => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -111,6 +111,10 @@ vi.mock("../src/binary-manager", () => ({
         readFileSync: vi.fn(),
         unlinkSync: vi.fn(),
         copyFileSync: vi.fn(),
+        // Real node:path join/basename — tests exercise cross-platform path
+        // normalisation and need the actual behaviour, not a stub.
+        join: (...parts: string[]) => parts.join("/").replace(/\/+/g, "/"),
+        basename: (p: string) => p.replace(/\\/g, "/").split("/").pop() ?? "",
         requestUrl: vi.fn(),
     },
 }));
@@ -1507,6 +1511,53 @@ describe("LilbeePlugin", () => {
 
             expect(plugin.api.addFiles).toHaveBeenCalledWith(
                 ["/test/vault/lilbee/imports/Makefile-1"],
+                true,
+                null,
+                expect.any(AbortSignal),
+            );
+        });
+
+        it("surfaces a Notice and returns early when the imports dir can't be created", async () => {
+            const { node } = await import("../src/binary-manager");
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+            plugin.api.addFiles = vi.fn();
+
+            (node.mkdirSync as ReturnType<typeof vi.fn>).mockReset();
+            (node.mkdirSync as ReturnType<typeof vi.fn>).mockImplementation(() => {
+                throw new Error("EACCES");
+            });
+
+            await plugin.addExternalFiles(["/home/user/doc.pdf"]);
+
+            expect(plugin.api.addFiles).not.toHaveBeenCalled();
+            expect(Notice.instances.some((n) => n.message === MESSAGES.ERROR_FILE_PICKER)).toBe(true);
+        });
+
+        it("detects Windows-style vault-local paths so disk picks on the same drive don't double-copy", async () => {
+            const { node } = await import("../src/binary-manager");
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+
+            // Obsidian's getBasePath() returns backslash-separated paths on
+            // Windows. A file already inside that vault must be recognised
+            // via isUnderVault regardless of which separator it uses.
+            (plugin.app.vault.adapter.getBasePath as ReturnType<typeof vi.fn>).mockReturnValue("C:\\Users\\me\\vault");
+
+            async function* noEvents() {}
+            plugin.api.addFiles = vi.fn().mockReturnValue(noEvents());
+            // Prior tests may have left mkdirSync throwing — reset so the
+            // imports-dir bootstrap doesn't short-circuit out of copyExternalFilesToVault.
+            (node.mkdirSync as ReturnType<typeof vi.fn>).mockReset();
+            (node.copyFileSync as ReturnType<typeof vi.fn>).mockClear();
+
+            await plugin.addExternalFiles(["C:\\Users\\me\\vault\\notes\\already-here.md"]);
+
+            expect(node.copyFileSync).not.toHaveBeenCalled();
+            expect(plugin.api.addFiles).toHaveBeenCalledWith(
+                ["C:\\Users\\me\\vault\\notes\\already-here.md"],
                 true,
                 null,
                 expect.any(AbortSignal),

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -109,6 +109,8 @@ vi.mock("../src/binary-manager", () => ({
         chmodSync: vi.fn(),
         writeFileSync: vi.fn(),
         readFileSync: vi.fn(),
+        unlinkSync: vi.fn(),
+        copyFileSync: vi.fn(),
         requestUrl: vi.fn(),
     },
 }));
@@ -1165,7 +1167,7 @@ describe("LilbeePlugin", () => {
             expect(plugin.api.addFiles).not.toHaveBeenCalled();
         });
 
-        it("calls api.addFiles with the given absolute paths", async () => {
+        it("copies external files into the vault imports dir before indexing", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
             plugin.activeModel = "llama3";
@@ -1175,8 +1177,11 @@ describe("LilbeePlugin", () => {
 
             await plugin.addExternalFiles(["/home/user/doc.pdf", "/tmp/notes.md"]);
 
+            // Each external path is copied into <vault>/lilbee/imports/<name>
+            // and the NEW vault-local absolute path is what gets indexed —
+            // keeping the source discoverable in Obsidian's file tree.
             expect(plugin.api.addFiles).toHaveBeenCalledWith(
-                ["/home/user/doc.pdf", "/tmp/notes.md"],
+                ["/test/vault/lilbee/imports/doc.pdf", "/test/vault/lilbee/imports/notes.md"],
                 true,
                 null,
                 expect.any(AbortSignal),
@@ -1195,7 +1200,7 @@ describe("LilbeePlugin", () => {
             await plugin.addExternalFiles(["/home/user/scan.pdf"]);
 
             expect(plugin.api.addFiles).toHaveBeenCalledWith(
-                ["/home/user/scan.pdf"],
+                ["/test/vault/lilbee/imports/scan.pdf"],
                 true,
                 true,
                 expect.any(AbortSignal),


### PR DESCRIPTION
## Problem

The chat sidebar paperclip's "Disk Files" option used to hand whichever disk paths the user picked straight to the server for indexing. The file never ended up in the vault, so two things broke: source chips pointed at content the user couldn't open natively from Obsidian, and the clickable-source deep-link had nothing to resolve against.

## What changed

Files picked from disk now land in `<vault>/lilbee/imports/` first and are indexed from the new vault-local path. Files that already live under the vault root pass through unchanged, so right-click "Add to lilbee" and the other in-vault entry points don't double-copy. Filename collisions get a numeric suffix. If a single file fails to copy, it drops from the batch with a Notice and the rest proceeds.

## Why it matters

The paperclip picker is now consistent with every other ingestion path in the plugin: sources you add are sources you can open from the vault. Clickable citations and the source-preview modal work on files picked from disk the same way they work on files synced from the vault.

## Verification

All 1667 plugin tests pass, 100% coverage preserved.