### PR TITLE
Restore working model pickers and clean labels everywhere

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-lilbee",
-  "version": "0.1.4",
+  "version": "0.6.66b420",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-lilbee",
-      "version": "0.1.4",
+      "version": "0.6.66b420",
       "dependencies": {
         "neverthrow": "^8.2.0"
       },

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ import {
     type VaultAdapter,
 } from "./types";
 import { MESSAGES } from "./locales/en";
+import { displayLabelForRef } from "./utils/model-ref";
 import {
     errorMessage,
     extractSseErrorMessage,
@@ -672,7 +673,8 @@ export default class LilbeePlugin extends Plugin {
 
     private updateStatusBar(text: string, dotState: DotState | null = null): void {
         if (!this.statusBarEl) return;
-        const model = this.activeModel ? ` (${this.activeModel})` : "";
+        const label = displayLabelForRef(this.activeModel);
+        const model = label ? ` (${label})` : "";
         this.statusBarEl.empty();
         if (dotState) {
             const dot = this.statusBarEl.createSpan({ cls: `lilbee-statusbar-dot is-${dotState}` });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,17 +12,9 @@ import {
     TASK_TYPE,
     ERROR_NAME,
 } from "./types";
-import type {
-    CatalogEntry,
-    ConfigResponse,
-    InstalledModel,
-    LilbeeSettings,
-    ModelCatalog,
-    ModelInfo,
-    ModelsResponse,
-    ServerMode,
-} from "./types";
+import type { CatalogEntry, ConfigResponse, InstalledModel, LilbeeSettings, ServerMode } from "./types";
 import { MESSAGES } from "./locales/en";
+import { displayLabelForRef, extractHfRepo } from "./utils/model-ref";
 import { CatalogModal } from "./views/catalog-modal";
 import { ConfirmModal } from "./views/confirm-modal";
 import { ConfirmPullModal } from "./views/confirm-pull-modal";
@@ -56,40 +48,6 @@ const CREDENTIAL_FIELDS = new Set([
     "hf_token",
     "manual_session_token",
 ]);
-
-/**
- * Remove `:latest` entries when a more specific tag of the same model exists.
- * e.g. if both `mistral:latest` and `mistral:7b` are present, drop `mistral:latest`.
- */
-export function deduplicateLatest(models: string[]): string[] {
-    const bases = new Set(models.filter((m) => !m.endsWith(":latest")).map((m) => m.split(":")[0]));
-    return models.filter((m) => {
-        if (!m.endsWith(":latest")) return true;
-        return !bases.has(m.split(":")[0]);
-    });
-}
-
-export function buildModelOptions(catalog: ModelCatalog): Record<string, string> {
-    const options: Record<string, string> = {};
-
-    const catalogNames = new Set(catalog.catalog.map((m) => m.name));
-    for (const model of catalog.catalog) {
-        const suffix = model.installed ? "" : MESSAGES.LABEL_NOT_INSTALLED;
-        const sourceTag = model.source ? ` [${model.source}]` : "";
-        options[model.name] = `${model.name}${sourceTag}${suffix}`;
-    }
-
-    const otherInstalled = deduplicateLatest(catalog.installed.filter((name) => !catalogNames.has(name))).sort();
-
-    if (otherInstalled.length > 0) {
-        options[SEPARATOR_KEY] = SEPARATOR_LABEL;
-        for (const name of otherInstalled) {
-            options[name] = name;
-        }
-    }
-
-    return options;
-}
 
 export { SEPARATOR_KEY, SEPARATOR_LABEL };
 
@@ -572,7 +530,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
 
     private renderGenerationSettings(containerEl: HTMLElement): void {
         const details = containerEl.createEl("details", { cls: "lilbee-generation-details lilbee-settings-section" });
-        const modelLabel = this.plugin.activeModel || MESSAGES.LABEL_NO_MODEL_SELECTED;
+        const modelLabel = displayLabelForRef(this.plugin.activeModel) || MESSAGES.LABEL_NO_MODEL_SELECTED;
         details.createEl("summary", { text: `${MESSAGES.LABEL_GENERATION} (${modelLabel})` });
         details.createEl("p", {
             text: MESSAGES.LABEL_GENERATION_HELP,
@@ -680,7 +638,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
                     .addDropdown((dropdown) => {
                         for (const model of models) {
                             const suffix = model.installed ? "" : MESSAGES.LABEL_NOT_INSTALLED;
-                            dropdown.addOption(model.name, `${model.name}${suffix}`);
+                            dropdown.addOption(model.hf_repo, `${model.display_name}${suffix}`);
                         }
                         dropdown.onChange(async (value) => {
                             if (!value) return;
@@ -752,21 +710,21 @@ export class LilbeeSettingTab extends PluginSettingTab {
     }
 
     private buildRerankerOptions(catalogEntries: CatalogEntry[], installed: InstalledModel[]): Array<[string, string]> {
-        // ``installed`` carries the server's canonical ``name:tag`` ref, while
-        // catalog entries expose ``name`` and ``tag`` separately. Compare via the
-        // same ``name:tag`` form so an installed reranker isn't mislabelled
-        // ``(not installed)`` just because the catalog exposes the hf_repo.
-        const installedRefs = new Set(installed.map((m) => m.name));
-        const ref = (e: CatalogEntry): string => `${e.name}:${e.tag}`;
-        const isInstalled = (e: CatalogEntry): boolean => installedRefs.has(ref(e));
+        // `installed[].name` is the server's canonical ref (full HF path, or `provider/name`).
+        // For HF refs we strip the trailing `/<filename>.gguf` so it matches `entry.hf_repo`;
+        // provider refs pass through unchanged, so a hosted reranker isn't mislabelled
+        // `(not installed)`.
+        const installedRepos = new Set(installed.map((m) => extractHfRepo(m.name)));
+        const isInstalled = (e: CatalogEntry): boolean => installedRepos.has(e.hf_repo);
         const opts: Array<[string, string]> = [[RERANKER_DISABLED_KEY, MESSAGES.LABEL_RERANKER_DISABLED]];
         const localInstalled = catalogEntries.filter((e) => e.source !== MODEL_SOURCE.LITELLM && isInstalled(e));
         const localNotInstalled = catalogEntries.filter((e) => e.source !== MODEL_SOURCE.LITELLM && !isInstalled(e));
         const hosted = catalogEntries.filter((e) => e.source === MODEL_SOURCE.LITELLM);
-        for (const e of localInstalled) opts.push([ref(e), e.hf_repo]);
-        for (const e of localNotInstalled) opts.push([ref(e), `${e.hf_repo}${MESSAGES.LABEL_NOT_INSTALLED}`]);
+        for (const e of localInstalled) opts.push([e.hf_repo, e.display_name]);
+        for (const e of localNotInstalled) opts.push([e.hf_repo, `${e.display_name}${MESSAGES.LABEL_NOT_INSTALLED}`]);
         if (hosted.length > 0) {
-            for (const e of hosted) opts.push([ref(e), `${e.hf_repo} — ${MESSAGES.LABEL_RERANKER_HOSTED_GROUP}`]);
+            for (const e of hosted)
+                opts.push([e.hf_repo, `${e.display_name} — ${MESSAGES.LABEL_RERANKER_HOSTED_GROUP}`]);
         }
         return opts;
     }
@@ -776,11 +734,11 @@ export class LilbeeSettingTab extends PluginSettingTab {
         catalogEntries: CatalogEntry[],
         installed: InstalledModel[],
     ): Promise<void> {
-        const installedRefs = new Set(installed.map((m) => m.name));
-        const catalogEntry = catalogEntries.find((e) => `${e.name}:${e.tag}` === value);
+        const installedRepos = new Set(installed.map((m) => extractHfRepo(m.name)));
+        const catalogEntry = catalogEntries.find((e) => e.hf_repo === value);
         if (
             value === RERANKER_DISABLED_KEY ||
-            installedRefs.has(value) ||
+            installedRepos.has(value) ||
             catalogEntry?.source === MODEL_SOURCE.LITELLM
         ) {
             await this.applyRerankerSelection(value);
@@ -794,17 +752,14 @@ export class LilbeeSettingTab extends PluginSettingTab {
     private async applyRerankerSelection(value: string): Promise<void> {
         const result = await this.plugin.api.setRerankerModel(value);
         if (result.isErr()) {
-            const fallback = result.error.message.includes("422")
-                ? MESSAGES.NOTICE_RERANKER_NEEDS_KEY
-                : MESSAGES.NOTICE_FAILED_RERANKER;
-            new Notice(noticeForResultError(result.error, fallback));
+            new Notice(noticeForResultError(result.error, MESSAGES.NOTICE_FAILED_RERANKER));
             return;
         }
         new Notice(MESSAGES.NOTICE_RERANKER_UPDATED);
     }
 
     private async pullAndSetReranker(entry: CatalogEntry): Promise<void> {
-        const taskId = this.plugin.taskQueue.enqueue(`Pull ${entry.hf_repo}`, TASK_TYPE.PULL);
+        const taskId = this.plugin.taskQueue.enqueue(`Pull ${entry.display_name}`, TASK_TYPE.PULL);
         if (taskId === null) {
             new Notice(MESSAGES.NOTICE_QUEUE_FULL);
             return;
@@ -814,7 +769,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         const ok = await this.streamRerankerPull(taskId, entry, controller.signal);
         if (!ok) return;
         this.plugin.taskQueue.complete(taskId);
-        await this.applyRerankerSelection(`${entry.name}:${entry.tag}`);
+        await this.applyRerankerSelection(entry.hf_repo);
     }
 
     private async streamRerankerPull(taskId: string, entry: CatalogEntry, signal: AbortSignal): Promise<boolean> {
@@ -838,13 +793,13 @@ export class LilbeeSettingTab extends PluginSettingTab {
         const d = data as { percent?: number; current?: number; total?: number };
         const pct = percentFromSse(d);
         if (pct !== undefined) {
-            this.plugin.taskQueue.update(taskId, pct, entry.hf_repo, { current: d.current, total: d.total });
+            this.plugin.taskQueue.update(taskId, pct, entry.display_name, { current: d.current, total: d.total });
         }
     }
 
     private handleRerankerPullSseError(taskId: string, entry: CatalogEntry, data: unknown): void {
         const msg = extractSseErrorMessage(data as { message?: string } | string, MESSAGES.ERROR_UNKNOWN);
-        new Notice(`${MESSAGES.ERROR_PULL_MODEL.replace("{model}", entry.hf_repo)}: ${msg}`);
+        new Notice(`${MESSAGES.ERROR_PULL_MODEL.replace("{model}", entry.display_name)}: ${msg}`);
         this.plugin.taskQueue.fail(taskId, msg);
     }
 
@@ -855,7 +810,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             return;
         }
         const reason = errorMessage(err, MESSAGES.ERROR_UNKNOWN);
-        new Notice(`${MESSAGES.ERROR_PULL_MODEL.replace("{model}", entry.hf_repo)}: ${reason}`);
+        new Notice(`${MESSAGES.ERROR_PULL_MODEL.replace("{model}", entry.display_name)}: ${reason}`);
         this.plugin.taskQueue.fail(taskId, reason);
     }
 
@@ -902,19 +857,20 @@ export class LilbeeSettingTab extends PluginSettingTab {
     }
 
     private buildVisionOptions(catalogEntries: CatalogEntry[], installed: InstalledModel[]): Array<[string, string]> {
-        const installedNames = new Set(installed.map((m) => m.name));
+        // Strip the trailing `/<filename>.gguf` from installed refs so they match the catalog's bare `hf_repo`.
+        const installedRepos = new Set(installed.map((m) => extractHfRepo(m.name)));
         const opts: Array<[string, string]> = [[VISION_DISABLED_KEY, MESSAGES.LABEL_VISION_DISABLED]];
         const localInstalled = catalogEntries.filter(
-            (e) => e.source !== MODEL_SOURCE.LITELLM && installedNames.has(e.hf_repo),
+            (e) => e.source !== MODEL_SOURCE.LITELLM && installedRepos.has(e.hf_repo),
         );
         const localNotInstalled = catalogEntries.filter(
-            (e) => e.source !== MODEL_SOURCE.LITELLM && !installedNames.has(e.hf_repo),
+            (e) => e.source !== MODEL_SOURCE.LITELLM && !installedRepos.has(e.hf_repo),
         );
         const hosted = catalogEntries.filter((e) => e.source === MODEL_SOURCE.LITELLM);
-        for (const e of localInstalled) opts.push([e.hf_repo, e.hf_repo]);
-        for (const e of localNotInstalled) opts.push([e.hf_repo, `${e.hf_repo}${MESSAGES.LABEL_NOT_INSTALLED}`]);
+        for (const e of localInstalled) opts.push([e.hf_repo, e.display_name]);
+        for (const e of localNotInstalled) opts.push([e.hf_repo, `${e.display_name}${MESSAGES.LABEL_NOT_INSTALLED}`]);
         if (hosted.length > 0) {
-            for (const e of hosted) opts.push([e.hf_repo, `${e.hf_repo} — ${MESSAGES.LABEL_VISION_HOSTED_GROUP}`]);
+            for (const e of hosted) opts.push([e.hf_repo, `${e.display_name} — ${MESSAGES.LABEL_VISION_HOSTED_GROUP}`]);
         }
         return opts;
     }
@@ -924,11 +880,11 @@ export class LilbeeSettingTab extends PluginSettingTab {
         catalogEntries: CatalogEntry[],
         installed: InstalledModel[],
     ): Promise<void> {
-        const installedNames = new Set(installed.map((m) => m.name));
+        const installedRepos = new Set(installed.map((m) => extractHfRepo(m.name)));
         const catalogEntry = catalogEntries.find((e) => e.hf_repo === value);
         if (
             value === VISION_DISABLED_KEY ||
-            installedNames.has(value) ||
+            installedRepos.has(value) ||
             catalogEntry?.source === MODEL_SOURCE.LITELLM
         ) {
             await this.applyVisionSelection(value);
@@ -942,17 +898,14 @@ export class LilbeeSettingTab extends PluginSettingTab {
     private async applyVisionSelection(value: string): Promise<void> {
         const result = await this.plugin.api.setVisionModel(value);
         if (result.isErr()) {
-            const fallback = result.error.message.includes("422")
-                ? MESSAGES.NOTICE_VISION_NEEDS_KEY
-                : MESSAGES.NOTICE_FAILED_VISION;
-            new Notice(noticeForResultError(result.error, fallback));
+            new Notice(noticeForResultError(result.error, MESSAGES.NOTICE_FAILED_VISION));
             return;
         }
         new Notice(MESSAGES.NOTICE_VISION_UPDATED);
     }
 
     private async pullAndSetVision(entry: CatalogEntry): Promise<void> {
-        const taskId = this.plugin.taskQueue.enqueue(`Pull ${entry.hf_repo}`, TASK_TYPE.PULL);
+        const taskId = this.plugin.taskQueue.enqueue(`Pull ${entry.display_name}`, TASK_TYPE.PULL);
         if (taskId === null) {
             new Notice(MESSAGES.NOTICE_QUEUE_FULL);
             return;
@@ -986,13 +939,13 @@ export class LilbeeSettingTab extends PluginSettingTab {
         const d = data as { percent?: number; current?: number; total?: number };
         const pct = percentFromSse(d);
         if (pct !== undefined) {
-            this.plugin.taskQueue.update(taskId, pct, entry.hf_repo, { current: d.current, total: d.total });
+            this.plugin.taskQueue.update(taskId, pct, entry.display_name, { current: d.current, total: d.total });
         }
     }
 
     private handleVisionPullSseError(taskId: string, entry: CatalogEntry, data: unknown): void {
         const msg = extractSseErrorMessage(data as { message?: string } | string, MESSAGES.ERROR_UNKNOWN);
-        new Notice(`${MESSAGES.ERROR_PULL_MODEL.replace("{model}", entry.hf_repo)}: ${msg}`);
+        new Notice(`${MESSAGES.ERROR_PULL_MODEL.replace("{model}", entry.display_name)}: ${msg}`);
         this.plugin.taskQueue.fail(taskId, msg);
     }
 
@@ -1003,7 +956,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             return;
         }
         const reason = errorMessage(err, MESSAGES.ERROR_UNKNOWN);
-        new Notice(`${MESSAGES.ERROR_PULL_MODEL.replace("{model}", entry.hf_repo)}: ${reason}`);
+        new Notice(`${MESSAGES.ERROR_PULL_MODEL.replace("{model}", entry.display_name)}: ${reason}`);
         this.plugin.taskQueue.fail(taskId, reason);
     }
 
@@ -1644,12 +1597,8 @@ export class LilbeeSettingTab extends PluginSettingTab {
 
     private async loadModels(container: HTMLElement): Promise<void> {
         container.empty();
-        try {
-            const models = await this.plugin.api.listModels();
-            this.renderModelSection(container, MESSAGES.LABEL_CHAT_MODEL, models.chat);
-        } catch {
-            // Connection status is shown via the Test button — no duplicate warning needed
-        }
+        const chatContainer = container.createDiv({ cls: "lilbee-chat-container" });
+        this.renderChatSection(chatContainer);
         const embeddingContainer = container.createDiv({ cls: "lilbee-embedding-container" });
         this.loadEmbeddingDropdown(embeddingContainer);
         const visionContainer = container.createDiv({ cls: "lilbee-vision-container" });
@@ -1658,25 +1607,46 @@ export class LilbeeSettingTab extends PluginSettingTab {
         this.renderRerankerSection(rerankerContainer);
     }
 
-    private renderModelSection(container: HTMLElement, label: string, catalog: ModelsResponse["chat"]): void {
+    private renderChatSection(container: HTMLElement): void {
+        Promise.all([
+            this.plugin.api.config(),
+            this.plugin.api.catalog({ task: MODEL_TASK.CHAT }),
+            this.plugin.api.installedModels({ task: MODEL_TASK.CHAT }).catch(() => ({ models: [] })),
+        ])
+            .then(([cfg, catalogResult, installedResp]) => {
+                const active = typeof cfg.chat_model === "string" ? cfg.chat_model : "";
+                const catalogEntries = catalogResult.isOk() ? catalogResult.value.models : [];
+                this.renderChatPicker(container, active, catalogEntries, installedResp.models);
+            })
+            .catch(() => {
+                // Connection status is shown via the Test button — no duplicate warning needed.
+            });
+    }
+
+    private renderChatPicker(
+        container: HTMLElement,
+        active: string,
+        catalogEntries: CatalogEntry[],
+        installed: InstalledModel[],
+    ): void {
         const section = container.createDiv("lilbee-model-section");
-        section.createEl("h4", { text: label });
+        section.createEl("h4", { text: MESSAGES.LABEL_CHAT_MODEL });
 
         const activeSetting = new Setting(section)
             .setName(`${MESSAGES.LABEL_ACTIVE} chat model`)
-            .setDesc(catalog.active || MESSAGES.LABEL_NOT_SET);
+            .setDesc(displayLabelForRef(active) || MESSAGES.LABEL_NOT_SET);
 
-        const options = buildModelOptions(catalog);
-
-        activeSetting.addDropdown((dropdown) =>
-            dropdown
-                .addOptions(options)
-                .setValue(catalog.active)
-                .onChange(async (value) => {
-                    if (value === SEPARATOR_KEY) return;
-                    await this.handleModelChange(value, catalog, label, container);
-                }),
-        );
+        const options = this.buildChatOptions(catalogEntries, installed);
+        activeSetting.addDropdown((dropdown) => {
+            for (const [value, label] of options) {
+                dropdown.addOption(value, label);
+            }
+            dropdown.setValue(active);
+            dropdown.onChange(async (value) => {
+                if (value === SEPARATOR_KEY) return;
+                await this.handleChatChange(value, catalogEntries);
+            });
+        });
 
         const catalogEl = section.createDiv("lilbee-model-catalog");
         const table = catalogEl.createEl("table");
@@ -1685,68 +1655,107 @@ export class LilbeeSettingTab extends PluginSettingTab {
         header.createEl("th", { text: MESSAGES.LABEL_SIZE });
         header.createEl("th", { text: MESSAGES.LABEL_DESCRIPTION });
         header.createEl("th", { text: "" });
-
-        for (const model of catalog.catalog) {
-            this.renderCatalogRow(table, model);
+        for (const entry of catalogEntries) {
+            this.renderChatCatalogRow(table, entry, active);
         }
     }
 
-    private async setModel(model: { name: string }): ReturnType<typeof this.plugin.api.setChatModel> {
-        return this.plugin.api.setChatModel(model.name);
+    private buildChatOptions(catalogEntries: CatalogEntry[], installed: InstalledModel[]): Array<[string, string]> {
+        const installedRepos = new Set(installed.map((m) => extractHfRepo(m.name)));
+        const opts: Array<[string, string]> = [];
+        for (const entry of catalogEntries) {
+            const sourceTag = entry.source && entry.source !== MODEL_SOURCE.NATIVE ? ` [${entry.source}]` : "";
+            const installedFlag = installedRepos.has(entry.hf_repo);
+            const suffix = installedFlag ? "" : MESSAGES.LABEL_NOT_INSTALLED;
+            opts.push([entry.hf_repo, `${entry.display_name}${sourceTag}${suffix}`]);
+        }
+        const featuredRepos = new Set(catalogEntries.map((e) => e.hf_repo));
+        const otherInstalled = installed
+            .filter((m) => !featuredRepos.has(extractHfRepo(m.name)))
+            .sort((a, b) => a.name.localeCompare(b.name));
+        if (otherInstalled.length > 0) {
+            opts.push([SEPARATOR_KEY, SEPARATOR_LABEL]);
+            for (const m of otherInstalled) {
+                opts.push([m.name, displayLabelForRef(m.name)]);
+            }
+        }
+        return opts;
     }
 
-    private async handleModelChange(
-        value: string,
-        catalog: ModelCatalog,
-        label: string,
-        container: HTMLElement,
-    ): Promise<void> {
-        const uninstalledCatalogModel = catalog.catalog.find((m) => m.name === value && !m.installed);
-        if (uninstalledCatalogModel) {
-            const modal = new ConfirmPullModal(this.app, uninstalledCatalogModel);
+    private async handleChatChange(value: string, catalogEntries: CatalogEntry[]): Promise<void> {
+        const featuredEntry = catalogEntries.find((e) => e.hf_repo === value);
+        if (featuredEntry && !featuredEntry.installed) {
+            const modal = new ConfirmPullModal(this.app, {
+                displayName: featuredEntry.display_name,
+                sizeGb: featuredEntry.size_gb,
+                minRamGb: featuredEntry.min_ram_gb,
+            });
             modal.open();
             const confirmed = await modal.result;
             if (!confirmed) return;
-            await this.autoPullAndSet(uninstalledCatalogModel, container);
+            await this.pullAndSetChat(featuredEntry);
             return;
         }
-        const result = await this.setModel({ name: value });
+        await this.applyChatSelection(value, displayLabelForRef(value));
+    }
+
+    private async applyChatSelection(ref: string, label: string): Promise<void> {
+        const result = await this.plugin.api.setChatModel(ref);
         if (result.isErr()) {
             new Notice(noticeForResultError(result.error, MESSAGES.NOTICE_FAILED_SET_MODEL(MODEL_TASK.CHAT)));
             return;
         }
-        new Notice(MESSAGES.NOTICE_SET_MODEL(label, value || MESSAGES.LABEL_NOT_SET.toLowerCase()));
+        new Notice(MESSAGES.NOTICE_SET_MODEL(MESSAGES.LABEL_CHAT_MODEL, label || MESSAGES.LABEL_NOT_SET.toLowerCase()));
         this.plugin.fetchActiveModel();
         this.display();
     }
 
-    private async autoPullAndSet(model: ModelInfo, _container: HTMLElement): Promise<void> {
-        const taskId = this.plugin.taskQueue.enqueue(`Pull ${model.name}`, TASK_TYPE.PULL);
+    private async pullAndSetChat(entry: CatalogEntry): Promise<void> {
+        const ok = await this.streamChatPull(entry);
+        if (!ok) return;
+        const setResult = await this.plugin.api.setChatModel(entry.hf_repo);
+        if (setResult.isErr()) {
+            new Notice(
+                noticeForResultError(setResult.error, MESSAGES.ERROR_SET_MODEL.replace("{model}", entry.display_name)),
+            );
+        } else {
+            new Notice(MESSAGES.NOTICE_MODEL_ACTIVATED_FULL(entry.display_name));
+        }
+        this.plugin.fetchActiveModel();
+        this.display();
+    }
+
+    private async streamChatPull(entry: CatalogEntry): Promise<boolean> {
+        const taskId = this.plugin.taskQueue.enqueue(`Pull ${entry.display_name}`, TASK_TYPE.PULL);
         if (taskId === null) {
             new Notice(MESSAGES.NOTICE_QUEUE_FULL);
-            return;
+            return false;
         }
         const controller = new AbortController();
         this.plugin.taskQueue.registerAbort(taskId, controller);
-        let pullFailed = false;
         try {
-            for await (const event of this.plugin.api.pullModel(model.name, MODEL_SOURCE.NATIVE, controller.signal)) {
+            for await (const event of this.plugin.api.pullModel(
+                entry.hf_repo,
+                MODEL_SOURCE.NATIVE,
+                controller.signal,
+            )) {
                 if (event.event === SSE_EVENT.PROGRESS) {
                     const d = event.data as { percent?: number; current?: number; total?: number };
                     const pct = percentFromSse(d);
                     if (pct !== undefined) {
-                        this.plugin.taskQueue.update(taskId, pct, model.name, {
+                        this.plugin.taskQueue.update(taskId, pct, entry.display_name, {
                             current: d.current,
                             total: d.total,
                         });
                     }
                 } else if (event.event === SSE_EVENT.ERROR) {
-                    const d = event.data as { message?: string } | string;
-                    const msg = extractSseErrorMessage(d, MESSAGES.ERROR_UNKNOWN);
-                    new Notice(`${MESSAGES.ERROR_PULL_MODEL.replace("{model}", model.name)}: ${msg}`);
+                    const msg = extractSseErrorMessage(
+                        event.data as { message?: string } | string,
+                        MESSAGES.ERROR_UNKNOWN,
+                    );
+                    new Notice(`${MESSAGES.ERROR_PULL_MODEL.replace("{model}", entry.display_name)}: ${msg}`);
                     this.plugin.taskQueue.fail(taskId, msg);
-                    pullFailed = true;
-                    break;
+                    return false;
                 }
             }
         } catch (err) {
@@ -1755,122 +1764,53 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 this.plugin.taskQueue.cancel(taskId);
             } else {
                 const reason = errorMessage(err, MESSAGES.ERROR_UNKNOWN);
-                new Notice(`${MESSAGES.ERROR_PULL_MODEL.replace("{model}", model.name)}: ${reason}`);
+                new Notice(`${MESSAGES.ERROR_PULL_MODEL.replace("{model}", entry.display_name)}: ${reason}`);
                 this.plugin.taskQueue.fail(taskId, reason);
             }
-            return;
+            return false;
         }
-
-        if (pullFailed) return;
-
         this.plugin.taskQueue.complete(taskId);
-
-        const setResult = await this.setModel(model);
-        if (setResult.isErr()) {
-            new Notice(noticeForResultError(setResult.error, MESSAGES.ERROR_SET_MODEL.replace("{model}", model.name)));
-        } else {
-            new Notice(MESSAGES.NOTICE_MODEL_ACTIVATED_FULL(model.name));
-        }
-        this.plugin.fetchActiveModel();
-        this.display();
+        return true;
     }
 
-    private renderCatalogRow(table: HTMLTableElement, model: ModelInfo): void {
+    private renderChatCatalogRow(table: HTMLTableElement, entry: CatalogEntry, active: string): void {
         const row = table.createEl("tr");
-        row.createEl("td", { text: model.name });
-        row.createEl("td", { text: `${model.size_gb} GB` });
-        row.createEl("td", { text: model.description });
+        row.createEl("td", { text: entry.display_name });
+        row.createEl("td", { text: `${entry.size_gb} GB` });
+        row.createEl("td", { text: entry.description });
         const actionCell = row.createEl("td");
-
-        if (model.installed) {
+        if (entry.installed) {
             actionCell.createEl("span", { text: MESSAGES.LABEL_INSTALLED, cls: "lilbee-installed" });
             const deleteBtn = actionCell.createEl("button", { cls: "lilbee-model-delete" }) as HTMLButtonElement;
             setIcon(deleteBtn, "trash-2");
             deleteBtn.setAttribute("aria-label", MESSAGES.LABEL_DELETE_MODEL);
-            deleteBtn.addEventListener("click", () => this.deleteModel(deleteBtn, model));
+            deleteBtn.addEventListener("click", () => this.deleteChatEntry(deleteBtn, entry, active));
         } else {
             const btn = actionCell.createEl("button", { text: MESSAGES.BUTTON_PULL }) as HTMLButtonElement;
-            btn.addEventListener("click", () => this.pullModel(model));
+            btn.addEventListener("click", () => this.pullAndSetChat(entry));
         }
     }
 
-    private async pullModel(model: ModelInfo): Promise<void> {
-        await this.executePull(model);
-    }
-
-    private async executePull(model: ModelInfo): Promise<void> {
-        const taskId = this.plugin.taskQueue.enqueue(`Pull ${model.name}`, TASK_TYPE.PULL);
-        if (taskId === null) {
-            new Notice(MESSAGES.NOTICE_QUEUE_FULL);
-            return;
-        }
-        const controller = new AbortController();
-        this.plugin.taskQueue.registerAbort(taskId, controller);
-        let pullFailed = false;
-        try {
-            for await (const event of this.plugin.api.pullModel(model.name, MODEL_SOURCE.NATIVE, controller.signal)) {
-                if (event.event === SSE_EVENT.PROGRESS) {
-                    const d = event.data as { percent?: number; current?: number; total?: number };
-                    const pct = percentFromSse(d);
-                    if (pct !== undefined) {
-                        this.plugin.taskQueue.update(taskId, pct, model.name, {
-                            current: d.current,
-                            total: d.total,
-                        });
-                    }
-                } else if (event.event === SSE_EVENT.ERROR) {
-                    const d = event.data as { message?: string } | string;
-                    const msg = extractSseErrorMessage(d, MESSAGES.ERROR_UNKNOWN);
-                    new Notice(`${MESSAGES.ERROR_PULL_MODEL.replace("{model}", model.name)}: ${msg}`);
-                    this.plugin.taskQueue.fail(taskId, msg);
-                    pullFailed = true;
-                    break;
-                }
-            }
-        } catch (err) {
-            if (err instanceof Error && err.name === ERROR_NAME.ABORT_ERROR) {
-                new Notice(MESSAGES.NOTICE_PULL_CANCELLED);
-                this.plugin.taskQueue.cancel(taskId);
-            } else {
-                const reason = errorMessage(err, MESSAGES.ERROR_UNKNOWN);
-                new Notice(`${MESSAGES.ERROR_PULL_MODEL.replace("{model}", model.name)}: ${reason}`);
-                this.plugin.taskQueue.fail(taskId, reason);
-            }
-            return;
-        }
-
-        if (pullFailed) return;
-
-        this.plugin.taskQueue.complete(taskId);
-
-        const setResult = await this.setModel(model);
-        if (setResult.isErr()) {
-            new Notice(noticeForResultError(setResult.error, MESSAGES.ERROR_SET_MODEL.replace("{model}", model.name)));
-        } else {
-            new Notice(MESSAGES.NOTICE_MODEL_ACTIVATED_FULL(model.name));
-        }
-        this.plugin.fetchActiveModel();
-        this.display();
-    }
-
-    private async deleteModel(btn: HTMLButtonElement, model: ModelInfo): Promise<void> {
-        const taskId = this.plugin.taskQueue.enqueue(`Remove ${model.name}`, TASK_TYPE.DELETE);
+    private async deleteChatEntry(btn: HTMLButtonElement, entry: CatalogEntry, active: string): Promise<void> {
+        const taskId = this.plugin.taskQueue.enqueue(`Remove ${entry.display_name}`, TASK_TYPE.DELETE);
         if (taskId === null) {
             new Notice(MESSAGES.NOTICE_QUEUE_FULL);
             return;
         }
         btn.disabled = true;
-        this.plugin.taskQueue.update(taskId, -1, model.name);
-        const result = await this.plugin.api.deleteModel(model.name);
+        this.plugin.taskQueue.update(taskId, -1, entry.display_name);
+        const result = await this.plugin.api.deleteModel(entry.hf_repo, entry.source);
         if (result.isErr()) {
-            new Notice(noticeForResultError(result.error, MESSAGES.ERROR_DELETE_MODEL.replace("{model}", model.name)));
+            new Notice(
+                noticeForResultError(result.error, MESSAGES.ERROR_DELETE_MODEL.replace("{model}", entry.display_name)),
+            );
             this.plugin.taskQueue.fail(taskId, errorMessage(result.error, result.error.message));
             btn.disabled = false;
             return;
         }
         this.plugin.taskQueue.complete(taskId);
-        new Notice(MESSAGES.NOTICE_REMOVED(model.name));
-        if (model.name === this.plugin.activeModel) {
+        new Notice(MESSAGES.NOTICE_REMOVED(entry.display_name));
+        if (extractHfRepo(active) === entry.hf_repo) {
             const clearResult = await this.plugin.api.setChatModel("");
             if (clearResult.isOk()) {
                 this.plugin.activeModel = "";

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1696,7 +1696,8 @@ export class LilbeeSettingTab extends PluginSettingTab {
             await this.pullAndSetChat(featuredEntry);
             return;
         }
-        await this.applyChatSelection(value, displayLabelForRef(value));
+        const label = featuredEntry?.display_name ?? displayLabelForRef(value);
+        await this.applyChatSelection(value, label);
     }
 
     private async applyChatSelection(ref: string, label: string): Promise<void> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -256,7 +256,8 @@ export const CONTENT_TYPE = {
 } as const;
 
 export interface CatalogEntry {
-    name: string;
+    hf_repo: string;
+    gguf_filename: string;
     display_name: string;
     size_gb: number;
     min_ram_gb: number;
@@ -264,12 +265,10 @@ export interface CatalogEntry {
     quality_tier: string;
     installed: boolean;
     source: string;
-    hf_repo: string;
-    tag: string;
     task: ModelTask;
     featured: boolean;
     downloads: number;
-    param_count?: string;
+    param_count: string;
 }
 
 export interface CatalogResponse {

--- a/src/utils/model-ref.ts
+++ b/src/utils/model-ref.ts
@@ -1,0 +1,51 @@
+// Helpers for the canonical model ref shape that lilbee server speaks (PR #183).
+// Refs come in three flavours:
+//   1. native HF refs  — "<org>/<repo>/<filename>.gguf"
+//   2. provider refs   — "ollama/qwen3:8b", "openai/gpt-4o", "anthropic/...", etc.
+//   3. opaque strings  — anything else; passed through unchanged
+// All three are valid identifiers on the wire; the helpers below convert them
+// for display or unwrap them for catalog comparison.
+
+const PROVIDER_PREFIXES = ["ollama/", "openai/", "anthropic/", "gemini/", "cohere/"];
+
+const STRIP_SUFFIXES = [/-GGUF$/i, /-Instruct$/i, /-Chat$/i, /-v\d+(\.\d+)*$/i, /-\d{4}$/];
+
+const META_PREFIX = /^Meta-/;
+
+/** Strip the trailing `/<filename>.gguf` from a full HF ref so it matches a `CatalogEntry.hf_repo`. */
+export function extractHfRepo(ref: string): string {
+    if (!ref.endsWith(".gguf")) return ref;
+    const slash = ref.lastIndexOf("/");
+    if (slash <= 0) return ref;
+    return ref.slice(0, slash);
+}
+
+/** Convert a `<repo>` segment (org-stripped) into a friendly label. Mirrors the server's `clean_display_name`. */
+export function cleanDisplayName(repo: string): string {
+    let name = repo.includes("/") ? repo.slice(repo.indexOf("/") + 1) : repo;
+    name = name.replace(META_PREFIX, "");
+    let changed = true;
+    while (changed) {
+        changed = false;
+        for (const suffix of STRIP_SUFFIXES) {
+            const next = name.replace(suffix, "");
+            if (next !== name) {
+                name = next;
+                changed = true;
+            }
+        }
+    }
+    return name.replace(/-/g, " ").replace(/\s+/g, " ").trim();
+}
+
+/** Turn any model ref into a label suitable for the status bar, dropdowns, and notices. */
+export function displayLabelForRef(ref: string): string {
+    if (!ref) return "";
+    if (ref.endsWith(".gguf") && ref.includes("/")) {
+        return cleanDisplayName(extractHfRepo(ref));
+    }
+    for (const prefix of PROVIDER_PREFIXES) {
+        if (ref.startsWith(prefix)) return ref.slice(prefix.length);
+    }
+    return ref;
+}

--- a/src/utils/model-ref.ts
+++ b/src/utils/model-ref.ts
@@ -47,5 +47,10 @@ export function displayLabelForRef(ref: string): string {
     for (const prefix of PROVIDER_PREFIXES) {
         if (ref.startsWith(prefix)) return ref.slice(prefix.length);
     }
+    // Bare HF repo (e.g. plugin.activeModel after a dropdown change, before
+    // fetchActiveModel re-syncs from /api/models) — strip the org and tidy.
+    if (ref.includes("/")) {
+        return cleanDisplayName(ref);
+    }
     return ref;
 }

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -3,6 +3,7 @@ import type LilbeePlugin from "../main";
 import type { CatalogEntry, CatalogViewMode, ModelTask, ModelSize } from "../types";
 import { MODEL_TASK, SSE_EVENT, TASK_TYPE, CATALOG_VIEW_MODE, ERROR_NAME, MODEL_SOURCE } from "../types";
 import { MESSAGES, FILTERS, CATALOG_FILTERS } from "../locales/en";
+import { extractHfRepo } from "../utils/model-ref";
 import { ConfirmModal } from "./confirm-modal";
 import { ConfirmPullModal } from "./confirm-pull-modal";
 import {
@@ -269,12 +270,10 @@ export class CatalogModal extends Modal {
     }
 
     private isActiveEntry(entry: CatalogEntry): boolean {
-        // 1s1 pinned the chat-model setter to entry.name (catalog short ref),
-        // but the value persisted on the server before that change was the
-        // hf_repo. Match both so the "active" badge stays correct on already-
-        // ingested vaults until the user re-selects the model.
-        const active = this.plugin.activeModel;
-        return active === entry.name || active === entry.hf_repo;
+        // After PR #183 the canonical chat ref is the full HF path
+        // (`<org>/<repo>/<filename>.gguf`). Strip the trailing filename
+        // before comparing to the catalog's bare `hf_repo`.
+        return extractHfRepo(this.plugin.activeModel) === entry.hf_repo;
     }
 
     private renderViewToggleCta(): void {
@@ -437,14 +436,9 @@ export class CatalogModal extends Modal {
         this.resetAndFetch();
     }
 
-    /**
-     * Identifier to surface in user-facing toasts. Chat models use the
-     * catalog short ref (matches what 1s1 persists as cfg.chat_model and
-     * what the status bar / settings dropdown render). Other model roles
-     * still set via hf_repo, so the toast names that.
-     */
+    /** Identifier to surface in user-facing toasts. */
     private activatedRefFor(entry: CatalogEntry): string {
-        return entry.task === MODEL_TASK.CHAT ? entry.name : entry.hf_repo;
+        return entry.display_name;
     }
 
     private async setActiveFor(entry: CatalogEntry): ReturnType<typeof this.plugin.api.setChatModel> {
@@ -457,25 +451,17 @@ export class CatalogModal extends Modal {
         if (entry.task === MODEL_TASK.VISION) {
             return this.plugin.api.setVisionModel(entry.hf_repo);
         }
-        // Pin chat to the catalog short ref (`name:tag`) so the dropdown,
-        // status bar, and Settings subtitle all read the same identifier.
-        // Setting via hf_repo persisted the long-form HF identity in
-        // cfg.chat_model, which left the Settings dropdown unable to
-        // round-trip the value back to a known option.
-        const result = await this.plugin.api.setChatModel(entry.name);
-        if (result.isOk()) this.plugin.activeModel = entry.name;
+        const result = await this.plugin.api.setChatModel(entry.hf_repo);
+        if (result.isOk()) this.plugin.activeModel = entry.hf_repo;
         return result;
     }
 
     private handlePull(entry: CatalogEntry): void {
-        const info = {
-            name: entry.hf_repo,
-            size_gb: entry.size_gb,
-            min_ram_gb: entry.min_ram_gb,
-            description: entry.description,
-            installed: entry.installed,
-        };
-        const confirmModal = new ConfirmPullModal(this.app, info);
+        const confirmModal = new ConfirmPullModal(this.app, {
+            displayName: entry.display_name,
+            sizeGb: entry.size_gb,
+            minRamGb: entry.min_ram_gb,
+        });
         confirmModal.open();
         void confirmModal.result.then((confirmed) => {
             if (!confirmed) return;

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -10,10 +10,11 @@ import {
 } from "obsidian";
 import type LilbeePlugin from "../main";
 import { MODEL_SOURCE, MODEL_TASK, SSE_EVENT, TASK_TYPE, ERROR_NAME } from "../types";
-import type { CatalogEntry, Message, ModelCatalog, SearchChunkType, Source, SSEEvent } from "../types";
+import type { CatalogEntry, InstalledModel, Message, SearchChunkType, Source, SSEEvent } from "../types";
 
 import { renderSourceChip } from "./results";
-import { buildModelOptions, SEPARATOR_KEY } from "../settings";
+import { SEPARATOR_KEY, SEPARATOR_LABEL } from "../settings";
+import { displayLabelForRef, extractHfRepo } from "../utils/model-ref";
 import { ConfirmPullModal } from "./confirm-pull-modal";
 import { ConfirmModal } from "./confirm-modal";
 import { CatalogModal } from "./catalog-modal";
@@ -62,7 +63,9 @@ export class ChatView extends ItemView {
     private sending = false;
     private streamController: AbortController | null = null;
     private pullController: AbortController | null = null;
-    private chatCatalog: ModelCatalog | null = null;
+    private chatCatalogEntries: CatalogEntry[] = [];
+    private chatInstalled: InstalledModel[] = [];
+    private chatActive = "";
     private chatSelectEl: HTMLSelectElement | null = null;
     private embeddingSelectEl: HTMLSelectElement | null = null;
     private embeddingModels: CatalogEntry[] = [];
@@ -239,26 +242,26 @@ export class ChatView extends ItemView {
 
     private fetchAndFillSelectors(): void {
         Promise.all([
-            this.plugin.api.listModels(),
-            this.plugin.api.installedModels().catch(() => ({ models: [] })),
+            this.plugin.api.catalog({ task: MODEL_TASK.CHAT }),
+            this.plugin.api.installedModels({ task: MODEL_TASK.CHAT }).catch(() => ({ models: [] })),
             this.plugin.api.catalog({ task: MODEL_TASK.EMBEDDING }).catch(() => null),
             this.plugin.api.config().catch(() => null),
         ])
-            .then(([models, installed, embeddingResult, serverConfig]) => {
+            .then(([chatCatalogResult, chatInstalled, embeddingResult, serverConfig]) => {
                 if (this.retryTimer) {
                     clearTimeout(this.retryTimer);
                     this.retryTimer = null;
                 }
                 this.retryCount = 0;
                 if (this.chatSelectEl) this.chatSelectEl.empty();
-                this.chatCatalog = models.chat;
-                const sourceMap = new Map(installed.models.map((m) => [m.name, m.source]));
-                if (this.chatSelectEl) this.fillSelectOptions(this.chatSelectEl, models.chat, sourceMap);
+                this.chatCatalogEntries = chatCatalogResult.isOk() ? chatCatalogResult.value.models : [];
+                this.chatInstalled = chatInstalled.models;
+                this.chatActive = serverConfig ? String(serverConfig["chat_model"] ?? "") : "";
+                if (this.chatSelectEl) this.fillSelectOptions(this.chatSelectEl);
 
                 this.fillEmbeddingSelector(embeddingResult, serverConfig);
 
-                // No models installed — show empty state with catalog button
-                if (models.chat.installed.length === 0) {
+                if (this.chatInstalled.length === 0) {
                     this.showEmptyState();
                     this.retryTimer = setTimeout(() => this.fetchAndFillSelectors(), RETRY_INTERVAL_MS);
                 } else {
@@ -299,39 +302,52 @@ export class ChatView extends ItemView {
         this.embeddingModels = models;
 
         for (const model of models) {
-            const option = this.embeddingSelectEl.createEl("option", { text: model.name });
-            (option as HTMLOptionElement).value = model.name;
-            if (model.name === activeModel) {
+            const option = this.embeddingSelectEl.createEl("option", { text: model.display_name });
+            (option as HTMLOptionElement).value = model.hf_repo;
+            if (model.hf_repo === extractHfRepo(activeModel)) {
                 (option as HTMLOptionElement).selected = true;
             }
         }
 
         if (models.length === 0 && activeModel) {
-            const option = this.embeddingSelectEl.createEl("option", { text: activeModel });
+            const option = this.embeddingSelectEl.createEl("option", { text: displayLabelForRef(activeModel) });
             (option as HTMLOptionElement).value = activeModel;
             (option as HTMLOptionElement).selected = true;
         }
     }
 
-    private fillSelectOptions(
-        selectEl: HTMLSelectElement,
-        catalog: ModelCatalog,
-        sourceMap: Map<string, string> = new Map(),
-    ): void {
-        const installedOnly: ModelCatalog = {
-            ...catalog,
-            catalog: catalog.catalog.filter((m) => m.installed),
-        };
-        const options = buildModelOptions(installedOnly);
-        for (const [value, label] of Object.entries(options)) {
-            const source = sourceMap.get(value) ?? "";
-            const suffix = source && source !== MODEL_SOURCE.NATIVE ? ` [${source}]` : "";
-            const option = selectEl.createEl("option", { text: `${label}${suffix}` });
-            (option as HTMLOptionElement).value = value;
-            if (value === SEPARATOR_KEY) {
-                (option as HTMLOptionElement).disabled = true;
+    private fillSelectOptions(selectEl: HTMLSelectElement): void {
+        const sourceMap = new Map(this.chatInstalled.map((m) => [m.name, m.source]));
+        const installedRepos = new Set(this.chatInstalled.map((m) => extractHfRepo(m.name)));
+        const activeRepo = extractHfRepo(this.chatActive);
+
+        // Featured rows that have an installed quant.
+        const featuredInstalled = this.chatCatalogEntries.filter((e) => installedRepos.has(e.hf_repo));
+        for (const entry of featuredInstalled) {
+            const sourceTag = entry.source && entry.source !== MODEL_SOURCE.NATIVE ? ` [${entry.source}]` : "";
+            const option = selectEl.createEl("option", { text: `${entry.display_name}${sourceTag}` });
+            (option as HTMLOptionElement).value = entry.hf_repo;
+            if (entry.hf_repo === activeRepo) {
+                (option as HTMLOptionElement).selected = true;
             }
-            if (value === catalog.active) {
+        }
+
+        // Anything installed that isn't in the featured catalog (manually pulled, ollama/, openai/, …).
+        const featuredRepos = new Set(this.chatCatalogEntries.map((e) => e.hf_repo));
+        const otherInstalled = this.chatInstalled
+            .filter((m) => !featuredRepos.has(extractHfRepo(m.name)))
+            .sort((a, b) => a.name.localeCompare(b.name));
+        if (otherInstalled.length > 0 && featuredInstalled.length > 0) {
+            const sep = selectEl.createEl("option", { text: SEPARATOR_LABEL });
+            (sep as HTMLOptionElement).value = SEPARATOR_KEY;
+            (sep as HTMLOptionElement).disabled = true;
+        }
+        for (const m of otherInstalled) {
+            const source = sourceMap.get(m.name) ?? "";
+            const suffix = source && source !== MODEL_SOURCE.NATIVE ? ` [${source}]` : "";
+            const option = selectEl.createEl("option", { text: `${displayLabelForRef(m.name)}${suffix}` });
+            (option as HTMLOptionElement).value = m.name;
+            if (m.name === this.chatActive) {
                 (option as HTMLOptionElement).selected = true;
             }
         }
@@ -340,9 +356,13 @@ export class ChatView extends ItemView {
     private attachChatListener(el: HTMLSelectElement): void {
         el.addEventListener("change", () => {
             if (!el.value || el.value === SEPARATOR_KEY) return;
-            const uninstalled = this.chatCatalog?.catalog.find((m) => m.name === el.value && !m.installed);
+            const uninstalled = this.chatCatalogEntries.find((e) => e.hf_repo === el.value && !e.installed);
             if (uninstalled) {
-                const modal = new ConfirmPullModal(this.plugin.app, uninstalled);
+                const modal = new ConfirmPullModal(this.plugin.app, {
+                    displayName: uninstalled.display_name,
+                    sizeGb: uninstalled.size_gb,
+                    minRamGb: uninstalled.min_ram_gb,
+                });
                 modal.open();
                 void modal.result.then((confirmed) => {
                     if (confirmed) {
@@ -403,8 +423,8 @@ export class ChatView extends ItemView {
         void this.fetchAndFillSelectors();
     }
 
-    private async autoPullAndSet(model: { name: string }): Promise<void> {
-        const taskId = this.plugin.taskQueue.enqueue(`Pull ${model.name}`, TASK_TYPE.PULL);
+    private async autoPullAndSet(entry: CatalogEntry): Promise<void> {
+        const taskId = this.plugin.taskQueue.enqueue(`Pull ${entry.display_name}`, TASK_TYPE.PULL);
         if (taskId === null) {
             new Notice(MESSAGES.NOTICE_QUEUE_FULL);
             return;
@@ -414,7 +434,7 @@ export class ChatView extends ItemView {
         let pullFailed = false;
         try {
             for await (const event of this.plugin.api.pullModel(
-                model.name,
+                entry.hf_repo,
                 MODEL_SOURCE.NATIVE,
                 this.pullController.signal,
             )) {
@@ -422,7 +442,7 @@ export class ChatView extends ItemView {
                     const d = event.data as { percent?: number; current?: number; total?: number };
                     const pct = percentFromSse(d);
                     if (pct !== undefined) {
-                        this.plugin.taskQueue.update(taskId, pct, model.name, {
+                        this.plugin.taskQueue.update(taskId, pct, entry.display_name, {
                             current: d.current,
                             total: d.total,
                         });
@@ -430,7 +450,7 @@ export class ChatView extends ItemView {
                 } else if (event.event === SSE_EVENT.ERROR) {
                     const d = event.data as { message?: string } | string;
                     const msg = extractSseErrorMessage(d, MESSAGES.ERROR_UNKNOWN);
-                    new Notice(MESSAGES.ERROR_PULL_MODEL.replace("{model}", model.name));
+                    new Notice(MESSAGES.ERROR_PULL_MODEL.replace("{model}", entry.display_name));
                     this.plugin.taskQueue.fail(taskId, msg);
                     pullFailed = true;
                     break;
@@ -442,7 +462,7 @@ export class ChatView extends ItemView {
                 this.plugin.taskQueue.cancel(taskId);
             } else {
                 const reason = errorMessage(err, MESSAGES.ERROR_UNKNOWN);
-                new Notice(`${MESSAGES.ERROR_PULL_MODEL.replace("{model}", model.name)}: ${reason}`);
+                new Notice(`${MESSAGES.ERROR_PULL_MODEL.replace("{model}", entry.display_name)}: ${reason}`);
                 this.plugin.taskQueue.fail(taskId, reason);
             }
             this.pullController = null;
@@ -454,12 +474,14 @@ export class ChatView extends ItemView {
 
         this.plugin.taskQueue.complete(taskId);
 
-        const result = await this.plugin.api.setChatModel(model.name);
+        const result = await this.plugin.api.setChatModel(entry.hf_repo);
         if (result.isErr()) {
-            new Notice(noticeForResultError(result.error, MESSAGES.ERROR_SET_MODEL.replace("{model}", model.name)));
+            new Notice(
+                noticeForResultError(result.error, MESSAGES.ERROR_SET_MODEL.replace("{model}", entry.display_name)),
+            );
         } else {
-            this.plugin.activeModel = model.name;
-            new Notice(MESSAGES.NOTICE_MODEL_ACTIVATED_FULL(model.name));
+            this.plugin.activeModel = entry.hf_repo;
+            new Notice(MESSAGES.NOTICE_MODEL_ACTIVATED_FULL(entry.display_name));
             this.plugin.refreshSettingsTab();
         }
         this.plugin.fetchActiveModel();

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -337,13 +337,13 @@ export class ChatView extends ItemView {
         const otherInstalled = this.chatInstalled
             .filter((m) => !featuredRepos.has(extractHfRepo(m.name)))
             .sort((a, b) => a.name.localeCompare(b.name));
-        if (otherInstalled.length > 0 && featuredInstalled.length > 0) {
+        if (otherInstalled.length > 0) {
             const sep = selectEl.createEl("option", { text: SEPARATOR_LABEL });
             (sep as HTMLOptionElement).value = SEPARATOR_KEY;
             (sep as HTMLOptionElement).disabled = true;
         }
         for (const m of otherInstalled) {
-            const source = sourceMap.get(m.name) ?? "";
+            const source = sourceMap.get(m.name);
             const suffix = source && source !== MODEL_SOURCE.NATIVE ? ` [${source}]` : "";
             const option = selectEl.createEl("option", { text: `${displayLabelForRef(m.name)}${suffix}` });
             (option as HTMLOptionElement).value = m.name;

--- a/src/views/confirm-pull-modal.ts
+++ b/src/views/confirm-pull-modal.ts
@@ -1,14 +1,19 @@
 import { App, Modal } from "obsidian";
-import type { ModelInfo } from "../types";
 import { MESSAGES } from "../locales/en";
 
+export interface ConfirmPullInfo {
+    displayName: string;
+    sizeGb: number;
+    minRamGb: number;
+}
+
 export class ConfirmPullModal extends Modal {
-    private model: ModelInfo;
+    private model: ConfirmPullInfo;
     private _resolve: ((value: boolean) => void) | null = null;
     private decided = false;
     readonly result: Promise<boolean>;
 
-    constructor(app: App, model: ModelInfo) {
+    constructor(app: App, model: ConfirmPullInfo) {
         super(app);
         this.model = model;
         this.result = new Promise<boolean>((resolve) => {
@@ -24,9 +29,9 @@ export class ConfirmPullModal extends Modal {
         contentEl.createEl("h2", { text: MESSAGES.TITLE_DOWNLOAD_MODEL });
 
         const info = contentEl.createDiv({ cls: "lilbee-confirm-pull-info" });
-        info.createEl("p", { text: `${MESSAGES.LABEL_MODEL}: ${this.model.name}` });
-        info.createEl("p", { text: `${MESSAGES.LABEL_SIZE}: ${this.model.size_gb} GB` });
-        info.createEl("p", { text: `${MESSAGES.LABEL_MIN_RAM}: ${this.model.min_ram_gb} GB` });
+        info.createEl("p", { text: `${MESSAGES.LABEL_MODEL}: ${this.model.displayName}` });
+        info.createEl("p", { text: `${MESSAGES.LABEL_SIZE}: ${this.model.sizeGb} GB` });
+        info.createEl("p", { text: `${MESSAGES.LABEL_MIN_RAM}: ${this.model.minRamGb} GB` });
 
         const actions = contentEl.createDiv({ cls: "lilbee-confirm-pull-actions" });
         const pullBtn = actions.createEl("button", {

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -69,7 +69,21 @@ export function recommendedIndex(models: FeaturedModel[], memGB: number | null):
  * as the first four tiles gets an immediate sense of what's familiar. Any
  * native models outside these families backfill after.
  */
-const PREFERRED_FAMILIES = ["gemma-4", "gemma-3", "gemma-2", "qwen3", "qwen2", "llama-3", "phi-3"];
+// Substrings (lowercase) matched against `hf_repo`. Featured chat repos ship under varied orgs
+// (`Qwen/`, `unsloth/`, `ggml-org/`, `bartowski/`, …), so we don't pin to `<org>/<family>`.
+// Order matters: more specific families (Qwen3 Coder) come before less specific (Qwen3).
+const PREFERRED_FAMILIES = [
+    "gemma-4",
+    "gemma-3",
+    "gemma-2",
+    "qwen3-coder",
+    "qwen3",
+    "qwen2",
+    "llama-3",
+    "phi-3",
+    "mistral",
+    "smollm",
+];
 const MAX_FEATURED_PICKS = 8;
 
 /**
@@ -94,7 +108,7 @@ export function pickNativeChatModels(
     const ordered: FeaturedModel[] = [];
     for (const prefix of PREFERRED_FAMILIES) {
         for (const m of eligible) {
-            if (m.name.startsWith(prefix) && !seen.has(m.hf_repo)) {
+            if (m.hf_repo.toLowerCase().includes(prefix) && !seen.has(m.hf_repo)) {
                 ordered.push(m);
                 seen.add(m.hf_repo);
                 if (ordered.length >= MAX_FEATURED_PICKS) return ordered;
@@ -594,12 +608,7 @@ export class SetupWizard extends Modal {
                 }
             }
 
-            // Use the catalog short ref (`name:tag`) so cfg.chat_model is the
-            // same identifier the dropdown / status bar show. Setting via
-            // hf_repo stored the long-form HF identity, which made the
-            // Settings dropdown go blank and the subtitle show two different
-            // labels for the same model.
-            const setResult = await this.plugin.api.setChatModel(model.name);
+            const setResult = await this.plugin.api.setChatModel(model.hf_repo);
             if (setResult.isErr()) {
                 new Notice(MESSAGES.ERROR_SET_MODEL.replace("{model}", model.display_name));
                 statusEl.textContent = setResult.error.message;
@@ -607,7 +616,7 @@ export class SetupWizard extends Modal {
                 (downloadBtn as HTMLButtonElement).disabled = false;
                 return;
             }
-            this.plugin.activeModel = model.name;
+            this.plugin.activeModel = model.hf_repo;
             this.plugin.fetchActiveModel();
             this.pulledModelName = model.display_name;
             this.step = WIZARD_STEP.EMBEDDING_PICKER;
@@ -657,11 +666,12 @@ export class SetupWizard extends Modal {
                 return;
             }
             if (this.selectedEmbedding.installed) {
-                const name = this.selectedEmbedding.name;
+                const ref = this.selectedEmbedding.hf_repo;
+                const label = this.selectedEmbedding.display_name;
                 void (async () => {
-                    const result = await this.plugin.api.setEmbeddingModel(name);
+                    const result = await this.plugin.api.setEmbeddingModel(ref);
                     if (result.isErr()) {
-                        new Notice(MESSAGES.ERROR_SET_MODEL.replace("{model}", name));
+                        new Notice(MESSAGES.ERROR_SET_MODEL.replace("{model}", label));
                         return;
                     }
                     this.step = WIZARD_STEP.SYNC;
@@ -699,7 +709,7 @@ export class SetupWizard extends Modal {
             return;
         }
 
-        const recommended = this.embeddingModels.findIndex((m) => m.name.includes("nomic-embed-text"));
+        const recommended = this.embeddingModels.findIndex((m) => m.hf_repo.toLowerCase().includes("nomic-embed-text"));
         const defaultIdx = recommended >= 0 ? recommended : 0;
         this.selectedEmbedding = this.embeddingModels[defaultIdx] ?? null;
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,15 +1,9 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { App, Notice, Setting } from "obsidian";
 import { MockElement } from "./__mocks__/obsidian";
-import {
-    LilbeeSettingTab,
-    buildModelOptions,
-    deduplicateLatest,
-    SEPARATOR_KEY,
-    SEPARATOR_LABEL,
-} from "../src/settings";
-import type { LilbeeSettings, ModelCatalog, ModelsResponse } from "../src/types";
-import { DEFAULT_SETTINGS, SSE_EVENT } from "../src/types";
+import { LilbeeSettingTab, SEPARATOR_KEY } from "../src/settings";
+import type { CatalogEntry, CatalogResponse, InstalledModel, LilbeeSettings } from "../src/types";
+import { DEFAULT_SETTINGS, MODEL_TASK, SSE_EVENT } from "../src/types";
 import { MESSAGES } from "../src/locales/en";
 import { ok, err } from "neverthrow";
 import { TaskQueue } from "../src/task-queue";
@@ -110,21 +104,65 @@ function makeTab(plugin: ReturnType<typeof makePlugin>) {
     return new LilbeeSettingTab(app as any, plugin as any);
 }
 
-function makeModelsResponse(): ModelsResponse {
-    const empty: ModelCatalog = { active: "", installed: [], catalog: [] };
+const LLAMA_REF = "meta-llama/Llama-3-8B-Instruct-GGUF/Llama-3-8B-Instruct.Q4_K_M.gguf";
+const PHI_REF = "microsoft/Phi-3-mini-4k-Instruct-GGUF/Phi-3-mini-4k-Instruct.Q4_K_M.gguf";
+
+function chatEntry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
     return {
-        chat: {
-            active: "llama3",
-            installed: ["llama3"],
-            catalog: [
-                { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta Llama 3", installed: true },
-                { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "Microsoft Phi-3", installed: false },
-            ],
-        },
-        embedding: empty,
-        vision: empty,
-        reranker: empty,
+        hf_repo: "meta-llama/Llama-3-8B-Instruct-GGUF",
+        gguf_filename: "*Q4_K_M.gguf",
+        display_name: "Llama 3 8B",
+        size_gb: 4.7,
+        min_ram_gb: 8,
+        description: "Meta Llama 3",
+        quality_tier: "balanced",
+        installed: true,
+        source: "native",
+        task: MODEL_TASK.CHAT,
+        featured: true,
+        downloads: 0,
+        param_count: "8B",
+        ...overrides,
     };
+}
+
+function makeChatCatalogResult(entries: CatalogEntry[]): ReturnType<typeof ok<CatalogResponse, Error>> {
+    return ok({ total: entries.length, limit: 50, offset: 0, has_more: false, models: entries });
+}
+
+function makeChatInstalled(refs: string[]): { models: InstalledModel[] } {
+    return { models: refs.map((name) => ({ name, source: "native" })) };
+}
+
+/**
+ * Wire the chat-picker mocks (catalog + installedModels) so the Settings → Models
+ * section renders a recognisable Llama+Phi pair. Does NOT mock `api.config` —
+ * tests that care about config values should mock it themselves; the chat picker
+ * tolerates `chat_model` being undefined and renders an empty active value.
+ */
+function mockChatPicker(plugin: ReturnType<typeof makePlugin>, _active = LLAMA_REF, phiInstalled = false): void {
+    const entries = [
+        chatEntry({ installed: true }),
+        chatEntry({
+            hf_repo: "microsoft/Phi-3-mini-4k-Instruct-GGUF",
+            display_name: "Phi 3 Mini",
+            description: "Microsoft Phi-3",
+            installed: phiInstalled,
+            param_count: "3.8B",
+            size_gb: 2.3,
+            min_ram_gb: 4,
+        }),
+    ];
+    const installedRefs = [LLAMA_REF];
+    if (phiInstalled) installedRefs.push(PHI_REF);
+    (plugin.api.catalog as ReturnType<typeof vi.fn>).mockImplementation((params?: { task?: string }) => {
+        if (params?.task === MODEL_TASK.CHAT) return Promise.resolve(makeChatCatalogResult(entries));
+        return Promise.resolve(err(new Error("unmocked")));
+    });
+    (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockImplementation((params?: { task?: string }) => {
+        if (params?.task === MODEL_TASK.CHAT) return Promise.resolve(makeChatInstalled(installedRefs));
+        return Promise.resolve({ models: [] });
+    });
 }
 
 type TextOnChange = (v: string) => Promise<void>;
@@ -352,14 +390,14 @@ describe("LilbeeSettingTab", () => {
     describe("display()", () => {
         it("renders server URL, topK, and sync-mode settings without error", () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             expect(() => tab.display()).not.toThrow();
         });
 
         it("creates h3 'Models' and description paragraph", () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
             const h3 = tab.containerEl.children.find((c) => c.tagName === "H3");
@@ -372,7 +410,7 @@ describe("LilbeeSettingTab", () => {
 
         it("creates a models container div", () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
             const container = tab.containerEl.find("lilbee-models-container");
@@ -381,7 +419,7 @@ describe("LilbeeSettingTab", () => {
 
         it("shows sync-debounce setting when syncMode is 'auto'", () => {
             const plugin = makePlugin({ syncMode: "auto" });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
             // serverPort + 6 generation + syncDebounce + 10 crawling + wikiVaultFolder + 2 chunks + rerank_candidates + hfToken + litellm = 24
@@ -390,7 +428,7 @@ describe("LilbeeSettingTab", () => {
 
         it("does NOT show sync-debounce when syncMode is 'manual'", () => {
             const plugin = makePlugin({ syncMode: "manual" });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
             // serverPort + 6 generation + 10 crawling + wikiVaultFolder + 2 chunks + rerank_candidates + hfToken + litellm = 23
@@ -401,7 +439,7 @@ describe("LilbeeSettingTab", () => {
     describe("serverUrl setting onChange", () => {
         it("updates plugin settings and calls saveSettings", async () => {
             const plugin = makePlugin({ serverMode: "external" });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -414,7 +452,7 @@ describe("LilbeeSettingTab", () => {
     describe("manual token setting onChange", () => {
         it("updates manualToken and calls saveSettings", async () => {
             const plugin = makePlugin({ serverMode: "external" });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -428,7 +466,7 @@ describe("LilbeeSettingTab", () => {
     describe("topK slider onChange", () => {
         it("updates topK and calls saveSettings", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { sliderOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -441,7 +479,7 @@ describe("LilbeeSettingTab", () => {
     describe("maxDistance slider onChange", () => {
         it("updates maxDistance and calls saveSettings", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { sliderOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -452,7 +490,7 @@ describe("LilbeeSettingTab", () => {
 
         it("uses default value when maxDistance is undefined", async () => {
             const plugin = makePlugin({ maxDistance: undefined });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             captureSettingCallbacks(() => tab.display());
 
@@ -465,7 +503,7 @@ describe("LilbeeSettingTab", () => {
     describe("adaptiveThreshold toggle onChange", () => {
         it("updates adaptiveThreshold and calls saveSettings", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -476,7 +514,7 @@ describe("LilbeeSettingTab", () => {
 
         it("uses default value when adaptiveThreshold is undefined", async () => {
             const plugin = makePlugin({ adaptiveThreshold: undefined });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
 
             // When adaptiveThreshold is undefined, setValue should use ?? false fallback
@@ -493,7 +531,7 @@ describe("LilbeeSettingTab", () => {
 
         it("onChange true persists and triggers configureManagedStorage", async () => {
             const plugin = makePlugin({ serverMode: "managed", storeContentInVault: false });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -505,7 +543,7 @@ describe("LilbeeSettingTab", () => {
 
         it("onChange false persists and does not trigger configureManagedStorage", async () => {
             const plugin = makePlugin({ serverMode: "managed", storeContentInVault: true });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -516,7 +554,7 @@ describe("LilbeeSettingTab", () => {
 
         it("is disabled and marks the row in external mode", async () => {
             const plugin = makePlugin({ serverMode: "external", storeContentInVault: true });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
 
@@ -528,7 +566,7 @@ describe("LilbeeSettingTab", () => {
     describe("syncMode dropdown onChange", () => {
         it("updates syncMode, saves, and re-renders display", async () => {
             const plugin = makePlugin({ serverMode: "external", syncMode: "manual" });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
 
             const { dropdownOnChanges } = captureSettingCallbacks(() => tab.display());
@@ -549,7 +587,7 @@ describe("LilbeeSettingTab", () => {
 
         it("updates syncDebounceMs for valid positive number", async () => {
             const plugin = makePlugin({ syncMode: "auto" });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -560,7 +598,7 @@ describe("LilbeeSettingTab", () => {
 
         it("accepts zero as a valid debounce value", async () => {
             const plugin = makePlugin({ syncMode: "auto" });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -572,7 +610,7 @@ describe("LilbeeSettingTab", () => {
 
         it("does NOT save for NaN input", async () => {
             const plugin = makePlugin({ syncMode: "auto" });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -584,7 +622,7 @@ describe("LilbeeSettingTab", () => {
 
         it("does NOT save for negative number input", async () => {
             const plugin = makePlugin({ syncMode: "auto" });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -598,7 +636,7 @@ describe("LilbeeSettingTab", () => {
     describe("system prompt setting", () => {
         it("saves systemPrompt when changed", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textAreaOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -622,7 +660,7 @@ describe("LilbeeSettingTab", () => {
         for (const { idx, key, value, expected } of GEN_FIELDS) {
             it(`patches ${key} to parsed number`, async () => {
                 const plugin = makePlugin();
-                (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+                mockChatPicker(plugin);
                 const tab = makeTab(plugin);
                 const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -632,7 +670,7 @@ describe("LilbeeSettingTab", () => {
 
             it(`patches ${key} to null when cleared`, async () => {
                 const plugin = makePlugin();
-                (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+                mockChatPicker(plugin);
                 const tab = makeTab(plugin);
                 const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -643,7 +681,7 @@ describe("LilbeeSettingTab", () => {
 
         it("does not patch for NaN integer input", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -655,7 +693,7 @@ describe("LilbeeSettingTab", () => {
 
         it("does not patch for NaN float input", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -668,7 +706,7 @@ describe("LilbeeSettingTab", () => {
         it("surfaces a failure notice when the server rejects the patch", async () => {
             Notice.clear();
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("boom"));
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
@@ -680,7 +718,7 @@ describe("LilbeeSettingTab", () => {
         it("surfaces a failure notice when the null-clear PATCH is rejected", async () => {
             Notice.clear();
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("boom"));
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
@@ -691,7 +729,7 @@ describe("LilbeeSettingTab", () => {
 
         it("renders inside a <details> element", () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
             const details = tab.containerEl.children.find(
@@ -704,7 +742,7 @@ describe("LilbeeSettingTab", () => {
 
         it("uses 'Not set' placeholders on fresh mount", () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
 
             const placeholders: string[] = [];
@@ -735,7 +773,7 @@ describe("LilbeeSettingTab", () => {
         it("shows model name in summary when active model is set", () => {
             const plugin = makePlugin();
             (plugin as any).activeModel = "llama3";
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
             const details = tab.containerEl.children.find(
@@ -749,7 +787,7 @@ describe("LilbeeSettingTab", () => {
     describe("Refresh models button", () => {
         it("onClick calls loadModels with the models container", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
@@ -764,7 +802,7 @@ describe("LilbeeSettingTab", () => {
         it("onClick opens SetupWizard", async () => {
             const { SetupWizard } = await import("../src/views/setup-wizard");
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
@@ -779,7 +817,7 @@ describe("LilbeeSettingTab", () => {
         it("onClick opens CatalogModal", async () => {
             const { CatalogModal } = await import("../src/views/catalog-modal");
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
@@ -793,21 +831,25 @@ describe("LilbeeSettingTab", () => {
     describe("loadModels()", () => {
         it("renders chat section on success", async () => {
             const plugin = makePlugin();
-            const models = makeModelsResponse();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(models);
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({ chat_model: LLAMA_REF });
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const container = new MockElement("div") as unknown as HTMLElement;
             await (tab as any).loadModels(container);
+            await new Promise((r) => setTimeout(r, 0));
             const sections = (container as unknown as MockElement).findAll("lilbee-model-section");
             expect(sections.length).toBe(1);
         });
 
         it("silently handles API failure without showing warning", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("network"));
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("network"));
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("network"));
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("network"));
             const tab = makeTab(plugin);
             const container = new MockElement("div") as unknown as HTMLElement;
             await (tab as any).loadModels(container);
+            await new Promise((r) => setTimeout(r, 0));
             const p = (container as unknown as MockElement).children.find(
                 (c) => c.tagName === "P" && c.textContent.includes("Could not connect"),
             );
@@ -815,73 +857,77 @@ describe("LilbeeSettingTab", () => {
         });
     });
 
-    describe("renderModelSection()", () => {
-        it("chat section does NOT have 'Disabled' dropdown option", () => {
+    describe("renderChatPicker()", () => {
+        function buildEntries(opts: { phiInstalled?: boolean } = {}): CatalogEntry[] {
+            return [
+                chatEntry({ installed: true }),
+                chatEntry({
+                    hf_repo: "microsoft/Phi-3-mini-4k-Instruct-GGUF",
+                    display_name: "Phi 3 Mini",
+                    description: "Microsoft Phi-3",
+                    installed: opts.phiInstalled ?? false,
+                    param_count: "3.8B",
+                    size_gb: 2.3,
+                    min_ram_gb: 4,
+                }),
+            ];
+        }
+
+        function renderPicker(plugin: ReturnType<typeof makePlugin>, active: string, phiInstalled = false) {
+            const tab = makeTab(plugin);
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const entries = buildEntries({ phiInstalled });
+            const installed: InstalledModel[] = [{ name: LLAMA_REF, source: "native" }];
+            if (phiInstalled) installed.push({ name: PHI_REF, source: "native" });
+            const captured = captureSettingCallbacks(() => {
+                (tab as any).renderChatPicker(container, active, entries, installed);
+            });
+            return { tab, container, captured };
+        }
+
+        it("chat section has no 'Disabled' option", () => {
             const plugin = makePlugin();
             const tab = makeTab(plugin);
             const container = new MockElement("div") as unknown as HTMLElement;
-
             const allOptions = captureDropdownOptions(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
+                (tab as any).renderChatPicker(container, LLAMA_REF, buildEntries(), [
+                    { name: LLAMA_REF, source: "native" },
+                ]);
             });
-
             expect(allOptions.length).toBeGreaterThan(0);
             expect("" in allOptions[0]).toBe(false);
         });
 
-        it("active chat model onChange calls setChatModel and shows Notice for installed model", async () => {
+        it("dropdown switch to installed featured ref calls setChatModel", async () => {
             const plugin = makePlugin();
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
+            const { tab, captured } = renderPicker(plugin, LLAMA_REF, true);
             const displaySpy = vi.spyOn(tab, "display").mockImplementation(() => {});
-            await dropdownOnChanges[0]("llama3");
-            expect(plugin.api.setChatModel).toHaveBeenCalledWith("llama3");
-            expect(Notice.instances.some((n) => n.message.includes("llama3"))).toBe(true);
+            await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
+            expect(plugin.api.setChatModel).toHaveBeenCalledWith("microsoft/Phi-3-mini-4k-Instruct-GGUF");
+            expect(Notice.instances.some((n) => n.message.toLowerCase().includes("phi 3 mini"))).toBe(true);
             expect(displaySpy).toHaveBeenCalled();
         });
 
-        it("setting model to empty string shows 'not set' in Notice", async () => {
+        it("setting model to empty string shows 'not set' in notice", async () => {
             const plugin = makePlugin();
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-            const catalog = { ...makeModelsResponse().chat, active: "" };
-
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", catalog);
-            });
-
-            await dropdownOnChanges[0]("");
+            const { captured } = renderPicker(plugin, "");
+            await captured.dropdownOnChanges[0]("");
             expect(Notice.instances.some((n) => n.message.includes("not set"))).toBe(true);
         });
 
-        it("active model onChange shows failure Notice on API error for installed model", async () => {
+        it("dropdown switch shows failure notice on setChatModel error", async () => {
             const plugin = makePlugin();
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(err(new Error("fail")));
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
-            // llama3 is installed, so it goes through the direct set path
-            await dropdownOnChanges[0]("llama3");
+            const { captured } = renderPicker(plugin, LLAMA_REF, true);
+            await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
             expect(Notice.instances.some((n) => n.message.includes("Failed to set"))).toBe(true);
         });
 
-        it("renders table with header columns", () => {
+        it("renders catalog table with rows", () => {
             const plugin = makePlugin();
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-            (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
+            const { container } = renderPicker(plugin, LLAMA_REF);
             function findTag(el: MockElement, tag: string): MockElement | null {
                 if (el.tagName === tag.toUpperCase()) return el;
                 for (const child of el.children) {
@@ -894,33 +940,24 @@ describe("LilbeeSettingTab", () => {
             expect(table).not.toBeNull();
         });
 
-        it("desc shows active model name when set", () => {
+        it("desc shows clean display label when active is set", () => {
             const plugin = makePlugin();
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-            expect(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            }).not.toThrow();
+            expect(() => renderPicker(plugin, LLAMA_REF)).not.toThrow();
         });
 
-        it("desc shows 'Not set' for chat when active is empty", () => {
+        it("desc shows 'Not set' when active is empty", () => {
             const plugin = makePlugin();
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-            const catalog = { ...makeModelsResponse().chat, active: "" };
-            expect(() => {
-                (tab as any).renderModelSection(container, "Chat Model", catalog);
-            }).not.toThrow();
+            expect(() => renderPicker(plugin, "")).not.toThrow();
         });
     });
 
-    describe("renderCatalogRow()", () => {
+    describe("renderChatCatalogRow()", () => {
         it("shows 'Installed' badge for installed models", () => {
             const plugin = makePlugin();
             const tab = makeTab(plugin);
             const table = new MockElement("table") as unknown as HTMLTableElement;
-            const model = makeModelsResponse().chat.catalog[0];
-            (tab as any).renderCatalogRow(table, model);
+            const entry = chatEntry({ installed: true });
+            (tab as any).renderChatCatalogRow(table, entry, LLAMA_REF);
             const row = (table as unknown as MockElement).children[0];
             const actionCell = row.children[3];
             const badge = actionCell.children[0];
@@ -932,8 +969,8 @@ describe("LilbeeSettingTab", () => {
             const plugin = makePlugin();
             const tab = makeTab(plugin);
             const table = new MockElement("table") as unknown as HTMLTableElement;
-            const model = makeModelsResponse().chat.catalog[1];
-            (tab as any).renderCatalogRow(table, model);
+            const entry = chatEntry({ installed: false, hf_repo: "microsoft/Phi-3", display_name: "Phi 3" });
+            (tab as any).renderChatCatalogRow(table, entry, "");
             const row = (table as unknown as MockElement).children[0];
             const actionCell = row.children[3];
             const btn = actionCell.children[0];
@@ -941,40 +978,34 @@ describe("LilbeeSettingTab", () => {
             expect(btn.textContent).toBe("Pull");
         });
 
-        it("renders model name, size, and description cells", () => {
+        it("renders display_name, size, and description cells", () => {
             const plugin = makePlugin();
             const tab = makeTab(plugin);
             const table = new MockElement("table") as unknown as HTMLTableElement;
-            const model = makeModelsResponse().chat.catalog[0];
-            (tab as any).renderCatalogRow(table, model);
+            const entry = chatEntry({ installed: true });
+            (tab as any).renderChatCatalogRow(table, entry, LLAMA_REF);
             const row = (table as unknown as MockElement).children[0];
-            expect(row.children[0].textContent).toBe("llama3");
+            expect(row.children[0].textContent).toBe("Llama 3 8B");
             expect(row.children[1].textContent).toBe("4.7 GB");
             expect(row.children[2].textContent).toBe("Meta Llama 3");
         });
     });
 
-    describe("Delete button", () => {
-        function setupDeleteButton(plugin: ReturnType<typeof makePlugin>) {
+    describe("deleteChatEntry()", () => {
+        function setupDeleteButton(plugin: ReturnType<typeof makePlugin>, active = "") {
             const tab = makeTab(plugin);
             const table = new MockElement("table") as unknown as HTMLTableElement;
-            const catalog = makeModelsResponse();
-            const model = catalog.chat.catalog[0];
-
-            (tab as any).renderCatalogRow(table, model);
-
+            const entry = chatEntry({ installed: true });
+            (tab as any).renderChatCatalogRow(table, entry, active);
             const row = (table as unknown as MockElement).children[0];
             const actionCell = row.children[3];
-            // actionCell children: [0] = "Installed" span, [1] = delete button
             const deleteBtn = actionCell.children[1];
-
-            return { tab, deleteBtn, actionCell };
+            return { tab, deleteBtn, actionCell, entry };
         }
 
         it("shows trash icon button with lilbee-model-delete class for installed model", () => {
             const plugin = makePlugin();
             const { deleteBtn } = setupDeleteButton(plugin);
-
             expect(deleteBtn.tagName).toBe("BUTTON");
             expect(deleteBtn.classList.contains("lilbee-model-delete")).toBe(true);
             expect(deleteBtn.attributes["data-icon"]).toBe("trash-2");
@@ -984,7 +1015,7 @@ describe("LilbeeSettingTab", () => {
         it("successful delete shows 'Deleted' notice", async () => {
             const plugin = makePlugin();
             (plugin.api.deleteModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
             const { tab, deleteBtn } = setupDeleteButton(plugin);
             const modelsContainer = new MockElement("div");
@@ -994,18 +1025,17 @@ describe("LilbeeSettingTab", () => {
             await (deleteBtn as unknown as MockElement).trigger("click");
             await new Promise((r) => setTimeout(r, 0));
 
-            expect(plugin.api.deleteModel).toHaveBeenCalledWith("llama3");
-            expect(Notice.instances.some((n) => n.message.includes("Deleted llama3"))).toBe(true);
+            expect(plugin.api.deleteModel).toHaveBeenCalledWith("meta-llama/Llama-3-8B-Instruct-GGUF", "native");
+            expect(Notice.instances.some((n) => n.message.includes("Llama 3 8B"))).toBe(true);
             expect(plugin.fetchActiveModel).toHaveBeenCalled();
         });
 
         it("successful delete reloads models container when found", async () => {
             const plugin = makePlugin();
             (plugin.api.deleteModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
             const { tab, deleteBtn } = setupDeleteButton(plugin);
-
             Object.defineProperty(globalThis, "HTMLElement", {
                 value: MockElement,
                 configurable: true,
@@ -1017,20 +1047,21 @@ describe("LilbeeSettingTab", () => {
             await (deleteBtn as unknown as MockElement).trigger("click");
             await new Promise((r) => setTimeout(r, 0));
 
-            expect(plugin.api.listModels).toHaveBeenCalled();
+            // After deletion, the chat picker is rebuilt via the new endpoints.
+            expect(plugin.api.catalog).toHaveBeenCalled();
 
             // @ts-expect-error removing test-only global
             delete (globalThis as any).HTMLElement;
         });
 
-        it("deleting active chat model clears it", async () => {
+        it("deleting active chat model clears it (active = full HF ref)", async () => {
             const plugin = makePlugin();
-            (plugin as any).activeModel = "llama3";
+            (plugin as any).activeModel = LLAMA_REF;
             (plugin.api.deleteModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
-            const { tab, deleteBtn } = setupDeleteButton(plugin);
+            const { tab, deleteBtn } = setupDeleteButton(plugin, LLAMA_REF);
             tab.containerEl.querySelector = vi.fn().mockReturnValue(null);
 
             await (deleteBtn as unknown as MockElement).trigger("click");
@@ -1074,7 +1105,11 @@ describe("LilbeeSettingTab", () => {
 
             const tab = makeTab(plugin);
             const table = new MockElement("table") as unknown as HTMLTableElement;
-            const model = makeModelsResponse().chat.catalog[1];
+            const entry = chatEntry({
+                installed: false,
+                hf_repo: "microsoft/Phi-3-mini-4k-Instruct-GGUF",
+                display_name: "Phi 3 Mini",
+            });
 
             const clickHandlers: Function[] = [];
             const origAddEventListener = MockElement.prototype.addEventListener;
@@ -1082,7 +1117,7 @@ describe("LilbeeSettingTab", () => {
                 if (event === "click") clickHandlers.push(handler);
                 origAddEventListener.call(this, event, handler);
             };
-            (tab as any).renderCatalogRow(table, model);
+            (tab as any).renderChatCatalogRow(table, entry, "");
             MockElement.prototype.addEventListener = origAddEventListener;
 
             const pullPromise = clickHandlers[0]();
@@ -1099,21 +1134,32 @@ describe("LilbeeSettingTab", () => {
     });
 
     describe("ConfirmPullModal integration", () => {
+        function renderPickerWithPhi(plugin: ReturnType<typeof makePlugin>) {
+            const tab = makeTab(plugin);
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const entries = [
+                chatEntry({ installed: true }),
+                chatEntry({
+                    hf_repo: "microsoft/Phi-3-mini-4k-Instruct-GGUF",
+                    display_name: "Phi 3 Mini",
+                    installed: false,
+                }),
+            ];
+            const installed: InstalledModel[] = [{ name: LLAMA_REF, source: "native" }];
+            const captured = captureSettingCallbacks(() => {
+                (tab as any).renderChatPicker(container, LLAMA_REF, entries, installed);
+            });
+            return { tab, captured };
+        }
+
         it("dropdown onChange for uninstalled model opens ConfirmPullModal", async () => {
             const plugin = makePlugin();
             async function* fakePull() {}
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
 
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
-            await dropdownOnChanges[0]("phi3");
+            const { captured } = renderPickerWithPhi(plugin);
+            await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
 
             expect(ConfirmPullModal).toHaveBeenCalled();
             expect(plugin.api.pullModel).toHaveBeenCalled();
@@ -1122,22 +1168,33 @@ describe("LilbeeSettingTab", () => {
         it("canceling modal prevents pull from starting", async () => {
             (mockConfirmResult as any) = false;
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
 
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
-            await dropdownOnChanges[0]("phi3");
+            const { captured } = renderPickerWithPhi(plugin);
+            await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
 
             expect(plugin.api.pullModel).not.toHaveBeenCalled();
         });
     });
 
-    describe("Auto-pull task queue updates", () => {
+    describe("auto-pull (chat picker dropdown)", () => {
+        function renderPickerWithPhi(plugin: ReturnType<typeof makePlugin>) {
+            const tab = makeTab(plugin);
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const entries = [
+                chatEntry({ installed: true }),
+                chatEntry({
+                    hf_repo: "microsoft/Phi-3-mini-4k-Instruct-GGUF",
+                    display_name: "Phi 3 Mini",
+                    installed: false,
+                }),
+            ];
+            const installed: InstalledModel[] = [{ name: LLAMA_REF, source: "native" }];
+            const captured = captureSettingCallbacks(() => {
+                (tab as any).renderChatPicker(container, LLAMA_REF, entries, installed);
+            });
+            return { tab, captured };
+        }
+
         it("progress events update the task queue with percent", async () => {
             const plugin = makePlugin();
             async function* fakePull() {
@@ -1145,19 +1202,12 @@ describe("LilbeeSettingTab", () => {
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
 
             const updateSpy = vi.spyOn(plugin.taskQueue, "update");
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
+            const { captured } = renderPickerWithPhi(plugin);
+            await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
 
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
-            await dropdownOnChanges[0]("phi3");
-
-            expect(updateSpy).toHaveBeenCalledWith(expect.any(String), 50, "phi3", expect.any(Object));
+            expect(updateSpy).toHaveBeenCalledWith(expect.any(String), 50, "Phi 3 Mini", expect.any(Object));
         });
 
         it("taskQueue.cancel during auto-pull aborts and shows notice", async () => {
@@ -1177,14 +1227,8 @@ describe("LilbeeSettingTab", () => {
                 (n: string, s: string, sig: AbortSignal) => slowPull(n, s, sig),
             );
 
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
-            const pullPromise = dropdownOnChanges[0]("phi3");
+            const { captured } = renderPickerWithPhi(plugin);
+            const pullPromise = captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
             await new Promise((r) => setTimeout(r, 10));
 
             const active = plugin.taskQueue.active;
@@ -1195,12 +1239,9 @@ describe("LilbeeSettingTab", () => {
 
             expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_PULL_CANCELLED)).toBe(true);
         });
-    });
 
-    describe("Auto-pull AbortError", () => {
         it("auto-pull AbortError shows 'Pull cancelled' notice", async () => {
             const plugin = makePlugin();
-
             async function* abortingPull(): AsyncGenerator<never> {
                 const err = new Error("The operation was aborted");
                 err.name = "AbortError";
@@ -1208,85 +1249,55 @@ describe("LilbeeSettingTab", () => {
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(abortingPull());
 
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
-            // phi3 is uninstalled in catalog — triggers autoPullAndSet
-            await dropdownOnChanges[0]("phi3");
+            const { captured } = renderPickerWithPhi(plugin);
+            await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
             expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_PULL_CANCELLED)).toBe(true);
         });
-    });
 
-    describe("Auto-pull SSE_EVENT.ERROR", () => {
-        it("shows failure notice and fails task on SSE error event", async () => {
+        it("SSE error event (object with message) fails the task", async () => {
             const plugin = makePlugin();
-
             async function* errorPull() {
                 yield { event: SSE_EVENT.ERROR, data: { message: "pull exploded" } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(errorPull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
 
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
-            await dropdownOnChanges[0]("phi3");
+            const { captured } = renderPickerWithPhi(plugin);
+            await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
             expect(Notice.instances.some((n) => n.message.includes("failed to pull"))).toBe(true);
             expect(plugin.taskQueue.completed.some((t: any) => t.status === "failed")).toBe(true);
         });
 
-        it("handles SSE error event with string data", async () => {
+        it("SSE error event with string data fails the task", async () => {
             const plugin = makePlugin();
-
             async function* errorPull() {
                 yield { event: SSE_EVENT.ERROR, data: "raw error string" };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(errorPull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
 
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
-            await dropdownOnChanges[0]("phi3");
+            const { captured } = renderPickerWithPhi(plugin);
+            await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
             expect(Notice.instances.some((n) => n.message.includes("failed to pull"))).toBe(true);
             expect(plugin.taskQueue.completed.some((t: any) => t.status === "failed")).toBe(true);
         });
 
-        it("handles SSE error event with empty object (no message)", async () => {
+        it("SSE error event with empty object falls back to unknown message", async () => {
             const plugin = makePlugin();
-
             async function* errorPull() {
                 yield { event: SSE_EVENT.ERROR, data: {} };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(errorPull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
 
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
-            await dropdownOnChanges[0]("phi3");
+            const { captured } = renderPickerWithPhi(plugin);
+            await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
             expect(Notice.instances.some((n) => n.message.includes("failed to pull"))).toBe(true);
             expect(plugin.taskQueue.completed.some((t: any) => t.status === "failed")).toBe(true);
         });
     });
 
-    describe("Pull button", () => {
+    describe("Pull button (catalog table)", () => {
         interface PullSetup {
             tab: LilbeeSettingTab;
             clickHandler: () => Promise<void>;
@@ -1296,36 +1307,37 @@ describe("LilbeeSettingTab", () => {
         async function setupPullButton(plugin: ReturnType<typeof makePlugin>): Promise<PullSetup> {
             const tab = makeTab(plugin);
             const table = new MockElement("table") as unknown as HTMLTableElement;
-            const catalog = makeModelsResponse();
-            const model = catalog.chat.catalog[1];
+            const entry = chatEntry({
+                hf_repo: "microsoft/Phi-3-mini-4k-Instruct-GGUF",
+                display_name: "Phi 3 Mini",
+                installed: false,
+                description: "Microsoft Phi-3",
+                size_gb: 2.3,
+                min_ram_gb: 4,
+            });
 
             let clickHandler: (() => Promise<void>) | null = null;
             const origAddEventListener = MockElement.prototype.addEventListener;
             MockElement.prototype.addEventListener = function (event: string, handler: Function) {
-                if (event === "click") {
-                    clickHandler = handler as () => Promise<void>;
-                }
+                if (event === "click") clickHandler = handler as () => Promise<void>;
                 origAddEventListener.call(this, event, handler);
             };
-
-            (tab as any).renderCatalogRow(table, model);
+            (tab as any).renderChatCatalogRow(table, entry, "");
             MockElement.prototype.addEventListener = origAddEventListener;
 
             const row = (table as unknown as MockElement).children[0];
             const actionCell = row.children[3];
-
             return { tab, clickHandler: clickHandler!, actionCell };
         }
 
         it("successful pull: updates taskQueue with percent and shows success Notice", async () => {
             const plugin = makePlugin();
-
             async function* fakePull() {
                 yield { event: "progress", data: { percent: 75 } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
             const updateSpy = vi.spyOn(plugin.taskQueue, "update");
             const { tab, clickHandler } = await setupPullButton(plugin);
@@ -1335,20 +1347,21 @@ describe("LilbeeSettingTab", () => {
 
             await clickHandler();
 
-            expect(updateSpy).toHaveBeenCalledWith(expect.any(String), 75, "phi3", expect.any(Object));
-            expect(Notice.instances.some((n) => n.message.includes("phi3") && n.message.includes("pulled"))).toBe(true);
-            expect(plugin.api.setChatModel).toHaveBeenCalledWith("phi3");
+            expect(updateSpy).toHaveBeenCalledWith(expect.any(String), 75, "Phi 3 Mini", expect.any(Object));
+            expect(Notice.instances.some((n) => n.message.includes("Phi 3 Mini") && n.message.includes("pulled"))).toBe(
+                true,
+            );
+            expect(plugin.api.setChatModel).toHaveBeenCalledWith("microsoft/Phi-3-mini-4k-Instruct-GGUF");
         });
 
         it("progress event with no percent and no total: skips taskQueue.update", async () => {
             const plugin = makePlugin();
-
             async function* fakePull() {
                 yield { event: "progress", data: {} };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
             const updateSpy = vi.spyOn(plugin.taskQueue, "update");
             const { tab, clickHandler } = await setupPullButton(plugin);
@@ -1357,19 +1370,17 @@ describe("LilbeeSettingTab", () => {
             tab.containerEl.children.push(modelsContainer);
 
             await clickHandler();
-
             expect(updateSpy).not.toHaveBeenCalled();
         });
 
         it("progress event with current/total (no percent): computes percentage", async () => {
             const plugin = makePlugin();
-
             async function* fakePull() {
                 yield { event: "progress", data: { current: 50, total: 100 } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
             const updateSpy = vi.spyOn(plugin.taskQueue, "update");
             const { tab, clickHandler } = await setupPullButton(plugin);
@@ -1378,19 +1389,17 @@ describe("LilbeeSettingTab", () => {
             tab.containerEl.children.push(modelsContainer);
 
             await clickHandler();
-
-            expect(updateSpy).toHaveBeenCalledWith(expect.any(String), 50, "phi3", expect.any(Object));
+            expect(updateSpy).toHaveBeenCalledWith(expect.any(String), 50, "Phi 3 Mini", expect.any(Object));
         });
 
         it("progress event with percent=0: updates taskQueue with 0", async () => {
             const plugin = makePlugin();
-
             async function* fakePull() {
                 yield { event: "progress", data: { percent: 0 } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
             const updateSpy = vi.spyOn(plugin.taskQueue, "update");
             const { tab, clickHandler } = await setupPullButton(plugin);
@@ -1399,39 +1408,30 @@ describe("LilbeeSettingTab", () => {
             tab.containerEl.children.push(modelsContainer);
 
             await clickHandler();
-
-            expect(updateSpy).toHaveBeenCalledWith(expect.any(String), 0, "phi3", expect.any(Object));
+            expect(updateSpy).toHaveBeenCalledWith(expect.any(String), 0, "Phi 3 Mini", expect.any(Object));
         });
 
-        it("pull failure: shows failure Notice and re-enables button with 'Pull' text", async () => {
+        it("pull failure: shows failure Notice", async () => {
             const plugin = makePlugin();
-
             async function* failingPull(): AsyncGenerator<never> {
                 throw new Error("network error");
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(failingPull());
 
-            const { tab: _tab, clickHandler, actionCell } = await setupPullButton(plugin);
-            const btn = actionCell.children[0];
-
+            const { clickHandler } = await setupPullButton(plugin);
             await clickHandler();
-
             expect(Notice.instances.some((n) => n.message.includes("failed to pull"))).toBe(true);
-            expect(btn.disabled).toBe(false);
-            expect(btn.textContent).toBe("Pull");
         });
 
         it("pull failure with non-Error throw uses 'unknown' in taskQueue", async () => {
             const plugin = makePlugin();
-
             async function* failingPull(): AsyncGenerator<never> {
                 throw "string error";
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(failingPull());
 
-            const { tab: _tab, clickHandler } = await setupPullButton(plugin);
+            const { clickHandler } = await setupPullButton(plugin);
             await clickHandler();
-
             const failed = plugin.taskQueue.completed.find((t: any) => t.status === "failed");
             expect(failed).toBeDefined();
             expect(failed!.error).toBe("unknown error");
@@ -1439,123 +1439,67 @@ describe("LilbeeSettingTab", () => {
 
         it("SSE_EVENT.ERROR shows failure notice and fails the task", async () => {
             const plugin = makePlugin();
-
             async function* errorPull() {
                 yield { event: SSE_EVENT.ERROR, data: { message: "pull exploded" } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(errorPull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
-            const { tab: _tab, clickHandler } = await setupPullButton(plugin);
+            const { clickHandler } = await setupPullButton(plugin);
             await clickHandler();
-
             expect(Notice.instances.some((n) => n.message.includes("failed to pull"))).toBe(true);
             expect(plugin.taskQueue.completed.some((t: any) => t.status === "failed")).toBe(true);
         });
 
         it("SSE_EVENT.ERROR with string data fails the task", async () => {
             const plugin = makePlugin();
-
             async function* errorPull() {
                 yield { event: SSE_EVENT.ERROR, data: "raw error string" };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(errorPull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
-            const { tab: _tab, clickHandler } = await setupPullButton(plugin);
+            const { clickHandler } = await setupPullButton(plugin);
             await clickHandler();
-
             expect(Notice.instances.some((n) => n.message.includes("failed to pull"))).toBe(true);
             expect(plugin.taskQueue.completed.some((t: any) => t.status === "failed")).toBe(true);
         });
 
         it("SSE_EVENT.ERROR with empty object uses fallback message", async () => {
             const plugin = makePlugin();
-
             async function* errorPull() {
                 yield { event: SSE_EVENT.ERROR, data: {} };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(errorPull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
-            const { tab: _tab, clickHandler } = await setupPullButton(plugin);
+            const { clickHandler } = await setupPullButton(plugin);
             await clickHandler();
-
             expect(Notice.instances.some((n) => n.message.includes("failed to pull"))).toBe(true);
             expect(plugin.taskQueue.completed.some((t: any) => t.status === "failed")).toBe(true);
         });
 
         it("successful pull without models container: does not crash", async () => {
             const plugin = makePlugin();
-
             async function* fakePull() {}
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
             const { clickHandler } = await setupPullButton(plugin);
-
             await expect(clickHandler()).resolves.not.toThrow();
             expect(Notice.instances.some((n) => n.message.includes("pulled"))).toBe(true);
         });
 
-        it("successful pull with HTMLElement container: reloads models", async () => {
-            const plugin = makePlugin();
-
-            async function* fakePull() {}
-            (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
-
-            const { tab, clickHandler } = await setupPullButton(plugin);
-
-            Object.defineProperty(globalThis, "HTMLElement", {
-                value: MockElement,
-                configurable: true,
-                writable: true,
-            });
-            const fakeContainer = new MockElement("div");
-            tab.containerEl.querySelector = vi.fn().mockReturnValue(fakeContainer);
-
-            await clickHandler();
-
-            expect(plugin.api.listModels).toHaveBeenCalled();
-
-            // @ts-expect-error removing test-only global
-            delete (globalThis as any).HTMLElement;
-        });
-
-        it("pull progress updates taskQueue", async () => {
-            const plugin = makePlugin();
-
-            async function* fakePull() {
-                yield { event: "progress", data: { percent: 45 } };
-            }
-            (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
-
-            const { tab, clickHandler } = await setupPullButton(plugin);
-            const modelsContainer = new MockElement("div");
-            modelsContainer.classList.add("lilbee-models-container");
-            tab.containerEl.children.push(modelsContainer);
-
-            await clickHandler();
-
-            // Task should be completed in history
-            expect(plugin.taskQueue.completed.length).toBeGreaterThan(0);
-        });
-
         it("successful pull calls fetchActiveModel", async () => {
             const plugin = makePlugin();
-
             async function* fakePull() {}
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
             const { tab, clickHandler } = await setupPullButton(plugin);
             const modelsContainer = new MockElement("div");
@@ -1563,44 +1507,39 @@ describe("LilbeeSettingTab", () => {
             tab.containerEl.children.push(modelsContainer);
 
             await clickHandler();
-
             expect(plugin.fetchActiveModel).toHaveBeenCalled();
         });
 
         it("pull progress does not update status bar when statusBarEl is null", async () => {
             const plugin = makePlugin();
             (plugin as any).statusBarEl = null;
-
             async function* fakePull() {
                 yield { event: "progress", data: { percent: 50 } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
             const { tab, clickHandler } = await setupPullButton(plugin);
             const modelsContainer = new MockElement("div");
             modelsContainer.classList.add("lilbee-models-container");
             tab.containerEl.children.push(modelsContainer);
-
             await expect(clickHandler()).resolves.not.toThrow();
         });
 
         it("non-progress events during pull are ignored (no crash)", async () => {
             const plugin = makePlugin();
-
             async function* fakePull() {
                 yield { event: "other", data: {} };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
             const { tab, clickHandler } = await setupPullButton(plugin);
             const modelsContainer = new MockElement("div");
             modelsContainer.classList.add("lilbee-models-container");
             tab.containerEl.children.push(modelsContainer);
-
             await expect(clickHandler()).resolves.not.toThrow();
         });
     });
@@ -1710,7 +1649,7 @@ describe("LilbeeSettingTab", () => {
         it("auto-checks server endpoint on display", async () => {
             globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
             const plugin = makePlugin({ serverMode: "external" });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
 
             tab.display();
@@ -1729,7 +1668,7 @@ describe("LilbeeSettingTab", () => {
         it("Test button calls checkEndpoint", async () => {
             globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
             const plugin = makePlugin({ serverMode: "external" });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
 
             const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
@@ -1754,9 +1693,11 @@ describe("LilbeeSettingTab", () => {
             const plugin = makePlugin();
             const tab = makeTab(plugin);
             const container = new MockElement("div") as unknown as HTMLElement;
+            const entries = [chatEntry({ installed: true })];
+            const installed: InstalledModel[] = [{ name: LLAMA_REF, source: "native" }];
 
             const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
+                (tab as any).renderChatPicker(container, LLAMA_REF, entries, installed);
             });
 
             await dropdownOnChanges[0](SEPARATOR_KEY);
@@ -1765,71 +1706,68 @@ describe("LilbeeSettingTab", () => {
     });
 
     describe("auto-pull via dropdown", () => {
+        function pickerSetup(plugin: ReturnType<typeof makePlugin>) {
+            const tab = makeTab(plugin);
+            const container = new MockElement("div") as unknown as HTMLElement;
+            tab.containerEl.querySelector = vi.fn().mockReturnValue(null);
+            const entries = [
+                chatEntry({ installed: true }),
+                chatEntry({
+                    hf_repo: "microsoft/Phi-3-mini-4k-Instruct-GGUF",
+                    display_name: "Phi 3 Mini",
+                    installed: false,
+                }),
+            ];
+            const installed: InstalledModel[] = [{ name: LLAMA_REF, source: "native" }];
+            const captured = captureSettingCallbacks(() => {
+                (tab as any).renderChatPicker(container, LLAMA_REF, entries, installed);
+            });
+            return { tab, captured };
+        }
+
         it("selecting uninstalled catalog model triggers auto-pull", async () => {
             const plugin = makePlugin();
-
             async function* fakePull() {
                 yield { event: "progress", data: { percent: 50 } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-            const modelsContainer = new MockElement("div");
-            modelsContainer.classList.add("lilbee-models-container");
-            tab.containerEl.children.push(modelsContainer);
-            tab.containerEl.querySelector = vi.fn().mockReturnValue(null);
+            const { captured } = pickerSetup(plugin);
+            await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
 
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
-            // phi3 is uninstalled in catalog, should trigger auto-pull
-            await dropdownOnChanges[0]("phi3");
-            expect(plugin.api.pullModel).toHaveBeenCalledWith("phi3", "native", expect.any(AbortSignal));
-            expect(plugin.api.setChatModel).toHaveBeenCalledWith("phi3");
-            expect(Notice.instances.some((n) => n.message === "lilbee: phi3 pulled and activated")).toBe(true);
+            expect(plugin.api.pullModel).toHaveBeenCalledWith(
+                "microsoft/Phi-3-mini-4k-Instruct-GGUF",
+                "native",
+                expect.any(AbortSignal),
+            );
+            expect(plugin.api.setChatModel).toHaveBeenCalledWith("microsoft/Phi-3-mini-4k-Instruct-GGUF");
+            expect(Notice.instances.some((n) => n.message === "lilbee: Phi 3 Mini pulled and activated")).toBe(true);
         });
 
         it("auto-pull failure shows failure notice", async () => {
             const plugin = makePlugin();
-
             async function* failingPull(): AsyncGenerator<never> {
                 throw new Error("network");
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(failingPull());
 
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
-            await dropdownOnChanges[0]("phi3");
+            const { captured } = pickerSetup(plugin);
+            await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
             expect(Notice.instances.some((n) => n.message.includes("failed to pull"))).toBe(true);
         });
 
         it("auto-pull failure with non-Error throw uses 'unknown' in taskQueue", async () => {
             const plugin = makePlugin();
-
             async function* failingPull(): AsyncGenerator<never> {
                 throw "string error";
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(failingPull());
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-            tab.containerEl.querySelector = vi.fn().mockReturnValue(null);
-
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
-            await dropdownOnChanges[0]("phi3");
+            const { captured } = pickerSetup(plugin);
+            await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
 
             const failed = plugin.taskQueue.completed.find((t: any) => t.status === "failed");
             expect(failed).toBeDefined();
@@ -1838,355 +1776,138 @@ describe("LilbeeSettingTab", () => {
 
         it("auto-pull updates taskQueue with progress", async () => {
             const plugin = makePlugin();
-
             async function* fakePull() {
                 yield { event: "progress", data: { percent: 75 } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-            tab.containerEl.querySelector = vi.fn().mockReturnValue(null);
-
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
-            await dropdownOnChanges[0]("phi3");
-            // Task should be completed in history with progress
+            const { captured } = pickerSetup(plugin);
+            await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
             expect(plugin.taskQueue.completed.length).toBeGreaterThan(0);
         });
 
         it("auto-pull completes task in taskQueue", async () => {
             const plugin = makePlugin();
-
             async function* fakePull() {
                 yield { event: "progress", data: { current: 60, total: 100 } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-            tab.containerEl.querySelector = vi.fn().mockReturnValue(null);
-
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
-            await dropdownOnChanges[0]("phi3");
+            const { captured } = pickerSetup(plugin);
+            await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
             const done = plugin.taskQueue.completed.find((t: any) => t.status === "done");
             expect(done).toBeDefined();
         });
 
         it("auto-pull progress with no percent and no total skips update", async () => {
             const plugin = makePlugin();
-
             async function* fakePull() {
                 yield { event: "progress", data: {} };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-            tab.containerEl.querySelector = vi.fn().mockReturnValue(null);
-
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
-            await dropdownOnChanges[0]("phi3");
+            const { captured } = pickerSetup(plugin);
+            await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
             expect(plugin.taskQueue.completed.length).toBeGreaterThan(0);
-        });
-
-        it("auto-pull with total=0 does not update status bar", async () => {
-            const plugin = makePlugin();
-
-            async function* fakePull() {
-                yield { event: "progress", data: { percent: 0 } };
-            }
-            (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
-
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-            tab.containerEl.querySelector = vi.fn().mockReturnValue(null);
-
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
-            await dropdownOnChanges[0]("phi3");
-            // total=0 means no status bar update for progress
-            expect(plugin.statusBarEl!.setText).not.toHaveBeenCalled();
         });
 
         it("auto-pull without statusBarEl does not crash", async () => {
             const plugin = makePlugin();
             (plugin as any).statusBarEl = null;
-
             async function* fakePull() {
                 yield { event: "progress", data: { percent: 50 } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-            tab.containerEl.querySelector = vi.fn().mockReturnValue(null);
-
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
-            await expect(dropdownOnChanges[0]("phi3")).resolves.not.toThrow();
-        });
-
-        it("auto-pull without statusBarEl does not crash (via dropdown)", async () => {
-            const plugin = makePlugin();
-            (plugin as any).statusBarEl = null;
-
-            async function* fakePull() {
-                yield { event: "progress", data: { percent: 50 } };
-            }
-            (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
-
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-            tab.containerEl.querySelector = vi.fn().mockReturnValue(null);
-
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
-            await expect(dropdownOnChanges[0]("phi3")).resolves.not.toThrow();
+            const { captured } = pickerSetup(plugin);
+            await expect(captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF")).resolves.not.toThrow();
         });
 
         it("auto-pull re-renders settings after success", async () => {
             const plugin = makePlugin();
-
             async function* fakePull() {}
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
-
+            const { tab, captured } = pickerSetup(plugin);
             const displaySpy = vi.spyOn(tab, "display").mockImplementation(() => {});
-            await dropdownOnChanges[0]("phi3");
+            await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
             expect(displaySpy).toHaveBeenCalled();
         });
     });
 
     describe("queue-full on pull", () => {
-        it("autoPullAndSet surfaces NOTICE_QUEUE_FULL when enqueue returns null", async () => {
-            const plugin = makePlugin();
-            plugin.taskQueue.enqueue = vi.fn(() => null) as any;
+        function pickerSetup(plugin: ReturnType<typeof makePlugin>) {
             const tab = makeTab(plugin);
             const container = new MockElement("div") as unknown as HTMLElement;
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
+            const entries = [
+                chatEntry({ installed: true }),
+                chatEntry({
+                    hf_repo: "microsoft/Phi-3-mini-4k-Instruct-GGUF",
+                    display_name: "Phi 3 Mini",
+                    installed: false,
+                }),
+            ];
+            const installed: InstalledModel[] = [{ name: LLAMA_REF, source: "native" }];
+            const captured = captureSettingCallbacks(() => {
+                (tab as any).renderChatPicker(container, LLAMA_REF, entries, installed);
             });
-            Notice.clear();
-            await dropdownOnChanges[0]("phi3");
-            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_QUEUE_FULL)).toBe(true);
-        });
+            return { tab, captured };
+        }
 
-        it("executePull (manual) surfaces NOTICE_QUEUE_FULL when enqueue returns null", async () => {
+        it("pullAndSetChat surfaces NOTICE_QUEUE_FULL when enqueue returns null", async () => {
             const plugin = makePlugin();
             plugin.taskQueue.enqueue = vi.fn(() => null) as any;
-            const tab = makeTab(plugin);
+            const { captured } = pickerSetup(plugin);
             Notice.clear();
-            await (tab as any).executePull({ name: "phi3" });
+            await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
             expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_QUEUE_FULL)).toBe(true);
         });
 
-        it("deleteModel surfaces NOTICE_QUEUE_FULL when enqueue returns null", async () => {
+        it("deleteChatEntry surfaces NOTICE_QUEUE_FULL when enqueue returns null", async () => {
             const plugin = makePlugin();
             plugin.taskQueue.enqueue = vi.fn(() => null) as any;
             const tab = makeTab(plugin);
             const btn = new MockElement("button") as unknown as HTMLButtonElement;
             Notice.clear();
-            await (tab as any).deleteModel(btn, { name: "phi3" });
+            await (tab as any).deleteChatEntry(btn, chatEntry({ installed: true }), "");
             expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_QUEUE_FULL)).toBe(true);
             expect(plugin.api.deleteModel).not.toHaveBeenCalled();
         });
 
-        it("autoPullAndSet completes pull and shows set-failed notice when setModel throws", async () => {
+        it("pullAndSetChat completes pull and shows set-failed notice when setModel throws", async () => {
             const plugin = makePlugin();
             async function* fakePull() {}
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
             (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(err(new Error("set fail")));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
 
-            const tab = makeTab(plugin);
-            const container = new MockElement("div") as unknown as HTMLElement;
-            const { dropdownOnChanges } = captureSettingCallbacks(() => {
-                (tab as any).renderModelSection(container, "Chat Model", makeModelsResponse().chat);
-            });
+            const { captured } = pickerSetup(plugin);
             Notice.clear();
 
-            await dropdownOnChanges[0]("phi3");
+            await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
 
-            const setFailed = MESSAGES.ERROR_SET_MODEL.replace("{model}", "phi3");
+            const setFailed = MESSAGES.ERROR_SET_MODEL.replace("{model}", "Phi 3 Mini");
             expect(Notice.instances.some((n) => n.message === setFailed)).toBe(true);
             expect(plugin.taskQueue.completed.some((t: any) => t.status === "done")).toBe(true);
             expect(plugin.taskQueue.completed.some((t: any) => t.status === "failed")).toBe(false);
         });
-
-        it("executePull (manual) completes pull and shows set-failed notice when setModel throws", async () => {
-            const plugin = makePlugin();
-            async function* fakePull() {}
-            (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(err(new Error("set fail")));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
-
-            const tab = makeTab(plugin);
-            Notice.clear();
-
-            await (tab as any).executePull({ name: "phi3" });
-
-            const setFailed = MESSAGES.ERROR_SET_MODEL.replace("{model}", "phi3");
-            expect(Notice.instances.some((n) => n.message === setFailed)).toBe(true);
-            expect(plugin.taskQueue.completed.some((t: any) => t.status === "done")).toBe(true);
-            expect(plugin.taskQueue.completed.some((t: any) => t.status === "failed")).toBe(false);
-        });
-    });
-});
-
-describe("buildModelOptions()", () => {
-    it("chat: catalog models first, then separator, then other installed", () => {
-        const catalog: ModelCatalog = {
-            active: "llama3",
-            catalog: [
-                { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta Llama 3", installed: true },
-                { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "Microsoft Phi-3", installed: false },
-            ],
-            installed: ["llama3", "custom-model"],
-        };
-        const options = buildModelOptions(catalog);
-        const keys = Object.keys(options);
-        expect(keys).toEqual(["llama3", "phi3", SEPARATOR_KEY, "custom-model"]);
-        expect(options["llama3"]).toBe("llama3");
-        expect(options["phi3"]).toBe("phi3 (not installed)");
-        expect(options[SEPARATOR_KEY]).toBe(SEPARATOR_LABEL);
-        expect(options["custom-model"]).toBe("custom-model");
-    });
-
-    it("no separator when all installed models are in catalog", () => {
-        const catalog: ModelCatalog = {
-            active: "llama3",
-            catalog: [{ name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true }],
-            installed: ["llama3"],
-        };
-        const options = buildModelOptions(catalog);
-        expect(SEPARATOR_KEY in options).toBe(false);
-    });
-
-    it("preserves server catalog order (no alphabetical sort)", () => {
-        const catalog: ModelCatalog = {
-            active: "zeta",
-            catalog: [
-                { name: "zeta", size_gb: 1, min_ram_gb: 2, description: "Z", installed: true },
-                { name: "alpha", size_gb: 1, min_ram_gb: 2, description: "A", installed: true },
-            ],
-            installed: ["zeta", "alpha"],
-        };
-        const options = buildModelOptions(catalog);
-        const keys = Object.keys(options);
-        expect(keys[0]).toBe("zeta");
-        expect(keys[1]).toBe("alpha");
-    });
-
-    it("sorts other installed models alphabetically", () => {
-        const catalog: ModelCatalog = {
-            active: "foo",
-            catalog: [],
-            installed: ["zoo", "bar", "foo"],
-        };
-        const options = buildModelOptions(catalog);
-        const keys = Object.keys(options);
-        // separator then bar, foo, zoo
-        expect(keys).toEqual([SEPARATOR_KEY, "bar", "foo", "zoo"]);
-    });
-
-    it("empty catalog and empty installed returns empty for chat", () => {
-        const catalog: ModelCatalog = { active: "", catalog: [], installed: [] };
-        const options = buildModelOptions(catalog);
-        expect(Object.keys(options).length).toBe(0);
-    });
-
-    it("shows source tag when model has source", () => {
-        const catalog: ModelCatalog = {
-            active: "llama3",
-            catalog: [
-                { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true, source: "native" },
-            ],
-            installed: ["llama3"],
-        };
-        const options = buildModelOptions(catalog);
-        expect(options["llama3"]).toBe("llama3 [native]");
-    });
-
-    it("deduplicates :latest when a specific tag exists", () => {
-        const catalog: ModelCatalog = {
-            active: "mistral:7b",
-            catalog: [],
-            installed: ["mistral:latest", "mistral:7b", "llama3:latest"],
-        };
-        const options = buildModelOptions(catalog);
-        const keys = Object.keys(options);
-        expect(keys).toContain("mistral:7b");
-        expect(keys).not.toContain("mistral:latest");
-        // llama3:latest has no specific tag sibling, so it stays
-        expect(keys).toContain("llama3:latest");
-    });
-});
-
-describe("deduplicateLatest()", () => {
-    it("removes :latest when a more specific tag exists", () => {
-        const result = deduplicateLatest(["mistral:latest", "mistral:7b"]);
-        expect(result).toEqual(["mistral:7b"]);
-    });
-
-    it("keeps :latest when no specific tag exists", () => {
-        const result = deduplicateLatest(["llama3:latest"]);
-        expect(result).toEqual(["llama3:latest"]);
-    });
-
-    it("handles models without tags", () => {
-        const result = deduplicateLatest(["phi3", "phi3:latest"]);
-        expect(result).toEqual(["phi3"]);
-    });
-
-    it("handles empty list", () => {
-        expect(deduplicateLatest([])).toEqual([]);
-    });
-
-    it("handles multiple model families", () => {
-        const result = deduplicateLatest(["mistral:latest", "mistral:7b", "llama3:latest", "llama3:8b", "phi3:latest"]);
-        expect(result).toEqual(["mistral:7b", "llama3:8b", "phi3:latest"]);
     });
 });
 
 describe("managed mode settings", () => {
     it("server mode dropdown onChange updates serverMode and re-renders", async () => {
         const plugin = makePlugin({ serverMode: "managed" });
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
         const { dropdownOnChanges } = captureSettingCallbacks(() => tab.display());
@@ -2202,7 +1923,7 @@ describe("managed mode settings", () => {
 
     it("port field onChange updates serverPort", async () => {
         const plugin = makePlugin({ serverMode: "managed" });
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
         const { textOnChanges } = captureSettingCallbacks(() => tab.display());
@@ -2216,7 +1937,7 @@ describe("managed mode settings", () => {
 
     it("port field displays empty string when serverPort is null", () => {
         const plugin = makePlugin({ serverMode: "managed", serverPort: null });
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
         captureSettingCallbacks(() => tab.display());
@@ -2225,7 +1946,7 @@ describe("managed mode settings", () => {
 
     it("port field ignores invalid values", async () => {
         const plugin = makePlugin({ serverMode: "managed", serverPort: 7433 });
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
         const { textOnChanges } = captureSettingCallbacks(() => tab.display());
@@ -2237,7 +1958,7 @@ describe("managed mode settings", () => {
 
     it("port field sets to null when empty string is entered", async () => {
         const plugin = makePlugin({ serverMode: "managed", serverPort: 7433 });
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
         const { textOnChanges } = captureSettingCallbacks(() => tab.display());
@@ -2249,7 +1970,7 @@ describe("managed mode settings", () => {
 
     it("port field sets to null when 0 is entered", async () => {
         const plugin = makePlugin({ serverMode: "managed", serverPort: 7433 });
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
         const { textOnChanges } = captureSettingCallbacks(() => tab.display());
@@ -2266,7 +1987,7 @@ describe("managed mode settings", () => {
         (plugin as any).checkForUpdate = vi
             .fn()
             .mockResolvedValue({ available: true, release: { tag: "v0.2.0", assetUrl: "https://example.com" } });
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
@@ -2283,7 +2004,7 @@ describe("managed mode settings", () => {
 
         const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.1.0" });
         (plugin as any).checkForUpdate = vi.fn().mockResolvedValue({ available: false });
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
@@ -2302,7 +2023,7 @@ describe("managed mode settings", () => {
 
         const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "" });
         (plugin as any).checkForUpdate = vi.fn().mockResolvedValue({ available: false });
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
@@ -2324,7 +2045,7 @@ describe("managed mode settings", () => {
             .mockImplementation(async (_release: any, onProgress?: (msg: string) => void) => {
                 onProgress?.("Downloading...");
             });
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
@@ -2345,7 +2066,7 @@ describe("managed mode settings", () => {
         (plugin as any).checkForUpdate = vi
             .fn()
             .mockResolvedValue({ available: true, release: { tag: "v0.2.0", assetUrl: "https://example.com" } });
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
@@ -2365,7 +2086,7 @@ describe("managed mode settings", () => {
             .fn()
             .mockResolvedValue({ available: true, release: { tag: "v0.2.0", assetUrl: "https://example.com" } });
         (plugin as any).updateServer = vi.fn().mockRejectedValue(new Error("download failed"));
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
@@ -2382,7 +2103,7 @@ describe("managed mode settings", () => {
 
         const plugin = makePlugin({ serverMode: "managed" });
         (plugin as any).checkForUpdate = vi.fn().mockRejectedValue(new Error("network error"));
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
@@ -2395,7 +2116,7 @@ describe("managed mode settings", () => {
 
     it("renders server status indicator in managed mode", () => {
         const plugin = makePlugin({ serverMode: "managed" });
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         const tab = makeTab(plugin);
         tab.display();
 
@@ -2408,7 +2129,7 @@ describe("managed mode settings", () => {
     it("renders server state from serverManager when present", () => {
         const plugin = makePlugin({ serverMode: "managed" });
         (plugin as any).serverManager = { state: "ready" };
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         const tab = makeTab(plugin);
         tab.display();
 
@@ -2421,7 +2142,7 @@ describe("managed mode settings", () => {
 
     it("Reset to managed button resets serverMode and serverUrl", async () => {
         const plugin = makePlugin({ serverMode: "external", serverUrl: "http://remote:9999" });
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
@@ -2440,7 +2161,7 @@ describe("managed mode settings", () => {
     it("shows Start button when server is stopped", () => {
         const plugin = makePlugin({ serverMode: "managed" });
         (plugin as any).serverManager = null; // state defaults to "stopped"
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         (plugin as any).startManagedServer = vi.fn().mockResolvedValue(undefined);
         const tab = makeTab(plugin);
 
@@ -2453,7 +2174,7 @@ describe("managed mode settings", () => {
     it("Start button calls startManagedServer", async () => {
         const plugin = makePlugin({ serverMode: "managed" });
         (plugin as any).serverManager = null; // state defaults to "stopped"
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         const mockStart = vi.fn().mockResolvedValue(undefined);
         (plugin as any).startManagedServer = mockStart;
         const tab = makeTab(plugin);
@@ -2471,7 +2192,7 @@ describe("managed mode settings", () => {
         const plugin = makePlugin({ serverMode: "managed" });
         const mockStop = vi.fn().mockResolvedValue(undefined);
         (plugin as any).serverManager = { state: "ready", stop: mockStop, restart: vi.fn() };
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
@@ -2487,7 +2208,7 @@ describe("managed mode settings", () => {
         const plugin = makePlugin({ serverMode: "managed" });
         const mockRestart = vi.fn().mockResolvedValue(undefined);
         (plugin as any).serverManager = { state: "ready", stop: vi.fn(), restart: mockRestart };
-        (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+        mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
@@ -2502,7 +2223,7 @@ describe("managed mode settings", () => {
     describe("Advanced chunk fields onChange", () => {
         it("chunk_size calls updateConfig after confirm", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -2513,7 +2234,7 @@ describe("managed mode settings", () => {
 
         it("chunk_overlap calls updateConfig after confirm", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -2524,7 +2245,7 @@ describe("managed mode settings", () => {
 
         it("skips empty value", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -2534,7 +2255,7 @@ describe("managed mode settings", () => {
 
         it("skips invalid number", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -2544,7 +2265,7 @@ describe("managed mode settings", () => {
 
         it("skips negative number", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -2555,7 +2276,7 @@ describe("managed mode settings", () => {
         it("aborts when user cancels confirm", async () => {
             mockGenericConfirmResult = false;
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -2570,7 +2291,7 @@ describe("managed mode settings", () => {
                 updated: ["chunk_size"],
                 reindex_required: true,
             });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -2581,7 +2302,7 @@ describe("managed mode settings", () => {
         it("shows error notice on updateConfig failure", async () => {
             const plugin = makePlugin();
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("fail"));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -2593,7 +2314,7 @@ describe("managed mode settings", () => {
     describe("Embedding model dropdown", () => {
         it("calls setEmbeddingModel when catalog loads successfully", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
                 ok({
                     total: 1,
@@ -2615,7 +2336,7 @@ describe("managed mode settings", () => {
 
         it("embedding dropdown onChange sets model and triggers sync", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             (plugin.api.setEmbeddingModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
             (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
                 ok({
@@ -2659,7 +2380,7 @@ describe("managed mode settings", () => {
         it("embedding dropdown onChange aborts when user cancels confirm", async () => {
             mockGenericConfirmResult = false;
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
                 ok({
                     total: 1,
@@ -2697,7 +2418,7 @@ describe("managed mode settings", () => {
 
         it("embedding dropdown shows error notice on failure", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             (plugin.api.setEmbeddingModel as ReturnType<typeof vi.fn>).mockResolvedValue(err(new Error("fail")));
             (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
                 ok({
@@ -2737,7 +2458,7 @@ describe("managed mode settings", () => {
 
         it("embedding dropdown skips empty value", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
                 ok({
                     total: 1,
@@ -2774,7 +2495,7 @@ describe("managed mode settings", () => {
 
         it("falls back to text input when catalog fails", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             (plugin.api.catalog as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("fail"));
             const tab = makeTab(plugin);
             tab.display();
@@ -2786,7 +2507,7 @@ describe("managed mode settings", () => {
 
         it("falls back to text input when catalog returns error result", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
 
@@ -2797,7 +2518,7 @@ describe("managed mode settings", () => {
 
         it("fallback text input calls setEmbeddingModel on non-empty value", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const container = new MockElement("div") as unknown as HTMLElement;
             const tab = makeTab(plugin);
 
@@ -2826,7 +2547,7 @@ describe("managed mode settings", () => {
 
         it("fallback text input skips empty value", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const container = new MockElement("div") as unknown as HTMLElement;
             const tab = makeTab(plugin);
 
@@ -2855,7 +2576,7 @@ describe("managed mode settings", () => {
         it("fallback text input aborts when user cancels confirm", async () => {
             mockGenericConfirmResult = false;
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const container = new MockElement("div") as unknown as HTMLElement;
             const tab = makeTab(plugin);
 
@@ -2885,7 +2606,7 @@ describe("managed mode settings", () => {
         it("fallback text input shows error notice on failure", async () => {
             const plugin = makePlugin();
             (plugin.api.setEmbeddingModel as ReturnType<typeof vi.fn>).mockResolvedValue(err(new Error("fail")));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const container = new MockElement("div") as unknown as HTMLElement;
             const tab = makeTab(plugin);
 
@@ -2917,7 +2638,7 @@ describe("managed mode settings", () => {
     describe("Crawling fields onChange", () => {
         it("calls updateConfig with valid crawl_max_depth", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -2928,7 +2649,7 @@ describe("managed mode settings", () => {
 
         it("calls updateConfig with valid crawl_max_pages", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -2938,7 +2659,7 @@ describe("managed mode settings", () => {
 
         it("sends null when nullable crawl_max_depth is cleared", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -2948,7 +2669,7 @@ describe("managed mode settings", () => {
 
         it("skips invalid number", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -2958,7 +2679,7 @@ describe("managed mode settings", () => {
 
         it("skips negative number", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -2968,7 +2689,7 @@ describe("managed mode settings", () => {
 
         it("skips blank on non-nullable crawl_timeout (index 9)", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -2978,7 +2699,7 @@ describe("managed mode settings", () => {
 
         it("accepts float for crawl_mean_delay (index 10)", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -2988,7 +2709,7 @@ describe("managed mode settings", () => {
 
         it("accepts int for crawl_concurrent_requests (index 12)", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -2998,7 +2719,7 @@ describe("managed mode settings", () => {
 
         it("rejects non-integer for crawl_concurrent_requests (index 12)", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -3008,7 +2729,7 @@ describe("managed mode settings", () => {
 
         it("accepts float for crawl_retry_max_backoff (index 15)", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -3018,7 +2739,7 @@ describe("managed mode settings", () => {
 
         it("crawl_retry_on_rate_limit toggle updates config", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -3030,7 +2751,7 @@ describe("managed mode settings", () => {
         it("toggle shows error notice when updateConfig rejects", async () => {
             const plugin = makePlugin();
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("boom"));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -3041,7 +2762,7 @@ describe("managed mode settings", () => {
         it("nullable-clear shows error notice when updateConfig rejects", async () => {
             const plugin = makePlugin();
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("boom"));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -3052,7 +2773,7 @@ describe("managed mode settings", () => {
         it("shows error notice on updateConfig failure", async () => {
             const plugin = makePlugin();
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("fail"));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -3069,7 +2790,7 @@ describe("managed mode settings", () => {
                 chunk_overlap: 64,
                 embedding_model: "nomic-embed-text",
             });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
 
@@ -3085,7 +2806,7 @@ describe("managed mode settings", () => {
                 chunk_size: 512,
                 // chunk_overlap and embedding_model are absent
             });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
 
@@ -3101,7 +2822,7 @@ describe("managed mode settings", () => {
                 crawl_max_pages: 200,
                 crawl_retry_on_rate_limit: true,
             });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
 
@@ -3126,7 +2847,7 @@ describe("managed mode settings", () => {
 
         it("does not echo-patch the server when populating a toggle from cfg (bb-t6yg)", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
             await new Promise((r) => setTimeout(r, 0));
@@ -3144,7 +2865,7 @@ describe("managed mode settings", () => {
 
         it("without the suppress flag, a toggle setValue onChange WOULD echo-patch", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
             await new Promise((r) => setTimeout(r, 0));
@@ -3158,7 +2879,7 @@ describe("managed mode settings", () => {
 
         it("suppressToggleChanges === true short-circuits the crawl-retry toggle onChange", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
             await new Promise((r) => setTimeout(r, 0));
@@ -3180,7 +2901,7 @@ describe("managed mode settings", () => {
                 seed: 42,
                 system_prompt: "You are helpful.",
             });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
 
             // Track input elements to verify the value was written.
@@ -3231,7 +2952,7 @@ describe("managed mode settings", () => {
             (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
                 crawl_exclude_patterns: ["/page/\\d+/?$", "/tag/"],
             });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const textAreas: Array<{ value: string; placeholder: string }> = [];
             const origAddTextArea = (Setting.prototype as any).addTextArea;
@@ -3257,7 +2978,7 @@ describe("managed mode settings", () => {
     describe("loadConfigDefaults", () => {
         it("caches the server response for later reset lookups", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             (plugin.api.configDefaults as ReturnType<typeof vi.fn>).mockResolvedValue({ chunk_size: 512 });
             const tab = makeTab(plugin);
             tab.display();
@@ -3268,7 +2989,7 @@ describe("managed mode settings", () => {
 
         it("falls back to an empty map when the endpoint is missing", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             (plugin.api.configDefaults as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("404"));
             const tab = makeTab(plugin);
             tab.display();
@@ -3281,7 +3002,7 @@ describe("managed mode settings", () => {
     describe("crawl_exclude_patterns textarea", () => {
         it("PATCHes the array split on newlines, trimmed, empties dropped", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textAreaOnChanges } = captureSettingCallbacks(() => tab.display());
             // textAreaOnChanges[0] = systemPrompt, textAreaOnChanges[1] = crawl_exclude_patterns.
@@ -3294,7 +3015,7 @@ describe("managed mode settings", () => {
         it("surfaces a failure notice when the server rejects", async () => {
             Notice.clear();
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("boom"));
             const tab = makeTab(plugin);
             const { textAreaOnChanges } = captureSettingCallbacks(() => tab.display());
@@ -3313,7 +3034,7 @@ describe("managed mode settings", () => {
         it("server-backed reset PATCHes the cached default", async () => {
             Notice.clear();
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { extraButtonOnClicks } = captureSettingCallbacks(() => tab.display());
             // Seed the cache directly so we don't race the async configDefaults fetch.
@@ -3325,7 +3046,7 @@ describe("managed mode settings", () => {
         it("server-backed reset silently no-ops when defaults haven't loaded yet", async () => {
             Notice.clear();
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { extraButtonOnClicks } = captureSettingCallbacks(() => tab.display());
             (tab as any).configDefaults = {};
@@ -3338,7 +3059,7 @@ describe("managed mode settings", () => {
         it("server-backed reset surfaces a reset-failure notice when updateConfig rejects", async () => {
             Notice.clear();
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("boom"));
             const tab = makeTab(plugin);
             const { extraButtonOnClicks } = captureSettingCallbacks(() => tab.display());
@@ -3349,7 +3070,7 @@ describe("managed mode settings", () => {
 
         it("local reset writes DEFAULT_SETTINGS[key] to plugin state", async () => {
             const plugin = makePlugin({ serverMode: "external" });
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { extraButtonOnClicks } = captureSettingCallbacks(() => tab.display());
             // Index 0 is the serverMode reset (local).
@@ -3364,7 +3085,7 @@ describe("managed mode settings", () => {
             Notice.clear();
             const plugin = makePlugin({ wikiEnabled: true, wikiPruneRaw: true });
             (plugin as any).wikiEnabled = true;
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             // configDefaults is re-fetched on each display(); keep it resolving to our seed.
             (plugin.api.configDefaults as ReturnType<typeof vi.fn>).mockResolvedValue({ wiki_prune_raw: false });
             const tab = makeTab(plugin);
@@ -3389,7 +3110,7 @@ describe("managed mode settings", () => {
             Notice.clear();
             const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             // configDefaults resolves to empty so the early-return branch is exercised.
             (plugin.api.configDefaults as ReturnType<typeof vi.fn>).mockResolvedValue({});
             const tab = makeTab(plugin);
@@ -3409,7 +3130,7 @@ describe("managed mode settings", () => {
             Notice.clear();
             const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("boom"));
             (plugin.api.configDefaults as ReturnType<typeof vi.fn>).mockResolvedValue({ wiki_prune_raw: false });
             const tab = makeTab(plugin);
@@ -3429,7 +3150,7 @@ describe("managed mode settings", () => {
             Notice.clear();
             mockGenericConfirmResult = false;
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
             (tab as any).configDefaults = { chunk_size: 512 };
@@ -3443,7 +3164,7 @@ describe("managed mode settings", () => {
             Notice.clear();
             mockGenericConfirmResult = true;
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
             (tab as any).configDefaults = {
@@ -3461,7 +3182,7 @@ describe("managed mode settings", () => {
         it("does not PATCH when every default is filtered out by the credential block", async () => {
             mockGenericConfirmResult = true;
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
             (tab as any).configDefaults = { openai_api_key: "", hf_token: "" };
@@ -3474,7 +3195,7 @@ describe("managed mode settings", () => {
             Notice.clear();
             mockGenericConfirmResult = true;
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("boom"));
             const tab = makeTab(plugin);
             const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
@@ -3487,7 +3208,7 @@ describe("managed mode settings", () => {
     describe("API key on blur", () => {
         it("calls updateConfig with openai_api_key on blur", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { blurHandlers } = captureSettingCallbacks(() => tab.display());
 
@@ -3499,7 +3220,7 @@ describe("managed mode settings", () => {
 
         it("calls updateConfig with anthropic_api_key on blur", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { blurHandlers } = captureSettingCallbacks(() => tab.display());
 
@@ -3510,7 +3231,7 @@ describe("managed mode settings", () => {
 
         it("calls updateConfig with gemini_api_key on blur", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { blurHandlers } = captureSettingCallbacks(() => tab.display());
 
@@ -3521,7 +3242,7 @@ describe("managed mode settings", () => {
 
         it("skips empty value on blur", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { blurHandlers } = captureSettingCallbacks(() => tab.display());
 
@@ -3533,7 +3254,7 @@ describe("managed mode settings", () => {
         it("shows error notice on failure", async () => {
             const plugin = makePlugin();
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("fail"));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { blurHandlers } = captureSettingCallbacks(() => tab.display());
 
@@ -3546,7 +3267,7 @@ describe("managed mode settings", () => {
     describe("HuggingFace token onChange", () => {
         it("calls updateConfig and saves settings on non-empty value", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -3559,7 +3280,7 @@ describe("managed mode settings", () => {
 
         it("saves empty token", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -3570,7 +3291,7 @@ describe("managed mode settings", () => {
         it("shows error notice on failure", async () => {
             const plugin = makePlugin();
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("fail"));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -3584,7 +3305,7 @@ describe("managed mode settings", () => {
     describe("settings filter", () => {
         it("renders a filter input at the top", () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
             const input = tab.containerEl.children.find(
@@ -3595,7 +3316,7 @@ describe("managed mode settings", () => {
 
         it("calls filterSettings on input event", () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
 
@@ -3614,7 +3335,7 @@ describe("managed mode settings", () => {
 
         it("filterSettings hides non-matching items and shows matching ones", () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
 
@@ -3641,7 +3362,7 @@ describe("managed mode settings", () => {
 
         it("filterSettings handles items without setting-item-name", () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
 
@@ -3659,7 +3380,7 @@ describe("managed mode settings", () => {
 
         it("filterSettings hides entire section when no items match", () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
 
@@ -3678,7 +3399,7 @@ describe("managed mode settings", () => {
 
         it("filterSettings shows all items when query is empty", () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
 
@@ -3699,7 +3420,7 @@ describe("managed mode settings", () => {
 
         it("di8: filterSettings hides non-matching top-level setting items", () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
 
@@ -3717,7 +3438,7 @@ describe("managed mode settings", () => {
 
         it("di8: empty query restores top-level items hidden by an earlier filter", () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
 
@@ -3734,7 +3455,7 @@ describe("managed mode settings", () => {
 
         it("di8: top-level items without setting-item-name are hidden when a query is present", () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
 
@@ -3747,7 +3468,7 @@ describe("managed mode settings", () => {
 
         it("di8: non-setting-item children of containerEl are left untouched", () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
 
@@ -3768,7 +3489,7 @@ describe("managed mode settings", () => {
     describe("LiteLLM base URL onChange", () => {
         it("calls updateConfig on non-empty value", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -3779,7 +3500,7 @@ describe("managed mode settings", () => {
 
         it("skips empty value", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -3790,7 +3511,7 @@ describe("managed mode settings", () => {
         it("shows error notice on failure", async () => {
             const plugin = makePlugin();
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("fail"));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -3803,7 +3524,7 @@ describe("managed mode settings", () => {
         it("always renders wiki section heading even when wikiEnabled is false", () => {
             const plugin = makePlugin({ wikiEnabled: false });
             (plugin as any).wikiEnabled = false;
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
             const details = tab.containerEl.children.find(
@@ -3823,7 +3544,7 @@ describe("managed mode settings", () => {
         it("shows wiki settings when wikiEnabled is true", () => {
             const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { toggleOnChanges, buttonOnClicks } = captureSettingCallbacks(() => tab.display());
             // Wiki section adds: 1 toggle (enable) + 1 toggle (prune raw) + 1 slider (faithfulness) + 1 dropdown (search mode) + 2 buttons (lint, prune)
@@ -3835,7 +3556,7 @@ describe("managed mode settings", () => {
         it("wiki enable toggle saves setting and syncs runtime flag", async () => {
             const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -3859,7 +3580,7 @@ describe("managed mode settings", () => {
         it("wiki enable toggle re-enables sub-settings when toggled back on", async () => {
             const plugin = makePlugin({ wikiEnabled: false });
             (plugin as any).wikiEnabled = false;
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -3882,7 +3603,7 @@ describe("managed mode settings", () => {
         it("sub-settings hidden when wikiEnabled setting is false", () => {
             const plugin = makePlugin({ wikiEnabled: false });
             (plugin as any).wikiEnabled = false;
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
             const details = tab.containerEl.children.find(
@@ -3901,7 +3622,7 @@ describe("managed mode settings", () => {
         it("sub-settings visible when wikiEnabled setting is true", () => {
             const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             tab.display();
             const details = tab.containerEl.children.find(
@@ -3920,7 +3641,7 @@ describe("managed mode settings", () => {
         it("prune raw toggle calls updateConfig", async () => {
             const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -3935,7 +3656,7 @@ describe("managed mode settings", () => {
         it("faithfulness slider calls updateConfig", async () => {
             const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { sliderOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -3950,7 +3671,7 @@ describe("managed mode settings", () => {
         it("search mode dropdown updates settings", async () => {
             const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { dropdownOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -3967,7 +3688,7 @@ describe("managed mode settings", () => {
         it("lint button click calls runWikiLint", async () => {
             const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
@@ -3981,7 +3702,7 @@ describe("managed mode settings", () => {
         it("prune button click calls runWikiPrune", async () => {
             const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
@@ -3994,7 +3715,7 @@ describe("managed mode settings", () => {
             const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("fail"));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -4008,7 +3729,7 @@ describe("managed mode settings", () => {
         it("sync-to-vault toggle enables wiki sync", async () => {
             const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -4023,7 +3744,7 @@ describe("managed mode settings", () => {
         it("sync-to-vault toggle disabling clears wikiSync", async () => {
             const plugin = makePlugin({ wikiEnabled: true, wikiSyncToVault: true });
             (plugin as any).wikiEnabled = true;
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -4036,7 +3757,7 @@ describe("managed mode settings", () => {
         it("vault folder text field updates settings", async () => {
             const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -4056,7 +3777,7 @@ describe("managed mode settings", () => {
         it("vault folder text field defaults to lilbee-wiki when empty", async () => {
             const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -4073,7 +3794,7 @@ describe("managed mode settings", () => {
         it("vault folder change re-initializes WikiSync when sync enabled", async () => {
             const plugin = makePlugin({ wikiEnabled: true, wikiSyncToVault: true });
             (plugin as any).wikiEnabled = true;
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -4093,7 +3814,7 @@ describe("managed mode settings", () => {
             const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("fail"));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { sliderOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -4108,7 +3829,7 @@ describe("managed mode settings", () => {
     describe("LLM provider dropdown onChange", () => {
         it("calls updateConfig with selected provider", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { dropdownOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -4120,7 +3841,7 @@ describe("managed mode settings", () => {
 
         it("hides litellm container when provider is not litellm", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { dropdownOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -4132,7 +3853,7 @@ describe("managed mode settings", () => {
         it("shows error notice on failure", async () => {
             const plugin = makePlugin();
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("fail"));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { dropdownOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -4145,7 +3866,7 @@ describe("managed mode settings", () => {
     describe("password masking for sensitive fields", () => {
         it("sets API key input types to password", () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const inputs: Array<{ type?: string }> = [];
             const origAddText = Setting.prototype.addText;
@@ -4171,7 +3892,7 @@ describe("managed mode settings", () => {
 
         it("sets HF token input type to password", () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const inputs: Array<{ type?: string }> = [];
             const origAddText = Setting.prototype.addText;
@@ -4269,9 +3990,8 @@ describe("managed mode settings", () => {
                     offset: 0,
                     models: [
                         {
-                            name: "bge-reranker-v2-m3",
-                            tag: "latest",
                             hf_repo: "BAAI/bge-reranker-v2-m3",
+                            gguf_filename: "*Q4_K_M.gguf",
                             display_name: "BGE v2",
                             size_gb: 1,
                             min_ram_gb: 4,
@@ -4280,13 +4000,16 @@ describe("managed mode settings", () => {
                             installed: true,
                             source: "native",
                             task: "rerank",
+                            featured: true,
+                            downloads: 0,
+                            param_count: "335M",
                         },
                     ],
                     has_more: false,
                 }),
             );
             (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({
-                models: [{ name: "bge-reranker-v2-m3:latest", source: "native" }],
+                models: [{ name: "BAAI/bge-reranker-v2-m3/bge-reranker-v2-m3.Q4_K_M.gguf", source: "native" }],
             });
             const container = new MockElement("div") as unknown as HTMLElement;
             const tab = makeTab(plugin);
@@ -4297,8 +4020,7 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
 
             expect(options[0][""]).toBe(MESSAGES.LABEL_RERANKER_DISABLED);
-            // Dropdown option keys use hf_repo (canonical id), not display name
-            expect(options[0]["bge-reranker-v2-m3:latest"]).toBe("BAAI/bge-reranker-v2-m3");
+            expect(options[0]["BAAI/bge-reranker-v2-m3"]).toBe("BGE v2");
             expect(values[0]).toBe("");
         });
 
@@ -4386,10 +4108,9 @@ describe("managed mode settings", () => {
                     offset: 0,
                     models: [
                         {
-                            name: "bge",
-                            tag: "latest",
                             hf_repo: "BAAI/bge",
-                            display_name: "",
+                            gguf_filename: "*Q4_K_M.gguf",
+                            display_name: "BGE",
                             size_gb: 1,
                             min_ram_gb: 4,
                             description: "",
@@ -4397,13 +4118,16 @@ describe("managed mode settings", () => {
                             installed: true,
                             source: "native",
                             task: "rerank",
+                            featured: true,
+                            downloads: 0,
+                            param_count: "335M",
                         },
                     ],
                     has_more: false,
                 }),
             );
             (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({
-                models: [{ name: "bge:latest", source: "native" }],
+                models: [{ name: "BAAI/bge/bge.Q4_K_M.gguf", source: "native" }],
             });
             const container = new MockElement("div") as unknown as HTMLElement;
             const tab = makeTab(plugin);
@@ -4413,7 +4137,7 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            await dropdowns[0]("bge:latest");
+            await dropdowns[0]("BAAI/bge");
             expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_FAILED_RERANKER)).toBe(true);
         });
 
@@ -4434,10 +4158,9 @@ describe("managed mode settings", () => {
                     offset: 0,
                     models: [
                         {
-                            name: "bge-reranker-large",
-                            tag: "latest",
                             hf_repo: "BAAI/bge-reranker-large",
-                            display_name: "",
+                            gguf_filename: "*Q4_K_M.gguf",
+                            display_name: "BGE Reranker Large",
                             size_gb: 2,
                             min_ram_gb: 4,
                             description: "",
@@ -4445,6 +4168,9 @@ describe("managed mode settings", () => {
                             installed: false,
                             source: "native",
                             task: "rerank",
+                            featured: true,
+                            downloads: 0,
+                            param_count: "560M",
                         },
                     ],
                     has_more: false,
@@ -4459,14 +4185,13 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            // pullModel and setRerankerModel must use hf_repo (canonical id), not display name
-            await dropdowns[0]("bge-reranker-large:latest");
+            await dropdowns[0]("BAAI/bge-reranker-large");
             expect(plugin.api.pullModel).toHaveBeenCalledWith(
                 "BAAI/bge-reranker-large",
                 "native",
                 expect.any(AbortSignal),
             );
-            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("bge-reranker-large:latest");
+            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("BAAI/bge-reranker-large");
         });
 
         it("hosted litellm entry skips pull and calls setRerankerModel directly", async () => {
@@ -4482,10 +4207,9 @@ describe("managed mode settings", () => {
                     offset: 0,
                     models: [
                         {
-                            name: "rerank-english-v3.0",
-                            tag: "latest",
                             hf_repo: "cohere/rerank-english-v3.0",
-                            display_name: "Cohere",
+                            gguf_filename: "",
+                            display_name: "Cohere Rerank",
                             size_gb: 0,
                             min_ram_gb: 0,
                             description: "",
@@ -4493,6 +4217,9 @@ describe("managed mode settings", () => {
                             installed: false,
                             source: "litellm",
                             task: "rerank",
+                            featured: false,
+                            downloads: 0,
+                            param_count: "",
                         },
                     ],
                     has_more: false,
@@ -4507,15 +4234,15 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            await dropdowns[0]("rerank-english-v3.0:latest");
+            await dropdowns[0]("cohere/rerank-english-v3.0");
             expect(plugin.api.pullModel).not.toHaveBeenCalled();
-            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("rerank-english-v3.0:latest");
+            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("cohere/rerank-english-v3.0");
         });
 
-        it("hosted litellm entry with 422 response surfaces API-key notice", async () => {
+        it("422 response surfaces failure notice (no LiteLLM-key fallback)", async () => {
             const plugin = makePlugin();
             (plugin.api.setRerankerModel as ReturnType<typeof vi.fn>).mockResolvedValue(
-                err(new Error("Server responded 422: key missing")),
+                err(new Error("Server responded 422: bare name:tag is rejected")),
             );
             (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
                 reranker_model: "",
@@ -4528,10 +4255,9 @@ describe("managed mode settings", () => {
                     offset: 0,
                     models: [
                         {
-                            name: "rerank",
-                            tag: "latest",
                             hf_repo: "cohere/rerank",
-                            display_name: "",
+                            gguf_filename: "",
+                            display_name: "Cohere Rerank",
                             size_gb: 0,
                             min_ram_gb: 0,
                             description: "",
@@ -4539,6 +4265,9 @@ describe("managed mode settings", () => {
                             installed: false,
                             source: "litellm",
                             task: "rerank",
+                            featured: false,
+                            downloads: 0,
+                            param_count: "",
                         },
                     ],
                     has_more: false,
@@ -4553,8 +4282,11 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            await dropdowns[0]("rerank:latest");
-            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_RERANKER_NEEDS_KEY)).toBe(true);
+            await dropdowns[0]("cohere/rerank");
+            // The previous code mapped any 422 to NOTICE_RERANKER_NEEDS_KEY ("configure LiteLLM API key");
+            // that misled users hitting unrelated 422 paths. Now the generic fallback fires.
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_FAILED_RERANKER)).toBe(true);
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_RERANKER_NEEDS_KEY)).toBe(false);
         });
 
         it("role-mismatch 422 surfaces the server's detail verbatim (not the API-key notice)", async () => {
@@ -4679,10 +4411,9 @@ describe("managed mode settings", () => {
                     offset: 0,
                     models: [
                         {
-                            name: "bge",
-                            tag: "latest",
                             hf_repo: "BAAI/bge",
-                            display_name: "",
+                            gguf_filename: "*Q4_K_M.gguf",
+                            display_name: "BGE",
                             size_gb: 1,
                             min_ram_gb: 4,
                             description: "",
@@ -4690,6 +4421,9 @@ describe("managed mode settings", () => {
                             installed: false,
                             source: "native",
                             task: "rerank",
+                            featured: true,
+                            downloads: 0,
+                            param_count: "335M",
                         },
                     ],
                     has_more: false,
@@ -4704,7 +4438,7 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            await dropdowns[0]("bge:latest");
+            await dropdowns[0]("BAAI/bge");
             expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_QUEUE_FULL)).toBe(true);
             expect(plugin.api.pullModel).not.toHaveBeenCalled();
         });
@@ -4726,10 +4460,9 @@ describe("managed mode settings", () => {
                     offset: 0,
                     models: [
                         {
-                            name: "bge",
-                            tag: "latest",
                             hf_repo: "BAAI/bge",
-                            display_name: "",
+                            gguf_filename: "*Q4_K_M.gguf",
+                            display_name: "BGE",
                             size_gb: 1,
                             min_ram_gb: 4,
                             description: "",
@@ -4737,6 +4470,9 @@ describe("managed mode settings", () => {
                             installed: false,
                             source: "native",
                             task: "rerank",
+                            featured: true,
+                            downloads: 0,
+                            param_count: "335M",
                         },
                     ],
                     has_more: false,
@@ -4751,7 +4487,7 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            await dropdowns[0]("bge:latest");
+            await dropdowns[0]("BAAI/bge");
             expect(Notice.instances.some((n) => n.message.includes("failed to pull"))).toBe(true);
             expect(plugin.api.setRerankerModel).not.toHaveBeenCalled();
         });
@@ -4775,10 +4511,9 @@ describe("managed mode settings", () => {
                     offset: 0,
                     models: [
                         {
-                            name: "bge",
-                            tag: "latest",
                             hf_repo: "BAAI/bge",
-                            display_name: "",
+                            gguf_filename: "*Q4_K_M.gguf",
+                            display_name: "BGE",
                             size_gb: 1,
                             min_ram_gb: 4,
                             description: "",
@@ -4786,6 +4521,9 @@ describe("managed mode settings", () => {
                             installed: false,
                             source: "native",
                             task: "rerank",
+                            featured: true,
+                            downloads: 0,
+                            param_count: "335M",
                         },
                     ],
                     has_more: false,
@@ -4800,7 +4538,7 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            await dropdowns[0]("bge:latest");
+            await dropdowns[0]("BAAI/bge");
             expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_PULL_CANCELLED)).toBe(true);
         });
 
@@ -4821,10 +4559,9 @@ describe("managed mode settings", () => {
                     offset: 0,
                     models: [
                         {
-                            name: "bge",
-                            tag: "latest",
                             hf_repo: "BAAI/bge",
-                            display_name: "",
+                            gguf_filename: "*Q4_K_M.gguf",
+                            display_name: "BGE",
                             size_gb: 1,
                             min_ram_gb: 4,
                             description: "",
@@ -4832,6 +4569,9 @@ describe("managed mode settings", () => {
                             installed: false,
                             source: "native",
                             task: "rerank",
+                            featured: true,
+                            downloads: 0,
+                            param_count: "335M",
                         },
                     ],
                     has_more: false,
@@ -4846,7 +4586,7 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            await dropdowns[0]("bge:latest");
+            await dropdowns[0]("BAAI/bge");
             const failed = plugin.taskQueue.completed.find((t: any) => t.status === "failed");
             expect(failed).toBeDefined();
             expect(failed!.error).toBe("unknown error");
@@ -4869,10 +4609,9 @@ describe("managed mode settings", () => {
                     offset: 0,
                     models: [
                         {
-                            name: "bge",
-                            tag: "latest",
                             hf_repo: "BAAI/bge",
-                            display_name: "",
+                            gguf_filename: "*Q4_K_M.gguf",
+                            display_name: "BGE",
                             size_gb: 1,
                             min_ram_gb: 4,
                             description: "",
@@ -4880,6 +4619,9 @@ describe("managed mode settings", () => {
                             installed: false,
                             source: "native",
                             task: "rerank",
+                            featured: true,
+                            downloads: 0,
+                            param_count: "335M",
                         },
                     ],
                     has_more: false,
@@ -4894,11 +4636,11 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            await expect(dropdowns[0]("bge:latest")).resolves.not.toThrow();
-            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("bge:latest");
+            await expect(dropdowns[0]("BAAI/bge")).resolves.not.toThrow();
+            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("BAAI/bge");
         });
 
-        it("buildRerankerOptions includes only installed-first then not-installed then hosted", async () => {
+        it("buildRerankerOptions: installed first, then not-installed, then hosted", async () => {
             const plugin = makePlugin();
             (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
                 reranker_model: "",
@@ -4911,10 +4653,9 @@ describe("managed mode settings", () => {
                     offset: 0,
                     models: [
                         {
-                            name: "bge-installed",
-                            tag: "latest",
                             hf_repo: "BAAI/bge-installed",
-                            display_name: "",
+                            gguf_filename: "*Q4_K_M.gguf",
+                            display_name: "BGE Installed",
                             size_gb: 1,
                             min_ram_gb: 4,
                             description: "",
@@ -4922,12 +4663,14 @@ describe("managed mode settings", () => {
                             installed: true,
                             source: "native",
                             task: "rerank",
+                            featured: true,
+                            downloads: 0,
+                            param_count: "335M",
                         },
                         {
-                            name: "bge-not-installed",
-                            tag: "latest",
                             hf_repo: "BAAI/bge-not-installed",
-                            display_name: "",
+                            gguf_filename: "*Q4_K_M.gguf",
+                            display_name: "BGE Not Installed",
                             size_gb: 1,
                             min_ram_gb: 4,
                             description: "",
@@ -4935,12 +4678,14 @@ describe("managed mode settings", () => {
                             installed: false,
                             source: "native",
                             task: "rerank",
+                            featured: true,
+                            downloads: 0,
+                            param_count: "335M",
                         },
                         {
-                            name: "rerank",
-                            tag: "latest",
                             hf_repo: "cohere/rerank",
-                            display_name: "",
+                            gguf_filename: "",
+                            display_name: "Cohere Rerank",
                             size_gb: 0,
                             min_ram_gb: 0,
                             description: "",
@@ -4948,13 +4693,16 @@ describe("managed mode settings", () => {
                             installed: false,
                             source: "litellm",
                             task: "rerank",
+                            featured: false,
+                            downloads: 0,
+                            param_count: "",
                         },
                     ],
                     has_more: false,
                 }),
             );
             (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({
-                models: [{ name: "bge-installed:latest", source: "native" }],
+                models: [{ name: "BAAI/bge-installed/bge-installed.Q4_K_M.gguf", source: "native" }],
             });
             const container = new MockElement("div") as unknown as HTMLElement;
             const tab = makeTab(plugin);
@@ -4964,27 +4712,24 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            // Dropdown VALUES use the canonical ``name:tag`` ref so the
-            // server's active-reranker string (returned in name:tag form)
-            // matches an option and setValue resolves. Display labels still
-            // show hf_repo so the UI stays human-readable.
             const keys = Object.keys(options[0]);
-            expect(keys).toEqual(["", "bge-installed:latest", "bge-not-installed:latest", "rerank:latest"]);
-            expect(options[0]["bge-installed:latest"]).toBe("BAAI/bge-installed");
-            expect(options[0]["bge-not-installed:latest"]).toContain(MESSAGES.LABEL_NOT_INSTALLED);
-            expect(options[0]["rerank:latest"]).toContain(MESSAGES.LABEL_RERANKER_HOSTED_GROUP);
+            expect(keys).toEqual(["", "BAAI/bge-installed", "BAAI/bge-not-installed", "cohere/rerank"]);
+            expect(options[0]["BAAI/bge-installed"]).toBe("BGE Installed");
+            expect(options[0]["BAAI/bge-not-installed"]).toContain(MESSAGES.LABEL_NOT_INSTALLED);
+            expect(options[0]["cohere/rerank"]).toContain(MESSAGES.LABEL_RERANKER_HOSTED_GROUP);
         });
 
-        it("installed reranker with server's name:tag ref is NOT labelled (not installed)", async () => {
-            // Regression: buildRerankerOptions used to compare against
-            // ``entry.hf_repo`` but the server's ``/api/models/installed``
-            // returns the canonical ``name:tag`` ref. That mismatch made
-            // installed rerankers render as "(not installed)" and the
-            // dropdown fall back to "(disabled)" even when the server had
-            // an active reranker set. Guard the both forms here.
+        it("installed reranker with full HF ref is NOT mislabelled (not installed)", async () => {
+            // Regression for bb-e45z: post-PR-#183 the server's installed list
+            // returns full HF refs (`<repo>/<file>.gguf`). Membership against
+            // `entry.hf_repo` only works after stripping the trailing filename.
+            // Otherwise every installed reranker would render `(not installed)`
+            // and the dropdown would fall back to "(disabled)" even when the
+            // server had an active reranker set.
             const plugin = makePlugin();
+            const installedRef = "gpustack/bge-reranker-v2-m3-GGUF/bge-reranker-v2-m3.Q4_K_M.gguf";
             (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
-                reranker_model: "bge-reranker-v2-m3:latest",
+                reranker_model: installedRef,
                 rerank_candidates: 20,
                 reranker_available: true,
             });
@@ -4995,10 +4740,9 @@ describe("managed mode settings", () => {
                     offset: 0,
                     models: [
                         {
-                            name: "bge-reranker-v2-m3",
-                            tag: "latest",
                             hf_repo: "gpustack/bge-reranker-v2-m3-GGUF",
-                            display_name: "BGE",
+                            gguf_filename: "*Q4_K_M.gguf",
+                            display_name: "BGE Reranker v2 m3",
                             size_gb: 0.4,
                             min_ram_gb: 2,
                             description: "",
@@ -5006,13 +4750,16 @@ describe("managed mode settings", () => {
                             installed: true,
                             source: "native",
                             task: "rerank",
+                            featured: true,
+                            downloads: 0,
+                            param_count: "335M",
                         },
                     ],
                     has_more: false,
                 }),
             );
             (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({
-                models: [{ name: "bge-reranker-v2-m3:latest", source: "native" }],
+                models: [{ name: installedRef, source: "native" }],
             });
             const container = new MockElement("div") as unknown as HTMLElement;
             const tab = makeTab(plugin);
@@ -5022,9 +4769,9 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             await new Promise((r) => setTimeout(r, 0));
 
-            expect(options[0]["bge-reranker-v2-m3:latest"]).toBe("gpustack/bge-reranker-v2-m3-GGUF");
-            expect(options[0]["bge-reranker-v2-m3:latest"]).not.toContain(MESSAGES.LABEL_NOT_INSTALLED);
-            expect(values[0]).toBe("bge-reranker-v2-m3:latest");
+            expect(options[0]["gpustack/bge-reranker-v2-m3-GGUF"]).toBe("BGE Reranker v2 m3");
+            expect(options[0]["gpustack/bge-reranker-v2-m3-GGUF"]).not.toContain(MESSAGES.LABEL_NOT_INSTALLED);
+            expect(values[0]).toBe(installedRef);
         });
 
         it("parses reranker_model as empty when config lacks the field", async () => {
@@ -5101,9 +4848,9 @@ describe("managed mode settings", () => {
                     offset: 0,
                     models: [
                         {
-                            name: "qwen2-vl",
-                            hf_repo: "Qwen/Qwen2-VL-7B-Instruct",
-                            display_name: "Qwen2-VL",
+                            hf_repo: "Qwen/Qwen2-VL-7B-Instruct-GGUF",
+                            gguf_filename: "*Q4_K_M.gguf",
+                            display_name: "Qwen2 VL 7B",
                             size_gb: 8,
                             min_ram_gb: 16,
                             description: "vision",
@@ -5111,13 +4858,16 @@ describe("managed mode settings", () => {
                             installed: true,
                             source: "native",
                             task: "vision",
+                            featured: true,
+                            downloads: 0,
+                            param_count: "7B",
                         },
                     ],
                     has_more: false,
                 }),
             );
             (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({
-                models: [{ name: "Qwen/Qwen2-VL-7B-Instruct", source: "native" }],
+                models: [{ name: "Qwen/Qwen2-VL-7B-Instruct-GGUF/Qwen2-VL-7B-Instruct.Q4_K_M.gguf", source: "native" }],
             });
             const container = new MockElement("div") as unknown as HTMLElement;
             const tab = makeTab(plugin);
@@ -5128,7 +4878,7 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
 
             expect(options[0][""]).toBe(MESSAGES.LABEL_VISION_DISABLED);
-            expect(options[0]["Qwen/Qwen2-VL-7B-Instruct"]).toBe("Qwen/Qwen2-VL-7B-Instruct");
+            expect(options[0]["Qwen/Qwen2-VL-7B-Instruct-GGUF"]).toBe("Qwen2 VL 7B");
             expect(values[0]).toBe("");
         });
 
@@ -5319,10 +5069,10 @@ describe("managed mode settings", () => {
             expect(plugin.api.setVisionModel).toHaveBeenCalledWith("openai/gpt-4o");
         });
 
-        it("hosted litellm entry with 422 response surfaces API-key notice", async () => {
+        it("422 response surfaces failure notice (no LiteLLM-key fallback)", async () => {
             const plugin = makePlugin();
             (plugin.api.setVisionModel as ReturnType<typeof vi.fn>).mockResolvedValue(
-                err(new Error("Server responded 422: key missing")),
+                err(new Error("Server responded 422: bare name:tag rejected")),
             );
             (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({ vision_model: "" });
             (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
@@ -5332,9 +5082,9 @@ describe("managed mode settings", () => {
                     offset: 0,
                     models: [
                         {
-                            name: "gpt-4o",
                             hf_repo: "openai/gpt-4o",
-                            display_name: "",
+                            gguf_filename: "",
+                            display_name: "GPT-4o",
                             size_gb: 0,
                             min_ram_gb: 0,
                             description: "",
@@ -5342,6 +5092,9 @@ describe("managed mode settings", () => {
                             installed: false,
                             source: "litellm",
                             task: "vision",
+                            featured: false,
+                            downloads: 0,
+                            param_count: "",
                         },
                     ],
                     has_more: false,
@@ -5357,7 +5110,8 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
 
             await dropdowns[0]("openai/gpt-4o");
-            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_VISION_NEEDS_KEY)).toBe(true);
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_FAILED_VISION)).toBe(true);
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_VISION_NEEDS_KEY)).toBe(false);
         });
 
         it("role-mismatch 422 surfaces the server's detail verbatim (not the API-key notice)", async () => {
@@ -5887,7 +5641,7 @@ describe("managed mode settings", () => {
 
         it("calls updateConfig with parsed number after debounce", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -5901,7 +5655,7 @@ describe("managed mode settings", () => {
 
         it("debounces rapid changes into a single PATCH", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -5915,7 +5669,7 @@ describe("managed mode settings", () => {
 
         it("skips empty value", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -5926,7 +5680,7 @@ describe("managed mode settings", () => {
 
         it("rejects NaN input", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -5937,7 +5691,7 @@ describe("managed mode settings", () => {
 
         it("rejects out-of-range low value", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -5948,7 +5702,7 @@ describe("managed mode settings", () => {
 
         it("rejects out-of-range high value", async () => {
             const plugin = makePlugin();
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
@@ -5960,7 +5714,7 @@ describe("managed mode settings", () => {
         it("shows error notice on updateConfig failure", async () => {
             const plugin = makePlugin();
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("fail"));
-            (plugin.api.listModels as ReturnType<typeof vi.fn>).mockResolvedValue(makeModelsResponse());
+            mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -949,6 +949,45 @@ describe("LilbeeSettingTab", () => {
             const plugin = makePlugin();
             expect(() => renderPicker(plugin, "")).not.toThrow();
         });
+
+        it("renders 'Other installed' group for installed models outside the featured catalog", () => {
+            const plugin = makePlugin();
+            const tab = makeTab(plugin);
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const entries = [chatEntry({ installed: true })];
+            const installed: InstalledModel[] = [
+                { name: LLAMA_REF, source: "native" },
+                { name: "ollama/qwen3:8b", source: "ollama" },
+            ];
+            const opts: Array<[string, string]> = (tab as any).buildChatOptions(entries, installed);
+            const keys = opts.map(([k]) => k);
+            expect(keys).toContain("meta-llama/Llama-3-8B-Instruct-GGUF");
+            expect(keys).toContain(SEPARATOR_KEY);
+            expect(keys).toContain("ollama/qwen3:8b");
+            (tab as any).renderChatPicker(container, LLAMA_REF, entries, installed);
+        });
+
+        it("appends provider source tag for non-native featured entries", () => {
+            const plugin = makePlugin();
+            const tab = makeTab(plugin);
+            const entries = [chatEntry({ installed: true, source: "ollama" })];
+            const installed: InstalledModel[] = [{ name: LLAMA_REF, source: "ollama" }];
+            const opts: Array<[string, string]> = (tab as any).buildChatOptions(entries, installed);
+            expect(opts[0][1]).toContain("[ollama]");
+        });
+
+        it("falls back to empty active when catalog fetch errors", async () => {
+            const plugin = makePlugin();
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({ chat_model: LLAMA_REF });
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(err(new Error("nope")));
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({ models: [] });
+            const tab = makeTab(plugin);
+            const container = new MockElement("div") as unknown as HTMLElement;
+            await (tab as any).renderChatSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            // Renders without throwing even when the catalog Result is err.
+            expect((container as unknown as MockElement).findAll("lilbee-model-section").length).toBe(1);
+        });
     });
 
     describe("renderChatCatalogRow()", () => {

--- a/tests/utils/model-ref.test.ts
+++ b/tests/utils/model-ref.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { cleanDisplayName, displayLabelForRef, extractHfRepo } from "../../src/utils/model-ref";
+
+describe("displayLabelForRef", () => {
+    it("returns empty string for empty input", () => {
+        expect(displayLabelForRef("")).toBe("");
+    });
+
+    it("cleans a full native HF ref", () => {
+        expect(displayLabelForRef("Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q4_K_M.gguf")).toBe("Qwen3 0.6B");
+    });
+
+    it("cleans a Meta-prefixed Llama ref", () => {
+        expect(
+            displayLabelForRef("meta-llama/Meta-Llama-3-8B-Instruct-GGUF/Meta-Llama-3-8B-Instruct.Q4_K_M.gguf"),
+        ).toBe("Llama 3 8B");
+    });
+
+    it("cleans a Mistral ref with vendor versioning", () => {
+        expect(displayLabelForRef("bartowski/Mistral-7B-Instruct-v0.3-GGUF/Mistral-7B-Instruct-v0.3.Q4_K_M.gguf")).toBe(
+            "Mistral 7B",
+        );
+    });
+
+    it("returns the segment after ollama/", () => {
+        expect(displayLabelForRef("ollama/qwen3:8b")).toBe("qwen3:8b");
+    });
+
+    it("returns the segment after openai/", () => {
+        expect(displayLabelForRef("openai/gpt-4o")).toBe("gpt-4o");
+    });
+
+    it("returns the segment after anthropic/", () => {
+        expect(displayLabelForRef("anthropic/claude-opus-4-7")).toBe("claude-opus-4-7");
+    });
+
+    it("returns the segment after gemini/", () => {
+        expect(displayLabelForRef("gemini/gemini-2.5-flash")).toBe("gemini-2.5-flash");
+    });
+
+    it("returns the segment after cohere/", () => {
+        expect(displayLabelForRef("cohere/rerank-english-v3.0")).toBe("rerank-english-v3.0");
+    });
+
+    it("passes through unrecognised refs unchanged", () => {
+        expect(displayLabelForRef("weird-thing")).toBe("weird-thing");
+    });
+
+    it("passes through a bare repo (no .gguf, no provider prefix)", () => {
+        expect(displayLabelForRef("Qwen/Qwen3-0.6B-GGUF")).toBe("Qwen/Qwen3-0.6B-GGUF");
+    });
+});
+
+describe("extractHfRepo", () => {
+    it("strips the trailing /<filename>.gguf segment", () => {
+        expect(extractHfRepo("Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q4_K_M.gguf")).toBe("Qwen/Qwen3-0.6B-GGUF");
+    });
+
+    it("returns provider refs unchanged", () => {
+        expect(extractHfRepo("ollama/qwen3:8b")).toBe("ollama/qwen3:8b");
+    });
+
+    it("returns bare repos unchanged", () => {
+        expect(extractHfRepo("Qwen/Qwen3-0.6B-GGUF")).toBe("Qwen/Qwen3-0.6B-GGUF");
+    });
+
+    it("returns empty string unchanged", () => {
+        expect(extractHfRepo("")).toBe("");
+    });
+
+    it("returns a .gguf ref with no slash unchanged", () => {
+        expect(extractHfRepo("loose.gguf")).toBe("loose.gguf");
+    });
+});
+
+describe("cleanDisplayName", () => {
+    it("handles bare repo names", () => {
+        expect(cleanDisplayName("Qwen3-0.6B-GGUF")).toBe("Qwen3 0.6B");
+    });
+
+    it("strips org prefix when present", () => {
+        expect(cleanDisplayName("Qwen/Qwen3-8B-GGUF")).toBe("Qwen3 8B");
+    });
+
+    it("drops Meta- prefix", () => {
+        expect(cleanDisplayName("meta-llama/Meta-Llama-3-8B-Instruct-GGUF")).toBe("Llama 3 8B");
+    });
+
+    it("drops version and date suffixes iteratively", () => {
+        expect(cleanDisplayName("bartowski/Mistral-7B-Instruct-v0.3-GGUF")).toBe("Mistral 7B");
+        expect(cleanDisplayName("Qwen/Qwen2.5-7B-Instruct-GGUF")).toBe("Qwen2.5 7B");
+        expect(cleanDisplayName("Qwen/Qwen3-Coder-30B-A3B-Instruct-GGUF")).toBe("Qwen3 Coder 30B A3B");
+        expect(cleanDisplayName("anthropic/foo-2507")).toBe("foo");
+    });
+
+    it("collapses multiple internal spaces", () => {
+        expect(cleanDisplayName("foo--bar---baz")).toBe("foo bar baz");
+    });
+});

--- a/tests/utils/model-ref.test.ts
+++ b/tests/utils/model-ref.test.ts
@@ -46,8 +46,12 @@ describe("displayLabelForRef", () => {
         expect(displayLabelForRef("weird-thing")).toBe("weird-thing");
     });
 
-    it("passes through a bare repo (no .gguf, no provider prefix)", () => {
-        expect(displayLabelForRef("Qwen/Qwen3-0.6B-GGUF")).toBe("Qwen/Qwen3-0.6B-GGUF");
+    it("cleans a bare HF repo (set-then-fetchActiveModel transient state)", () => {
+        expect(displayLabelForRef("Qwen/Qwen3-0.6B-GGUF")).toBe("Qwen3 0.6B");
+    });
+
+    it("cleans a Meta-prefixed bare repo", () => {
+        expect(displayLabelForRef("meta-llama/Meta-Llama-3-8B-Instruct-GGUF")).toBe("Llama 3 8B");
     });
 });
 

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -31,7 +31,8 @@ vi.mock("../../src/views/confirm-modal", () => ({
 
 function makeEntry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
     return {
-        name: "qwen3",
+        hf_repo: "Qwen/Qwen3-8B-GGUF",
+        gguf_filename: "*Q4_K_M.gguf",
         display_name: "Qwen3 8B",
         size_gb: 5,
         min_ram_gb: 8,
@@ -39,11 +40,10 @@ function makeEntry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
         quality_tier: "balanced",
         installed: false,
         source: "native",
-        hf_repo: "qwen/qwen3-8b",
-        tag: "8b",
         task: "chat",
         featured: false,
         downloads: 0,
+        param_count: "8B",
         ...overrides,
     };
 }
@@ -176,7 +176,7 @@ describe("CatalogModal", () => {
                 ok(
                     makeCatalogResponse([
                         makeEntry({ name: "qwen3:0.6b", display_name: "Qwen3 0.6B", installed: true }),
-                        makeEntry({ hf_repo: "qwen/qwen3-8b", display_name: "Qwen3 8B", installed: false }),
+                        makeEntry({ hf_repo: "Qwen/Qwen3-8B-GGUF", display_name: "Qwen3 8B", installed: false }),
                     ]),
                 ),
             );
@@ -277,11 +277,11 @@ describe("CatalogModal", () => {
             expect(content.find("lilbee-catalog-remove")).not.toBeNull();
         });
 
-        it("shows Active when the entry is the plugin's active model (legacy hf_repo value)", async () => {
-            // Back-compat: vaults set up before 1s1 stored hf_repo; the badge
-            // must still resolve so users don't see "Use" on a model that's
-            // already active.
-            const plugin = makePlugin({ activeModel: "qwen/qwen3-8b" });
+        it("shows Active when activeModel's leading hf_repo segment matches the entry", async () => {
+            // Post-PR-#183 the active ref is the full HF path. The Active badge
+            // resolves by stripping the trailing `<file>.gguf` and comparing the
+            // bare repo to `entry.hf_repo`.
+            const plugin = makePlugin({ activeModel: "Qwen/Qwen3-8B-GGUF/Qwen3-8B-Q4_K_M.gguf" });
             plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry({ installed: true })])));
             const modal = await openModal(plugin);
             const content = contentEl(modal);
@@ -290,23 +290,8 @@ describe("CatalogModal", () => {
             expect(content.find("lilbee-catalog-active")).not.toBeNull();
         });
 
-        it("shows Active when activeModel matches entry.name (1s1 short ref)", async () => {
-            // After 1s1, fresh sets persist entry.name. The Active badge must
-            // resolve from the short ref too — otherwise the badge silently
-            // disappears the moment the user picks a model from the catalog.
-            const plugin = makePlugin({ activeModel: "qwen3" });
-            plugin.api.catalog.mockResolvedValue(
-                ok(makeCatalogResponse([makeEntry({ installed: true, name: "qwen3", hf_repo: "qwen/qwen3-8b" })])),
-            );
-            const modal = await openModal(plugin);
-            const content = contentEl(modal);
-            content.find("lilbee-catalog-view-toggle")!.trigger("click");
-            await tick();
-            expect(content.find("lilbee-catalog-active")).not.toBeNull();
-        });
-
-        it("does NOT show Active when activeModel matches neither entry.name nor entry.hf_repo", async () => {
-            const plugin = makePlugin({ activeModel: "some-other-model" });
+        it("does NOT show Active when activeModel doesn't match entry.hf_repo", async () => {
+            const plugin = makePlugin({ activeModel: "some/other-model-GGUF/file.gguf" });
             plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry({ installed: true })])));
             const modal = await openModal(plugin);
             const content = contentEl(modal);
@@ -672,7 +657,7 @@ describe("CatalogModal", () => {
             pullBtn.trigger("click");
             await tick();
             await tick();
-            expect(plugin.api.pullModel).toHaveBeenCalledWith("qwen/qwen3-8b", "native", expect.any(AbortSignal));
+            expect(plugin.api.pullModel).toHaveBeenCalledWith("Qwen/Qwen3-8B-GGUF", "native", expect.any(AbortSignal));
         });
 
         it("does not run pull when user cancels the confirm modal", async () => {
@@ -748,7 +733,7 @@ describe("CatalogModal", () => {
             useBtn.trigger("click");
             await tick();
             await tick();
-            expect(plugin.api.setEmbeddingModel).toHaveBeenCalledWith("qwen/qwen3-8b");
+            expect(plugin.api.setEmbeddingModel).toHaveBeenCalledWith("Qwen/Qwen3-8B-GGUF");
         });
 
         it("4u1: handleUse refreshes the Settings tab on success", async () => {
@@ -801,7 +786,7 @@ describe("CatalogModal", () => {
             useBtn.trigger("click");
             await tick();
             await tick();
-            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("qwen/qwen3-8b");
+            expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("Qwen/Qwen3-8B-GGUF");
             expect(plugin.api.setChatModel).not.toHaveBeenCalled();
             // activeModel is the chat model and must NOT be mutated by the rerank branch
             expect(plugin.activeModel).toBe("");
@@ -818,12 +803,12 @@ describe("CatalogModal", () => {
             useBtn.trigger("click");
             await tick();
             await tick();
-            expect(plugin.api.setVisionModel).toHaveBeenCalledWith("qwen/qwen3-8b");
+            expect(plugin.api.setVisionModel).toHaveBeenCalledWith("Qwen/Qwen3-8B-GGUF");
             expect(plugin.api.setChatModel).not.toHaveBeenCalled();
             expect(plugin.activeModel).toBe("");
         });
 
-        it("1s1: uses setChatModel with the catalog short ref (entry.name), not the long-form hf_repo", async () => {
+        it("uses setChatModel with hf_repo and stores it as plugin.activeModel", async () => {
             const plugin = makePlugin();
             plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry({ installed: true })])));
             const modal = await openModal(plugin);
@@ -832,13 +817,11 @@ describe("CatalogModal", () => {
             useBtn.trigger("click");
             await tick();
             await tick();
-            // Default makeEntry has name="qwen3" and hf_repo="qwen/qwen3-8b" — must use the short name.
-            expect(plugin.api.setChatModel).toHaveBeenCalledWith("qwen3");
-            expect(plugin.api.setChatModel).not.toHaveBeenCalledWith("qwen/qwen3-8b");
-            expect(plugin.activeModel).toBe("qwen3");
+            expect(plugin.api.setChatModel).toHaveBeenCalledWith("Qwen/Qwen3-8B-GGUF");
+            expect(plugin.activeModel).toBe("Qwen/Qwen3-8B-GGUF");
         });
 
-        it("1s1: chat-task activation toast names the catalog short ref, not hf_repo", async () => {
+        it("activation toast uses display_name (chat task)", async () => {
             Notice.clear();
             const plugin = makePlugin();
             plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry({ installed: true })])));
@@ -848,13 +831,10 @@ describe("CatalogModal", () => {
             useBtn.trigger("click");
             await tick();
             await tick();
-            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_MODEL_ACTIVATED("qwen3"))).toBe(true);
-            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_MODEL_ACTIVATED("qwen/qwen3-8b"))).toBe(
-                false,
-            );
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_MODEL_ACTIVATED("Qwen3 8B"))).toBe(true);
         });
 
-        it("1s1: embedding-task activation toast still names hf_repo (set via hf_repo)", async () => {
+        it("activation toast uses display_name (embedding task)", async () => {
             Notice.clear();
             const plugin = makePlugin();
             plugin.api.catalog.mockResolvedValue(
@@ -866,9 +846,7 @@ describe("CatalogModal", () => {
             useBtn.trigger("click");
             await tick();
             await tick();
-            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_MODEL_ACTIVATED("qwen/qwen3-8b"))).toBe(
-                true,
-            );
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_MODEL_ACTIVATED("Qwen3 8B"))).toBe(true);
         });
 
         it("notices failure when Use fails", async () => {
@@ -882,7 +860,7 @@ describe("CatalogModal", () => {
             await tick();
             await tick();
             const messages = Notice.instances.map((n) => n.message);
-            expect(messages.some((m) => m.includes("qwen/qwen3-8b"))).toBe(true);
+            expect(messages.some((m) => m.includes("Qwen/Qwen3-8B-GGUF"))).toBe(true);
         });
 
         it("surfaces server role-mismatch detail verbatim when Use hits a vision endpoint with a reranker model", async () => {
@@ -892,7 +870,7 @@ describe("CatalogModal", () => {
                 ok(makeCatalogResponse([makeEntry({ installed: true, task: "vision" })])),
             );
             const detail =
-                "Model 'qwen/qwen3-8b' is a rerank model, not vision. Set it via PUT /api/models/reranker instead.";
+                "Model 'Qwen/Qwen3-8B-GGUF' is a rerank model, not vision. Set it via PUT /api/models/reranker instead.";
             plugin.api.setVisionModel = vi
                 .fn()
                 .mockResolvedValue(err(new Error(`Server responded 422: {"detail": "${detail}"}`)));
@@ -905,7 +883,7 @@ describe("CatalogModal", () => {
             const messages = Notice.instances.map((n) => n.message);
             expect(messages).toContain(detail);
             // The generic fallback must NOT also appear — role-mismatch wins.
-            expect(messages.some((m) => m === MESSAGES.ERROR_SET_MODEL.replace("{model}", "qwen/qwen3-8b"))).toBe(
+            expect(messages.some((m) => m === MESSAGES.ERROR_SET_MODEL.replace("{model}", "Qwen/Qwen3-8B-GGUF"))).toBe(
                 false,
             );
         });
@@ -917,7 +895,7 @@ describe("CatalogModal", () => {
                 ok(makeCatalogResponse([makeEntry({ installed: true, task: "rerank" })])),
             );
             const detail =
-                "Model 'qwen/qwen3-8b' is a vision model, not rerank. Set it via PUT /api/models/vision instead.";
+                "Model 'Qwen/Qwen3-8B-GGUF' is a vision model, not rerank. Set it via PUT /api/models/vision instead.";
             plugin.api.setRerankerModel = vi
                 .fn()
                 .mockResolvedValue(err(new Error(`Server responded 422: {"detail": "${detail}"}`)));
@@ -929,7 +907,7 @@ describe("CatalogModal", () => {
             await tick();
             const messages = Notice.instances.map((n) => n.message);
             expect(messages).toContain(detail);
-            expect(messages.some((m) => m === MESSAGES.ERROR_SET_MODEL.replace("{model}", "qwen/qwen3-8b"))).toBe(
+            expect(messages.some((m) => m === MESSAGES.ERROR_SET_MODEL.replace("{model}", "Qwen/Qwen3-8B-GGUF"))).toBe(
                 false,
             );
         });
@@ -939,14 +917,14 @@ describe("CatalogModal", () => {
             plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry({ installed: true })])));
             plugin.api.deleteModel = vi
                 .fn()
-                .mockResolvedValue(ok({ deleted: true, model: "qwen/qwen3-8b", freed_gb: 5 }));
+                .mockResolvedValue(ok({ deleted: true, model: "Qwen/Qwen3-8B-GGUF", freed_gb: 5 }));
             const modal = await openModal(plugin);
             const content = contentEl(modal);
             const removeBtn = findButtons(content).find((b) => b.textContent === MESSAGES.BUTTON_REMOVE)!;
             removeBtn.trigger("click");
             await tick();
             await tick();
-            expect(plugin.api.deleteModel).toHaveBeenCalledWith("qwen/qwen3-8b", "native");
+            expect(plugin.api.deleteModel).toHaveBeenCalledWith("Qwen/Qwen3-8B-GGUF", "native");
         });
 
         it("skips delete when confirm is cancelled", async () => {
@@ -974,7 +952,7 @@ describe("CatalogModal", () => {
             await tick();
             await tick();
             const messages = Notice.instances.map((n) => n.message);
-            expect(messages.some((m) => m.includes("qwen/qwen3-8b"))).toBe(true);
+            expect(messages.some((m) => m.includes("Qwen/Qwen3-8B-GGUF"))).toBe(true);
         });
 
         it("fails the task and surfaces a Notice when pull aborts", async () => {
@@ -1006,7 +984,7 @@ describe("CatalogModal", () => {
             pullBtn.trigger("click");
             await tick();
             await tick();
-            const prefix = MESSAGES.ERROR_PULL_MODEL.replace("{model}", "qwen/qwen3-8b");
+            const prefix = MESSAGES.ERROR_PULL_MODEL.replace("{model}", "Qwen/Qwen3-8B-GGUF");
             expect(Notice.instances.map((n) => n.message)).toContain(`${prefix}: Server responded 403: forbidden`);
         });
 
@@ -1022,7 +1000,7 @@ describe("CatalogModal", () => {
             pullBtn.trigger("click");
             await tick();
             await tick();
-            const prefix = MESSAGES.ERROR_PULL_MODEL.replace("{model}", "qwen/qwen3-8b");
+            const prefix = MESSAGES.ERROR_PULL_MODEL.replace("{model}", "Qwen/Qwen3-8B-GGUF");
             expect(Notice.instances.map((n) => n.message)).toContain(`${prefix}: unknown error`);
         });
 
@@ -1038,7 +1016,7 @@ describe("CatalogModal", () => {
             pullBtn.trigger("click");
             await tick();
             await tick();
-            const prefix = MESSAGES.ERROR_PULL_MODEL.replace("{model}", "qwen/qwen3-8b");
+            const prefix = MESSAGES.ERROR_PULL_MODEL.replace("{model}", "Qwen/Qwen3-8B-GGUF");
             expect(Notice.instances.map((n) => n.message)).toContain(`${prefix}: pull exploded`);
             expect(plugin.taskQueue.completed.some((t: any) => t.status === "failed")).toBe(true);
         });
@@ -1055,7 +1033,7 @@ describe("CatalogModal", () => {
             pullBtn.trigger("click");
             await tick();
             await tick();
-            const prefix = MESSAGES.ERROR_PULL_MODEL.replace("{model}", "qwen/qwen3-8b");
+            const prefix = MESSAGES.ERROR_PULL_MODEL.replace("{model}", "Qwen/Qwen3-8B-GGUF");
             expect(Notice.instances.map((n) => n.message)).toContain(`${prefix}: raw error string`);
             expect(plugin.taskQueue.completed.some((t: any) => t.status === "failed")).toBe(true);
         });
@@ -1072,7 +1050,7 @@ describe("CatalogModal", () => {
             pullBtn.trigger("click");
             await tick();
             await tick();
-            const prefix = MESSAGES.ERROR_PULL_MODEL.replace("{model}", "qwen/qwen3-8b");
+            const prefix = MESSAGES.ERROR_PULL_MODEL.replace("{model}", "Qwen/Qwen3-8B-GGUF");
             expect(Notice.instances.map((n) => n.message)).toContain(`${prefix}: unknown error`);
             expect(plugin.taskQueue.completed.some((t: any) => t.status === "failed")).toBe(true);
         });
@@ -1090,7 +1068,7 @@ describe("CatalogModal", () => {
             pullBtn.trigger("click");
             await tick();
             await tick();
-            const setFailedNotice = MESSAGES.ERROR_SET_MODEL.replace("{model}", "qwen/qwen3-8b");
+            const setFailedNotice = MESSAGES.ERROR_SET_MODEL.replace("{model}", "Qwen/Qwen3-8B-GGUF");
             expect(Notice.instances.map((n) => n.message)).toContain(setFailedNotice);
             expect(plugin.taskQueue.completed.some((t: any) => t.status === "done")).toBe(true);
             expect(plugin.taskQueue.completed.some((t: any) => t.status === "failed")).toBe(false);
@@ -1131,7 +1109,7 @@ describe("CatalogModal", () => {
             plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry({ installed: true })])));
             plugin.api.deleteModel = vi
                 .fn()
-                .mockResolvedValue(ok({ deleted: true, model: "qwen/qwen3-8b", freed_gb: 5 }));
+                .mockResolvedValue(ok({ deleted: true, model: "Qwen/Qwen3-8B-GGUF", freed_gb: 5 }));
             const modal = await openModal(plugin);
             const content = contentEl(modal);
             const removeBtn = findButtons(content).find((b) => b.textContent === MESSAGES.BUTTON_REMOVE)!;

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -97,44 +97,60 @@ function makePlugin(): LilbeePlugin {
     return {
         api: {
             chatStream: vi.fn(),
-            listModels: vi.fn().mockResolvedValue({
-                chat: { active: "llama3", installed: ["llama3", "phi3"], catalog: [] },
-            }),
-            installedModels: vi.fn().mockResolvedValue({
-                models: [
-                    { name: "llama3", source: "native" },
-                    { name: "phi3", source: "native" },
-                ],
+            installedModels: vi.fn().mockImplementation((params?: { task?: string }) => {
+                if (params?.task === "chat") {
+                    return Promise.resolve({
+                        models: [
+                            { name: "llama3", source: "native" },
+                            { name: "phi3", source: "native" },
+                        ],
+                    });
+                }
+                return Promise.resolve({
+                    models: [
+                        { name: "llama3", source: "native" },
+                        { name: "phi3", source: "native" },
+                        { name: "nomic-embed-text", source: "native" },
+                    ],
+                });
             }),
             setChatModel: vi.fn().mockResolvedValue(ok(undefined)),
             setEmbeddingModel: vi.fn().mockResolvedValue(ok(undefined)),
             pullModel: vi.fn(),
-            catalog: vi.fn().mockResolvedValue(
-                ok({
-                    total: 1,
-                    limit: 50,
-                    offset: 0,
-                    models: [
-                        {
-                            name: "nomic-embed-text",
-                            display_name: "nomic-embed-text",
-                            size_gb: 0.3,
-                            min_ram_gb: 1,
-                            description: "Embedding",
-                            installed: true,
-                            source: "native",
-                            hf_repo: "nomic-embed-text",
-                            tag: "",
-                            task: "embedding",
-                            featured: true,
-                            downloads: 1000,
-                            quality_tier: "good",
-                        },
-                    ],
-                    has_more: false,
-                }),
-            ),
-            config: vi.fn().mockResolvedValue({ embedding_model: "nomic-embed-text" }),
+            catalog: vi.fn().mockImplementation((params?: { task?: string }) => {
+                if (params?.task === "chat") {
+                    // Empty featured chat catalog — installed refs go under the "Other" group.
+                    return Promise.resolve(ok({ total: 0, limit: 50, offset: 0, models: [], has_more: false }));
+                }
+                // Embedding picker keeps the legacy nomic-embed entry for the
+                // separate embedding-selector flow.
+                return Promise.resolve(
+                    ok({
+                        total: 1,
+                        limit: 50,
+                        offset: 0,
+                        models: [
+                            {
+                                hf_repo: "nomic-embed-text",
+                                gguf_filename: "",
+                                display_name: "nomic-embed-text",
+                                size_gb: 0.3,
+                                min_ram_gb: 1,
+                                description: "Embedding",
+                                installed: true,
+                                source: "native",
+                                task: "embedding",
+                                featured: true,
+                                downloads: 1000,
+                                quality_tier: "good",
+                                param_count: "137M",
+                            },
+                        ],
+                        has_more: false,
+                    }),
+                );
+            }),
+            config: vi.fn().mockResolvedValue({ chat_model: "llama3", embedding_model: "nomic-embed-text" }),
         },
         settings: { topK: 5, enableOcr: null as boolean | null, wikiEnabled: true, searchChunkType: "all" as const },
         activeModel: "llama3",
@@ -152,6 +168,64 @@ function makePlugin(): LilbeePlugin {
             },
         },
     } as unknown as LilbeePlugin;
+}
+
+/**
+ * Map the legacy `chat: { active, installed, catalog }` test fixture into the
+ * three endpoints the post-PR-#183 chat picker actually calls. Catalog entries
+ * are stamped with the minimum CatalogEntry shape; we keep the legacy short
+ * names as `hf_repo` so existing dropdown-value assertions still hold.
+ */
+function mockChatPicker(
+    plugin: LilbeePlugin,
+    chat: {
+        active: string;
+        installed: string[];
+        catalog: Array<{
+            name: string;
+            size_gb: number;
+            min_ram_gb: number;
+            description: string;
+            installed: boolean;
+            source?: string;
+        }>;
+    },
+): void {
+    (plugin.api as any).config = vi.fn().mockResolvedValue({ chat_model: chat.active });
+    (plugin.api as any).installedModels = vi.fn().mockImplementation((params?: { task?: string }) => {
+        if (params?.task === "chat" || params === undefined) {
+            return Promise.resolve({ models: chat.installed.map((name) => ({ name, source: "native" })) });
+        }
+        return Promise.resolve({ models: [] });
+    });
+    (plugin.api as any).catalog = vi.fn().mockImplementation((params?: { task?: string }) => {
+        if (params?.task === "chat") {
+            return Promise.resolve(
+                ok({
+                    total: chat.catalog.length,
+                    limit: 50,
+                    offset: 0,
+                    has_more: false,
+                    models: chat.catalog.map((m) => ({
+                        hf_repo: m.name,
+                        gguf_filename: "",
+                        display_name: m.name,
+                        size_gb: m.size_gb,
+                        min_ram_gb: m.min_ram_gb,
+                        description: m.description,
+                        installed: m.installed,
+                        source: m.source ?? "native",
+                        task: "chat",
+                        featured: true,
+                        downloads: 0,
+                        quality_tier: "balanced",
+                        param_count: "",
+                    })),
+                }),
+            );
+        }
+        return Promise.resolve(ok({ total: 0, limit: 50, offset: 0, has_more: false, models: [] }));
+    });
 }
 
 function makeSource(overrides: Partial<Source> = {}): Source {
@@ -879,11 +953,61 @@ describe("ChatView.onOpen — model selector", () => {
         await view.onClose();
     });
 
+    it("appends provider suffix when a featured entry has non-native source", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        plugin.api.catalog = vi.fn().mockImplementation((p?: { task?: string }) => {
+            if (p?.task === "chat") {
+                return Promise.resolve(
+                    ok({
+                        total: 1,
+                        limit: 50,
+                        offset: 0,
+                        has_more: false,
+                        models: [
+                            {
+                                hf_repo: "ollama/qwen3:8b",
+                                gguf_filename: "",
+                                display_name: "qwen3:8b",
+                                size_gb: 0,
+                                min_ram_gb: 0,
+                                description: "",
+                                installed: true,
+                                source: "ollama",
+                                task: "chat",
+                                featured: true,
+                                downloads: 0,
+                                quality_tier: "",
+                                param_count: "",
+                            },
+                        ],
+                    }),
+                );
+            }
+            return Promise.resolve(ok({ total: 0, limit: 50, offset: 0, has_more: false, models: [] }));
+        });
+        plugin.api.installedModels = vi.fn().mockResolvedValue({
+            models: [{ name: "ollama/qwen3:8b", source: "ollama" }],
+        });
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const c = view.containerEl.children[1] as unknown as MockElement;
+        const select = c.find("lilbee-chat-model-select")!;
+        const options = select.children.filter((ch) => ch.tagName === "OPTION");
+        const labels = options.map((o) => o.textContent);
+        expect(labels).toContain("qwen3:8b [ollama]");
+        await view.onClose();
+    });
+
     it("shows (connecting...) option on both selects when listModels fails", async () => {
         vi.useFakeTimers();
         Notice.clear();
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.catalog = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.installedModels = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.config = vi.fn().mockRejectedValue(new Error("offline"));
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
         await vi.advanceTimersByTimeAsync(0);
@@ -998,15 +1122,13 @@ describe("ChatView.onOpen — model selector", () => {
     it("excludes uninstalled catalog models from dropdown options", async () => {
         Notice.clear();
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockResolvedValue({
-            chat: {
-                active: "llama3",
-                installed: ["llama3"],
-                catalog: [
-                    { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
-                    { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
-                ],
-            },
+        mockChatPicker(plugin, {
+            active: "llama3",
+            installed: ["llama3"],
+            catalog: [
+                { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
+                { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
+            ],
         });
 
         const view = new ChatView(makeLeaf(), plugin);
@@ -1025,15 +1147,13 @@ describe("ChatView.onOpen — model selector", () => {
     it("selecting uninstalled catalog model triggers auto-pull with progress", async () => {
         Notice.clear();
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockResolvedValue({
-            chat: {
-                active: "llama3",
-                installed: ["llama3"],
-                catalog: [
-                    { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
-                    { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
-                ],
-            },
+        mockChatPicker(plugin, {
+            active: "llama3",
+            installed: ["llama3"],
+            catalog: [
+                { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
+                { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
+            ],
         });
 
         async function* fakePull() {
@@ -1062,15 +1182,13 @@ describe("ChatView.onOpen — model selector", () => {
     it("auto-pull progress with no percent and no total skips update", async () => {
         Notice.clear();
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockResolvedValue({
-            chat: {
-                active: "llama3",
-                installed: ["llama3"],
-                catalog: [
-                    { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
-                    { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
-                ],
-            },
+        mockChatPicker(plugin, {
+            active: "llama3",
+            installed: ["llama3"],
+            catalog: [
+                { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
+                { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
+            ],
         });
 
         async function* fakePull() {
@@ -1096,15 +1214,13 @@ describe("ChatView.onOpen — model selector", () => {
     it("auto-pull progress with current/total computes percentage", async () => {
         Notice.clear();
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockResolvedValue({
-            chat: {
-                active: "llama3",
-                installed: ["llama3"],
-                catalog: [
-                    { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
-                    { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
-                ],
-            },
+        mockChatPicker(plugin, {
+            active: "llama3",
+            installed: ["llama3"],
+            catalog: [
+                { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
+                { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
+            ],
         });
 
         async function* fakePull() {
@@ -1130,15 +1246,13 @@ describe("ChatView.onOpen — model selector", () => {
     it("auto-pull failure shows failure notice", async () => {
         Notice.clear();
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockResolvedValue({
-            chat: {
-                active: "llama3",
-                installed: ["llama3"],
-                catalog: [
-                    { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
-                    { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
-                ],
-            },
+        mockChatPicker(plugin, {
+            active: "llama3",
+            installed: ["llama3"],
+            catalog: [
+                { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
+                { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
+            ],
         });
 
         async function* failingPull(): AsyncGenerator<never> {
@@ -1163,15 +1277,13 @@ describe("ChatView.onOpen — model selector", () => {
     it("auto-pull SSE_EVENT.ERROR shows failure notice and fails task", async () => {
         Notice.clear();
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockResolvedValue({
-            chat: {
-                active: "llama3",
-                installed: ["llama3"],
-                catalog: [
-                    { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
-                    { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
-                ],
-            },
+        mockChatPicker(plugin, {
+            active: "llama3",
+            installed: ["llama3"],
+            catalog: [
+                { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
+                { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
+            ],
         });
 
         async function* errorPull() {
@@ -1197,15 +1309,13 @@ describe("ChatView.onOpen — model selector", () => {
     it("auto-pull SSE_EVENT.ERROR with string data fails the task", async () => {
         Notice.clear();
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockResolvedValue({
-            chat: {
-                active: "llama3",
-                installed: ["llama3"],
-                catalog: [
-                    { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
-                    { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
-                ],
-            },
+        mockChatPicker(plugin, {
+            active: "llama3",
+            installed: ["llama3"],
+            catalog: [
+                { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
+                { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
+            ],
         });
 
         async function* errorPull() {
@@ -1231,15 +1341,13 @@ describe("ChatView.onOpen — model selector", () => {
     it("auto-pull SSE_EVENT.ERROR with empty object uses fallback message", async () => {
         Notice.clear();
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockResolvedValue({
-            chat: {
-                active: "llama3",
-                installed: ["llama3"],
-                catalog: [
-                    { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
-                    { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
-                ],
-            },
+        mockChatPicker(plugin, {
+            active: "llama3",
+            installed: ["llama3"],
+            catalog: [
+                { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
+                { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
+            ],
         });
 
         async function* errorPull() {
@@ -1265,15 +1373,13 @@ describe("ChatView.onOpen — model selector", () => {
     it("auto-pull AbortError shows Pull cancelled notice", async () => {
         Notice.clear();
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockResolvedValue({
-            chat: {
-                active: "llama3",
-                installed: ["llama3"],
-                catalog: [
-                    { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
-                    { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
-                ],
-            },
+        mockChatPicker(plugin, {
+            active: "llama3",
+            installed: ["llama3"],
+            catalog: [
+                { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
+                { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
+            ],
         });
 
         const abortError = new Error("Aborted");
@@ -1300,15 +1406,13 @@ describe("ChatView.onOpen — model selector", () => {
     it("auto-pull non-Error throw uses 'unknown' in taskQueue", async () => {
         Notice.clear();
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockResolvedValue({
-            chat: {
-                active: "llama3",
-                installed: ["llama3"],
-                catalog: [
-                    { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
-                    { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
-                ],
-            },
+        mockChatPicker(plugin, {
+            active: "llama3",
+            installed: ["llama3"],
+            catalog: [
+                { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
+                { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
+            ],
         });
 
         async function* failingPull(): AsyncGenerator<never> {
@@ -1335,15 +1439,13 @@ describe("ChatView.onOpen — model selector", () => {
     it("auto-pull with total=0 does not send progress", async () => {
         Notice.clear();
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockResolvedValue({
-            chat: {
-                active: "llama3",
-                installed: ["llama3"],
-                catalog: [
-                    { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
-                    { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
-                ],
-            },
+        mockChatPicker(plugin, {
+            active: "llama3",
+            installed: ["llama3"],
+            catalog: [
+                { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
+                { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
+            ],
         });
 
         async function* fakePull() {
@@ -2215,15 +2317,13 @@ describe("ChatView.onClose — aborts both controllers", () => {
     it("aborts pullController when active", async () => {
         Notice.clear();
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockResolvedValue({
-            chat: {
-                active: "llama3",
-                installed: ["llama3"],
-                catalog: [
-                    { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
-                    { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
-                ],
-            },
+        mockChatPicker(plugin, {
+            active: "llama3",
+            installed: ["llama3"],
+            catalog: [
+                { name: "llama3", size_gb: 4.7, min_ram_gb: 8, description: "Meta", installed: true },
+                { name: "phi3", size_gb: 2.3, min_ram_gb: 4, description: "MS", installed: false },
+            ],
         });
 
         let resolveWait!: () => void;
@@ -2418,13 +2518,23 @@ describe("ChatView — offline retry", () => {
 
     it("retries fetching models after failure", async () => {
         const plugin = makePlugin();
-        let callCount = 0;
-        plugin.api.listModels = vi.fn().mockImplementation(() => {
-            callCount++;
-            if (callCount === 1) return Promise.reject(new Error("offline"));
-            return Promise.resolve({
-                chat: { active: "llama3", installed: ["llama3"], catalog: [] },
-            });
+        let online = false;
+        const offline = () => Promise.reject(new Error("offline"));
+        const installedOk = (p?: { task?: string }) => {
+            if (p?.task === "chat" || p === undefined) {
+                return Promise.resolve({ models: [{ name: "llama3", source: "native" }] });
+            }
+            return Promise.resolve({ models: [] });
+        };
+        const catalogOk = () => Promise.resolve(ok({ total: 0, limit: 50, offset: 0, has_more: false, models: [] }));
+        plugin.api.installedModels = vi.fn().mockImplementation((p?: { task?: string }) => {
+            return online ? installedOk(p) : offline();
+        });
+        plugin.api.config = vi.fn().mockImplementation(() => {
+            return online ? Promise.resolve({ chat_model: "llama3" }) : offline();
+        });
+        plugin.api.catalog = vi.fn().mockImplementation(() => {
+            return online ? catalogOk() : offline();
         });
 
         const view = new ChatView(makeLeaf(), plugin);
@@ -2437,7 +2547,8 @@ describe("ChatView — offline retry", () => {
         const chatOptions = chatSelect.children.filter((c) => c.tagName === "OPTION");
         expect(chatOptions.some((o) => o.textContent === "(connecting...)")).toBe(true);
 
-        // Advance past the 5s retry
+        // Server comes back online; the 5s retry hits the new mocks.
+        online = true;
         await vi.advanceTimersByTimeAsync(5000);
 
         const updatedOptions = chatSelect.children.filter((c) => c.tagName === "OPTION");
@@ -2449,7 +2560,9 @@ describe("ChatView — offline retry", () => {
 
     it("shows offline notice only at threshold", async () => {
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.catalog = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.installedModels = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.config = vi.fn().mockRejectedValue(new Error("offline"));
 
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
@@ -2475,13 +2588,22 @@ describe("ChatView — offline retry", () => {
 
     it("clears retry timer and retryCount on successful fetch", async () => {
         const plugin = makePlugin();
-        let callCount = 0;
-        plugin.api.listModels = vi.fn().mockImplementation(() => {
-            callCount++;
-            if (callCount === 1) return Promise.reject(new Error("offline"));
-            return Promise.resolve({
-                chat: { active: "llama3", installed: ["llama3"], catalog: [] },
-            });
+        let online = false;
+        const offline = () => Promise.reject(new Error("offline"));
+        plugin.api.installedModels = vi.fn().mockImplementation((p?: { task?: string }) => {
+            if (!online) return offline();
+            if (p?.task === "chat" || p === undefined) {
+                return Promise.resolve({ models: [{ name: "llama3", source: "native" }] });
+            }
+            return Promise.resolve({ models: [] });
+        });
+        plugin.api.config = vi.fn().mockImplementation(() => {
+            return online ? Promise.resolve({ chat_model: "llama3" }) : offline();
+        });
+        plugin.api.catalog = vi.fn().mockImplementation(() => {
+            return online
+                ? Promise.resolve(ok({ total: 0, limit: 50, offset: 0, has_more: false, models: [] }))
+                : offline();
         });
 
         const view = new ChatView(makeLeaf(), plugin);
@@ -2493,6 +2615,7 @@ describe("ChatView — offline retry", () => {
         expect((view as any).retryCount).toBe(1);
 
         // Advance past retry — success
+        online = true;
         await vi.advanceTimersByTimeAsync(5000);
 
         expect((view as any).retryTimer).toBeNull();
@@ -2503,7 +2626,9 @@ describe("ChatView — offline retry", () => {
 
     it("clears retry timer and retryCount on close", async () => {
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.catalog = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.installedModels = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.config = vi.fn().mockRejectedValue(new Error("offline"));
 
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
@@ -2520,7 +2645,9 @@ describe("ChatView — offline retry", () => {
 
     it("clears existing options before retry", async () => {
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.catalog = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.installedModels = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.config = vi.fn().mockRejectedValue(new Error("offline"));
 
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
@@ -2549,7 +2676,9 @@ describe("ChatView — offline retry", () => {
 
     it("shows (connecting...) then (offline) after threshold", async () => {
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.catalog = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.installedModels = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.config = vi.fn().mockRejectedValue(new Error("offline"));
 
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
@@ -2576,16 +2705,22 @@ describe("ChatView — offline retry", () => {
     it("retries when server reachable but no models installed", async () => {
         const plugin = makePlugin();
         let callCount = 0;
-        plugin.api.listModels = vi.fn().mockImplementation(() => {
-            callCount++;
-            if (callCount <= 2) {
-                return Promise.resolve({
-                    chat: { active: "", installed: [], catalog: [{ name: "llama3", installed: false }] },
-                });
+        plugin.api.installedModels = vi.fn().mockImplementation((p?: { task?: string }) => {
+            if (p?.task === "chat") {
+                callCount++;
+                if (callCount <= 2) return Promise.resolve({ models: [] });
+                return Promise.resolve({ models: [{ name: "llama3", source: "native" }] });
             }
-            return Promise.resolve({
-                chat: { active: "llama3", installed: ["llama3"], catalog: [{ name: "llama3", installed: true }] },
-            });
+            return Promise.resolve({ models: [] });
+        });
+        plugin.api.config = vi.fn().mockImplementation(() => {
+            return Promise.resolve({ chat_model: callCount <= 2 ? "" : "llama3" });
+        });
+        plugin.api.catalog = vi.fn().mockImplementation((p?: { task?: string }) => {
+            if (p?.task === "chat") {
+                return Promise.resolve(ok({ total: 0, limit: 50, offset: 0, has_more: false, models: [] }));
+            }
+            return Promise.resolve(ok({ total: 0, limit: 50, offset: 0, has_more: false, models: [] }));
         });
 
         const view = new ChatView(makeLeaf(), plugin);
@@ -2613,9 +2748,11 @@ describe("ChatView — offline retry", () => {
 
     it("stops no-installed-models retry on close", async () => {
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockResolvedValue({
-            chat: { active: "", installed: [], catalog: [] },
-        });
+        plugin.api.installedModels = vi.fn().mockResolvedValue({ models: [] });
+        plugin.api.config = vi.fn().mockResolvedValue({ chat_model: "" });
+        plugin.api.catalog = vi
+            .fn()
+            .mockResolvedValue(ok({ total: 0, limit: 50, offset: 0, has_more: false, models: [] }));
 
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
@@ -2631,9 +2768,11 @@ describe("ChatView — offline retry", () => {
     it("Browse Catalog button in empty state opens CatalogModal", async () => {
         const { CatalogModal } = await import("../../src/views/catalog-modal");
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockResolvedValue({
-            chat: { active: "", installed: [], catalog: [] },
-        });
+        plugin.api.installedModels = vi.fn().mockResolvedValue({ models: [] });
+        plugin.api.config = vi.fn().mockResolvedValue({ chat_model: "" });
+        plugin.api.catalog = vi
+            .fn()
+            .mockResolvedValue(ok({ total: 0, limit: 50, offset: 0, has_more: false, models: [] }));
 
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
@@ -2654,13 +2793,22 @@ describe("ChatView — offline retry", () => {
 
     it("resets retryCount on success after failures", async () => {
         const plugin = makePlugin();
-        let callCount = 0;
-        plugin.api.listModels = vi.fn().mockImplementation(() => {
-            callCount++;
-            if (callCount <= 2) return Promise.reject(new Error("offline"));
-            return Promise.resolve({
-                chat: { active: "llama3", installed: ["llama3"], catalog: [] },
-            });
+        let online = false;
+        const offline = () => Promise.reject(new Error("offline"));
+        plugin.api.installedModels = vi.fn().mockImplementation((p?: { task?: string }) => {
+            if (!online) return offline();
+            if (p?.task === "chat" || p === undefined) {
+                return Promise.resolve({ models: [{ name: "llama3", source: "native" }] });
+            }
+            return Promise.resolve({ models: [] });
+        });
+        plugin.api.config = vi.fn().mockImplementation(() => {
+            return online ? Promise.resolve({ chat_model: "llama3" }) : offline();
+        });
+        plugin.api.catalog = vi.fn().mockImplementation(() => {
+            return online
+                ? Promise.resolve(ok({ total: 0, limit: 50, offset: 0, has_more: false, models: [] }))
+                : offline();
         });
 
         const view = new ChatView(makeLeaf(), plugin);
@@ -2674,7 +2822,8 @@ describe("ChatView — offline retry", () => {
         await vi.advanceTimersByTimeAsync(5000);
         expect((view as any).retryCount).toBe(2);
 
-        // Success — resets to 0
+        // Server comes back online; the next retry succeeds.
+        online = true;
         await vi.advanceTimersByTimeAsync(5000);
         expect((view as any).retryCount).toBe(0);
 
@@ -2913,7 +3062,9 @@ describe("ChatView — embedding model selector", () => {
     it("shows connecting label on embedding select when offline", async () => {
         vi.useFakeTimers();
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.catalog = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.installedModels = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.config = vi.fn().mockRejectedValue(new Error("offline"));
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
         await vi.advanceTimersByTimeAsync(0);
@@ -2930,7 +3081,9 @@ describe("ChatView — embedding model selector", () => {
     it("shows offline label on embedding select after threshold", async () => {
         vi.useFakeTimers();
         const plugin = makePlugin();
-        plugin.api.listModels = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.catalog = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.installedModels = vi.fn().mockRejectedValue(new Error("offline"));
+        plugin.api.config = vi.fn().mockRejectedValue(new Error("offline"));
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
 
@@ -3054,7 +3207,14 @@ describe("ChatView — embedding model selector", () => {
 
     it("handles null catalog result in fillEmbeddingSelector", async () => {
         const plugin = makePlugin();
-        plugin.api.catalog = vi.fn().mockRejectedValue(new Error("fail"));
+        // Chat catalog still succeeds — only the embedding catalog rejects, so the
+        // embedding selector falls back to displaying the active model from config.
+        plugin.api.catalog = vi.fn().mockImplementation((p?: { task?: string }) => {
+            if (p?.task === "chat") {
+                return Promise.resolve(ok({ total: 0, limit: 50, offset: 0, has_more: false, models: [] }));
+            }
+            return Promise.reject(new Error("fail"));
+        });
         plugin.api.config = vi.fn().mockResolvedValue({ embedding_model: "fallback" });
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
@@ -3101,8 +3261,14 @@ describe("ChatView — autoPullAndSet post-pull set failure", () => {
         plugin.api.setChatModel = vi.fn().mockResolvedValue(err(new Error("activate-failed")));
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
-        await (view as any).autoPullAndSet({ name: "phi3" });
-        const setFailed = MESSAGES.ERROR_SET_MODEL.replace("{model}", "phi3");
+        const entry = {
+            hf_repo: "microsoft/Phi-3-mini-4k-Instruct-GGUF",
+            display_name: "Phi 3 Mini",
+            size_gb: 2.3,
+            min_ram_gb: 4,
+        };
+        await (view as any).autoPullAndSet(entry);
+        const setFailed = MESSAGES.ERROR_SET_MODEL.replace("{model}", "Phi 3 Mini");
         expect(Notice.instances.map((n: any) => n.message)).toContain(setFailed);
         expect(plugin.taskQueue.completed.some((t: any) => t.status === "done")).toBe(true);
         expect(plugin.taskQueue.completed.some((t: any) => t.status === "failed")).toBe(false);
@@ -3155,65 +3321,59 @@ describe("ChatView — role separation on main-screen selectors", () => {
         // Contaminated models.chat.installed: server has (incorrectly) mixed vision/reranker
         // names into the chat role. The plugin must still render them — this proves the
         // plugin is NOT filtering client-side; filtering is the server's job.
-        plugin.api.listModels = vi.fn().mockResolvedValue({
-            chat: {
-                active: "llama3",
-                installed: ["llama3", "Qwen/Qwen2-VL-7B-Instruct", "BAAI/bge-reranker-v2-m3"],
-                catalog: [],
-            },
-            embedding: {
-                active: "nomic-embed-text",
-                installed: ["nomic-embed-text"],
-                catalog: [],
-            },
-            vision: {
-                active: "Qwen/Qwen2-VL-7B-Instruct",
-                installed: ["Qwen/Qwen2-VL-7B-Instruct"],
-                catalog: [],
-            },
-            reranker: {
-                active: "BAAI/bge-reranker-v2-m3",
-                installed: ["BAAI/bge-reranker-v2-m3"],
-                catalog: [],
-            },
-        });
-        plugin.api.installedModels = vi.fn().mockResolvedValue({
-            models: [
-                { name: "llama3", source: "native" },
-                { name: "nomic-embed-text", source: "native" },
-                { name: "Qwen/Qwen2-VL-7B-Instruct", source: "native" },
-                { name: "BAAI/bge-reranker-v2-m3", source: "native" },
-            ],
-        });
-        // catalog({task: EMBEDDING}) returns embedding-only. If the plugin ever called
-        // catalog with a different task or with no filter, this mock would not cover
-        // those other tasks and the embedding selector would end up empty / wrong.
-        plugin.api.catalog = vi.fn().mockResolvedValue(
-            ok({
-                total: 1,
-                limit: 50,
-                offset: 0,
+        // Server-side filtering: chat task returns the installed list scoped to chat
+        // (which here contains some "contaminated" rows the server lets through). The
+        // chat picker echoes that list verbatim — no client-side re-filter.
+        plugin.api.installedModels = vi.fn().mockImplementation((p?: { task?: string }) => {
+            if (p?.task === "chat") {
+                return Promise.resolve({
+                    models: [
+                        { name: "llama3", source: "native" },
+                        { name: "Qwen/Qwen2-VL-7B-Instruct", source: "native" },
+                        { name: "BAAI/bge-reranker-v2-m3", source: "native" },
+                    ],
+                });
+            }
+            return Promise.resolve({
                 models: [
-                    {
-                        name: "nomic-embed-text",
-                        display_name: "nomic-embed-text",
-                        size_gb: 0.3,
-                        min_ram_gb: 1,
-                        description: "embedding",
-                        installed: true,
-                        source: "native",
-                        hf_repo: "nomic-embed-text",
-                        tag: "",
-                        task: "embedding",
-                        featured: true,
-                        downloads: 100,
-                        quality_tier: "good",
-                    },
+                    { name: "llama3", source: "native" },
+                    { name: "nomic-embed-text", source: "native" },
+                    { name: "Qwen/Qwen2-VL-7B-Instruct", source: "native" },
+                    { name: "BAAI/bge-reranker-v2-m3", source: "native" },
                 ],
-                has_more: false,
-            }),
-        );
-        plugin.api.config = vi.fn().mockResolvedValue({ embedding_model: "nomic-embed-text" });
+            });
+        });
+        plugin.api.catalog = vi.fn().mockImplementation((p?: { task?: string }) => {
+            if (p?.task === "chat") {
+                return Promise.resolve(ok({ total: 0, limit: 50, offset: 0, has_more: false, models: [] }));
+            }
+            return Promise.resolve(
+                ok({
+                    total: 1,
+                    limit: 50,
+                    offset: 0,
+                    models: [
+                        {
+                            hf_repo: "nomic-embed-text",
+                            gguf_filename: "",
+                            display_name: "nomic-embed-text",
+                            size_gb: 0.3,
+                            min_ram_gb: 1,
+                            description: "embedding",
+                            installed: true,
+                            source: "native",
+                            task: "embedding",
+                            featured: true,
+                            downloads: 100,
+                            quality_tier: "good",
+                            param_count: "",
+                        },
+                    ],
+                    has_more: false,
+                }),
+            );
+        });
+        plugin.api.config = vi.fn().mockResolvedValue({ chat_model: "llama3", embedding_model: "nomic-embed-text" });
 
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();

--- a/tests/views/confirm-pull-modal.test.ts
+++ b/tests/views/confirm-pull-modal.test.ts
@@ -2,15 +2,13 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { App, Notice } from "obsidian";
 import { MockElement } from "../__mocks__/obsidian";
 import { ConfirmPullModal } from "../../src/views/confirm-pull-modal";
-import type { ModelInfo } from "../../src/types";
+import type { ConfirmPullInfo } from "../../src/views/confirm-pull-modal";
 
-function makeModel(overrides: Partial<ModelInfo> = {}): ModelInfo {
+function makeInfo(overrides: Partial<ConfirmPullInfo> = {}): ConfirmPullInfo {
     return {
-        name: "phi3",
-        size_gb: 2.3,
-        min_ram_gb: 4,
-        description: "Microsoft Phi-3",
-        installed: false,
+        displayName: "Phi 3 Mini",
+        sizeGb: 2.3,
+        minRamGb: 4,
         ...overrides,
     };
 }
@@ -37,20 +35,18 @@ describe("ConfirmPullModal", () => {
         Notice.clear();
     });
 
-    it("renders model name in onOpen", () => {
+    it("renders display name in onOpen", () => {
         const app = new App();
-        const model = makeModel({ name: "mistral" });
-        const modal = new ConfirmPullModal(app as any, model);
+        const modal = new ConfirmPullModal(app as any, makeInfo({ displayName: "Mistral 7B" }));
         modal.onOpen();
 
         const texts = collectTexts(modal.contentEl as unknown as MockElement);
-        expect(texts.some((t) => t.includes("mistral"))).toBe(true);
+        expect(texts.some((t) => t.includes("Mistral 7B"))).toBe(true);
     });
 
     it("renders model size in onOpen", () => {
         const app = new App();
-        const model = makeModel({ size_gb: 4.7 });
-        const modal = new ConfirmPullModal(app as any, model);
+        const modal = new ConfirmPullModal(app as any, makeInfo({ sizeGb: 4.7 }));
         modal.onOpen();
 
         const texts = collectTexts(modal.contentEl as unknown as MockElement);
@@ -59,8 +55,7 @@ describe("ConfirmPullModal", () => {
 
     it("renders minimum RAM in onOpen", () => {
         const app = new App();
-        const model = makeModel({ min_ram_gb: 8 });
-        const modal = new ConfirmPullModal(app as any, model);
+        const modal = new ConfirmPullModal(app as any, makeInfo({ minRamGb: 8 }));
         modal.onOpen();
 
         const texts = collectTexts(modal.contentEl as unknown as MockElement);
@@ -69,7 +64,7 @@ describe("ConfirmPullModal", () => {
 
     it("renders Pull Model and Cancel buttons", () => {
         const app = new App();
-        const modal = new ConfirmPullModal(app as any, makeModel());
+        const modal = new ConfirmPullModal(app as any, makeInfo());
         modal.onOpen();
 
         const buttons = findButtons(modal.contentEl as unknown as MockElement);
@@ -80,7 +75,7 @@ describe("ConfirmPullModal", () => {
 
     it("clicking Pull Model resolves result to true", async () => {
         const app = new App();
-        const modal = new ConfirmPullModal(app as any, makeModel());
+        const modal = new ConfirmPullModal(app as any, makeInfo());
         modal.onOpen();
 
         const buttons = findButtons(modal.contentEl as unknown as MockElement);
@@ -93,7 +88,7 @@ describe("ConfirmPullModal", () => {
 
     it("clicking Cancel resolves result to false", async () => {
         const app = new App();
-        const modal = new ConfirmPullModal(app as any, makeModel());
+        const modal = new ConfirmPullModal(app as any, makeInfo());
         modal.onOpen();
 
         const buttons = findButtons(modal.contentEl as unknown as MockElement);
@@ -106,7 +101,7 @@ describe("ConfirmPullModal", () => {
 
     it("onClose resolves result to false", async () => {
         const app = new App();
-        const modal = new ConfirmPullModal(app as any, makeModel());
+        const modal = new ConfirmPullModal(app as any, makeInfo());
         modal.onOpen();
         modal.onClose();
 
@@ -116,7 +111,7 @@ describe("ConfirmPullModal", () => {
 
     it("decide is idempotent — second call is a no-op", async () => {
         const app = new App();
-        const modal = new ConfirmPullModal(app as any, makeModel());
+        const modal = new ConfirmPullModal(app as any, makeInfo());
         modal.onOpen();
 
         const buttons = findButtons(modal.contentEl as unknown as MockElement);

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -17,7 +17,8 @@ vi.mock("../../src/views/catalog-modal", () => ({
 
 function makeEntry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
     return {
-        name: "qwen3",
+        hf_repo: "Qwen/Qwen3-0.6B-GGUF",
+        gguf_filename: "*Q4_K_M.gguf",
         display_name: "Qwen3 0.6B",
         size_gb: 0.5,
         min_ram_gb: 4,
@@ -25,11 +26,10 @@ function makeEntry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
         quality_tier: "balanced",
         installed: false,
         source: "native",
-        hf_repo: "qwen/qwen3-0.6B",
-        tag: "0.6b",
         task: "chat",
         featured: true,
         downloads: 0,
+        param_count: "0.6B",
         ...overrides,
     };
 }
@@ -780,11 +780,8 @@ describe("SetupWizard", () => {
             expect(plugin.api.pullModel).toHaveBeenCalled();
         });
 
-        it("1s1: Download & continue pins activeModel + setChatModel to entry.name (short ref)", async () => {
-            // entry.name is the short catalog ref ("qwen3:0.6b"); entry.hf_repo
-            // is the long HF identity. The wizard used to set chat via hf_repo,
-            // which made cfg.chat_model and the Settings dropdown disagree.
-            const entries = [makeEntry({ name: "qwen3:0.6b", hf_repo: "qwen/qwen3-0.6B" })];
+        it("Download & continue uses hf_repo for both pull and setChatModel", async () => {
+            const entries = [makeEntry({ hf_repo: "Qwen/Qwen3-0.6B-GGUF" })];
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             plugin.api.pullModel = vi.fn().mockReturnValue(
@@ -811,17 +808,19 @@ describe("SetupWizard", () => {
             await tick();
             await tick();
 
-            // Pull still uses hf_repo (server caches by HF identity).
-            expect(plugin.api.pullModel).toHaveBeenCalledWith("qwen/qwen3-0.6B", "native", expect.any(AbortSignal));
-            // setChatModel and activeModel use the catalog short ref so the
-            // dropdown can round-trip the value back to a known option.
-            expect(plugin.api.setChatModel).toHaveBeenCalledWith("qwen3:0.6b");
-            expect(plugin.api.setChatModel).not.toHaveBeenCalledWith("qwen/qwen3-0.6B");
-            expect(plugin.activeModel).toBe("qwen3:0.6b");
+            // Post-PR-#183 the canonical model identity is the HF ref. Both pull
+            // and set use it; cfg.chat_model and the Settings dropdown line up.
+            expect(plugin.api.pullModel).toHaveBeenCalledWith(
+                "Qwen/Qwen3-0.6B-GGUF",
+                "native",
+                expect.any(AbortSignal),
+            );
+            expect(plugin.api.setChatModel).toHaveBeenCalledWith("Qwen/Qwen3-0.6B-GGUF");
+            expect(plugin.activeModel).toBe("Qwen/Qwen3-0.6B-GGUF");
         });
 
         it("Download & continue pulls model and advances to sync step", async () => {
-            const entries = [makeEntry({ name: "qwen/qwen3-0.6B" })];
+            const entries = [makeEntry({ hf_repo: "Qwen/Qwen3-0.6B-GGUF" })];
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             plugin.api.pullModel = vi.fn().mockReturnValue(
@@ -851,8 +850,12 @@ describe("SetupWizard", () => {
             await tick();
             await tick();
 
-            expect(plugin.api.pullModel).toHaveBeenCalledWith("qwen/qwen3-0.6B", "native", expect.any(AbortSignal));
-            expect(plugin.api.setChatModel).toHaveBeenCalledWith("qwen/qwen3-0.6B");
+            expect(plugin.api.pullModel).toHaveBeenCalledWith(
+                "Qwen/Qwen3-0.6B-GGUF",
+                "native",
+                expect.any(AbortSignal),
+            );
+            expect(plugin.api.setChatModel).toHaveBeenCalledWith("Qwen/Qwen3-0.6B-GGUF");
             // After pull completes, it goes to step 3 (embedding picker)
             await tick();
             await tick();
@@ -1829,25 +1832,27 @@ describe("SetupWizard", () => {
 
         it("orders recognised families before others", () => {
             const models = [
-                makeEntry({ name: "smollm2", hf_repo: "a/a" }),
-                makeEntry({ name: "qwen3-0.6b", hf_repo: "b/b" }),
-                makeEntry({ name: "gemma-3-1b", hf_repo: "c/c" }),
+                makeEntry({ hf_repo: "bartowski/SmolLM2-135M-Instruct-GGUF", display_name: "SmolLM2 135M" }),
+                makeEntry({ hf_repo: "Qwen/Qwen3-0.6B-GGUF", display_name: "Qwen3 0.6B" }),
+                makeEntry({ hf_repo: "ggml-org/gemma-3-1b-it-GGUF", display_name: "Gemma 3 1B" }),
             ];
             const picks = pickNativeChatModels(models);
             // Gemma family comes first in PREFERRED_FAMILIES order.
-            expect(picks[0].name).toBe("gemma-3-1b");
-            expect(picks[1].name).toBe("qwen3-0.6b");
-            expect(picks[2].name).toBe("smollm2");
+            expect(picks[0].display_name).toBe("Gemma 3 1B");
+            expect(picks[1].display_name).toBe("Qwen3 0.6B");
+            expect(picks[2].display_name).toBe("SmolLM2 135M");
         });
 
         it("dedupes entries sharing the same hf_repo", () => {
-            const dup = makeEntry({ name: "qwen3-0.6b", hf_repo: "q/a" });
+            const dup = makeEntry({ hf_repo: "Qwen/Qwen3-0.6B-GGUF" });
             const picks = pickNativeChatModels([dup, dup]);
             expect(picks.length).toBe(1);
         });
 
         it("caps at MAX_FEATURED_PICKS even after preferred-family and backfill rounds", () => {
-            const models = Array.from({ length: 20 }, (_, i) => makeEntry({ name: `other-${i}`, hf_repo: `x/${i}` }));
+            const models = Array.from({ length: 20 }, (_, i) =>
+                makeEntry({ hf_repo: `org/other-${i}-GGUF`, display_name: `Other ${i}` }),
+            );
             const picks = pickNativeChatModels(models);
             expect(picks.length).toBe(8);
         });
@@ -1855,7 +1860,7 @@ describe("SetupWizard", () => {
         it("caps MID-preferred-family iteration when max is reached", () => {
             // Exercise the early-return inside the preferred-families loop.
             const models = Array.from({ length: 10 }, (_, i) =>
-                makeEntry({ name: `gemma-3-${i}b`, hf_repo: `g/${i}` }),
+                makeEntry({ hf_repo: `ggml-org/gemma-3-${i}b-it-GGUF`, display_name: `Gemma 3 ${i}B` }),
             );
             const picks = pickNativeChatModels(models);
             expect(picks.length).toBe(8);
@@ -1863,8 +1868,8 @@ describe("SetupWizard", () => {
 
         it("applies a custom filter predicate when provided", () => {
             const models = [
-                makeEntry({ name: "qwen3-0.6b", hf_repo: "q/a", source: "litellm" }),
-                makeEntry({ name: "gemma-3-1b", hf_repo: "g/b", source: "native" }),
+                makeEntry({ hf_repo: "Qwen/Qwen3-0.6B-GGUF", source: "litellm" }),
+                makeEntry({ hf_repo: "ggml-org/gemma-3-1b-it-GGUF", source: "native" }),
             ];
             const picks = pickNativeChatModels(models, (m) => m.source !== "litellm");
             expect(picks.length).toBe(1);
@@ -2053,8 +2058,8 @@ describe("SetupWizard", () => {
         it("download & continue with installed model sets embedding and advances to sync step", async () => {
             const entries = [
                 makeEntry({
-                    name: "nomic-embed-text",
-                    hf_repo: "nomic/nomic-embed-text",
+                    hf_repo: "nomic-ai/nomic-embed-text-v1.5-GGUF",
+                    display_name: "nomic-embed-text",
                     task: "embedding",
                     installed: true,
                 }),
@@ -2078,7 +2083,7 @@ describe("SetupWizard", () => {
                 .trigger("click");
             await tick();
 
-            expect(plugin.api.setEmbeddingModel).toHaveBeenCalledWith("nomic-embed-text");
+            expect(plugin.api.setEmbeddingModel).toHaveBeenCalledWith("nomic-ai/nomic-embed-text-v1.5-GGUF");
             const texts = collectTexts(wizard.contentEl as unknown as MockElement);
             expect(texts.some((t) => t.includes("Index your vault"))).toBe(true);
         });
@@ -2087,8 +2092,8 @@ describe("SetupWizard", () => {
             Notice.clear();
             const entries = [
                 makeEntry({
-                    name: "nomic-embed-text",
-                    hf_repo: "nomic/nomic-embed-text",
+                    hf_repo: "nomic-ai/nomic-embed-text-v1.5-GGUF",
+                    display_name: "nomic-embed-text",
                     task: "embedding",
                     installed: true,
                 }),


### PR DESCRIPTION
## What broke

After the lilbee server stopped using `name:tag` for model identity and switched to HuggingFace refs, the plugin's pickers and the status bar fell out of sync with what the server now speaks.

The catalog modal lost its Active badge: every row showed Use even on the model that was already loaded. The bottom-right status bar started rendering the raw HF path (`Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q4_K_M.gguf:latest`) instead of a clean label. Selecting any reranker the server reported as installed sent a legacy short ref the new server now rejects with a 422, and the resulting fallback notice told the user to "configure their LiteLLM API key", which had nothing to do with the actual problem.

## What's fixed

The chat picker, embedding picker, reranker picker, and vision picker all now drive off the new server endpoints. Across every place the user sees a model — the status bar, the Settings panel, the catalog modal, the chat sidebar, and the setup wizard — the label is the cleaned display name (`Qwen3 0.6B`, `Llama 3 8B`, `gpt-4o`, `claude-opus-4-7`). Selections route through the per-role endpoint with a ref the server can resolve, and the catalog modal compares the active model against each entry by stripping the trailing GGUF filename, so the Active badge stays correct.

The reranker's misleading "configure your LiteLLM key" fallback is gone — the server's actual error reaches the user instead.

## Side effect

Closes the standalone bug filed during prep (`obsidian-lilbee-kr2`) where the status bar was leaking the raw HF path with a stale `:latest` suffix.