### PR TITLE
Wizard: keep activeModel as hf_repo for catalog-match parity

### DIFF
--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -601,7 +601,7 @@ export class SetupWizard extends Modal {
                 (downloadBtn as HTMLButtonElement).disabled = false;
                 return;
             }
-            this.plugin.activeModel = model.display_name;
+            this.plugin.activeModel = model.hf_repo;
             this.plugin.fetchActiveModel();
             this.pulledModelName = model.display_name;
             this.step = WIZARD_STEP.EMBEDDING_PICKER;


### PR DESCRIPTION
Orphan follow-up to #52. The setup wizard's DONE step was stashing `model.display_name` as `plugin.activeModel` after a successful pull. The catalog-match code on the status bar side looks up by `hf_repo`, so the active-model label would miss the catalog lookup and fall back to a raw string display. Using `hf_repo` keeps the two sides on the same key.

One-line change in `src/views/setup-wizard.ts`. All 1691 tests pass with 100% coverage held.