### PR TITLE
Add Browse more escape hatch to model pickers

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -15,6 +15,7 @@ export const MESSAGES = {
     BUTTON_REFRESH: "Refresh",
     BUTTON_BROWSE_CATALOG: "Browse Catalog",
     BUTTON_BROWSE_FULL_CATALOG: "Browse full catalog",
+    BUTTON_BROWSE_MORE: "Browse more…",
     BUTTON_DOWNLOAD_CONTINUE: "Download & continue",
     BUTTON_DELETE_SELECTED: "Delete selected",
     BUTTON_CRAWL: "Crawl",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -676,7 +676,12 @@ export class LilbeeSettingTab extends PluginSettingTab {
                             new Notice(MESSAGES.NOTICE_REINDEX_REQUIRED);
                             void this.plugin.triggerSync();
                         });
-                    });
+                    })
+                    .addButton((btn) =>
+                        btn.setButtonText(MESSAGES.BUTTON_BROWSE_MORE).onClick(() => {
+                            new CatalogModal(this.app, this.plugin, MODEL_TASK.EMBEDDING).open();
+                        }),
+                    );
             })
             .catch(() => {
                 this.renderEmbeddingFallback(container);
@@ -717,7 +722,12 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 dropdown.onChange(async (value) => {
                     await this.handleRerankerChange(value, catalogEntries, installed);
                 });
-            });
+            })
+            .addButton((btn) =>
+                btn.setButtonText(MESSAGES.BUTTON_BROWSE_MORE).onClick(() => {
+                    new CatalogModal(this.app, this.plugin, MODEL_TASK.RERANK).open();
+                }),
+            );
     }
 
     private buildRerankerOptions(catalogEntries: CatalogEntry[], installed: InstalledModel[]): Array<[string, string]> {
@@ -862,7 +872,12 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 dropdown.onChange(async (value) => {
                     await this.handleVisionChange(value, catalogEntries, installed);
                 });
-            });
+            })
+            .addButton((btn) =>
+                btn.setButtonText(MESSAGES.BUTTON_BROWSE_MORE).onClick(() => {
+                    new CatalogModal(this.app, this.plugin, MODEL_TASK.VISION).open();
+                }),
+            );
     }
 
     private buildVisionOptions(catalogEntries: CatalogEntry[], installed: InstalledModel[]): Array<[string, string]> {

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -133,6 +133,15 @@ export class ChatView extends ItemView {
         }) as HTMLSelectElement;
         this.attachEmbeddingListener(this.embeddingSelectEl);
 
+        const embedBrowseBtn = embedGroup.createEl("button", {
+            text: MESSAGES.BUTTON_BROWSE_MORE,
+            cls: "lilbee-embed-browse",
+        });
+        embedBrowseBtn.setAttribute("aria-label", MESSAGES.BUTTON_BROWSE_MORE);
+        embedBrowseBtn.addEventListener("click", () => {
+            new CatalogModal(this.app, this.plugin, MODEL_TASK.EMBEDDING).open();
+        });
+
         this.ocrToggleEl = toolbar.createDiv({ cls: "lilbee-ocr-toggle" });
         this.updateOcrToggle();
         this.ocrToggleEl.addEventListener("click", () => this.cycleOcr());

--- a/styles.css
+++ b/styles.css
@@ -145,6 +145,21 @@
     gap: 2px;
 }
 
+.lilbee-embed-browse {
+    font-size: var(--font-smallest, 10px);
+    padding: 2px 6px;
+    color: var(--text-muted);
+    background: transparent;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-s, 4px);
+    cursor: pointer;
+}
+
+.lilbee-embed-browse:hover {
+    color: var(--text-normal);
+    background-color: var(--background-modifier-hover);
+}
+
 .lilbee-toolbar-spacer {
     flex: 1;
 }

--- a/tests/locales/en.test.ts
+++ b/tests/locales/en.test.ts
@@ -18,6 +18,7 @@ describe("MESSAGES", () => {
             expect(MESSAGES.BUTTON_REFRESH).toBe("Refresh");
             expect(MESSAGES.BUTTON_BROWSE_CATALOG).toBe("Browse Catalog");
             expect(MESSAGES.BUTTON_BROWSE_FULL_CATALOG).toBe("Browse full catalog");
+            expect(MESSAGES.BUTTON_BROWSE_MORE).toBe("Browse more…");
             expect(MESSAGES.BUTTON_DOWNLOAD_CONTINUE).toBe("Download & continue");
             expect(MESSAGES.BUTTON_DELETE_SELECTED).toBe("Delete selected");
             expect(MESSAGES.BUTTON_CRAWL).toBe("Crawl");

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -5673,6 +5673,122 @@ describe("managed mode settings", () => {
         });
     });
 
