### PR TITLE
Recursively copy picked directories into vault imports

### DIFF
--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -1,6 +1,16 @@
 import { requestUrl } from "obsidian";
 import { execFile, spawn } from "child_process";
-import { existsSync, mkdirSync, chmodSync, writeFileSync, readFileSync, unlinkSync, copyFileSync } from "fs";
+import {
+    existsSync,
+    mkdirSync,
+    chmodSync,
+    writeFileSync,
+    readFileSync,
+    unlinkSync,
+    copyFileSync,
+    cpSync,
+    statSync,
+} from "fs";
 import { basename, join } from "path";
 import { promisify } from "util";
 import { ARCH, PLATFORM } from "./types";
@@ -18,6 +28,8 @@ export const node = {
     readFileSync,
     unlinkSync,
     copyFileSync,
+    cpSync,
+    statSync,
     join,
     basename,
     requestUrl,

--- a/src/main.ts
+++ b/src/main.ts
@@ -892,6 +892,12 @@ export default class LilbeePlugin extends Plugin {
      * are returned unchanged. On copy failure the offending file is dropped
      * with a user-visible Notice so the rest of the batch still proceeds.
      *
+     * Directory sources are copied recursively with ``node.cpSync`` — the
+     * native file picker's "openDirectory" mode returns folder paths, and
+     * ``copyFileSync`` on a directory throws EISDIR. Without the stat-first
+     * branch every picked folder would fall into the catch and get silently
+     * dropped, regressing folder ingestion.
+     *
      * All path joins go through ``node.path`` so Windows ``\\`` separators
      * round-trip correctly — a naïve string ``startsWith(vaultBase + "/")``
      * check would miss every file on Windows and mis-copy them into imports.
@@ -915,7 +921,12 @@ export default class LilbeePlugin extends Plugin {
             const name = node.basename(source) || "imported";
             const dest = this.uniqueImportPath(importsDir, name);
             try {
-                node.copyFileSync(source, dest);
+                const isDirectory = node.statSync(source).isDirectory();
+                if (isDirectory) {
+                    node.cpSync(source, dest, { recursive: true });
+                } else {
+                    node.copyFileSync(source, dest);
+                }
                 results.push(dest);
             } catch (err) {
                 console.error("[lilbee] import copy failed:", source, err);

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -111,6 +111,11 @@ vi.mock("../src/binary-manager", () => ({
         readFileSync: vi.fn(),
         unlinkSync: vi.fn(),
         copyFileSync: vi.fn(),
+        cpSync: vi.fn(),
+        // Default every stat-ed source to a regular file so pre-existing
+        // tests (which only exercise the file path) keep hitting copyFileSync
+        // rather than cpSync. Directory tests override this per-test.
+        statSync: vi.fn(() => ({ isDirectory: () => false })),
         // Real node:path join/basename — tests exercise cross-platform path
         // normalisation and need the actual behaviour, not a stub.
         join: (...parts: string[]) => parts.join("/").replace(/\/+/g, "/"),
@@ -1558,6 +1563,100 @@ describe("LilbeePlugin", () => {
             expect(node.copyFileSync).not.toHaveBeenCalled();
             expect(plugin.api.addFiles).toHaveBeenCalledWith(
                 ["C:\\Users\\me\\vault\\notes\\already-here.md"],
+                true,
+                null,
+                expect.any(AbortSignal),
+            );
+        });
+
+        it("recursively copies picked directories into imports/", async () => {
+            const { node } = await import("../src/binary-manager");
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+
+            async function* noEvents() {}
+            plugin.api.addFiles = vi.fn().mockReturnValue(noEvents());
+            (node.mkdirSync as ReturnType<typeof vi.fn>).mockReset();
+            (node.copyFileSync as ReturnType<typeof vi.fn>).mockClear();
+            (node.cpSync as ReturnType<typeof vi.fn>).mockClear();
+            (node.statSync as ReturnType<typeof vi.fn>).mockReset();
+            (node.statSync as ReturnType<typeof vi.fn>).mockReturnValue({
+                isDirectory: () => true,
+            });
+
+            await plugin.addExternalFiles(["/home/user/notes-folder"]);
+
+            expect(node.cpSync).toHaveBeenCalledWith(
+                "/home/user/notes-folder",
+                "/test/vault/lilbee/imports/notes-folder",
+                {
+                    recursive: true,
+                },
+            );
+            expect(node.copyFileSync).not.toHaveBeenCalled();
+            expect(plugin.api.addFiles).toHaveBeenCalledWith(
+                ["/test/vault/lilbee/imports/notes-folder"],
+                true,
+                null,
+                expect.any(AbortSignal),
+            );
+        });
+
+        it("handles a mixed batch of file and directory sources", async () => {
+            const { node } = await import("../src/binary-manager");
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+
+            async function* noEvents() {}
+            plugin.api.addFiles = vi.fn().mockReturnValue(noEvents());
+            (node.mkdirSync as ReturnType<typeof vi.fn>).mockReset();
+            (node.copyFileSync as ReturnType<typeof vi.fn>).mockClear();
+            (node.cpSync as ReturnType<typeof vi.fn>).mockClear();
+            (node.statSync as ReturnType<typeof vi.fn>).mockReset();
+            (node.statSync as ReturnType<typeof vi.fn>).mockImplementation((p: unknown) => ({
+                isDirectory: () => p === "/home/user/folder",
+            }));
+
+            await plugin.addExternalFiles(["/home/user/doc.pdf", "/home/user/folder"]);
+
+            expect(node.copyFileSync).toHaveBeenCalledWith("/home/user/doc.pdf", "/test/vault/lilbee/imports/doc.pdf");
+            expect(node.cpSync).toHaveBeenCalledWith("/home/user/folder", "/test/vault/lilbee/imports/folder", {
+                recursive: true,
+            });
+            expect(plugin.api.addFiles).toHaveBeenCalledWith(
+                ["/test/vault/lilbee/imports/doc.pdf", "/test/vault/lilbee/imports/folder"],
+                true,
+                null,
+                expect.any(AbortSignal),
+            );
+        });
+
+        it("surfaces a Notice when a directory copy fails and keeps the rest of the batch", async () => {
+            const { node } = await import("../src/binary-manager");
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+
+            async function* noEvents() {}
+            plugin.api.addFiles = vi.fn().mockReturnValue(noEvents());
+            (node.mkdirSync as ReturnType<typeof vi.fn>).mockReset();
+            (node.copyFileSync as ReturnType<typeof vi.fn>).mockClear();
+            (node.statSync as ReturnType<typeof vi.fn>).mockReset();
+            (node.statSync as ReturnType<typeof vi.fn>).mockImplementation((p: unknown) => ({
+                isDirectory: () => p === "/home/user/bad-folder",
+            }));
+            (node.cpSync as ReturnType<typeof vi.fn>).mockReset();
+            (node.cpSync as ReturnType<typeof vi.fn>).mockImplementation(() => {
+                throw new Error("EACCES: nested permission denied");
+            });
+
+            await plugin.addExternalFiles(["/home/user/bad-folder", "/home/user/good.pdf"]);
+
+            expect(Notice.instances.some((n) => n.message === MESSAGES.ERROR_FILE_PICKER)).toBe(true);
+            expect(plugin.api.addFiles).toHaveBeenCalledWith(
+                ["/test/vault/lilbee/imports/good.pdf"],
                 true,
                 null,
                 expect.any(AbortSignal),


### PR DESCRIPTION
## Problem

After the paperclip copy-to-vault change, picking a folder from the disk file picker silently dropped it. `copyFileSync` throws `EISDIR` on a directory, and the catch branch only surfaced the generic file-picker Notice before moving on — so the user saw no indexing, no error, no trace of the folder they just selected.

## What changed

The vault import step now stats each picked path. Regular files continue through `copyFileSync` as before; directories go through a recursive copy into `<vault>/lilbee/imports/<folder>/` and are then forwarded to the server for indexing. The existing unique-name flow already handled both file and directory destinations, so folders with the same basename as an existing import get `-1`, `-2`, ... suffixes just like files do.

Mixed selections (a file and a folder in the same batch) are supported in one round-trip — each source routes to the right copy helper, and all resulting paths are indexed together.

## Error handling

A permission error inside a recursive copy surfaces the same file-picker Notice used for per-file failures and does not break the rest of the batch — the other picked sources still import. Empty directories copy fine.

## Verification

`npm test` — 1680 tests, 100% coverage held. `npm run lint` and `npm run format:check` clean.