### PR TITLE
Cockpit: visible chat + task center on launch, plus chat ribbon and a louder task pulse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-lilbee",
-  "version": "0.6.66b423",
+  "version": "0.6.66b424",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-lilbee",
-      "version": "0.6.66b423",
+      "version": "0.6.66b424",
       "dependencies": {
         "neverthrow": "^8.2.0"
       },

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -251,6 +251,7 @@ export const MESSAGES = {
     LABEL_CHAT_VIEW: "lilbee Chat",
     LABEL_TASKS_VIEW: "lilbee Tasks",
     LABEL_RIBBON_OPEN_TASK_CENTER: "Open lilbee Task Center",
+    LABEL_RIBBON_OPEN_CHAT: "Open lilbee chat",
     LABEL_STATUSBAR_OPEN_SETTINGS: "Open lilbee settings",
     ERROR_STREAM_IDLE: "server stopped sending events — check that lilbee is running",
     LABEL_SKIP_SETUP: "Skip setup",

--- a/src/main.ts
+++ b/src/main.ts
@@ -185,6 +185,7 @@ export default class LilbeePlugin extends Plugin {
     statusBarEl: HTMLElement | null = null;
     syncHintEl: HTMLElement | null = null;
     ribbonIconEl: HTMLElement | null = null;
+    chatRibbonIconEl: HTMLElement | null = null;
     binaryManager: BinaryManager | null = null;
     serverManager: ServerManager | null = null;
     syncController: AbortController | null = null;
@@ -222,6 +223,10 @@ export default class LilbeePlugin extends Plugin {
         this.syncHintEl.style.display = "none";
         this.syncHintEl.setAttribute("aria-label", MESSAGES.TOOLTIP_PENDING_SYNC_HINT);
         this.syncHintEl.addEventListener("click", () => void this.triggerSync());
+        this.chatRibbonIconEl = this.addRibbonIcon("messages-square", MESSAGES.LABEL_RIBBON_OPEN_CHAT, () =>
+            this.activateChatView(),
+        );
+        this.chatRibbonIconEl.addClass("lilbee-ribbon-icon", "lilbee-ribbon-chat");
         this.ribbonIconEl = this.addRibbonIcon("list-checks", MESSAGES.LABEL_RIBBON_OPEN_TASK_CENTER, () =>
             this.activateTaskView(),
         );
@@ -1324,10 +1329,11 @@ export default class LilbeePlugin extends Plugin {
 
         let tasksLeaf = existingTasks[0] ?? null;
         if (!tasksLeaf) {
-            // Stack the task center below chat in the right sidebar so both
-            // are visible at once. createLeafBySplit on a sidebar leaf splits
-            // within the sidebar itself.
-            const split = workspace.createLeafBySplit(chatLeaf, "horizontal", false);
+            // getRightLeaf(true) splits the existing right sidebar leaf so the
+            // new leaf stacks underneath rather than becoming a tab. Without
+            // this, both views land in the same sidebar slot and only one is
+            // visible at a time.
+            const split = workspace.getRightLeaf(true);
             if (split) {
                 tasksLeaf = split;
                 await tasksLeaf.setViewState({ type: VIEW_TYPE_TASKS, active: true });

--- a/src/main.ts
+++ b/src/main.ts
@@ -701,7 +701,9 @@ export default class LilbeePlugin extends Plugin {
     onunload(): void {
         if (this.pendingHintTimeout) {
             clearTimeout(this.pendingHintTimeout);
+            this.pendingHintTimeout = null;
         }
+        this.syncHintEl = null;
         this.taskQueue.dispose();
         void this.serverManager?.stop();
     }
@@ -1366,13 +1368,21 @@ export default class LilbeePlugin extends Plugin {
         }
         this.pendingHintTimeout = setTimeout(() => {
             this.pendingHintTimeout = null;
+            // Bail if the plugin was unloaded between scheduling and firing.
+            // The syncHintEl guard inside updatePendingSyncHint covers this,
+            // but the explicit check here keeps the contract local.
+            if (!this.syncHintEl) return;
             void this.updatePendingSyncHint();
         }, PENDING_SYNC_HINT_DEBOUNCE_MS);
     }
 
     private async countPendingSync(): Promise<number> {
-        const vaultFiles = this.app.vault
-            .getFiles()
+        // The vault adapter can be gone if the timer fires after the host
+        // environment teared down (vitest end-of-file cleanup while a real
+        // setTimeout was still pending). Bail cleanly instead of crashing.
+        const files = this.app?.vault?.getFiles?.();
+        if (!Array.isArray(files)) return 0;
+        const vaultFiles = files
             .filter((f) => SUPPORTED_SYNC_EXTENSIONS.has(f.extension.toLowerCase()))
             .filter((f) => !this.wikiSync?.isWikiPath(f.path) && !f.path.startsWith("lilbee/"));
         const known = new Set<string>();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1327,13 +1327,14 @@ export default class LilbeePlugin extends Plugin {
             await chatLeaf.setViewState({ type: VIEW_TYPE_CHAT, active: true });
         }
 
+        // Task center lives as a bottom panel under the editor — not a right
+        // sidebar tab, because the right sidebar collapses sibling leaves into
+        // tabs and only one would be visible at a time. getLeaf("split",
+        // "horizontal") splits the active root leaf in the main editor area
+        // along the horizontal axis (editor on top, task center beneath).
         let tasksLeaf = existingTasks[0] ?? null;
         if (!tasksLeaf) {
-            // getRightLeaf(true) splits the existing right sidebar leaf so the
-            // new leaf stacks underneath rather than becoming a tab. Without
-            // this, both views land in the same sidebar slot and only one is
-            // visible at a time.
-            const split = workspace.getRightLeaf(true);
+            const split = workspace.getLeaf("split", "horizontal");
             if (split) {
                 tasksLeaf = split;
                 await tasksLeaf.setViewState({ type: VIEW_TYPE_TASKS, active: true });

--- a/styles.css
+++ b/styles.css
@@ -2599,10 +2599,10 @@
 .side-dock-ribbon-action.lilbee-ribbon-icon.lilbee-ribbon-error::after {
     content: "";
     position: absolute;
-    top: 4px;
-    right: 4px;
-    width: 8px;
-    height: 8px;
+    top: 3px;
+    right: 3px;
+    width: 10px;
+    height: 10px;
     border-radius: 50%;
     border: 1.5px solid var(--background-primary);
     pointer-events: none;
@@ -2610,7 +2610,18 @@
 
 .side-dock-ribbon-action.lilbee-ribbon-icon.lilbee-ribbon-active::after {
     background-color: var(--interactive-accent);
-    animation: lilbee-dot-pulse 1s ease-in-out infinite;
+    animation: lilbee-ribbon-glow 1.4s ease-in-out infinite;
+}
+
+@keyframes lilbee-ribbon-glow {
+    0%, 100% {
+        transform: scale(1);
+        box-shadow: 0 0 0 0 color-mix(in srgb, var(--interactive-accent) 70%, transparent);
+    }
+    50% {
+        transform: scale(1.18);
+        box-shadow: 0 0 0 5px color-mix(in srgb, var(--interactive-accent) 0%, transparent);
+    }
 }
 
 .side-dock-ribbon-action.lilbee-ribbon-icon.lilbee-ribbon-success::after {

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -267,6 +267,7 @@ export class App {
         getLeavesOfType: vi.fn().mockReturnValue([]),
         getRightLeaf: vi.fn().mockReturnValue(null),
         createLeafBySplit: vi.fn().mockReturnValue(null),
+        getLeaf: vi.fn().mockReturnValue(null),
         revealLeaf: vi.fn(),
         on: vi.fn().mockReturnValue({ id: "mock-event" }),
         getActiveFile: vi.fn().mockReturnValue(null),

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -145,8 +145,10 @@ export class MockElement {
         node.parentElement = null;
     }
 
-    addClass(cls: string): void {
-        cls.split(" ").forEach((c) => this.classList.add(c));
+    addClass(...classes: string[]): void {
+        for (const arg of classes) {
+            arg.split(" ").forEach((c) => c && this.classList.add(c));
+        }
     }
 
     removeClass(...classes: string[]): void {
@@ -488,8 +490,9 @@ export class Plugin {
         return el;
     });
 
-    addRibbonIcon = vi.fn((_icon: string, _title: string, _callback: () => void) => {
+    addRibbonIcon = vi.fn((_icon: string, _title: string, callback: () => void) => {
         const el = new MockElement("div");
+        el.addEventListener("click", callback);
         return el;
     });
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -991,6 +991,18 @@ describe("LilbeePlugin", () => {
             expect(updateSpy).toHaveBeenCalledTimes(1);
             vi.useRealTimers();
         });
+
+        it("timer callback bails when the plugin was disposed mid-debounce", async () => {
+            vi.useFakeTimers();
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            const updateSpy = vi.spyOn(plugin, "updatePendingSyncHint").mockResolvedValue(undefined);
+            (plugin as any).schedulePendingSyncHint();
+            plugin.syncHintEl = null;
+            vi.advanceTimersByTime(2000);
+            expect(updateSpy).not.toHaveBeenCalled();
+            vi.useRealTimers();
+        });
     });
 
     describe("updatePendingSyncHint()", () => {
@@ -1109,6 +1121,14 @@ describe("LilbeePlugin", () => {
             await plugin.onload();
             plugin.syncHintEl = null;
             await expect(plugin.updatePendingSyncHint()).resolves.toBeUndefined();
+        });
+
+        it("returns 0 silently when the vault adapter is gone (timer fired post-teardown)", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+            await expect(plugin.updatePendingSyncHint()).resolves.toBeUndefined();
+            expect(plugin.syncHintEl?.style.display).toBe("none");
         });
 
         it("hint click triggers sync", async () => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -2896,13 +2896,13 @@ describe("LilbeePlugin", () => {
             const chatLeaf = { setViewState: vi.fn().mockResolvedValue(undefined) };
             const tasksLeaf = { setViewState: vi.fn().mockResolvedValue(undefined) };
             plugin.app.workspace.getLeavesOfType = vi.fn().mockReturnValue([]);
-            plugin.app.workspace.getRightLeaf = vi.fn().mockReturnValue(chatLeaf);
-            plugin.app.workspace.createLeafBySplit = vi.fn().mockReturnValue(tasksLeaf);
+            const getRightLeaf = vi.fn().mockImplementation((split: boolean) => (split ? tasksLeaf : chatLeaf));
+            plugin.app.workspace.getRightLeaf = getRightLeaf;
             plugin.app.workspace.revealLeaf = vi.fn();
             await plugin.openCockpit();
-            expect(plugin.app.workspace.getRightLeaf).toHaveBeenCalled();
+            expect(getRightLeaf).toHaveBeenNthCalledWith(1, false);
+            expect(getRightLeaf).toHaveBeenNthCalledWith(2, true);
             expect(chatLeaf.setViewState).toHaveBeenCalledWith({ type: "lilbee-chat", active: true });
-            expect(plugin.app.workspace.createLeafBySplit).toHaveBeenCalledWith(chatLeaf, "horizontal", false);
             expect(tasksLeaf.setViewState).toHaveBeenCalledWith({ type: "lilbee-tasks", active: true });
             expect(plugin.app.workspace.revealLeaf).toHaveBeenCalledWith(chatLeaf);
             expect(plugin.app.workspace.revealLeaf).toHaveBeenCalledWith(tasksLeaf);
@@ -2919,11 +2919,9 @@ describe("LilbeePlugin", () => {
                 return [];
             });
             plugin.app.workspace.getRightLeaf = vi.fn();
-            plugin.app.workspace.createLeafBySplit = vi.fn();
             plugin.app.workspace.revealLeaf = vi.fn();
             await plugin.openCockpit();
             expect(plugin.app.workspace.getRightLeaf).not.toHaveBeenCalled();
-            expect(plugin.app.workspace.createLeafBySplit).not.toHaveBeenCalled();
             expect(existingChat.setViewState).not.toHaveBeenCalled();
             expect(existingTasks.setViewState).not.toHaveBeenCalled();
             expect(plugin.app.workspace.revealLeaf).toHaveBeenCalledWith(existingChat);
@@ -2935,20 +2933,19 @@ describe("LilbeePlugin", () => {
             await plugin.onload();
             plugin.app.workspace.getLeavesOfType = vi.fn().mockReturnValue([]);
             plugin.app.workspace.getRightLeaf = vi.fn().mockReturnValue(null);
-            plugin.app.workspace.createLeafBySplit = vi.fn();
             plugin.app.workspace.revealLeaf = vi.fn();
             await plugin.openCockpit();
-            expect(plugin.app.workspace.createLeafBySplit).not.toHaveBeenCalled();
             expect(plugin.app.workspace.revealLeaf).not.toHaveBeenCalled();
         });
 
-        it("opens chat alone when createLeafBySplit returns null", async () => {
+        it("opens chat alone when the split call returns null", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
             const chatLeaf = { setViewState: vi.fn().mockResolvedValue(undefined) };
             plugin.app.workspace.getLeavesOfType = vi.fn().mockReturnValue([]);
-            plugin.app.workspace.getRightLeaf = vi.fn().mockReturnValue(chatLeaf);
-            plugin.app.workspace.createLeafBySplit = vi.fn().mockReturnValue(null);
+            plugin.app.workspace.getRightLeaf = vi
+                .fn()
+                .mockImplementation((split: boolean) => (split ? null : chatLeaf));
             plugin.app.workspace.revealLeaf = vi.fn();
             await plugin.openCockpit();
             expect(plugin.app.workspace.revealLeaf).toHaveBeenCalledWith(chatLeaf);
@@ -3255,7 +3252,8 @@ describe("LilbeePlugin", () => {
             await plugin.onload();
             const spy = vi.spyOn(plugin, "activateTaskView").mockResolvedValue(undefined);
             const calls = (plugin.addRibbonIcon as ReturnType<typeof vi.fn>).mock.calls;
-            const callback = calls[0]?.[2] as () => void;
+            const taskCenterCall = calls.find((c) => c[0] === "list-checks")!;
+            const callback = taskCenterCall[2] as () => void;
             callback();
             expect(spy).toHaveBeenCalledTimes(1);
         });
@@ -3379,6 +3377,26 @@ describe("LilbeePlugin", () => {
             expect(ribbon.classList.contains("lilbee-ribbon-success")).toBe(false);
             expect(ribbon.classList.contains("lilbee-ribbon-error")).toBe(false);
             expect(ribbon.classList.contains("lilbee-ribbon-active")).toBe(false);
+        });
+
+        it("registers a chat ribbon icon distinct from the task ribbon", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const chatRibbon = (plugin as any).chatRibbonIconEl as any;
+            const taskRibbon = (plugin as any).ribbonIconEl as any;
+            expect(chatRibbon).toBeTruthy();
+            expect(chatRibbon).not.toBe(taskRibbon);
+            expect(chatRibbon.classList.contains("lilbee-ribbon-chat")).toBe(true);
+        });
+
+        it("chat ribbon click activates the chat view", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const chatRibbon = (plugin as any).chatRibbonIconEl as any;
+            const spy = vi.spyOn(plugin, "activateChatView").mockResolvedValue(undefined);
+            chatRibbon.trigger("click");
+            expect(spy).toHaveBeenCalled();
+            spy.mockRestore();
         });
     });
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -2890,19 +2890,18 @@ describe("LilbeePlugin", () => {
     });
 
     describe("openCockpit()", () => {
-        it("opens chat in the right sidebar and stacks the task center below it", async () => {
+        it("opens chat in the right sidebar and splits the task center under the editor", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
             const chatLeaf = { setViewState: vi.fn().mockResolvedValue(undefined) };
             const tasksLeaf = { setViewState: vi.fn().mockResolvedValue(undefined) };
             plugin.app.workspace.getLeavesOfType = vi.fn().mockReturnValue([]);
-            const getRightLeaf = vi.fn().mockImplementation((split: boolean) => (split ? tasksLeaf : chatLeaf));
-            plugin.app.workspace.getRightLeaf = getRightLeaf;
+            plugin.app.workspace.getRightLeaf = vi.fn().mockReturnValue(chatLeaf);
+            plugin.app.workspace.getLeaf = vi.fn().mockReturnValue(tasksLeaf);
             plugin.app.workspace.revealLeaf = vi.fn();
             await plugin.openCockpit();
-            expect(getRightLeaf).toHaveBeenNthCalledWith(1, false);
-            expect(getRightLeaf).toHaveBeenNthCalledWith(2, true);
             expect(chatLeaf.setViewState).toHaveBeenCalledWith({ type: "lilbee-chat", active: true });
+            expect(plugin.app.workspace.getLeaf).toHaveBeenCalledWith("split", "horizontal");
             expect(tasksLeaf.setViewState).toHaveBeenCalledWith({ type: "lilbee-tasks", active: true });
             expect(plugin.app.workspace.revealLeaf).toHaveBeenCalledWith(chatLeaf);
             expect(plugin.app.workspace.revealLeaf).toHaveBeenCalledWith(tasksLeaf);
@@ -2938,14 +2937,13 @@ describe("LilbeePlugin", () => {
             expect(plugin.app.workspace.revealLeaf).not.toHaveBeenCalled();
         });
 
-        it("opens chat alone when the split call returns null", async () => {
+        it("opens chat alone when the editor-split call returns null", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
             const chatLeaf = { setViewState: vi.fn().mockResolvedValue(undefined) };
             plugin.app.workspace.getLeavesOfType = vi.fn().mockReturnValue([]);
-            plugin.app.workspace.getRightLeaf = vi
-                .fn()
-                .mockImplementation((split: boolean) => (split ? null : chatLeaf));
+            plugin.app.workspace.getRightLeaf = vi.fn().mockReturnValue(chatLeaf);
+            plugin.app.workspace.getLeaf = vi.fn().mockReturnValue(null);
             plugin.app.workspace.revealLeaf = vi.fn();
             await plugin.openCockpit();
             expect(plugin.app.workspace.revealLeaf).toHaveBeenCalledWith(chatLeaf);


### PR DESCRIPTION
## Problem

Auto-open on launch dropped both views into the same right-sidebar slot. Obsidian collapsed them into tabs, so only one was visible at a time — and there was no obvious entry point for chat besides the slash command.

```
┌────┬─────────────────────────┬──────────────────────┐
│    │                         │  [Chat] [Tasks]      │  ← tabs
│ Rib│                         │                      │
│ bon│      Note / PDF         │     Chat panel       │
│    │                         │   (Tasks hidden)     │
│    │                         │                      │
└────┴─────────────────────────┴──────────────────────┘
```

## Solution

Chat goes in the right sidebar. Task center splits the main editor horizontally and sits underneath whatever you're reading. Both visible, no tabs.

```
┌────┬─────────────────────────┬──────────────────────┐
│    │                         │                      │
│ Rib│      Note / PDF         │                      │
│ bon│                         │        Chat          │
│    ├─────────────────────────┤                      │
│    │     Task center         │                      │
└────┴─────────────────────────┴──────────────────────┘
```

A new chat ribbon icon sits next to the task icon so the entry point is always visible:

```
┌────┐
│ 💬 │  ← new: messages-square, opens chat
│ ✓• │  ← list-checks, pulses while tasks run
│ ...│
└────┘
```

The task-ribbon pulse got louder too — the dot grew from 8px to 10px and now pulses with a scaling glow ring while tasks are in flight. Reduced-motion users still get the static dot.

## Changes

- `openCockpit` calls `getRightLeaf(false)` for chat and `getLeaf("split", "horizontal")` for the task center.
- Added `addRibbonIcon("messages-square", …)` for chat. Both ribbon icons live for the lifetime of the plugin.
- `styles.css` keyframe `lilbee-ribbon-glow` replaces the old static dot animation.
- Tests cover both ribbon icons, the layout call sequence, and the split-returns-null fallback. 2073 tests, 100% coverage.