### PR TITLE
Recover from failed adds: fail the task, skip reindex confirm on retry

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -166,6 +166,7 @@ export const MESSAGES = {
     LABEL_NO_QUEUED_TASKS: "No queued tasks",
     LABEL_NO_COMPLETED_TASKS: "No completed tasks",
     LABEL_CANCEL_TASK: "Cancel task",
+    LABEL_RETRY_TASK: "Retry",
     LABEL_DOWNLOAD_QUEUED: "+{count} queued",
     LABEL_TASK_STATE_QUEUED: "queued",
     LABEL_TASK_STATE_DONE: "done",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -172,6 +172,8 @@ export const MESSAGES = {
     LABEL_TASK_STATE_DONE: "done",
     LABEL_TASK_STATE_FAILED: "failed",
     LABEL_TASK_STATE_CANCELLED: "cancelled",
+    LABEL_TASK_STATE_WAITING: "waiting on server",
+    STATUS_WAITING_ON_SERVER: "Already ingesting on the server — waiting for it to finish",
     STATUS_TASKS_RUNNING_PLURAL: "{count} tasks running · {name} {pct}%",
     STATUS_TASK_RUNNING_SINGLE: "{name} {pct}%",
     STATUS_TASKS_QUEUED_ONLY: "{count} queued",
@@ -378,6 +380,8 @@ export const MESSAGES = {
     ERROR_SERVER_UNREACHABLE: "Could not connect to lilbee server. Is it running?",
     ERROR_STREAM: (msg: string) => `lilbee: ${msg}`,
     ERROR_ADD_FAILED_DETAIL: (msg: string) => `lilbee: add failed — ${msg}`,
+    NOTICE_ALREADY_INGESTING: (source: string) =>
+        `lilbee: server is already ingesting ${source} — waiting for it to finish`,
 
     NOTICE_NO_CHAT_MODEL: "lilbee: no chat model set — select one in settings",
     NOTICE_MODEL_ACTIVATED: (model: string) => `Now using ${model}`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -180,6 +180,8 @@ export default class LilbeePlugin extends Plugin {
     private startingServer = false;
     private serverStartFailed = false;
     taskQueue: TaskQueue = new TaskQueue();
+    /** Paths whose most-recent add failed — retry skips the reindex confirm. */
+    private failedAddPaths = new Set<string>();
     wikiEnabled = false;
     wikiPageCount = 0;
     wikiDraftCount = 0;
@@ -871,7 +873,8 @@ export default class LilbeePlugin extends Plugin {
         if (!this.assertActiveModel()) return;
         const label = paths.length === 1 ? paths[0].split("/").pop() || paths[0] : `${paths.length} files`;
 
-        if (paths.length === 1 && !(await this.confirmReindexIfNeeded(label))) return;
+        const isRetry = paths.length === 1 && this.failedAddPaths.has(paths[0]);
+        if (paths.length === 1 && !isRetry && !(await this.confirmReindexIfNeeded(label))) return;
 
         // Copy disk-picked files into the vault before indexing so the
         // resulting source lives where the user expects — visible in the
@@ -883,7 +886,7 @@ export default class LilbeePlugin extends Plugin {
         if (copiedPaths.length === 0) return;
 
         new Notice(MESSAGES.STATUS_ADDING.replace("{label}", label));
-        await this.runAdd(copiedPaths);
+        await this.runAdd(copiedPaths, paths, () => this.addExternalFiles(paths));
     }
 
     /**
@@ -966,10 +969,11 @@ export default class LilbeePlugin extends Plugin {
         const absolutePath = `${this.getVaultBasePath()}/${file.path}`;
         const name = file.name ?? file.path;
 
-        if (!(await this.confirmReindexIfNeeded(name))) return;
+        const isRetry = this.failedAddPaths.has(absolutePath);
+        if (!isRetry && !(await this.confirmReindexIfNeeded(name))) return;
 
         new Notice(MESSAGES.STATUS_ADDING.replace("{label}", name));
-        await this.runAdd([absolutePath]);
+        await this.runAdd([absolutePath], [absolutePath], () => this.addToLilbee(file));
     }
 
     cancelSync(): void {
@@ -977,12 +981,17 @@ export default class LilbeePlugin extends Plugin {
         this.syncController = null;
     }
 
-    private async runAdd(paths: string[]): Promise<void> {
-        const taskId = this.taskQueue.enqueue("Adding files", TASK_TYPE.ADD);
+    private async runAdd(
+        paths: string[],
+        retryKeys: string[] = paths,
+        retry?: () => void | Promise<void>,
+    ): Promise<void> {
+        const taskId = this.taskQueue.enqueue("Adding files", TASK_TYPE.ADD, retry);
         if (taskId === null) {
             new Notice(MESSAGES.NOTICE_QUEUE_FULL);
             return;
         }
+        for (const p of retryKeys) this.failedAddPaths.delete(p);
         this.syncController = new AbortController();
         this.taskQueue.registerAbort(taskId, this.syncController);
 
@@ -1032,6 +1041,7 @@ export default class LilbeePlugin extends Plugin {
                     const msg = extractSseErrorMessage(d, MESSAGES.ERROR_UNKNOWN);
                     new Notice(MESSAGES.ERROR_ADD_FAILED_DETAIL(msg));
                     this.taskQueue.fail(taskId, msg);
+                    this.markAddFailed(retryKeys);
                     return;
                 }
             }
@@ -1045,18 +1055,29 @@ export default class LilbeePlugin extends Plugin {
             if (err instanceof StreamIdleError) {
                 new Notice(MESSAGES.ERROR_STREAM_IDLE);
                 this.taskQueue.fail(taskId, MESSAGES.ERROR_STREAM_IDLE);
+                this.markAddFailed(retryKeys);
             } else if (err instanceof Error && err.name === ERROR_NAME.ABORT_ERROR) {
                 new Notice(MESSAGES.STATUS_ADD_CANCELLED);
                 this.taskQueue.cancel(taskId);
+                this.markAddFailed(retryKeys);
+            } else if (err instanceof SessionTokenError) {
+                new Notice(MESSAGES.NOTICE_SESSION_TOKEN_INVALID);
+                this.taskQueue.fail(taskId, MESSAGES.NOTICE_SESSION_TOKEN_INVALID);
+                this.markAddFailed(retryKeys);
             } else {
                 console.error("[lilbee] add failed:", err);
                 const msg = errorMessage(err, MESSAGES.ERROR_CANNOT_CONNECT);
                 new Notice(MESSAGES.ERROR_ADD_FAILED_DETAIL(msg));
                 this.taskQueue.fail(taskId, msg);
+                this.markAddFailed(retryKeys);
             }
         } finally {
             this.syncController = null;
         }
+    }
+
+    private markAddFailed(paths: string[]): void {
+        for (const p of paths) this.failedAddPaths.add(p);
     }
 
     private updateAutoSync(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1036,6 +1036,12 @@ export default class LilbeePlugin extends Plugin {
                 } else if (event.event === SSE_EVENT.DONE) {
                     const parsed = parseAddDoneEvent(event.data);
                     if (parsed) syncResult = parsed;
+                } else if (event.event === SSE_EVENT.ALREADY_INGESTING) {
+                    const d = (event.data ?? {}) as { source?: string };
+                    const source = typeof d.source === "string" && d.source ? d.source : paths[0];
+                    new Notice(MESSAGES.NOTICE_ALREADY_INGESTING(source));
+                    this.taskQueue.markWaiting(taskId, MESSAGES.STATUS_WAITING_ON_SERVER);
+                    return;
                 } else if (event.event === SSE_EVENT.ERROR) {
                     const d = event.data as { message?: string } | string;
                     const msg = extractSseErrorMessage(d, MESSAGES.ERROR_UNKNOWN);

--- a/src/task-queue.ts
+++ b/src/task-queue.ts
@@ -163,6 +163,24 @@ export class TaskQueue {
         this.moveToHistory(id);
     }
 
+    /**
+     * Neutral terminal state: the server told us it is already handling this work
+     * (e.g. a concurrent /api/add for the same source). The task isn't done — the
+     * original request is still running — and it isn't failed either, so Retry
+     * would just collide again. Park it in history with a `waiting` status and
+     * no retry affordance.
+     */
+    markWaiting(id: string, detail?: string): void {
+        const task = this.tasks.get(id);
+        if (!task) return;
+
+        task.status = TASK_STATUS.WAITING;
+        if (detail !== undefined) task.detail = detail;
+        task.completedAt = Date.now();
+        task.retry = undefined;
+        this.moveToHistory(id);
+    }
+
     cancel(id: string): void {
         const task = this.tasks.get(id);
         if (!task) return;

--- a/src/task-queue.ts
+++ b/src/task-queue.ts
@@ -54,7 +54,7 @@ export class TaskQueue {
         return q;
     }
 
-    enqueue(name: string, type: TaskType): string | null {
+    enqueue(name: string, type: TaskType, retry?: () => void | Promise<void>): string | null {
         if (this.typeQueue(type).length >= TASK_QUEUE.MAX_QUEUED_PER_TYPE) {
             return null;
         }
@@ -70,6 +70,7 @@ export class TaskQueue {
             completedAt: null,
             error: null,
             canCancel: true,
+            retry,
         };
         this.tasks.set(id, task);
         this.typeQueue(type).push(id);

--- a/src/types.ts
+++ b/src/types.ts
@@ -225,6 +225,7 @@ export const SSE_EVENT = {
     SETUP_START: "setup_start",
     SETUP_PROGRESS: "setup_progress",
     SETUP_DONE: "setup_done",
+    ALREADY_INGESTING: "already_ingesting",
 } as const;
 
 export interface SetupStartPayload {
@@ -368,7 +369,7 @@ export interface VaultAdapter {
     getBasePath(): string;
 }
 
-export type TaskStatus = "queued" | "active" | "done" | "failed" | "cancelled";
+export type TaskStatus = "queued" | "active" | "done" | "failed" | "cancelled" | "waiting";
 
 export const TASK_STATUS = {
     QUEUED: "queued",
@@ -376,6 +377,7 @@ export const TASK_STATUS = {
     DONE: "done",
     FAILED: "failed",
     CANCELLED: "cancelled",
+    WAITING: "waiting",
 } as const satisfies Record<string, TaskStatus>;
 
 export type DotState = "primary" | "success" | "error";

--- a/src/types.ts
+++ b/src/types.ts
@@ -481,6 +481,7 @@ export interface TaskEntry {
     bytesTotal?: number;
     rateBps?: number;
     lastRateAt?: number;
+    retry?: () => void | Promise<void>;
 }
 
 export type ModelSize = "small" | "medium" | "large";

--- a/src/views/task-center.ts
+++ b/src/views/task-center.ts
@@ -197,7 +197,10 @@ export class TaskCenterView extends ItemView {
 
         const isActive = state === TASK_STATUS.ACTIVE;
         const isTerminal =
-            state === TASK_STATUS.DONE || state === TASK_STATUS.FAILED || state === TASK_STATUS.CANCELLED;
+            state === TASK_STATUS.DONE ||
+            state === TASK_STATUS.FAILED ||
+            state === TASK_STATUS.CANCELLED ||
+            state === TASK_STATUS.WAITING;
         const isIndeterminate = isActive && task.progress < 0;
         const rawPct = Math.max(0, Math.min(100, task.progress));
         const pct = isIndeterminate ? 100 : isActive ? Math.min(rawPct, ACTIVE_PCT_CAP) : rawPct;
@@ -279,6 +282,9 @@ function metaForRow(task: TaskEntry, state: TaskStatus): string {
     }
     if (state === TASK_STATUS.FAILED) {
         return task.completedAt !== null ? relativeTime(task.completedAt) : MESSAGES.LABEL_TASK_STATE_FAILED;
+    }
+    if (state === TASK_STATUS.WAITING) {
+        return task.completedAt !== null ? relativeTime(task.completedAt) : MESSAGES.LABEL_TASK_STATE_WAITING;
     }
     return task.completedAt !== null ? relativeTime(task.completedAt) : MESSAGES.LABEL_TASK_STATE_CANCELLED;
 }

--- a/src/views/task-center.ts
+++ b/src/views/task-center.ts
@@ -238,6 +238,16 @@ export class TaskCenterView extends ItemView {
             });
         }
 
+        if ((state === TASK_STATUS.FAILED || state === TASK_STATUS.CANCELLED) && task.retry) {
+            const retryBtn = row.createEl("button", { cls: "lilbee-task-retry" });
+            retryBtn.textContent = MESSAGES.LABEL_RETRY_TASK;
+            retryBtn.title = MESSAGES.LABEL_RETRY_TASK;
+            retryBtn.addEventListener("click", (e) => {
+                e.stopPropagation();
+                void task.retry?.();
+            });
+        }
+
         if (task.error && state === TASK_STATUS.FAILED) {
             row.title = task.error;
         }

--- a/styles.css
+++ b/styles.css
@@ -2128,6 +2128,10 @@
     background-color: var(--text-faint);
 }
 
+.lilbee-task-row[data-state="waiting"] .lilbee-task-rail {
+    background-color: var(--text-accent, var(--interactive-accent));
+}
+
 .lilbee-task-row[data-state="cancelled"] .lilbee-task-name,
 .lilbee-task-row[data-state="cancelled"] .lilbee-task-progress-fill {
     text-decoration: line-through;
@@ -2247,6 +2251,11 @@
 
 .lilbee-task-row[data-state="cancelled"] .lilbee-task-progress-fill {
     background-color: var(--text-faint);
+}
+
+.lilbee-task-row[data-state="waiting"] .lilbee-task-progress-fill {
+    background-color: var(--text-accent, var(--interactive-accent));
+    opacity: 0.6;
 }
 
 .lilbee-task-progress-fill.lilbee-task-progress-indeterminate {

--- a/styles.css
+++ b/styles.css
@@ -2326,6 +2326,25 @@
     background-color: color-mix(in srgb, var(--text-error) 10%, transparent);
 }
 
+.lilbee-task-retry {
+    background: none;
+    border: 1px solid var(--background-modifier-border);
+    cursor: pointer;
+    color: var(--text-muted);
+    font-size: 11px;
+    line-height: 1;
+    padding: 3px 8px;
+    border-radius: 6px;
+    flex-shrink: 0;
+    align-self: center;
+}
+
+.lilbee-task-retry:hover {
+    color: var(--text-normal);
+    border-color: var(--interactive-accent);
+    background-color: color-mix(in srgb, var(--interactive-accent) 10%, transparent);
+}
+
 .lilbee-tasks-empty {
     font-size: var(--font-small, 13px);
     color: var(--text-muted);

--- a/tests/locales/en.test.ts
+++ b/tests/locales/en.test.ts
@@ -265,6 +265,12 @@ describe("MESSAGES", () => {
             expect(MESSAGES.NOTICE_CRAWL_DONE(10)).toBe("lilbee: crawl done — 10 pages");
         });
 
+        it("NOTICE_ALREADY_INGESTING produces correct output", () => {
+            expect(MESSAGES.NOTICE_ALREADY_INGESTING("doc.pdf")).toBe(
+                "lilbee: server is already ingesting doc.pdf — waiting for it to finish",
+            );
+        });
+
         it("NOTICE_UPDATED_TO produces correct output", () => {
             expect(MESSAGES.NOTICE_UPDATED_TO("v0.1.0")).toBe("lilbee: updated to v0.1.0");
         });

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1024,6 +1024,74 @@ describe("LilbeePlugin", () => {
             expect(Notice.instances.some((n) => n.message.includes("add failed"))).toBe(true);
         });
 
+        it("runAdd parks the task in WAITING state on already_ingesting and leaves failedAddPaths clean", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+            (plugin as any).getVaultBasePath = () => "/vault";
+
+            async function* alreadyIngesting() {
+                yield {
+                    event: SSE_EVENT.ALREADY_INGESTING,
+                    data: { source: "test.md" },
+                };
+            }
+            plugin.api.addFiles = vi.fn().mockReturnValue(alreadyIngesting());
+
+            await (plugin as any).addToLilbee({ path: "test.md", name: "test.md" });
+
+            const waiting = plugin.taskQueue.completed.find((t) => t.status === "waiting");
+            expect(waiting).toBeDefined();
+            // Retry callback must be dropped so the Task Center does not
+            // surface a button that would just collide with the server again.
+            expect(waiting?.retry).toBeUndefined();
+
+            // Must NOT mark the path as failed — the server is still
+            // ingesting it; a subsequent user-driven add should behave
+            // like a normal add, not a retry.
+            expect((plugin as any).failedAddPaths.has("/vault/test.md")).toBe(false);
+
+            expect(
+                Notice.instances.some((n) => n.message.includes("already ingesting") && n.message.includes("test.md")),
+            ).toBe(true);
+        });
+
+        it("runAdd falls back to the first request path when the server omits a source name", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+            (plugin as any).getVaultBasePath = () => "/vault";
+
+            async function* alreadyIngestingNoSource() {
+                yield { event: SSE_EVENT.ALREADY_INGESTING, data: {} };
+            }
+            plugin.api.addFiles = vi.fn().mockReturnValue(alreadyIngestingNoSource());
+
+            await (plugin as any).addToLilbee({ path: "test.md", name: "test.md" });
+
+            expect(
+                Notice.instances.some(
+                    (n) => n.message.includes("already ingesting") && n.message.includes("/vault/test.md"),
+                ),
+            ).toBe(true);
+        });
+
+        it("runAdd tolerates a null data payload on already_ingesting", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+            (plugin as any).getVaultBasePath = () => "/vault";
+
+            async function* alreadyIngestingNullData() {
+                yield { event: SSE_EVENT.ALREADY_INGESTING, data: null as unknown as { source?: string } };
+            }
+            plugin.api.addFiles = vi.fn().mockReturnValue(alreadyIngestingNullData());
+
+            await (plugin as any).addToLilbee({ path: "test.md", name: "test.md" });
+
+            expect(plugin.taskQueue.completed.some((t) => t.status === "waiting")).toBe(true);
+        });
+
         it("addToLilbee returns early when statusBarEl is null", async () => {
             const plugin = await createPlugin();
             await plugin.onload();

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -3405,6 +3405,132 @@ describe("LilbeePlugin", () => {
         });
     });
 
+    describe("recovery from failed adds", () => {
+        it("runAdd surfaces the session-token-invalid notice and fails the task on SessionTokenError", async () => {
+            const { SessionTokenError } = await import("../src/api");
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+
+            plugin.api.addFiles = vi.fn().mockImplementation(async function* () {
+                throw new SessionTokenError(401, "stale");
+            });
+
+            await plugin.addExternalFiles(["/home/user/doc.pdf"]);
+
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_SESSION_TOKEN_INVALID)).toBe(true);
+            const failed = plugin.taskQueue.completed.find((t) => t.status === "failed");
+            expect(failed).toBeDefined();
+            expect(failed?.error).toBe(MESSAGES.NOTICE_SESSION_TOKEN_INVALID);
+        });
+
+        it("skips the reindex-confirm prompt when retrying a file whose previous add just failed", async () => {
+            const { StreamIdleError } = await import("../src/utils");
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+
+            // First attempt: stream goes idle mid-ingest. Server has partial
+            // chunks, so listDocuments would normally match and prompt the
+            // user with a reindex-confirm on retry.
+            plugin.api.listDocuments = vi.fn().mockResolvedValue({
+                documents: [{ filename: "doc.pdf", chunk_count: 42, ingested_at: "2026-01-01" }],
+                total: 1,
+                limit: 1,
+                offset: 0,
+            });
+            plugin.api.addFiles = vi.fn().mockImplementation(async function* () {
+                throw new StreamIdleError(1);
+            });
+            const mockConfirm = vi.spyOn(await import("../src/views/confirm-modal"), "ConfirmModal");
+
+            await plugin.addExternalFiles(["/home/user/doc.pdf"]);
+            expect(plugin.taskQueue.completed.some((t) => t.status === "failed")).toBe(true);
+
+            // Second attempt for the SAME path: ConfirmModal must NOT open —
+            // the retry path skips it so the user can just try again.
+            mockConfirm.mockClear();
+            async function* noEvents() {}
+            plugin.api.addFiles = vi.fn().mockReturnValue(noEvents());
+
+            await plugin.addExternalFiles(["/home/user/doc.pdf"]);
+
+            expect(mockConfirm).not.toHaveBeenCalled();
+            expect(plugin.api.addFiles).toHaveBeenCalled();
+            mockConfirm.mockRestore();
+        });
+
+        it("addToLilbee retry after a failed add also skips the reindex-confirm prompt", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+            (plugin as any).getVaultBasePath = () => "/vault";
+
+            plugin.api.listDocuments = vi.fn().mockResolvedValue({
+                documents: [{ filename: "test.md", chunk_count: 3, ingested_at: "2026-01-01" }],
+                total: 1,
+                limit: 1,
+                offset: 0,
+            });
+            plugin.api.addFiles = vi.fn().mockImplementation(async function* () {
+                throw new Error("boom");
+            });
+            const mockConfirm = vi.spyOn(await import("../src/views/confirm-modal"), "ConfirmModal");
+
+            await (plugin as any).addToLilbee({ path: "test.md", name: "test.md" });
+            expect(plugin.taskQueue.completed.some((t) => t.status === "failed")).toBe(true);
+
+            mockConfirm.mockClear();
+            async function* noEvents() {}
+            plugin.api.addFiles = vi.fn().mockReturnValue(noEvents());
+
+            await (plugin as any).addToLilbee({ path: "test.md", name: "test.md" });
+
+            expect(mockConfirm).not.toHaveBeenCalled();
+            expect(plugin.api.addFiles).toHaveBeenCalled();
+            mockConfirm.mockRestore();
+        });
+
+        it("clears the retry marker after a successful add so future adds prompt normally again", async () => {
+            const { StreamIdleError } = await import("../src/utils");
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+
+            plugin.api.listDocuments = vi.fn().mockResolvedValue({
+                documents: [{ filename: "doc.pdf", chunk_count: 5, ingested_at: "2026-01-01" }],
+                total: 1,
+                limit: 1,
+                offset: 0,
+            });
+
+            // Fail, then succeed, then a third add with the same partial
+            // state on server — the third add should show the confirm again
+            // because the retry marker was consumed by the successful add.
+            plugin.api.addFiles = vi.fn().mockImplementation(async function* () {
+                throw new StreamIdleError(1);
+            });
+            const mockConfirm = vi.spyOn(await import("../src/views/confirm-modal"), "ConfirmModal");
+
+            await plugin.addExternalFiles(["/home/user/doc.pdf"]);
+
+            mockConfirm.mockClear();
+            async function* noEvents() {}
+            plugin.api.addFiles = vi.fn().mockReturnValue(noEvents());
+            await plugin.addExternalFiles(["/home/user/doc.pdf"]);
+            expect(mockConfirm).not.toHaveBeenCalled();
+
+            // Third add — successful completion cleared the retry marker, so
+            // the reindex-confirm prompt is back in play.
+            mockConfirm.mockClear();
+            plugin.api.addFiles = vi.fn().mockReturnValue(noEvents());
+            await plugin.addExternalFiles(["/home/user/doc.pdf"]);
+            expect(mockConfirm).toHaveBeenCalled();
+
+            mockConfirm.mockRestore();
+        });
+    });
+
     describe("onunload with serverManager", () => {
         it("calls serverManager.stop on unload", async () => {
             const plugin = await createPlugin({ serverMode: "managed" });

--- a/tests/task-queue.test.ts
+++ b/tests/task-queue.test.ts
@@ -244,6 +244,38 @@ describe("TaskQueue", () => {
         });
     });
 
+    describe("markWaiting()", () => {
+        it("parks task in history with waiting status, no retry, detail applied", () => {
+            const retry = vi.fn();
+            const id = queue.enqueue("Adding files", TASK_TYPE.ADD, retry)!;
+
+            queue.markWaiting(id, "Waiting on server");
+
+            const completed = queue.completed;
+            expect(completed).toHaveLength(1);
+            expect(completed[0]!.status).toBe(TASK_STATUS.WAITING);
+            expect(completed[0]!.detail).toBe("Waiting on server");
+            expect(completed[0]!.retry).toBeUndefined();
+            expect(completed[0]!.completedAt).not.toBeNull();
+        });
+
+        it("preserves existing detail when called without a detail argument", () => {
+            const id = queue.enqueue("Adding files", TASK_TYPE.ADD)!;
+            queue.update(id, 10, "extracting page 1/3");
+
+            queue.markWaiting(id);
+
+            const completed = queue.completed;
+            expect(completed[0]!.status).toBe(TASK_STATUS.WAITING);
+            expect(completed[0]!.detail).toBe("extracting page 1/3");
+        });
+
+        it("is a no-op for an unknown id", () => {
+            queue.markWaiting("no-such-id", "whatever");
+            expect(queue.completed).toHaveLength(0);
+        });
+    });
+
     describe("cancel()", () => {
         it("removes queued task entirely", () => {
             queue.enqueue("Task 1", TASK_TYPE.SYNC);

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -329,6 +329,7 @@ describe("SSE_EVENT constants", () => {
         expect(SSE_EVENT.CRAWL_PAGE).toBe("crawl_page");
         expect(SSE_EVENT.CRAWL_DONE).toBe("crawl_done");
         expect(SSE_EVENT.CRAWL_ERROR).toBe("crawl_error");
+        expect(SSE_EVENT.ALREADY_INGESTING).toBe("already_ingesting");
     });
 });
 

--- a/tests/views/task-center.test.ts
+++ b/tests/views/task-center.test.ts
@@ -276,6 +276,37 @@ describe("TaskCenterView rendering", () => {
         expect(cancelBtns.length).toBe(0);
     });
 
+    it("renders retry button on failed task with a retry callback and invokes it on click", () => {
+        const retry = vi.fn();
+        const id = plugin.taskQueue.enqueue("Adding files", TASK_TYPE.ADD, retry)!;
+        plugin.taskQueue.fail(id, "stream idle");
+        (view as any).render();
+
+        const retryBtns = findByClass(contentEl, "lilbee-task-retry");
+        expect(retryBtns.length).toBe(1);
+        expect(retryBtns[0]!.textContent).toBe("Retry");
+
+        retryBtns[0]!.trigger("click", { stopPropagation: vi.fn() });
+        expect(retry).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders retry button on cancelled task with a retry callback", () => {
+        const retry = vi.fn();
+        const id = plugin.taskQueue.enqueue("Adding files", TASK_TYPE.ADD, retry)!;
+        plugin.taskQueue.cancel(id);
+        (view as any).render();
+
+        expect(findByClass(contentEl, "lilbee-task-retry").length).toBe(1);
+    });
+
+    it("does not render retry button when the failed task has no retry callback", () => {
+        const id = plugin.taskQueue.enqueue("Sync vault", TASK_TYPE.SYNC)!;
+        plugin.taskQueue.fail(id, "boom");
+        (view as any).render();
+
+        expect(findByClass(contentEl, "lilbee-task-retry").length).toBe(0);
+    });
+
     it("clears empty state when tasks are present", () => {
         plugin.taskQueue.enqueue("Sync vault", TASK_TYPE.SYNC);
         (view as any).render();

--- a/tests/views/task-center.test.ts
+++ b/tests/views/task-center.test.ts
@@ -307,6 +307,40 @@ describe("TaskCenterView rendering", () => {
         expect(findByClass(contentEl, "lilbee-task-retry").length).toBe(0);
     });
 
+    it("renders a waiting-on-server row with waiting state and no retry button", () => {
+        const retry = vi.fn();
+        const id = plugin.taskQueue.enqueue("Adding files", TASK_TYPE.ADD, retry)!;
+        plugin.taskQueue.markWaiting(id, "Already ingesting — waiting");
+        (view as any).render();
+
+        const row = contentEl.find("lilbee-task-row")!;
+        expect(row).not.toBeNull();
+        expect(row.dataset.state).toBe(TASK_STATUS.WAITING);
+
+        // The neutral state must not surface a Retry button (the server is
+        // still handling the original request; retrying would collide).
+        expect(findByClass(contentEl, "lilbee-task-retry").length).toBe(0);
+
+        // The detail line we passed through markWaiting is rendered in the row.
+        const statsLabel = row.find("lilbee-task-stats-label");
+        expect(statsLabel!.textContent).toBe("Already ingesting — waiting");
+    });
+
+    it("metaForRow falls back to the waiting label when completedAt is null", () => {
+        const id = plugin.taskQueue.enqueue("Adding files", TASK_TYPE.ADD)!;
+        plugin.taskQueue.markWaiting(id, "Waiting on server");
+        // Simulate a persisted/legacy row with no completedAt — metaForRow
+        // must fall back to the label instead of rendering "null ago".
+        const completed = plugin.taskQueue.completed;
+        (completed[0] as any).completedAt = null;
+
+        (view as any).render();
+
+        const row = contentEl.find("lilbee-task-row")!;
+        const texts = collectTexts(row);
+        expect(texts.some((t) => t === "waiting on server")).toBe(true);
+    });
+
     it("clears empty state when tasks are present", () => {
         plugin.taskQueue.enqueue("Sync vault", TASK_TYPE.SYNC);
         (view as any).render();


### PR DESCRIPTION
## Problem

When an add stream died mid-ingest — stream idle on a slow server, a stale session token, a transport failure — two things broke for the user. The "Adding files" entry in Task Center could linger looking like it was still running, and the only way to retry was to find the original file and paperclip it again, where you'd hit a "this file is already indexed — re-add?" confirm because the server had written partial chunks before the failure. The user's path out was to restart Obsidian.

## What changed

**Failed adds show up as failed.** Task Center transitions the in-progress row out of the active list on every real failure (idle stream, stale token, cancel, network error), with the right reason recorded.

**Failed adds get a Retry button.** The Task Center row for a failed or cancelled add has a Retry button right next to it. One click re-runs the same add with the same file — no hunting, no re-picking, no reindex-confirm dialog. Works for files from the paperclip picker and files added from inside the vault.

**Stale session token gets the actionable notice.** A 401 during add now surfaces the same "session token is invalid, paste a fresh one" message the manual sync path already used, instead of a generic "add failed".

## Out of scope

The server-side OCR hang that made the original add stall long enough to trip the idle timeout is a separate bug, not touched here.

## Verification

1698 tests pass, 100% coverage held.