### PR TITLE
Windows managed-mode plugin fixes

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -60,9 +60,13 @@ export class ServerStartingError extends Error {
     }
 }
 
+/** Coarse outcome of a single ``fetchWithRetry`` call, reported to subscribers. */
+export type RequestOutcome = "ok" | "auth_error" | "server_error" | "unreachable" | "starting";
+
 export class LilbeeClient {
     private token: string | null = null;
     private tokenProvider: (() => string | null) | null = null;
+    private outcomeCb: ((o: RequestOutcome) => void) | null = null;
 
     constructor(
         private baseUrl: string,
@@ -77,6 +81,15 @@ export class LilbeeClient {
 
     setTokenProvider(provider: (() => string | null) | null): void {
         this.tokenProvider = provider;
+    }
+
+    /** Subscribe to the outcome of every ``fetchWithRetry`` call. */
+    setOutcomeCallback(cb: ((o: RequestOutcome) => void) | null): void {
+        this.outcomeCb = cb;
+    }
+
+    private recordOutcome(outcome: RequestOutcome): void {
+        this.outcomeCb?.(outcome);
     }
 
     /** Repoint the client at a new base URL in place — lets the wizard update
@@ -140,7 +153,10 @@ export class LilbeeClient {
         init?: RequestInit,
         opts?: { stream?: boolean; signal?: AbortSignal },
     ): Promise<Response> {
-        if (!this.baseUrl) throw new ServerStartingError();
+        if (!this.baseUrl) {
+            this.recordOutcome("starting");
+            throw new ServerStartingError();
+        }
         const maxAttempts = RETRY_COUNT + 1;
         let lastError: unknown;
         let authRetried = false;
@@ -170,9 +186,12 @@ export class LilbeeClient {
                         // token still failed. The stored session token is stale — surface a
                         // typed error so the UI can tell the user what to do.
                         const text = await res.text().catch(() => "");
+                        this.recordOutcome("auth_error");
                         throw new SessionTokenError(res.status, text);
                     }
-                    return await this.assertOk(res);
+                    const okRes = await this.assertOk(res);
+                    this.recordOutcome("ok");
+                    return okRes;
                 } finally {
                     if (timer !== undefined) clearTimeout(timer);
                 }
@@ -182,6 +201,7 @@ export class LilbeeClient {
                     throw err;
                 }
                 if (err instanceof Error && err.message.startsWith("Server responded")) {
+                    this.recordOutcome("server_error");
                     throw err;
                 }
                 if (err instanceof Error && err.name === ERROR_NAME.ABORT_ERROR) {
@@ -189,6 +209,7 @@ export class LilbeeClient {
                 }
             }
         }
+        this.recordOutcome("unreachable");
         throw lastError;
     }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -48,6 +48,18 @@ export class SessionTokenError extends Error {
     }
 }
 
+/**
+ * Thrown when a request is attempted before the managed server has reported
+ * its random listen port. Lets callers (settings UI, status bar) render a
+ * "starting…" state instead of firing requests at the default port.
+ */
+export class ServerStartingError extends Error {
+    constructor() {
+        super("Server is still starting up");
+        this.name = ERROR_NAME.SERVER_STARTING;
+    }
+}
+
 export class LilbeeClient {
     private token: string | null = null;
     private tokenProvider: (() => string | null) | null = null;
@@ -128,6 +140,7 @@ export class LilbeeClient {
         init?: RequestInit,
         opts?: { stream?: boolean; signal?: AbortSignal },
     ): Promise<Response> {
+        if (!this.baseUrl) throw new ServerStartingError();
         const maxAttempts = RETRY_COUNT + 1;
         let lastError: unknown;
         let authRetried = false;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -352,6 +352,7 @@ export const MESSAGES = {
 
     ERROR_COULD_NOT_CONNECT: "lilbee: cannot connect to server",
     ERROR_SERVER_CRASHED: "lilbee: server crashed after multiple restarts",
+    ERROR_SERVER_SHUTDOWN_FAILED: "lilbee: failed to stop the managed server",
     ERROR_FAILED_DOWNLOAD: "lilbee: failed to download server",
     ERROR_FAILED_START: "lilbee: failed to start server",
     ERROR_FAILED_UPDATE: "lilbee: update failed",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -10,6 +10,9 @@ export const MESSAGES = {
     BUTTON_CANCEL: "Cancel",
     BUTTON_PULL: "Pull",
     BUTTON_PULL_MODEL: "Pull Model",
+    BUTTON_PULL_ANYWAY: "Pull anyway",
+    WARNING_MODEL_EXCEEDS_RAM: (needed: number, have: number) =>
+        `This model needs ${needed} GB of RAM but your system has only ${have} GB. Loading it will likely fail.`,
     BUTTON_USE: "Use",
     BUTTON_REMOVE: "Delete",
     BUTTON_REFRESH: "Refresh",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -316,6 +316,8 @@ export const MESSAGES = {
     STATUS_READY: "lilbee: ready",
     STATUS_READY_EXTERNAL: "lilbee: ready [external]",
     STATUS_ERROR: "lilbee: error",
+    STATUS_AUTH_ERROR: "lilbee: auth error",
+    NOTICE_SERVER_UNREACHABLE: "lilbee: server unreachable",
     STATUS_STOPPED: "lilbee: stopped",
     STATUS_ADDING: "lilbee: adding {label}...",
     STATUS_NOTHING_NEW: "lilbee: nothing new to add",

--- a/src/main.ts
+++ b/src/main.ts
@@ -169,7 +169,7 @@ function coerceSyncDone(obj: Record<string, unknown>): SyncDone | null {
 
 export default class LilbeePlugin extends Plugin {
     settings: LilbeeSettings = { ...DEFAULT_SETTINGS };
-    api: LilbeeClient = new LilbeeClient(DEFAULT_SETTINGS.serverUrl);
+    api: LilbeeClient = new LilbeeClient("");
     activeModel = "";
     statusBarEl: HTMLElement | null = null;
     ribbonIconEl: HTMLElement | null = null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { type EventRef, type Menu, type MenuItem, Notice, Plugin, type TAbstractFile } from "obsidian";
 import { LilbeeClient, SessionTokenError } from "./api";
+import type { RequestOutcome } from "./api";
 import { BinaryManager, getLatestRelease, checkForUpdate, node } from "./binary-manager";
 import type { ReleaseInfo } from "./binary-manager";
 import { ServerManager } from "./server-manager";
@@ -231,9 +232,7 @@ export default class LilbeePlugin extends Plugin {
             if (this.settings.serverMode === SERVER_MODE.MANAGED) {
                 void this.startManagedServer();
             } else {
-                this.api = new LilbeeClient(this.settings.serverUrl);
-                this.api.setTokenProvider(() => this.readCurrentToken());
-                this.api.setToken(this.readCurrentToken());
+                this.configureApi(this.settings.serverUrl);
                 this.setStatusReady();
                 this.fetchActiveModel();
             }
@@ -321,9 +320,7 @@ export default class LilbeePlugin extends Plugin {
                 this.setStatusClass("lilbee-status-starting");
                 onProgress?.({ phase: "starting", message: MESSAGES.STATUS_STARTING_SERVER });
                 await this.serverManager.start();
-                this.api = new LilbeeClient(this.serverManager.serverUrl);
-                this.api.setTokenProvider(() => this.readCurrentToken());
-                this.api.setToken(this.readCurrentToken());
+                this.configureApi(this.serverManager.serverUrl);
                 this.fetchActiveModel();
                 void this.configureManagedStorage();
                 onProgress?.({ phase: "ready", message: "" });
@@ -444,9 +441,7 @@ export default class LilbeePlugin extends Plugin {
         switch (state) {
             case SERVER_STATE.READY:
                 if (this.serverManager) {
-                    this.api = new LilbeeClient(this.serverManager.serverUrl);
-                    this.api.setTokenProvider(() => this.readCurrentToken());
-                    this.api.setToken(this.readCurrentToken());
+                    this.configureApi(this.serverManager.serverUrl);
                 }
                 this.serverUnreachable = false;
                 this.setStatusReady();
@@ -493,6 +488,32 @@ export default class LilbeePlugin extends Plugin {
         }
         const dataRoot = resolveExternalDataRoot(this.getVaultBasePath());
         return readSessionToken(dataRoot);
+    }
+
+    /** Build a fresh API client for *baseUrl* and re-register all hooks. */
+    private configureApi(baseUrl: string): void {
+        this.api = new LilbeeClient(baseUrl);
+        this.api.setTokenProvider(() => this.readCurrentToken());
+        this.api.setToken(this.readCurrentToken());
+        this.api.setOutcomeCallback((outcome) => this.handleRequestOutcome(outcome));
+    }
+
+    /** Update the status bar to reflect the latest API outcome. */
+    private handleRequestOutcome(outcome: RequestOutcome): void {
+        if (outcome === "ok") {
+            this.setStatusReady();
+            return;
+        }
+        if (outcome === "auth_error") {
+            this.updateStatusBar(MESSAGES.STATUS_AUTH_ERROR, DOT_STATE.ERROR);
+            this.setStatusClass("lilbee-status-error");
+            return;
+        }
+        if (outcome === "server_error" || outcome === "unreachable") {
+            this.updateStatusBar(MESSAGES.STATUS_ERROR, DOT_STATE.ERROR);
+            this.setStatusClass("lilbee-status-error");
+        }
+        // "starting" is a no-op — the existing startup UI already says so.
     }
 
     private registerCommands(): void {
@@ -649,9 +670,7 @@ export default class LilbeePlugin extends Plugin {
                 void this.startManagedServer();
             } else if (this.serverManager) {
                 this.serverManager.updatePort(this.settings.serverPort);
-                this.api = new LilbeeClient(this.serverManager.serverUrl);
-                this.api.setTokenProvider(() => this.readCurrentToken());
-                this.api.setToken(this.readCurrentToken());
+                this.configureApi(this.serverManager.serverUrl);
             }
         } else {
             if (previousMode === SERVER_MODE.MANAGED) {
@@ -659,9 +678,7 @@ export default class LilbeePlugin extends Plugin {
                 this.serverManager = null;
                 this.binaryManager = null;
             }
-            this.api = new LilbeeClient(this.settings.serverUrl);
-            this.api.setTokenProvider(() => this.readCurrentToken());
-            this.api.setToken(this.readCurrentToken());
+            this.configureApi(this.settings.serverUrl);
             // External mode owns its own status via the health probe; paint
             // "ready [external]" optimistically so the user doesn't see a
             // stale "stopped" label between the mode switch and the next

--- a/src/main.ts
+++ b/src/main.ts
@@ -312,6 +312,9 @@ export default class LilbeePlugin extends Plugin {
                         const detail = stderr ? `\n${stderr.split("\n").slice(-5).join("\n")}` : "";
                         new Notice(`${MESSAGES.ERROR_SERVER_CRASHED}${detail}`, NOTICE_PERMANENT);
                     },
+                    onShutdownFailure: (err: Error) => {
+                        new Notice(`${MESSAGES.ERROR_SERVER_SHUTDOWN_FAILED}: ${err.message}`);
+                    },
                 });
 
                 this.updateStatusBar(MESSAGES.STATUS_STARTING, DOT_STATE.PRIMARY);

--- a/src/server-manager.ts
+++ b/src/server-manager.ts
@@ -20,6 +20,7 @@ export interface ServerManagerOptions {
     systemPrompt: string;
     onStateChange?: (state: ServerState) => void;
     onRestartsExhausted?: (stderr: string) => void;
+    onShutdownFailure?: (error: Error) => void;
 }
 
 export class ServerManager {
@@ -96,6 +97,7 @@ export class ServerManager {
         const env: Record<string, string | undefined> = {
             ...process.env,
             LILBEE_CORS_ORIGINS: "app://obsidian.md",
+            LILBEE_PARENT_PID: String(process.pid),
         };
         if (this.opts.systemPrompt) {
             env.LILBEE_SYSTEM_PROMPT = this.opts.systemPrompt;
@@ -192,8 +194,8 @@ export class ServerManager {
         if (process.platform === PLATFORM.WIN32) {
             try {
                 await node.execFile("taskkill", ["/pid", String(child.pid), "/f", "/t"]);
-            } catch {
-                // process may already be gone
+            } catch (err) {
+                this.opts.onShutdownFailure?.(err instanceof Error ? err : new Error(String(err)));
             }
         } else {
             child.kill("SIGTERM");

--- a/src/server-manager.ts
+++ b/src/server-manager.ts
@@ -47,6 +47,7 @@ export class ServerManager {
 
     get serverUrl(): string {
         const port = this._actualPort ?? this.opts.port;
+        if (port === null) return "";
         return `http://127.0.0.1:${port}`;
     }
 
@@ -161,11 +162,14 @@ export class ServerManager {
 
     private async waitForReady(): Promise<void> {
         for (let i = 0; i < SERVER_MANAGER_CONFIG.HEALTH_POLL_MAX_ATTEMPTS; i++) {
-            try {
-                const res = await node.fetch(`${this.serverUrl}/api/health`);
-                if (res.ok) return;
-            } catch {
-                // not ready yet
+            const url = this.serverUrl;
+            if (url) {
+                try {
+                    const res = await node.fetch(`${url}/api/health`);
+                    if (res.ok) return;
+                } catch {
+                    // not ready yet
+                }
             }
             await new Promise((r) => setTimeout(r, SERVER_MANAGER_CONFIG.HEALTH_POLL_INTERVAL_MS));
         }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -27,6 +27,7 @@ import {
     extractSseErrorMessage,
     noticeForResultError,
     getRelevantSystemMemoryGB,
+    noticeServerUnreachableIfApplicable,
 } from "./utils";
 
 const CHECK_TIMEOUT_MS = 5000;
@@ -679,7 +680,8 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 const catalogEntries = catalogResult.isOk() ? catalogResult.value.models : [];
                 this.renderRerankerDropdown(container, active, catalogEntries, installedResp.models);
             })
-            .catch(() => {
+            .catch((err) => {
+                if (noticeServerUnreachableIfApplicable(err)) return;
                 new Notice(MESSAGES.NOTICE_RERANKER_LOAD_FAILED);
             });
     }
@@ -826,7 +828,8 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 const catalogEntries = catalogResult.isOk() ? catalogResult.value.models : [];
                 this.renderVisionDropdown(container, active, catalogEntries, installedResp.models);
             })
-            .catch(() => {
+            .catch((err) => {
+                if (noticeServerUnreachableIfApplicable(err)) return;
                 new Notice(MESSAGES.NOTICE_VISION_LOAD_FAILED);
             });
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -26,6 +26,7 @@ import {
     errorMessage,
     extractSseErrorMessage,
     noticeForResultError,
+    getSystemMemoryGB,
 } from "./utils";
 
 const CHECK_TIMEOUT_MS = 5000;
@@ -1689,6 +1690,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 displayName: featuredEntry.display_name,
                 sizeGb: featuredEntry.size_gb,
                 minRamGb: featuredEntry.min_ram_gb,
+                systemMemGb: getSystemMemoryGB(),
             });
             modal.open();
             const confirmed = await modal.result;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -26,7 +26,7 @@ import {
     errorMessage,
     extractSseErrorMessage,
     noticeForResultError,
-    getSystemMemoryGB,
+    getRelevantSystemMemoryGB,
 } from "./utils";
 
 const CHECK_TIMEOUT_MS = 5000;
@@ -1690,7 +1690,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 displayName: featuredEntry.display_name,
                 sizeGb: featuredEntry.size_gb,
                 minRamGb: featuredEntry.min_ram_gb,
-                systemMemGb: getSystemMemoryGB(),
+                systemMemGb: getRelevantSystemMemoryGB(this.plugin.settings.serverMode),
             });
             modal.open();
             const confirmed = await modal.result;

--- a/src/types.ts
+++ b/src/types.ts
@@ -470,6 +470,7 @@ export const MODEL_SOURCE = {
 export const ERROR_NAME = {
     ABORT_ERROR: "AbortError",
     SESSION_TOKEN: "SessionTokenError",
+    SERVER_STARTING: "ServerStartingError",
 } as const;
 
 export const WIZARD_STEP = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
 import { SessionTokenError } from "./api";
 import { MESSAGES } from "./locales/en";
+import { SERVER_MODE } from "./types";
+import type { ServerMode } from "./types";
 
 export function debounce<T extends (...args: unknown[]) => unknown>(
     fn: T,
@@ -240,4 +242,14 @@ export function getSystemMemoryGB(): number | null {
     } catch {
         return null;
     }
+}
+
+/**
+ * The local machine's RAM only constrains model loads in managed mode where
+ * the server runs on this machine. In external mode the server lives on
+ * another host whose RAM we don't know — return null and skip the warning.
+ */
+export function getRelevantSystemMemoryGB(serverMode: ServerMode): number | null {
+    if (serverMode !== SERVER_MODE.MANAGED) return null;
+    return getSystemMemoryGB();
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import { SessionTokenError } from "./api";
+import { Notice } from "obsidian";
+import { ServerStartingError, SessionTokenError } from "./api";
 import { MESSAGES } from "./locales/en";
 import { SERVER_MODE } from "./types";
 import type { ServerMode } from "./types";
@@ -252,4 +253,36 @@ export function getSystemMemoryGB(): number | null {
 export function getRelevantSystemMemoryGB(serverMode: ServerMode): number | null {
     if (serverMode !== SERVER_MODE.MANAGED) return null;
     return getSystemMemoryGB();
+}
+
+const SERVER_UNREACHABLE_DEBOUNCE_MS = 5000;
+let lastServerUnreachableAt = 0;
+
+/** Reset the debounce timer (test-only). */
+export function _resetServerUnreachableDebounce(): void {
+    lastServerUnreachableAt = 0;
+}
+
+function looksLikeConnectionRefused(err: Error): boolean {
+    const msg = err.message.toLowerCase();
+    return msg.includes("econnrefused") || msg.includes("failed to fetch") || msg.includes("fetch failed");
+}
+
+/**
+ * Inspect a thrown error and emit at most one "server unreachable" notice per
+ * debounce window, swallowing the per-feature message in that case. Returns
+ * ``true`` when the error was handled and the caller should skip its own
+ * follow-up notice. ``ServerStartingError`` is treated as unreachable too —
+ * the user can already see the "starting" UI elsewhere.
+ */
+export function noticeServerUnreachableIfApplicable(err: unknown): boolean {
+    if (err instanceof ServerStartingError) return true;
+    if (!(err instanceof Error)) return false;
+    if (!looksLikeConnectionRefused(err)) return false;
+    const now = Date.now();
+    if (now - lastServerUnreachableAt > SERVER_UNREACHABLE_DEBOUNCE_MS) {
+        lastServerUnreachableAt = now;
+        new Notice(MESSAGES.NOTICE_SERVER_UNREACHABLE);
+    }
+    return true;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -229,3 +229,15 @@ export function formatElapsed(ms: number): string {
     }
     return `${mm}:${ss}`;
 }
+
+/** Total system RAM in GB, rounded; null when ``os`` is unavailable. */
+export function getSystemMemoryGB(): number | null {
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const os = require("os") as { totalmem(): number };
+        return Math.round(os.totalmem() / (1024 * 1024 * 1024));
+        /* v8 ignore next 3 */
+    } catch {
+        return null;
+    }
+}

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -14,7 +14,7 @@ import {
     errorMessage,
     extractSseErrorMessage,
     noticeForResultError,
-    getSystemMemoryGB,
+    getRelevantSystemMemoryGB,
 } from "../utils";
 import { renderModelCard } from "../components/model-card";
 
@@ -462,7 +462,7 @@ export class CatalogModal extends Modal {
             displayName: entry.display_name,
             sizeGb: entry.size_gb,
             minRamGb: entry.min_ram_gb,
-            systemMemGb: getSystemMemoryGB(),
+            systemMemGb: getRelevantSystemMemoryGB(this.plugin.settings.serverMode),
         });
         confirmModal.open();
         void confirmModal.result.then((confirmed) => {

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -14,6 +14,7 @@ import {
     errorMessage,
     extractSseErrorMessage,
     noticeForResultError,
+    getSystemMemoryGB,
 } from "../utils";
 import { renderModelCard } from "../components/model-card";
 
@@ -461,6 +462,7 @@ export class CatalogModal extends Modal {
             displayName: entry.display_name,
             sizeGb: entry.size_gb,
             minRamGb: entry.min_ram_gb,
+            systemMemGb: getSystemMemoryGB(),
         });
         confirmModal.open();
         void confirmModal.result.then((confirmed) => {

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -27,6 +27,7 @@ import {
     errorMessage,
     extractSseErrorMessage,
     noticeForResultError,
+    getSystemMemoryGB,
 } from "../utils";
 
 interface OpenDialogResult {
@@ -362,6 +363,7 @@ export class ChatView extends ItemView {
                     displayName: uninstalled.display_name,
                     sizeGb: uninstalled.size_gb,
                     minRamGb: uninstalled.min_ram_gb,
+                    systemMemGb: getSystemMemoryGB(),
                 });
                 modal.open();
                 void modal.result.then((confirmed) => {

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -27,7 +27,7 @@ import {
     errorMessage,
     extractSseErrorMessage,
     noticeForResultError,
-    getSystemMemoryGB,
+    getRelevantSystemMemoryGB,
 } from "../utils";
 
 interface OpenDialogResult {
@@ -363,7 +363,7 @@ export class ChatView extends ItemView {
                     displayName: uninstalled.display_name,
                     sizeGb: uninstalled.size_gb,
                     minRamGb: uninstalled.min_ram_gb,
-                    systemMemGb: getSystemMemoryGB(),
+                    systemMemGb: getRelevantSystemMemoryGB(this.plugin.settings.serverMode),
                 });
                 modal.open();
                 void modal.result.then((confirmed) => {

--- a/src/views/confirm-pull-modal.ts
+++ b/src/views/confirm-pull-modal.ts
@@ -5,6 +5,8 @@ export interface ConfirmPullInfo {
     displayName: string;
     sizeGb: number;
     minRamGb: number;
+    /** Total system RAM in GB. When set and below ``minRamGb`` the modal warns the user. */
+    systemMemGb?: number | null;
 }
 
 export class ConfirmPullModal extends Modal {
@@ -33,9 +35,17 @@ export class ConfirmPullModal extends Modal {
         info.createEl("p", { text: `${MESSAGES.LABEL_SIZE}: ${this.model.sizeGb} GB` });
         info.createEl("p", { text: `${MESSAGES.LABEL_MIN_RAM}: ${this.model.minRamGb} GB` });
 
+        const tooLarge = typeof this.model.systemMemGb === "number" && this.model.systemMemGb < this.model.minRamGb;
+        if (tooLarge) {
+            const warn = contentEl.createDiv({ cls: "lilbee-confirm-pull-warning" });
+            warn.createEl("p", {
+                text: MESSAGES.WARNING_MODEL_EXCEEDS_RAM(this.model.minRamGb, this.model.systemMemGb!),
+            });
+        }
+
         const actions = contentEl.createDiv({ cls: "lilbee-confirm-pull-actions" });
         const pullBtn = actions.createEl("button", {
-            text: MESSAGES.BUTTON_PULL_MODEL,
+            text: tooLarge ? MESSAGES.BUTTON_PULL_ANYWAY : MESSAGES.BUTTON_PULL_MODEL,
             cls: "mod-cta",
         });
         pullBtn.addEventListener("click", () => this.decide(true));

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -6,7 +6,7 @@ import { SERVER_MODE, SERVER_STATE, SSE_EVENT, WIZARD_STEP, ERROR_NAME, MODEL_TA
 import { CatalogModal } from "./catalog-modal";
 import { MESSAGES, FILTERS } from "../locales/en";
 import { renderModelCard } from "../components/model-card";
-import { percentFromSse, extractSseErrorMessage } from "../utils";
+import { percentFromSse, extractSseErrorMessage, getSystemMemoryGB } from "../utils";
 
 type FeaturedModel = CatalogEntry;
 type EmbeddingModel = CatalogEntry;
@@ -39,16 +39,6 @@ const STEP_KEY: Record<number, string> = {
     [WIZARD_STEP.WIKI]: "wiki",
     [WIZARD_STEP.DONE]: "done",
 };
-
-export function getSystemMemoryGB(): number | null {
-    try {
-        const os = require("os") as { totalmem(): number };
-        return Math.round(os.totalmem() / (1024 * 1024 * 1024));
-        /* v8 ignore next 3 */
-    } catch {
-        return null;
-    }
-}
 
 export function recommendedIndex(models: FeaturedModel[], memGB: number | null): number {
     if (memGB === null || models.length === 0) return 0;

--- a/styles.css
+++ b/styles.css
@@ -284,13 +284,14 @@
 
 .lilbee-chat-message-error {
     align-self: flex-start;
-    background-color: var(--background-modifier-error, rgba(200, 60, 60, 0.15));
-    color: var(--text-error);
+    background-color: var(--background-modifier-error, rgba(200, 60, 60, 0.4));
+    color: var(--text-on-accent, var(--text-normal));
     border-left: 3px solid var(--text-error);
 }
 
 .lilbee-chat-error-text {
     font-style: italic;
+    color: var(--text-on-accent, var(--text-normal));
 }
 
 .lilbee-chat-content {

--- a/styles.css
+++ b/styles.css
@@ -2873,3 +2873,12 @@
     background-color: var(--interactive-accent-hover);
 }
 
+.lilbee-confirm-pull-warning {
+    margin: var(--size-4-2, 8px) 0;
+    padding: var(--size-4-2, 8px);
+    border-radius: var(--radius-s, 4px);
+    background-color: var(--background-modifier-error, rgba(200, 60, 60, 0.4));
+    color: var(--text-on-accent, var(--text-normal));
+    border-left: 3px solid var(--text-error);
+}
+

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,5 +1,5 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
-import { LilbeeClient, SessionTokenError } from "../src/api";
+import { LilbeeClient, ServerStartingError, SessionTokenError } from "../src/api";
 import type { Message } from "../src/types";
 
 const BASE_URL = "http://localhost:7433";
@@ -1827,6 +1827,50 @@ describe("fetchWithRetry() — signal and AbortError", () => {
         const result = await client.health();
         expect(result.isErr()).toBe(true);
         expect(result._unsafeUnwrapErr().name).toBe("AbortError");
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("ServerStartingError", () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn();
+        vi.stubGlobal("fetch", fetchMock);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("carries the expected name and message", () => {
+        const e = new ServerStartingError();
+        expect(e.name).toBe("ServerStartingError");
+        expect(e.message).toContain("starting");
+    });
+
+    it("is thrown by fetchWithRetry when baseUrl is empty (no fetch attempted)", async () => {
+        const c = new LilbeeClient("");
+        await expect(c.fetchWithRetry("/api/health")).rejects.toBeInstanceOf(ServerStartingError);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("surfaces via Result-returning methods as a typed error", async () => {
+        const c = new LilbeeClient("");
+        const result = await c.health();
+        expect(result.isErr()).toBe(true);
+        expect(result._unsafeUnwrapErr()).toBeInstanceOf(ServerStartingError);
+    });
+
+    it("clears once setBaseUrl is called with a real URL", async () => {
+        const c = new LilbeeClient("");
+        fetchMock.mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ status: "ok", version: "1" }),
+        } as unknown as Response);
+        c.setBaseUrl(BASE_URL);
+        const result = await c.health();
+        expect(result.isOk()).toBe(true);
         expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 });

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1874,3 +1874,76 @@ describe("ServerStartingError", () => {
         expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 });
+
+describe("setOutcomeCallback", () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+    let outcomes: string[];
+    let client: LilbeeClient;
+
+    beforeEach(() => {
+        fetchMock = vi.fn();
+        vi.stubGlobal("fetch", fetchMock);
+        outcomes = [];
+        client = new LilbeeClient(BASE_URL);
+        client.setOutcomeCallback((o) => outcomes.push(o));
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("fires 'starting' when baseUrl is empty", async () => {
+        const c = new LilbeeClient("");
+        c.setOutcomeCallback((o) => outcomes.push(o));
+        await c.health();
+        expect(outcomes).toContain("starting");
+    });
+
+    it("fires 'ok' on a successful request", async () => {
+        fetchMock.mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ status: "ok", version: "1" }),
+        } as unknown as Response);
+        await client.health();
+        expect(outcomes).toContain("ok");
+    });
+
+    it("fires 'auth_error' when 401 surfaces SessionTokenError", async () => {
+        fetchMock.mockResolvedValue({
+            ok: false,
+            status: 401,
+            text: () => Promise.resolve(""),
+        } as unknown as Response);
+        const result = await client.health();
+        expect(result.isErr()).toBe(true);
+        expect(outcomes).toContain("auth_error");
+    });
+
+    it("fires 'server_error' on a non-auth HTTP error", async () => {
+        fetchMock.mockResolvedValue({
+            ok: false,
+            status: 500,
+            text: () => Promise.resolve("boom"),
+        } as unknown as Response);
+        const result = await client.health();
+        expect(result.isErr()).toBe(true);
+        expect(outcomes).toContain("server_error");
+    });
+
+    it("fires 'unreachable' when fetch keeps rejecting", async () => {
+        fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+        const result = await client.health();
+        expect(result.isErr()).toBe(true);
+        expect(outcomes).toContain("unreachable");
+    });
+
+    it("setOutcomeCallback(null) detaches the subscriber", async () => {
+        client.setOutcomeCallback(null);
+        fetchMock.mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve({ status: "ok", version: "1" }),
+        } as unknown as Response);
+        await client.health();
+        expect(outcomes).toEqual([]);
+    });
+});

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -25,6 +25,7 @@ vi.mock("../src/api", () => ({
         setChatModel: vi.fn(),
         setToken: vi.fn(),
         setTokenProvider: vi.fn(),
+        setOutcomeCallback: vi.fn(),
         health: vi.fn().mockResolvedValue({ isErr: () => false, isOk: () => true, value: {} }),
         // Default config matches the test vault layout so the fire-and-forget
         // configureManagedStorage() in startManagedServer() hits the early
@@ -2501,6 +2502,45 @@ describe("LilbeePlugin", () => {
 
             expect(plugin.taskQueue.completed.length).toBeGreaterThan(0);
             expect(plugin.taskQueue.completed[0]!.name).toBe("Adding files");
+        });
+    });
+
+    describe("handleRequestOutcome", () => {
+        it("flips status to ready on 'ok'", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            (plugin as any).updateStatusBar(MESSAGES.STATUS_ERROR);
+            (plugin as any).handleRequestOutcome("ok");
+            expect((plugin.statusBarEl as any)?.textContent).toContain("ready");
+        });
+
+        it("flips status to auth error on 'auth_error'", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            (plugin as any).handleRequestOutcome("auth_error");
+            expect((plugin.statusBarEl as any)?.textContent).toContain("auth error");
+        });
+
+        it("flips status to error on 'server_error'", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            (plugin as any).handleRequestOutcome("server_error");
+            expect((plugin.statusBarEl as any)?.textContent).toContain("error");
+        });
+
+        it("flips status to error on 'unreachable'", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            (plugin as any).handleRequestOutcome("unreachable");
+            expect((plugin.statusBarEl as any)?.textContent).toContain("error");
+        });
+
+        it("does not change status on 'starting' (existing UI handles startup)", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            const before = (plugin.statusBarEl as any)?.textContent;
+            (plugin as any).handleRequestOutcome("starting");
+            expect((plugin.statusBarEl as any)?.textContent).toBe(before);
         });
     });
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -3045,6 +3045,21 @@ describe("LilbeePlugin", () => {
             expect(Notice.instances.length).toBe(beforeCount);
         });
 
+        it("onShutdownFailure shows a notice with the failure message", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const onShutdownFailure = mockServerOpts?.onShutdownFailure;
+            expect(onShutdownFailure).toBeDefined();
+
+            onShutdownFailure(new Error("process not found"));
+
+            const notice = Notice.instances.find((n) => n.message.includes("failed to stop"));
+            expect(notice).toBeDefined();
+            expect(notice!.message).toContain("process not found");
+        });
+
         it("showError includes lastStderr in the notice", async () => {
             mockLastStderr = "fatal: database locked";
             mockServerStart.mockRejectedValueOnce(new Error("startup failed"));

--- a/tests/server-manager.test.ts
+++ b/tests/server-manager.test.ts
@@ -97,6 +97,11 @@ describe("ServerManager", () => {
             expect(mgr.serverUrl).toBe("http://127.0.0.1:9999");
         });
 
+        it("serverUrl is empty in managed mode before the port file is read", () => {
+            const mgr = new ServerManager(defaultOpts({ port: null }));
+            expect(mgr.serverUrl).toBe("");
+        });
+
         it("dataDir getter returns the configured data dir", () => {
             const mgr = new ServerManager(defaultOpts({ dataDir: "/var/lilbee" }));
             expect(mgr.dataDir).toBe("/var/lilbee");

--- a/tests/server-manager.test.ts
+++ b/tests/server-manager.test.ts
@@ -125,6 +125,7 @@ describe("ServerManager", () => {
             expect(bin).toBe("/usr/local/bin/lilbee");
             expect(args).toEqual(["serve", "--host", "127.0.0.1", "--port", "7433", "--data-dir", "/tmp/data"]);
             expect(opts.env.LILBEE_CORS_ORIGINS).toBe("app://obsidian.md");
+            expect(opts.env.LILBEE_PARENT_PID).toBe(String(process.pid));
             expect(opts.env.LILBEE_SYSTEM_PROMPT).toBeUndefined();
             expect(opts.stdio).toEqual(["ignore", "ignore", "pipe"]);
             expect(opts.detached).toBe(false);
@@ -307,7 +308,33 @@ describe("ServerManager", () => {
             Object.defineProperty(process, "platform", { value: originalPlatform });
         });
 
-        it("handles taskkill failure gracefully on Windows", async () => {
+        it("surfaces taskkill failures on Windows via onShutdownFailure callback", async () => {
+            const originalPlatform = process.platform;
+            Object.defineProperty(process, "platform", { value: "win32" });
+            execFileSpy.mockImplementation(async () => {
+                setTimeout(() => child._emit("exit", 0, null), 10);
+                throw new Error("process not found");
+            });
+
+            const failures: Error[] = [];
+            const mgr = new ServerManager(defaultOpts({ onShutdownFailure: (err) => failures.push(err) }));
+            const p1 = mgr.start();
+            await vi.advanceTimersByTimeAsync(1000);
+            await p1;
+
+            const stopPromise = mgr.stop();
+            await vi.advanceTimersByTimeAsync(50);
+            await stopPromise;
+
+            // State still reaches stopped — but the failure is surfaced, not swallowed.
+            expect(mgr.state).toBe("stopped");
+            expect(failures).toHaveLength(1);
+            expect(failures[0].message).toBe("process not found");
+
+            Object.defineProperty(process, "platform", { value: originalPlatform });
+        });
+
+        it("does not invoke onShutdownFailure when no callback is registered", async () => {
             const originalPlatform = process.platform;
             Object.defineProperty(process, "platform", { value: "win32" });
             execFileSpy.mockImplementation(async () => {
@@ -322,11 +349,34 @@ describe("ServerManager", () => {
 
             const stopPromise = mgr.stop();
             await vi.advanceTimersByTimeAsync(50);
+            // Should not throw despite no callback.
             await stopPromise;
 
-            // Should not throw — error is swallowed
             expect(mgr.state).toBe("stopped");
+            Object.defineProperty(process, "platform", { value: originalPlatform });
+        });
 
+        it("wraps a non-Error thrown value when surfacing a shutdown failure", async () => {
+            const originalPlatform = process.platform;
+            Object.defineProperty(process, "platform", { value: "win32" });
+            execFileSpy.mockImplementation(async () => {
+                setTimeout(() => child._emit("exit", 0, null), 10);
+                throw "some string failure";
+            });
+
+            const failures: Error[] = [];
+            const mgr = new ServerManager(defaultOpts({ onShutdownFailure: (err) => failures.push(err) }));
+            const p1 = mgr.start();
+            await vi.advanceTimersByTimeAsync(1000);
+            await p1;
+
+            const stopPromise = mgr.stop();
+            await vi.advanceTimersByTimeAsync(50);
+            await stopPromise;
+
+            expect(failures).toHaveLength(1);
+            expect(failures[0]).toBeInstanceOf(Error);
+            expect(failures[0].message).toBe("some string failure");
             Object.defineProperty(process, "platform", { value: originalPlatform });
         });
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -4395,6 +4395,29 @@ describe("managed mode settings", () => {
             expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_RERANKER_LOAD_FAILED)).toBe(true);
         });
 
+        it("skips the load-failed notice when the error is ECONNREFUSED (server unreachable)", async () => {
+            Notice.clear();
+            const { _resetServerUnreachableDebounce } = await import("../src/utils");
+            _resetServerUnreachableDebounce();
+            const plugin = makePlugin();
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockRejectedValue(
+                new Error("connect ECONNREFUSED 127.0.0.1:7433"),
+            );
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ total: 0, limit: 20, offset: 0, models: [], has_more: false }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({ models: [] });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+
+            (tab as any).renderRerankerSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_RERANKER_LOAD_FAILED)).toBe(false);
+            expect(Notice.instances.some((n) => n.message.includes("server unreachable"))).toBe(true);
+        });
+
         it("falls back to notice when installedModels rejects (caught by inner catch)", async () => {
             const plugin = makePlugin();
             (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -5215,6 +5238,29 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
 
             expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_VISION_LOAD_FAILED)).toBe(true);
+        });
+
+        it("skips the load-failed notice when the error is ECONNREFUSED (server unreachable)", async () => {
+            Notice.clear();
+            const { _resetServerUnreachableDebounce } = await import("../src/utils");
+            _resetServerUnreachableDebounce();
+            const plugin = makePlugin();
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockRejectedValue(
+                new Error("connect ECONNREFUSED 127.0.0.1:7433"),
+            );
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ total: 0, limit: 20, offset: 0, models: [], has_more: false }),
+            );
+            (plugin.api.installedModels as ReturnType<typeof vi.fn>).mockResolvedValue({ models: [] });
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+
+            (tab as any).renderVisionSection(container);
+            await new Promise((r) => setTimeout(r, 0));
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_VISION_LOAD_FAILED)).toBe(false);
+            expect(Notice.instances.some((n) => n.message.includes("server unreachable"))).toBe(true);
         });
 
         it("falls back to empty dropdown when installedModels rejects", async () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Notice } from "obsidian";
 import {
+    _resetServerUnreachableDebounce,
     ensureUrlScheme,
     errorMessage,
     extractServerErrorDetail,
@@ -9,11 +11,12 @@ import {
     getRelevantSystemMemoryGB,
     isRoleMismatchDetail,
     noticeForResultError,
+    noticeServerUnreachableIfApplicable,
     percentFromSse,
     StreamIdleError,
     withIdleTimeout,
 } from "../src/utils";
-import { SessionTokenError } from "../src/api";
+import { ServerStartingError, SessionTokenError } from "../src/api";
 import { SERVER_MODE } from "../src/types";
 import { MESSAGES } from "../src/locales/en";
 import { ERROR_NAME } from "../src/types";
@@ -273,5 +276,63 @@ describe("getRelevantSystemMemoryGB()", () => {
 
     it("returns null in external mode (the server's RAM is on a remote host)", () => {
         expect(getRelevantSystemMemoryGB(SERVER_MODE.EXTERNAL)).toBeNull();
+    });
+});
+
+describe("noticeServerUnreachableIfApplicable()", () => {
+    beforeEach(() => {
+        Notice.clear();
+        _resetServerUnreachableDebounce();
+    });
+
+    it("returns true and emits one notice for ECONNREFUSED", () => {
+        const handled = noticeServerUnreachableIfApplicable(new Error("connect ECONNREFUSED 127.0.0.1"));
+        expect(handled).toBe(true);
+        expect(Notice.instances).toHaveLength(1);
+        expect(Notice.instances[0].message).toContain("server unreachable");
+    });
+
+    it("returns true and emits one notice for 'Failed to fetch'", () => {
+        const handled = noticeServerUnreachableIfApplicable(new TypeError("Failed to fetch"));
+        expect(handled).toBe(true);
+        expect(Notice.instances).toHaveLength(1);
+    });
+
+    it("treats ServerStartingError as handled but emits no notice", () => {
+        const handled = noticeServerUnreachableIfApplicable(new ServerStartingError());
+        expect(handled).toBe(true);
+        expect(Notice.instances).toHaveLength(0);
+    });
+
+    it("returns false for unrelated errors", () => {
+        const handled = noticeServerUnreachableIfApplicable(new Error("Server responded 500"));
+        expect(handled).toBe(false);
+        expect(Notice.instances).toHaveLength(0);
+    });
+
+    it("returns false for non-Error values", () => {
+        expect(noticeServerUnreachableIfApplicable("oops")).toBe(false);
+        expect(noticeServerUnreachableIfApplicable(null)).toBe(false);
+    });
+
+    it("debounces follow-up notices within the window", () => {
+        noticeServerUnreachableIfApplicable(new Error("ECONNREFUSED"));
+        noticeServerUnreachableIfApplicable(new Error("ECONNREFUSED"));
+        noticeServerUnreachableIfApplicable(new Error("ECONNREFUSED"));
+        expect(Notice.instances).toHaveLength(1);
+    });
+
+    it("re-emits after the debounce window expires", () => {
+        const realDateNow = Date.now;
+        let now = 1_000_000;
+        Date.now = () => now;
+        try {
+            noticeServerUnreachableIfApplicable(new Error("ECONNREFUSED"));
+            now += 6_000;
+            noticeServerUnreachableIfApplicable(new Error("ECONNREFUSED"));
+        } finally {
+            Date.now = realDateNow;
+        }
+        expect(Notice.instances).toHaveLength(2);
     });
 });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -6,6 +6,7 @@ import {
     formatBytes,
     formatRate,
     formatElapsed,
+    getRelevantSystemMemoryGB,
     isRoleMismatchDetail,
     noticeForResultError,
     percentFromSse,
@@ -13,6 +14,7 @@ import {
     withIdleTimeout,
 } from "../src/utils";
 import { SessionTokenError } from "../src/api";
+import { SERVER_MODE } from "../src/types";
 import { MESSAGES } from "../src/locales/en";
 import { ERROR_NAME } from "../src/types";
 
@@ -259,5 +261,17 @@ describe("isRoleMismatchDetail", () => {
         // a generic "see PUT /api/models/ for options") must NOT be misclassified as a
         // role-mismatch. The sentinel is the `Set it via PUT /api/models/` prefix.
         expect(isRoleMismatchDetail("Auth failed — see PUT /api/models/ docs for the right endpoint.")).toBe(false);
+    });
+});
+
+describe("getRelevantSystemMemoryGB()", () => {
+    it("returns the local system RAM in managed mode", () => {
+        const result = getRelevantSystemMemoryGB(SERVER_MODE.MANAGED);
+        expect(typeof result).toBe("number");
+        expect(result).toBeGreaterThan(0);
+    });
+
+    it("returns null in external mode (the server's RAM is on a remote host)", () => {
+        expect(getRelevantSystemMemoryGB(SERVER_MODE.EXTERNAL)).toBeNull();
     });
 });

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -68,6 +68,7 @@ function makePlugin(overrides: Record<string, unknown> = {}) {
             deleteModel: vi.fn().mockResolvedValue(ok({ deleted: true, model: "", freed_gb: 2.5 })),
         },
         activeModel: "",
+        settings: { serverMode: "managed" },
         fetchActiveModel: vi.fn(),
         refreshSettingsTab: vi.fn(),
         taskQueue: new TaskQueue(),

--- a/tests/views/confirm-pull-modal.test.ts
+++ b/tests/views/confirm-pull-modal.test.ts
@@ -123,4 +123,42 @@ describe("ConfirmPullModal", () => {
         // Second decide call should be a no-op (no throw, no infinite recursion)
         modal.onClose();
     });
+
+    it("renders a RAM warning when systemMemGb is below minRamGb", () => {
+        const app = new App();
+        const modal = new ConfirmPullModal(app as any, makeInfo({ minRamGb: 8, systemMemGb: 4 }));
+        modal.onOpen();
+
+        const texts = collectTexts(modal.contentEl as unknown as MockElement);
+        expect(texts.some((t) => t.includes("8 GB of RAM but your system has only 4 GB"))).toBe(true);
+    });
+
+    it("changes the action button to 'Pull anyway' when system RAM is insufficient", () => {
+        const app = new App();
+        const modal = new ConfirmPullModal(app as any, makeInfo({ minRamGb: 8, systemMemGb: 4 }));
+        modal.onOpen();
+
+        const buttons = findButtons(modal.contentEl as unknown as MockElement);
+        const buttonTexts = buttons.map((b) => b.textContent);
+        expect(buttonTexts).toContain("Pull anyway");
+        expect(buttonTexts).not.toContain("Pull Model");
+    });
+
+    it("does not warn when systemMemGb meets or exceeds minRamGb", () => {
+        const app = new App();
+        const modal = new ConfirmPullModal(app as any, makeInfo({ minRamGb: 4, systemMemGb: 16 }));
+        modal.onOpen();
+
+        const texts = collectTexts(modal.contentEl as unknown as MockElement);
+        expect(texts.some((t) => t.includes("RAM but your system has only"))).toBe(false);
+    });
+
+    it("does not warn when systemMemGb is null (could not be detected)", () => {
+        const app = new App();
+        const modal = new ConfirmPullModal(app as any, makeInfo({ minRamGb: 8, systemMemGb: null }));
+        modal.onOpen();
+
+        const texts = collectTexts(modal.contentEl as unknown as MockElement);
+        expect(texts.some((t) => t.includes("RAM but your system has only"))).toBe(false);
+    });
 });

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -1,7 +1,8 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { App, Notice } from "obsidian";
 import { MockElement } from "../__mocks__/obsidian";
-import { SetupWizard, getSystemMemoryGB, pickNativeChatModels, recommendedIndex } from "../../src/views/setup-wizard";
+import { SetupWizard, pickNativeChatModels, recommendedIndex } from "../../src/views/setup-wizard";
+import { getSystemMemoryGB } from "../../src/utils";
 import { SessionTokenError } from "../../src/api";
 import { SSE_EVENT, WIZARD_STEP } from "../../src/types";
 import { ok, err } from "neverthrow";

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -71,6 +71,7 @@ function makePlugin(overrides: Record<string, unknown> = {}) {
             setBaseUrl: vi.fn(),
             setToken: vi.fn(),
             setTokenProvider: vi.fn(),
+            setOutcomeCallback: vi.fn(),
         },
         activeModel: "",
         fetchActiveModel: vi.fn(),


### PR DESCRIPTION
## Problem

A Windows user running this plugin in managed mode reported a cluster of failures: the dev console flooded with `127.0.0.1:7433` connection-refused errors during the brief window before the managed server reported its random port; multiple `lilbee.exe` processes accumulated whenever Obsidian was closed because `taskkill` failures were silently swallowed; chat error bubbles were unreadable on Windows dark themes (red text on red background); large models that didn't fit in available RAM could be selected with no warning, leading to silent server crashes; the status bar said "ready" while every chat call 401'd; and opening Settings while the server was unreachable produced a vertical stack of redundant notices.

## Solution

**No more 7433 fallback.** A new `ServerStartingError` is thrown by the API client whenever its base URL is empty, so requests fail fast with a recognisable signal instead of being directed at the external-mode default port. The plugin starts with an empty base URL, the `ServerManager` exposes an empty server URL until the random port file is read, and the existing replacement points (managed-server-ready, external-mode setup, wizard) provide a real URL when one is known.

**LILBEE_PARENT_PID handshake.** The spawned server now receives the plugin's PID in the environment so the server-side counterpart (tobocop2/lilbee#192) can exit cleanly when Obsidian goes away. `taskkill` failures on Windows are surfaced through a new `onShutdownFailure` callback that turns into a Notice, so users actually see when a managed-server cleanup didn't take.

**Readable error bubbles.** The chat error bubble used `--text-error` for both the body text and the border, which on some Windows dark themes resolves to near-identical bright red on a translucent red background — users had to highlight the text to read it. Body text now uses `--text-on-accent` so the message stays legible against any error-coloured background, while the border keeps `--text-error` for the red accent stripe.

**RAM-fit warning (managed-only).** When the user goes to download a model whose minimum RAM requirement exceeds available system memory, the pull-confirm dialog shows a prominent warning with the exact GB shortfall and renames the action button to "Pull anyway". The check is skipped in external mode where the server runs on a different host whose RAM the plugin doesn't know about.

**Honest status bar.** Every API call's outcome (ok / auth_error / server_error / unreachable / starting) flows back to the plugin through a `setOutcomeCallback` hook on the API client. The status bar reflects the latest outcome — if every chat is 401-ing, the bar reads "lilbee: auth error" instead of pretending everything is fine.

**Single notice when unreachable.** Settings panes that fan out into multiple parallel API calls used to fire one feature-specific failure notice each when the server was down. They now route through a debounced "lilbee: server unreachable" helper that emits at most one notice per five-second window and silently swallows `ServerStartingError` (the user already sees the startup UI elsewhere).

## Validation

- `npm test`: 1833 passed, 100% coverage across statements, branches, functions, lines.
- `npm run format:check` clean.
- `npm run build` clean.