### PR TITLE
Security scanning for the plugin repo

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,9 @@
+name: obsidian-lilbee CodeQL config
+
+# Analyse the plugin's own TypeScript: shipped code in src/ and the test
+# suite. Everything outside these paths (build output, esbuild config,
+# generated site assets, vendored binaries) is excluded so findings are
+# strictly about code we author.
+paths:
+  - src
+  - tests

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    rebase-strategy: auto
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,82 @@
+name: Security Scan
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: security-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  code-scan:
+    name: Code scan (SAST + secrets)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+          config-file: ./.github/codeql-config.yml
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:javascript-typescript
+
+      - name: Run Gitleaks
+        if: always()
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  dependencies:
+    name: Dependency CVEs (npm audit)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - run: npm ci
+
+      # Fail only on high/critical so transient moderate dev-tool advisories
+      # (esbuild/vite/vitest/postcss) don't break CI before Dependabot rolls
+      # them forward. Runtime deps are minimal — only neverthrow ships in the
+      # bundle — and OSV-Scanner below covers the same surface from a second
+      # advisory feed.
+      - name: Run npm audit
+        run: npm audit --audit-level=high
+
+  osv-scan:
+    name: OSV-Scanner (multi-ecosystem CVEs)
+    # Complements npm audit: OSV.dev aggregates advisories from GHSA, OSV,
+    # and others, catching CVEs that npm's advisory feed may lag on. Also
+    # scans the GitHub Actions workflow files. Suppressions live in
+    # osv-scanner.toml at the repo root.
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    with:
+      scan-args: |-
+        --config=osv-scanner.toml
+        --recursive
+        ./

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release is supported with security updates.
+
+| Version | Supported |
+|---------|-----------|
+| Latest  | Yes       |
+| Older   | No        |
+
+## Reporting a Vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Instead, use one of these methods:
+
+1. **GitHub Private Vulnerability Reporting** — use the "Report a vulnerability" button on the
+   [Security tab](https://github.com/tobocop2/obsidian-lilbee/security/advisories/new)
+2. **Email** — contact [@tobocop2](https://github.com/tobocop2) directly
+
+### What to expect
+
+- Acknowledgment within 72 hours
+- Status update within 1 week
+- We will coordinate disclosure timing with you

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,10 @@
+# osv-scanner suppressions. Keep this list short and each entry justified.
+# OSV scans against the OSV.dev database, which covers more ecosystems than
+# `npm audit` (GHSA, OSV, and others). When a finding maps to something
+# already triaged in .github/workflows/security-scan.yml, mirror the
+# suppression here so osv-scanner and npm audit stay in sync.
+#
+# Format:
+#   [[IgnoredVulns]]
+#   id = "GHSA-xxxx-xxxx-xxxx"
+#   reason = "..."


### PR DESCRIPTION
## Problem

The plugin repo has no automated security scanning. The lilbee server has had this baseline for a while; the plugin should match so secrets, vulnerable deps, and SAST findings get caught before release.

## Solution

Mirrors the server's setup, adapted for Node:

- SAST + secret scanning on every push to `main`
- Dependency CVE scanning from two independent advisory feeds
- Monthly Dependabot updates for `npm` and GitHub Actions
- A `SECURITY.md` policy for private vulnerability reports