### PR TITLE
Status bar dot opens lilbee settings

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -190,6 +190,7 @@ export const MESSAGES = {
     LABEL_CHAT_VIEW: "lilbee Chat",
     LABEL_TASKS_VIEW: "lilbee Tasks",
     LABEL_RIBBON_OPEN_TASK_CENTER: "Open lilbee Task Center",
+    LABEL_STATUSBAR_OPEN_SETTINGS: "Open lilbee settings",
     ERROR_STREAM_IDLE: "server stopped sending events — check that lilbee is running",
     LABEL_SKIP_SETUP: "Skip setup",
     LABEL_OUR_PICKS: "Our picks",

--- a/src/main.ts
+++ b/src/main.ts
@@ -193,7 +193,8 @@ export default class LilbeePlugin extends Plugin {
 
         this.statusBarEl = this.addStatusBarItem();
         this.statusBarEl.style.cursor = "pointer";
-        this.statusBarEl.addEventListener("click", () => this.activateTaskView());
+        this.statusBarEl.setAttribute("aria-label", MESSAGES.LABEL_STATUSBAR_OPEN_SETTINGS);
+        this.statusBarEl.addEventListener("click", () => this.openPluginSettings());
         this.ribbonIconEl = this.addRibbonIcon("list-checks", MESSAGES.LABEL_RIBBON_OPEN_TASK_CENTER, () =>
             this.activateTaskView(),
         );
@@ -1085,6 +1086,16 @@ export default class LilbeePlugin extends Plugin {
             await leaf.setViewState({ type: VIEW_TYPE_TASKS, active: true });
             this.app.workspace.revealLeaf(leaf);
         }
+    }
+
+    openPluginSettings(): void {
+        // `app.setting` is an undocumented-but-stable Obsidian API used
+        // widely by community plugins to jump straight to their own tab.
+        const setting = (this.app as unknown as { setting?: { open: () => void; openTabById: (id: string) => void } })
+            .setting;
+        if (!setting) return;
+        setting.open();
+        setting.openTabById(this.manifest.id);
     }
 
     async activateWikiView(): Promise<void> {

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -227,6 +227,13 @@ export class App {
         on: vi.fn().mockReturnValue({ id: "mock-event" }),
         getActiveFile: vi.fn().mockReturnValue(null),
     };
+    // Undocumented-but-stable Obsidian API used by plugins to open their
+    // own Settings tab. Tests may replace this with `undefined` to exercise
+    // the defensive guard.
+    setting: { open: ReturnType<typeof vi.fn>; openTabById: ReturnType<typeof vi.fn> } | undefined = {
+        open: vi.fn(),
+        openTabById: vi.fn(),
+    };
     vault = {
         on: vi.fn().mockReturnValue({ id: "mock-vault-event" }),
         offref: vi.fn(),

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -2654,6 +2654,38 @@ describe("LilbeePlugin", () => {
             expect(spy).toHaveBeenCalledTimes(1);
         });
 
+        it("status bar click opens the lilbee plugin settings tab", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const settingApi = (plugin.app as any).setting as {
+                open: ReturnType<typeof vi.fn>;
+                openTabById: ReturnType<typeof vi.fn>;
+            };
+            settingApi.open.mockClear();
+            settingApi.openTabById.mockClear();
+
+            const statusBar = (plugin as any).statusBarEl as any;
+            statusBar.trigger("click");
+
+            expect(settingApi.open).toHaveBeenCalledTimes(1);
+            expect(settingApi.openTabById).toHaveBeenCalledWith(plugin.manifest.id);
+        });
+
+        it("status bar carries an aria-label pointing users at settings", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const statusBar = (plugin as any).statusBarEl as any;
+            expect(statusBar.attributes["aria-label"]).toBe("Open lilbee settings");
+        });
+
+        it("openPluginSettings no-ops when app.setting is unavailable", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            (plugin.app as any).setting = undefined;
+
+            expect(() => plugin.openPluginSettings()).not.toThrow();
+        });
+
         it("ribbon icon toggles lilbee-ribbon-active while any task is active", async () => {
             const plugin = await createPlugin();
             await plugin.onload();


### PR DESCRIPTION
The coloured status-bar dot (stopped / starting / ready / error) reflects server and config state, so clicking it should take you somewhere you can fix that state. Today it opens the Task Center, which is surprising when the dot is red and you're hunting for a setting.

Clicking the status bar now opens Obsidian's Settings dialog on the lilbee tab, matching what other community plugins do with their status indicators. The dot also gains an "Open lilbee settings" aria-label so it's discoverable by tooltip and screen reader. The ribbon icon and the `lilbee:tasks` command still open the Task Center.