### PR TITLE
Safer source previews, clearer setup-wizard errors, wiki client coverage

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -535,7 +535,7 @@ export class LilbeeClient {
     async wikiDraftAccept(slug: string): Promise<DraftAcceptResponse> {
         const res = await this.fetchWithRetry(`${this.baseUrl}/api/wiki/drafts/${encodeURIComponent(slug)}/accept`, {
             method: "POST",
-            headers: { ...JSON_HEADERS, ...this.authHeaders() },
+            headers: this.authHeaders(),
         });
         return res.json();
     }

--- a/src/api.ts
+++ b/src/api.ts
@@ -22,9 +22,11 @@ import type {
     DraftAcceptResponse,
     DraftInfoResponse,
     DraftRejectResponse,
+    WikiBuildResult,
     WikiCitationChain,
     WikiPage,
     WikiPageDetail,
+    WikiStatusResult,
 } from "./types";
 const DEFAULT_TIMEOUT_MS = 15_000;
 const RETRY_COUNT = 2;
@@ -453,6 +455,29 @@ export class LilbeeClient {
     async wikiLint(): Promise<LintResult> {
         const res = await this.fetchWithRetry(`${this.baseUrl}/api/wiki/lint`, {
             method: "POST",
+            headers: this.authHeaders(),
+        });
+        return res.json();
+    }
+
+    async wikiBuild(): Promise<WikiBuildResult> {
+        const res = await this.fetchWithRetry(`${this.baseUrl}/api/wiki/build`, {
+            method: "POST",
+            headers: { ...JSON_HEADERS, ...this.authHeaders() },
+        });
+        return res.json();
+    }
+
+    async wikiUpdate(): Promise<WikiBuildResult> {
+        const res = await this.fetchWithRetry(`${this.baseUrl}/api/wiki/update`, {
+            method: "PATCH",
+            headers: { ...JSON_HEADERS, ...this.authHeaders() },
+        });
+        return res.json();
+    }
+
+    async wikiStatus(): Promise<WikiStatusResult> {
+        const res = await this.fetchWithRetry(`${this.baseUrl}/api/wiki/status`, {
             headers: this.authHeaders(),
         });
         return res.json();

--- a/src/api.ts
+++ b/src/api.ts
@@ -463,7 +463,7 @@ export class LilbeeClient {
     async wikiBuild(): Promise<WikiBuildResult> {
         const res = await this.fetchWithRetry(`${this.baseUrl}/api/wiki/build`, {
             method: "POST",
-            headers: { ...JSON_HEADERS, ...this.authHeaders() },
+            headers: this.authHeaders(),
         });
         return res.json();
     }
@@ -471,7 +471,7 @@ export class LilbeeClient {
     async wikiUpdate(): Promise<WikiBuildResult> {
         const res = await this.fetchWithRetry(`${this.baseUrl}/api/wiki/update`, {
             method: "PATCH",
-            headers: { ...JSON_HEADERS, ...this.authHeaders() },
+            headers: this.authHeaders(),
         });
         return res.json();
     }

--- a/src/api.ts
+++ b/src/api.ts
@@ -27,6 +27,7 @@ import type {
     WikiPage,
     WikiPageDetail,
     WikiStatusResult,
+    WikiSynthesizeResult,
 } from "./types";
 const DEFAULT_TIMEOUT_MS = 15_000;
 const RETRY_COUNT = 2;
@@ -478,6 +479,14 @@ export class LilbeeClient {
 
     async wikiStatus(): Promise<WikiStatusResult> {
         const res = await this.fetchWithRetry(`${this.baseUrl}/api/wiki/status`, {
+            headers: this.authHeaders(),
+        });
+        return res.json();
+    }
+
+    async wikiSynthesize(): Promise<WikiSynthesizeResult> {
+        const res = await this.fetchWithRetry(`${this.baseUrl}/api/wiki/synthesize`, {
+            method: "POST",
             headers: this.authHeaders(),
         });
         return res.json();

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -519,6 +519,8 @@ export const MESSAGES = {
     TOOLTIP_PREVIEW_SAVE_SOON: "Coming soon — available once the server supports vault storage.",
     ERROR_PREVIEW_INVALID_SOURCE: "Cannot preview: source reference is empty.",
     ERROR_PREVIEW_LOAD: (reason: string) => `Failed to load source: ${reason}`,
+    ERROR_PREVIEW_UNSUPPORTED: (mime: string) =>
+        `Cannot preview content of type "${mime}". Open the original file in your vault to view it.`,
 
     // Lint
     TITLE_LINT_RESULTS: "Wiki lint results",

--- a/src/types.ts
+++ b/src/types.ts
@@ -404,6 +404,12 @@ export interface WikiStatusResult {
     lint_warnings: number;
 }
 
+/** Result of generating synthesis pages for cross-source clusters. */
+export interface WikiSynthesizeResult {
+    paths: string[];
+    count: number;
+}
+
 /** Obsidian's DataAdapter has these methods but the type declarations are incomplete. */
 export interface VaultAdapter {
     getBasePath(): string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -387,6 +387,23 @@ export interface LintResult {
     checked_at: string | null;
 }
 
+/** Result of a full wiki build/update. Mirrors `WikiBuildResult` on the server. */
+export interface WikiBuildResult {
+    paths: string[];
+    entities: number;
+    count: number;
+}
+
+/** Wiki layer status: page counts and recent lint counters. */
+export interface WikiStatusResult {
+    wiki_enabled: boolean;
+    summaries: number;
+    drafts: number;
+    pages: number;
+    lint_errors: number;
+    lint_warnings: number;
+}
+
 /** Obsidian's DataAdapter has these methods but the type declarations are incomplete. */
 export interface VaultAdapter {
     getBasePath(): string;

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -1,5 +1,6 @@
 import { App, Modal, Notice } from "obsidian";
 import type LilbeePlugin from "../main";
+import { SessionTokenError } from "../api";
 import type { CatalogEntry, SSEEvent, SyncDone } from "../types";
 import { SERVER_MODE, SERVER_STATE, SSE_EVENT, WIZARD_STEP, ERROR_NAME, MODEL_TASK, MODEL_SOURCE } from "../types";
 import { CatalogModal } from "./catalog-modal";
@@ -609,6 +610,9 @@ export class SetupWizard extends Modal {
         } catch (err) {
             if (err instanceof Error && err.name === ERROR_NAME.ABORT_ERROR) {
                 new Notice(MESSAGES.NOTICE_DOWNLOAD_CANCELLED);
+            } else if (err instanceof SessionTokenError) {
+                new Notice(MESSAGES.NOTICE_SESSION_TOKEN_INVALID);
+                statusEl.textContent = MESSAGES.NOTICE_SESSION_TOKEN_INVALID;
             } else {
                 statusEl.textContent = MESSAGES.ERROR_DOWNLOAD_FAILED;
             }
@@ -771,6 +775,9 @@ export class SetupWizard extends Modal {
         } catch (err) {
             if (err instanceof Error && err.name === ERROR_NAME.ABORT_ERROR) {
                 new Notice(MESSAGES.NOTICE_DOWNLOAD_CANCELLED);
+            } else if (err instanceof SessionTokenError) {
+                new Notice(MESSAGES.NOTICE_SESSION_TOKEN_INVALID);
+                statusEl.textContent = MESSAGES.NOTICE_SESSION_TOKEN_INVALID;
             } else {
                 statusEl.textContent = MESSAGES.ERROR_DOWNLOAD_FAILED;
             }
@@ -847,6 +854,9 @@ export class SetupWizard extends Modal {
         } catch (err) {
             if (err instanceof Error && err.name === ERROR_NAME.ABORT_ERROR) {
                 new Notice(MESSAGES.NOTICE_INDEXING_CANCELLED);
+            } else if (err instanceof SessionTokenError) {
+                new Notice(MESSAGES.NOTICE_SESSION_TOKEN_INVALID);
+                progressLabel.textContent = MESSAGES.NOTICE_SESSION_TOKEN_INVALID;
             } else {
                 progressLabel.textContent = MESSAGES.ERROR_INDEXING_FAILED;
             }

--- a/src/views/source-preview-modal.ts
+++ b/src/views/source-preview-modal.ts
@@ -10,9 +10,12 @@ import { formatLocation } from "./results";
  * Read-only preview for sources that aren't in the local vault (external
  * server mode, or a vault-bound source whose file was removed). Fetches
  * content via `/api/source` and renders markdown inline. For PDFs the modal
- * embeds an `<iframe>` pointing at the `raw=1` endpoint with a `#page=N`
- * fragment — Chromium's built-in PDF viewer (PDFium) honours that fragment in
- * iframe src, which lets the preview jump directly to the chunk's page.
+ * embeds an `<object type="application/pdf">` pointing at the `raw=1`
+ * endpoint with a `#page=N` fragment — Chromium's built-in PDFium viewer
+ * honours that fragment, which lets the preview jump directly to the
+ * chunk's page. The type-locked `<object>` tag (vs. an iframe) prevents an
+ * attacker-renamed `.html` source from being rendered as HTML inside the
+ * plugin origin even if the server's content-type allowlist is bypassed.
  *
  * A future "Save to vault" button will push the content into `<vault>/lilbee/`
  * once the server exposes the write path — disabled for now with a tooltip.
@@ -108,18 +111,27 @@ export class SourcePreviewModal extends Modal {
     }
 
     private renderBody(host: HTMLElement, content: SourceContent): void {
-        if (this.source.content_type === CONTENT_TYPE.PDF || content.content_type === CONTENT_TYPE.PDF) {
+        const isPdf = this.source.content_type === CONTENT_TYPE.PDF || content.content_type === CONTENT_TYPE.PDF;
+        if (isPdf) {
             this.renderPdf(host);
             return;
         }
-        const body = host.createDiv({ cls: "lilbee-preview-body" });
-        void MarkdownRenderer.render(this.app, content.markdown, body, "", this);
+        if (content.content_type === CONTENT_TYPE.MARKDOWN || content.content_type.startsWith("text/")) {
+            const body = host.createDiv({ cls: "lilbee-preview-body" });
+            void MarkdownRenderer.render(this.app, content.markdown, body, "", this);
+            return;
+        }
+        host.createEl("p", {
+            text: MESSAGES.ERROR_PREVIEW_UNSUPPORTED(content.content_type),
+            cls: "lilbee-preview-error",
+        });
     }
 
     private renderPdf(host: HTMLElement): void {
         const body = host.createDiv({ cls: "lilbee-preview-body" });
-        const frame = body.createEl("iframe", { cls: "lilbee-preview-pdf-frame" });
-        frame.setAttribute("src", this.rawSourceUrl(this.source.page_start));
+        const frame = body.createEl("object", { cls: "lilbee-preview-pdf-frame" });
+        frame.setAttribute("type", "application/pdf");
+        frame.setAttribute("data", this.rawSourceUrl(this.source.page_start));
     }
 
     private rawSourceUrl(page: number | null): string {

--- a/src/views/source-preview-modal.ts
+++ b/src/views/source-preview-modal.ts
@@ -6,6 +6,17 @@ import { MESSAGES } from "../locales/en";
 import { errorMessage } from "../utils";
 import { formatLocation } from "./results";
 
+// Text/* mime types that should NOT render inline through MarkdownRenderer
+// even though they pass the broad text/* category. Keep narrow and explicit;
+// broadening this set requires a security review.
+const TEXT_INLINE_RENDER_DENY = new Set([
+    "text/html",
+    "text/javascript",
+    "application/javascript",
+    "application/xhtml+xml",
+    "text/css",
+]);
+
 /**
  * Read-only preview for sources that aren't in the local vault (external
  * server mode, or a vault-bound source whose file was removed). Fetches
@@ -13,9 +24,8 @@ import { formatLocation } from "./results";
  * embeds an `<object type="application/pdf">` pointing at the `raw=1`
  * endpoint with a `#page=N` fragment — Chromium's built-in PDFium viewer
  * honours that fragment, which lets the preview jump directly to the
- * chunk's page. The type-locked `<object>` tag (vs. an iframe) prevents an
- * attacker-renamed `.html` source from being rendered as HTML inside the
- * plugin origin even if the server's content-type allowlist is bypassed.
+ * chunk's page. The type-locked `<object>` tag narrows the rendering
+ * surface for any non-PDF bytes the server might return.
  *
  * A future "Save to vault" button will push the content into `<vault>/lilbee/`
  * once the server exposes the write path — disabled for now with a tooltip.
@@ -111,18 +121,24 @@ export class SourcePreviewModal extends Modal {
     }
 
     private renderBody(host: HTMLElement, content: SourceContent): void {
-        const isPdf = this.source.content_type === CONTENT_TYPE.PDF || content.content_type === CONTENT_TYPE.PDF;
+        const ct = content.content_type;
+        const isPdf = this.source.content_type === CONTENT_TYPE.PDF || ct === CONTENT_TYPE.PDF;
         if (isPdf) {
             this.renderPdf(host);
             return;
         }
-        if (content.content_type === CONTENT_TYPE.MARKDOWN || content.content_type.startsWith("text/")) {
+        // Mirror the server's raw-content allowlist: any text/* may render through
+        // MarkdownRenderer, except formats that can carry script (text/html,
+        // text/javascript, application/xhtml+xml) or styling (text/css). The
+        // <object> tag protects the PDF path; this gate protects the JSON path.
+        const textBlocked = TEXT_INLINE_RENDER_DENY.has(ct);
+        if (!textBlocked && ct.startsWith("text/")) {
             const body = host.createDiv({ cls: "lilbee-preview-body" });
             void MarkdownRenderer.render(this.app, content.markdown, body, "", this);
             return;
         }
         host.createEl("p", {
-            text: MESSAGES.ERROR_PREVIEW_UNSUPPORTED(content.content_type),
+            text: MESSAGES.ERROR_PREVIEW_UNSUPPORTED(ct),
             cls: "lilbee-preview-error",
         });
     }

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1494,6 +1494,78 @@ describe("wikiLint()", () => {
     });
 });
 
+describe("wikiBuild()", () => {
+    it("POSTs to /api/wiki/build and returns the build summary", async () => {
+        const data = { paths: ["wiki/concepts/brake-systems.md"], entities: 7, count: 1 };
+        fetchMock.mockResolvedValue(jsonResponse(data));
+
+        const result = await client.wikiBuild();
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            `${BASE_URL}/api/wiki/build`,
+            expect.objectContaining({ method: "POST" }),
+        );
+        expect(result).toEqual(data);
+    });
+
+    it("propagates server errors via fetchWithRetry", async () => {
+        fetchMock.mockResolvedValue(new Response("boom", { status: 500 }));
+        await expect(client.wikiBuild()).rejects.toThrow();
+    });
+});
+
+describe("wikiUpdate()", () => {
+    it("PATCHes /api/wiki/update and returns the build summary", async () => {
+        const data = { paths: [], entities: 0, count: 0 };
+        fetchMock.mockResolvedValue(jsonResponse(data));
+
+        const result = await client.wikiUpdate();
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            `${BASE_URL}/api/wiki/update`,
+            expect.objectContaining({ method: "PATCH" }),
+        );
+        expect(result).toEqual(data);
+    });
+});
+
+describe("wikiStatus()", () => {
+    it("GETs /api/wiki/status and returns the status snapshot", async () => {
+        const data = {
+            wiki_enabled: true,
+            summaries: 4,
+            drafts: 2,
+            pages: 6,
+            lint_errors: 0,
+            lint_warnings: 1,
+        };
+        fetchMock.mockResolvedValue(jsonResponse(data));
+
+        const result = await client.wikiStatus();
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            `${BASE_URL}/api/wiki/status`,
+            expect.not.objectContaining({ method: "POST" }),
+        );
+        expect(result).toEqual(data);
+    });
+
+    it("returns the disabled-wiki shape when wiki is off on the server", async () => {
+        const data = {
+            wiki_enabled: false,
+            summaries: 0,
+            drafts: 0,
+            pages: 0,
+            lint_errors: 0,
+            lint_warnings: 0,
+        };
+        fetchMock.mockResolvedValue(jsonResponse(data));
+        const result = await client.wikiStatus();
+        expect(result.wiki_enabled).toBe(false);
+        expect(result.pages).toBe(0);
+    });
+});
+
 describe("wikiGenerate()", () => {
     it("POSTs to /api/wiki/generate with source and yields SSE events", async () => {
         fetchMock.mockResolvedValue(sseResponse(['event: wiki_generate_done\ndata: {"slug":"test"}\n\n']));

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1566,6 +1566,28 @@ describe("wikiStatus()", () => {
     });
 });
 
+describe("wikiSynthesize()", () => {
+    it("POSTs to /api/wiki/synthesize and returns the synthesis summary", async () => {
+        const data = { paths: ["wiki/synthesis/typing.md"], count: 1 };
+        fetchMock.mockResolvedValue(jsonResponse(data));
+
+        const result = await client.wikiSynthesize();
+
+        expect(fetchMock).toHaveBeenCalledWith(
+            `${BASE_URL}/api/wiki/synthesize`,
+            expect.objectContaining({ method: "POST" }),
+        );
+        expect(result).toEqual(data);
+    });
+
+    it("returns the empty-cluster shape when no clusters meet the threshold", async () => {
+        fetchMock.mockResolvedValue(jsonResponse({ paths: [], count: 0 }));
+        const result = await client.wikiSynthesize();
+        expect(result.count).toBe(0);
+        expect(result.paths).toEqual([]);
+    });
+});
+
 describe("wikiGenerate()", () => {
     it("POSTs to /api/wiki/generate with source and yields SSE events", async () => {
         fetchMock.mockResolvedValue(sseResponse(['event: wiki_generate_done\ndata: {"slug":"test"}\n\n']));

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -2,6 +2,7 @@ import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { App, Notice } from "obsidian";
 import { MockElement } from "../__mocks__/obsidian";
 import { SetupWizard, getSystemMemoryGB, pickNativeChatModels, recommendedIndex } from "../../src/views/setup-wizard";
+import { SessionTokenError } from "../../src/api";
 import { SSE_EVENT, WIZARD_STEP } from "../../src/types";
 import { ok, err } from "neverthrow";
 import { MESSAGES } from "../../src/locales/en";
@@ -850,6 +851,31 @@ describe("SetupWizard", () => {
             expect(texts.some((t) => t.includes("Download failed"))).toBe(true);
         });
 
+        it("pull surfaces token-stale message when stream throws SessionTokenError", async () => {
+            const entries = [makeEntry({ name: "qwen/qwen3-0.6B" })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
+            plugin.api.pullModel = vi.fn().mockReturnValue(
+                (async function* () {
+                    throw new SessionTokenError(401, "stale");
+                })(),
+            );
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const downloadBtn = findButtons(el).find((b) => b.textContent === "Download & continue")!;
+            downloadBtn.trigger("click");
+            await tick();
+            await tick();
+
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_SESSION_TOKEN_INVALID)).toBe(true);
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some((t) => t.includes(MESSAGES.NOTICE_SESSION_TOKEN_INVALID))).toBe(true);
+        });
+
         it("SSE_EVENT.ERROR during pull shows notice and updates status", async () => {
             const entries = [makeEntry({ name: "qwen/qwen3-0.6B" })];
             const plugin = makePlugin({ settings: { serverMode: "external" } });
@@ -1093,6 +1119,25 @@ describe("SetupWizard", () => {
             await tick();
 
             expect(Notice.instances.some((n) => n.message.includes("indexing cancelled"))).toBe(true);
+        });
+
+        it("sync surfaces token-stale message when stream throws SessionTokenError", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.syncStream = vi.fn().mockReturnValue(
+                (async function* () {
+                    throw new SessionTokenError(401, "stale");
+                })(),
+            );
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 4;
+            (wizard as any).renderStep();
+            await tick();
+            await tick();
+
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_SESSION_TOKEN_INVALID)).toBe(true);
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some((t) => t.includes(MESSAGES.NOTICE_SESSION_TOKEN_INVALID))).toBe(true);
         });
 
         it("sync failure shows error message", async () => {
@@ -2062,6 +2107,29 @@ describe("SetupWizard", () => {
             const btn = new MockElement("button") as unknown as HTMLElement;
             await (wizard as any).pullEmbeddingModel(btn, el, el, el, el, el);
             expect((btn as unknown as MockElement).disabled).toBe(false);
+        });
+
+        it("pullEmbeddingModel surfaces token-stale message on SessionTokenError", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.pullModel = vi.fn().mockReturnValue(
+                (async function* () {
+                    throw new SessionTokenError(401, "stale");
+                })(),
+            );
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).selectedEmbedding = makeEntry({
+                name: "nomic-embed-text",
+                hf_repo: "nomic/nomic-embed-text",
+                task: "embedding",
+                installed: false,
+            });
+            const statusEl = new MockElement("div") as unknown as HTMLElement;
+            const btn = new MockElement("button") as unknown as HTMLElement;
+            const otherEl = new MockElement("div") as unknown as HTMLElement;
+            await (wizard as any).pullEmbeddingModel(btn, otherEl, otherEl, otherEl, statusEl, otherEl);
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_SESSION_TOKEN_INVALID)).toBe(true);
+            expect((statusEl as unknown as MockElement).textContent).toBe(MESSAGES.NOTICE_SESSION_TOKEN_INVALID);
         });
 
         it("pullEmbeddingModel handles AbortError", async () => {

--- a/tests/views/source-preview-modal.test.ts
+++ b/tests/views/source-preview-modal.test.ts
@@ -188,7 +188,7 @@ describe("SourcePreviewModal — loading + success (markdown)", () => {
 });
 
 describe("SourcePreviewModal — success (PDF)", () => {
-    it("renders an <iframe> pointing to the raw URL for PDF content-type", async () => {
+    it('renders an <object type="application/pdf"> pointing to the raw URL', async () => {
         const app = new App();
         const api = makeApi({
             getSource: vi.fn().mockResolvedValue({
@@ -206,11 +206,15 @@ describe("SourcePreviewModal — success (PDF)", () => {
         const el = modal.contentEl as unknown as MockElement;
         const frame = el.find("lilbee-preview-pdf-frame");
         expect(frame).not.toBeNull();
-        expect(frame!.tagName).toBe("IFRAME");
-        expect(frame!.attributes["src"]).toContain("book.pdf");
+        // Type-locked <object> tag prevents server-controlled mime from rendering
+        // a malicious .html source as text/html inside the plugin origin.
+        expect(frame!.tagName).toBe("OBJECT");
+        expect(frame!.attributes["type"]).toBe("application/pdf");
+        expect(frame!.attributes["data"]).toContain("book.pdf");
+        expect(el.find("lilbee-preview-iframe")).toBeNull();
     });
 
-    it("renders a PDF iframe when source.content_type is PDF even if body content_type differs", async () => {
+    it("renders a PDF object when source.content_type is PDF even if body content_type differs", async () => {
         const app = new App();
         const api = makeApi({
             getSource: vi.fn().mockResolvedValue({
@@ -222,10 +226,11 @@ describe("SourcePreviewModal — success (PDF)", () => {
         modal.open();
         await tick();
         const el = modal.contentEl as unknown as MockElement;
-        expect(el.find("lilbee-preview-pdf-frame")).not.toBeNull();
+        const frame = el.find("lilbee-preview-pdf-frame")!;
+        expect(frame.tagName).toBe("OBJECT");
     });
 
-    it("appends #page=N to the iframe src when page_start is set", async () => {
+    it("appends #page=N to the object data URL when page_start is set", async () => {
         const app = new App();
         const api = makeApi({
             getSource: vi.fn().mockResolvedValue({
@@ -246,7 +251,7 @@ describe("SourcePreviewModal — success (PDF)", () => {
         await tick();
         const el = modal.contentEl as unknown as MockElement;
         const frame = el.find("lilbee-preview-pdf-frame")!;
-        expect(frame.attributes["src"]).toContain("#page=42");
+        expect(frame.attributes["data"]).toContain("#page=42");
     });
 
     it("omits the #page= fragment when page_start is null", async () => {
@@ -266,7 +271,35 @@ describe("SourcePreviewModal — success (PDF)", () => {
         await tick();
         const el = modal.contentEl as unknown as MockElement;
         const frame = el.find("lilbee-preview-pdf-frame")!;
-        expect(frame.attributes["src"]).not.toContain("#page=");
+        expect(frame.attributes["data"]).not.toContain("#page=");
+    });
+});
+
+describe("SourcePreviewModal — unsupported mime", () => {
+    it("renders an error message instead of treating unknown content as markdown", async () => {
+        const app = new App();
+        const api = makeApi({
+            getSource: vi.fn().mockResolvedValue({
+                markdown: "<script>alert(1)</script>",
+                content_type: "application/octet-stream",
+            }),
+        });
+        const modal = new SourcePreviewModal(
+            app as never,
+            api,
+            makeSource({
+                source: "evil.html",
+                content_type: "application/octet-stream",
+            }),
+        );
+        modal.open();
+        await tick();
+        const el = modal.contentEl as unknown as MockElement;
+        // No body rendered with attacker-controlled markup.
+        expect(el.find("lilbee-preview-body")).toBeNull();
+        const errorEl = el.find("lilbee-preview-error");
+        expect(errorEl).not.toBeNull();
+        expect(errorEl!.textContent).toContain("application/octet-stream");
     });
 });
 

--- a/tests/views/source-preview-modal.test.ts
+++ b/tests/views/source-preview-modal.test.ts
@@ -303,7 +303,7 @@ describe("SourcePreviewModal — unsupported mime", () => {
     });
 
     it.each(["text/html", "text/javascript", "application/javascript", "application/xhtml+xml", "text/css"])(
-        "denies inline render for %s even though it falls under text/*",
+        "denies inline render for script- or style-carrying mime %s",
         async (mime) => {
             const app = new App();
             const api = makeApi({

--- a/tests/views/source-preview-modal.test.ts
+++ b/tests/views/source-preview-modal.test.ts
@@ -301,6 +301,48 @@ describe("SourcePreviewModal — unsupported mime", () => {
         expect(errorEl).not.toBeNull();
         expect(errorEl!.textContent).toContain("application/octet-stream");
     });
+
+    it.each(["text/html", "text/javascript", "application/javascript", "application/xhtml+xml", "text/css"])(
+        "denies inline render for %s even though it falls under text/*",
+        async (mime) => {
+            const app = new App();
+            const api = makeApi({
+                getSource: vi.fn().mockResolvedValue({
+                    markdown: "<script>alert(1)</script>",
+                    content_type: mime,
+                }),
+            });
+            const modal = new SourcePreviewModal(app as never, api, makeSource({ source: "evil", content_type: mime }));
+            modal.open();
+            await tick();
+            const el = modal.contentEl as unknown as MockElement;
+            expect(el.find("lilbee-preview-body")).toBeNull();
+            const errorEl = el.find("lilbee-preview-error");
+            expect(errorEl).not.toBeNull();
+            expect(errorEl!.textContent).toContain(mime);
+        },
+    );
+
+    it("still renders text/plain inline (regression guard for the deny-list)", async () => {
+        const app = new App();
+        const api = makeApi({
+            getSource: vi.fn().mockResolvedValue({
+                markdown: "plain text body",
+                content_type: "text/plain",
+            }),
+        });
+        const modal = new SourcePreviewModal(
+            app as never,
+            api,
+            makeSource({ source: "notes.txt", content_type: "text/plain" }),
+        );
+        modal.open();
+        await tick();
+        const el = modal.contentEl as unknown as MockElement;
+        const body = el.find("lilbee-preview-body");
+        expect(body).not.toBeNull();
+        expect(body!.textContent).toContain("plain text body");
+    });
 });
 
 describe("SourcePreviewModal — error", () => {


### PR DESCRIPTION


## Safer source previews

Clicking a citation chip opens a preview modal which embedded PDFs through an iframe pointed at the server's raw-content endpoint. The server hadn't been guarding the Content-Type, so a malicious file in the documents dir would be served (and rendered) as HTML inside the plugin origin. The PDF preview now uses an `<object type="application/pdf">` element — the type-locked tag ignores whatever Content-Type the server returns, so even if the server's allowlist were bypassed an HTML response can't render as HTML. The modal also denies inline rendering for any text type that can carry script. Deep-linking to the cited page (`#page=N`) still works.

## Clearer errors during setup

If you finished the setup wizard with a stale session token, three of the wizard's catch blocks (chat pull, embedding pull, initial sync) were quietly relabelling the failure as "download failed" or "indexing failed" — leaving you with no signal that pasting a fresh token would unstick it. They now surface the token-stale notice inline and as a Notice, the same way the runtime call sites already do.

## Wiki client coverage

The plugin's API client now covers the full wiki surface — build, update, status, and synthesize — pairing with lilbee#182's new endpoints. UI hooks for these come in a follow-up; the contract is in place so managed-mode wiring isn't blocked.