+    describe("Browse more buttons on picker dropdowns", () => {
+        let origAddDropdown: typeof Setting.prototype.addDropdown;
+        let origAddButton: typeof Setting.prototype.addButton;
+
+        function captureDropdownAndButtons(): {
+            buttonOnClicks: ButtonOnClick[];
+        } {
+            const buttonOnClicks: ButtonOnClick[] = [];
+            Setting.prototype.addDropdown = function (cb: (dropdown: any) => void) {
+                const fakeDropdown = {
+                    addOption: () => fakeDropdown,
+                    setValue: () => fakeDropdown,
+                    onChange: () => fakeDropdown,
+                };
+                cb(fakeDropdown);
+                return this;
+            };
+            Setting.prototype.addButton = function (cb: (btn: any) => void) {
+                const fakeBtn = {
+                    setButtonText: () => fakeBtn,
+                    setDisabled: () => fakeBtn,
+                    setWarning: () => fakeBtn,
+                    onClick: (handler: ButtonOnClick) => {
+                        buttonOnClicks.push(handler);
+                        return fakeBtn;
+                    },
+                };
+                cb(fakeBtn);
+                return this;
+            };
+            return { buttonOnClicks };
+        }
+
+        beforeEach(() => {
+            origAddDropdown = Setting.prototype.addDropdown;
+            origAddButton = Setting.prototype.addButton;
+        });
+        afterEach(() => {
+            Setting.prototype.addDropdown = origAddDropdown;
+            Setting.prototype.addButton = origAddButton;
+        });
+
+        it("embedding picker exposes Browse more button that opens CatalogModal with task=embedding", async () => {
+            const { CatalogModal } = await import("../src/views/catalog-modal");
+            (CatalogModal as unknown as ReturnType<typeof vi.fn>).mockClear();
+
+            const plugin = makePlugin();
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({
+                    total: 1,
+                    limit: 20,
+                    offset: 0,
+                    models: [{ name: "nomic-embed-text", installed: true, task: "embedding" }],
+                    has_more: false,
+                }),
+            );
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { buttonOnClicks } = captureDropdownAndButtons();
+
+            await (tab as any).loadEmbeddingDropdown(container);
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(buttonOnClicks.length).toBe(1);
+            buttonOnClicks[0]();
+            expect(CatalogModal).toHaveBeenCalledWith(expect.anything(), plugin, "embedding");
+        });
+
+        it("reranker picker exposes Browse more button that opens CatalogModal with task=rerank", async () => {
+            const { CatalogModal } = await import("../src/views/catalog-modal");
+            (CatalogModal as unknown as ReturnType<typeof vi.fn>).mockClear();
+
+            const plugin = makePlugin();
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                reranker_model: "",
+                rerank_candidates: 20,
+            });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ total: 0, limit: 20, offset: 0, models: [], has_more: false }),
+            );
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { buttonOnClicks } = captureDropdownAndButtons();
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(buttonOnClicks.length).toBe(1);
+            buttonOnClicks[0]();
+            expect(CatalogModal).toHaveBeenCalledWith(expect.anything(), plugin, "rerank");
+        });
+
+        it("vision picker exposes Browse more button that opens CatalogModal with task=vision", async () => {
+            const { CatalogModal } = await import("../src/views/catalog-modal");
+            (CatalogModal as unknown as ReturnType<typeof vi.fn>).mockClear();
+
+            const plugin = makePlugin();
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({ vision_model: "" });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ total: 0, limit: 20, offset: 0, models: [], has_more: false }),
+            );
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+            const { buttonOnClicks } = captureDropdownAndButtons();
+
+            (tab as any).renderVisionSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(buttonOnClicks.length).toBe(1);
+            buttonOnClicks[0]();
+            expect(CatalogModal).toHaveBeenCalledWith(expect.anything(), plugin, "vision");
+        });
+    });
+
     describe("rerank_candidates advanced field", () => {
         // In manual mode: [0]=port, [1-6]=gen, [7-9]=crawl, [10]=wikiVaultFolder, [11-12]=chunks, [13]=rerank_candidates
         const RERANK_IDX = 20;

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -2727,6 +2727,23 @@ describe("ChatView — embedding model selector", () => {
         expect(plugin.api.setEmbeddingModel).not.toHaveBeenCalled();
     });
 
+    it("Browse more button opens CatalogModal pre-filtered to embedding", async () => {
+        const { CatalogModal } = await import("../../src/views/catalog-modal");
+        (CatalogModal as unknown as ReturnType<typeof vi.fn>).mockClear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const browseBtn = container.find("lilbee-embed-browse")!;
+        expect(browseBtn).not.toBeNull();
+        expect(browseBtn.textContent).toBe(MESSAGES.BUTTON_BROWSE_MORE);
+
+        browseBtn.trigger("click");
+        expect(CatalogModal).toHaveBeenCalledWith(expect.anything(), plugin, "embedding");
+    });
+
     it("shows connecting label on embedding select when offline", async () => {
         vi.useFakeTimers();
         const plugin = makePlugin();


### PR DESCRIPTION
The in-context model pickers for embedding, reranker, and vision were running a single `catalog({ task: X })` call and dropping `has_more` on the floor. Anyone with more than 20 models of a given role couldn't reach page 2 — the only way to switch to a paginated-out model was from the Model Catalog modal, and you had to know to go looking for it.

Each picker now has a "Browse more…" affordance next to the dropdown. The Catalog modal already paginates correctly and already accepts `initialTaskFilter` in its constructor, so the fix wires up four new entry points:

- Chat toolbar embedding picker (small button in the embed group)
- Settings → Search & Retrieval → Embedding
- Settings → Search & Retrieval → Reranker
- Settings → OCR → Vision

Clicking any of them opens the Catalog modal pre-filtered to that role. Pickers stay as single-page fast loaders — no N-request loops on Settings tab open or chat toolbar init.

Coverage is unchanged at 100%. Four new tests cover each of the four entry points and assert the modal is instantiated with the correct `task` filter string.