### PR TITLE
Fix four UI bugs surfaced found while making a demo reel

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "lilbee",
 	"name": "lilbee",
-	"version": "0.6.66b425",
+	"version": "0.6.66b426",
 	"minAppVersion": "1.0.0",
 	"description": "Chat with your vault and verify every answer at the source. Click any citation to preview the cited passage in place.",
 	"author": "tobocop2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-lilbee",
-  "version": "0.6.66b425",
+  "version": "0.6.66b426",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-lilbee",
-      "version": "0.6.66b425",
+      "version": "0.6.66b426",
       "dependencies": {
         "neverthrow": "^8.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-lilbee",
-  "version": "0.6.66b425",
+  "version": "0.6.66b426",
   "private": true,
   "scripts": {
     "build": "node esbuild.config.mjs production",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -125,33 +125,37 @@ export class LilbeeSettingTab extends PluginSettingTab {
     private filterSettings(containerEl: HTMLElement, query: string): void {
         const term = query.trim().toLowerCase();
         const matches = (item: Element): boolean => {
-            const nameEl = item.querySelector(".setting-item-name");
-            const name = nameEl?.textContent?.toLowerCase() ?? "";
-            return !term || name.includes(term);
+            const name = item.querySelector(".setting-item-name")?.textContent?.toLowerCase() ?? "";
+            const desc = item.querySelector(".setting-item-description")?.textContent?.toLowerCase() ?? "";
+            return !term || name.includes(term) || desc.includes(term);
         };
 
-        // Top-level setting-items live as direct children of containerEl,
-        // outside any .lilbee-settings-section wrapper. The original
-        // implementation only walked into sections, so the bulk of the
-        // settings page (server controls, port, models, etc.) stayed
-        // visible regardless of the filter query.
-        for (const child of Array.from(containerEl.children)) {
-            if (!child.classList.contains("setting-item")) continue;
-            (child as HTMLElement).style.display = matches(child) ? "" : "none";
+        // Hide / show every setting-item by walking the whole tree, not just
+        // direct children of containerEl. The previous implementation only
+        // touched top-level items + items inside `.lilbee-settings-section`,
+        // missing every row nested in `.lilbee-models-container`,
+        // `.lilbee-chat-container`, `.lilbee-embedding-container`, etc. -- so
+        // typing "results" used to leave Active chat model, Crawl depth,
+        // Page timeout and dozens of unrelated rows visible.
+        for (const item of Array.from(containerEl.querySelectorAll(".setting-item"))) {
+            (item as HTMLElement).style.display = matches(item) ? "" : "none";
         }
 
-        const sections = containerEl.querySelectorAll(".lilbee-settings-section");
-        for (const section of Array.from(sections)) {
-            const items = section.querySelectorAll(".setting-item");
-            let visibleCount = 0;
-            for (const item of Array.from(items)) {
-                const m = matches(item);
-                (item as HTMLElement).style.display = m ? "" : "none";
-                if (m) visibleCount++;
-            }
-            (section as HTMLElement).style.display = visibleCount > 0 || !term ? "" : "none";
-            if (term && visibleCount > 0) {
-                section.setAttribute("open", "");
+        // Container wrappers (sections + model-task containers) should hide
+        // themselves when they have nothing matching to show, so the filtered
+        // view doesn't end with a row of empty group headings.
+        const wrappers = containerEl.querySelectorAll(
+            ".lilbee-settings-section, .lilbee-models-container, .lilbee-chat-container, " +
+                ".lilbee-embedding-container, .lilbee-vision-container, .lilbee-reranker-container, " +
+                ".lilbee-model-section",
+        );
+        for (const wrapper of Array.from(wrappers)) {
+            const items = Array.from(wrapper.querySelectorAll(".setting-item"));
+            const anyVisible = items.some((i) => (i as HTMLElement).style.display !== "none");
+            (wrapper as HTMLElement).style.display = anyVisible || !term ? "" : "none";
+            // Auto-expand <details> sections when the filter narrows them.
+            if (term && anyVisible && wrapper.tagName === "DETAILS") {
+                wrapper.setAttribute("open", "");
             }
         }
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -130,20 +130,10 @@ export class LilbeeSettingTab extends PluginSettingTab {
             return !term || name.includes(term) || desc.includes(term);
         };
 
-        // Hide / show every setting-item by walking the whole tree, not just
-        // direct children of containerEl. The previous implementation only
-        // touched top-level items + items inside `.lilbee-settings-section`,
-        // missing every row nested in `.lilbee-models-container`,
-        // `.lilbee-chat-container`, `.lilbee-embedding-container`, etc. -- so
-        // typing "results" used to leave Active chat model, Crawl depth,
-        // Page timeout and dozens of unrelated rows visible.
         for (const item of Array.from(containerEl.querySelectorAll(".setting-item"))) {
             (item as HTMLElement).style.display = matches(item) ? "" : "none";
         }
 
-        // Container wrappers (sections + model-task containers) should hide
-        // themselves when they have nothing matching to show, so the filtered
-        // view doesn't end with a row of empty group headings.
         const wrappers = containerEl.querySelectorAll(
             ".lilbee-settings-section, .lilbee-models-container, .lilbee-chat-container, " +
                 ".lilbee-embedding-container, .lilbee-vision-container, .lilbee-reranker-container, " +
@@ -153,7 +143,6 @@ export class LilbeeSettingTab extends PluginSettingTab {
             const items = Array.from(wrapper.querySelectorAll(".setting-item"));
             const anyVisible = items.some((i) => (i as HTMLElement).style.display !== "none");
             (wrapper as HTMLElement).style.display = anyVisible || !term ? "" : "none";
-            // Auto-expand <details> sections when the filter narrows them.
             if (term && anyVisible && wrapper.tagName === "DETAILS") {
                 wrapper.setAttribute("open", "");
             }

--- a/src/types.ts
+++ b/src/types.ts
@@ -359,6 +359,17 @@ export const CONTENT_TYPE = {
     HTML: "text/html",
 } as const;
 
+/**
+ * True if `value` denotes a PDF. The server returns both the short form
+ * (``"pdf"`` from ``/api/search``) and the full MIME type
+ * (``"application/pdf"`` from ``/api/source``); the plugin's PDF-routing
+ * code paths must accept both or PDF citations silently fall through to
+ * native-open-without-page-anchor.
+ */
+export function isPdfContentType(value: string | null | undefined): boolean {
+    return value === CONTENT_TYPE.PDF || value === "pdf";
+}
+
 export interface SizeVariant {
     size_label: string;
     params: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -355,19 +355,13 @@ export const JSON_HEADERS = { "Content-Type": "application/json" } as const;
 /** MIME content types referenced across click dispatch + preview rendering. */
 export const CONTENT_TYPE = {
     PDF: "application/pdf",
+    PDF_SHORT: "pdf",
     MARKDOWN: "text/markdown",
     HTML: "text/html",
 } as const;
 
-/**
- * True if `value` denotes a PDF. The server returns both the short form
- * (``"pdf"`` from ``/api/search``) and the full MIME type
- * (``"application/pdf"`` from ``/api/source``); the plugin's PDF-routing
- * code paths must accept both or PDF citations silently fall through to
- * native-open-without-page-anchor.
- */
 export function isPdfContentType(value: string | null | undefined): boolean {
-    return value === CONTENT_TYPE.PDF || value === "pdf";
+    return value === CONTENT_TYPE.PDF || value === CONTENT_TYPE.PDF_SHORT;
 }
 
 export interface SizeVariant {
@@ -454,10 +448,31 @@ export interface EmbeddingModelResponse {
     model: string;
 }
 
-/** All page-type strings the server emits via /api/wiki. Matches
- * lilbee.wiki.shared.SUBDIR_TO_TYPE values; if a new subdir is added on
- * the server, this union must grow with it. */
-export type WikiPageType = "summary" | "synthesis" | "concept" | "entity" | "draft" | "archive";
+export const WIKI_PAGE_TYPE = {
+    SUMMARY: "summary",
+    SYNTHESIS: "synthesis",
+    CONCEPT: "concept",
+    ENTITY: "entity",
+    DRAFT: "draft",
+    ARCHIVE: "archive",
+} as const;
+
+export type WikiPageType = (typeof WIKI_PAGE_TYPE)[keyof typeof WIKI_PAGE_TYPE];
+
+/** Wiki pages that count as "published" — sidebar lists them, vault sync writes them. */
+export const PUBLISHED_WIKI_PAGE_TYPES: ReadonlySet<WikiPageType> = new Set([
+    WIKI_PAGE_TYPE.SUMMARY,
+    WIKI_PAGE_TYPE.SYNTHESIS,
+    WIKI_PAGE_TYPE.CONCEPT,
+    WIKI_PAGE_TYPE.ENTITY,
+]);
+
+/** Subset of published types grouped under "Concepts" in the sidebar. */
+export const CONCEPT_WIKI_PAGE_TYPES: ReadonlySet<WikiPageType> = new Set([
+    WIKI_PAGE_TYPE.SYNTHESIS,
+    WIKI_PAGE_TYPE.CONCEPT,
+    WIKI_PAGE_TYPE.ENTITY,
+]);
 
 export interface WikiPage {
     slug: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -454,10 +454,15 @@ export interface EmbeddingModelResponse {
     model: string;
 }
 
+/** All page-type strings the server emits via /api/wiki. Matches
+ * lilbee.wiki.shared.SUBDIR_TO_TYPE values; if a new subdir is added on
+ * the server, this union must grow with it. */
+export type WikiPageType = "summary" | "synthesis" | "concept" | "entity" | "draft" | "archive";
+
 export interface WikiPage {
     slug: string;
     title: string;
-    page_type: "summary" | "synthesis";
+    page_type: WikiPageType;
     source_count: number;
     created_at: string | null;
 }

--- a/src/utils/source-click.ts
+++ b/src/utils/source-click.ts
@@ -1,7 +1,7 @@
 import type { App, Vault } from "obsidian";
 import type { LilbeeClient } from "../api";
 import type { Source } from "../types";
-import { CONTENT_TYPE } from "../types";
+import { CONTENT_TYPE, isPdfContentType } from "../types";
 import { SourcePreviewModal } from "../views/source-preview-modal";
 
 /** Discriminator tags for `SourceClickAction`. */
@@ -56,7 +56,7 @@ function vaultAction(source: Source, path: string): SourceClickAction {
  * can be resolved.
  */
 export function sourceClickAction(source: Source, vault: Vault): SourceClickAction {
-    if (source.content_type === CONTENT_TYPE.PDF) {
+    if (isPdfContentType(source.content_type)) {
         return { kind: SOURCE_ACTION.PREVIEW, source };
     }
     const vaultPath = source.vault_path;

--- a/src/views/source-preview-modal.ts
+++ b/src/views/source-preview-modal.ts
@@ -1,7 +1,7 @@
 import { App, MarkdownRenderer, Modal, Notice } from "obsidian";
 import type { LilbeeClient } from "../api";
 import type { Source, SourceContent } from "../types";
-import { isPdfContentType } from "../types";
+import { CONTENT_TYPE, isPdfContentType } from "../types";
 import { MESSAGES } from "../locales/en";
 import { bindEscapeToClose, errorMessage } from "../utils";
 import { formatLocation } from "./results";
@@ -223,7 +223,7 @@ export class SourcePreviewModal extends Modal {
     private renderPdf(host: HTMLElement): void {
         const body = host.createDiv({ cls: "lilbee-preview-body" });
         const frame = body.createEl("object", { cls: "lilbee-preview-pdf-frame" });
-        frame.setAttribute("type", "application/pdf");
+        frame.setAttribute("type", CONTENT_TYPE.PDF);
         frame.setAttribute("data", this.rawSourceUrl(this.source.page_start));
     }
 

--- a/src/views/source-preview-modal.ts
+++ b/src/views/source-preview-modal.ts
@@ -1,7 +1,7 @@
 import { App, MarkdownRenderer, Modal, Notice } from "obsidian";
 import type { LilbeeClient } from "../api";
 import type { Source, SourceContent } from "../types";
-import { CONTENT_TYPE } from "../types";
+import { isPdfContentType } from "../types";
 import { MESSAGES } from "../locales/en";
 import { bindEscapeToClose, errorMessage } from "../utils";
 import { formatLocation } from "./results";
@@ -199,7 +199,7 @@ export class SourcePreviewModal extends Modal {
 
     private renderBody(host: HTMLElement, content: SourceContent): void {
         const ct = content.content_type;
-        const isPdf = this.source.content_type === CONTENT_TYPE.PDF || ct === CONTENT_TYPE.PDF;
+        const isPdf = isPdfContentType(this.source.content_type) || isPdfContentType(ct);
         if (isPdf) {
             this.renderPdf(host);
             return;

--- a/src/views/wiki-view.ts
+++ b/src/views/wiki-view.ts
@@ -99,9 +99,15 @@ export class WikiView extends ItemView {
             return;
         }
 
-        // Group by type
+        // Group by type. The server emits "summary" + "synthesis" +
+        // "concept" + "entity" (lilbee.wiki.shared.SUBDIR_TO_TYPE);
+        // grouping concept/entity/synthesis together as "concepts" keeps
+        // the sidebar layout simple while still surfacing every published
+        // page the server knows about.
         const summaries = filtered.filter((p) => p.page_type === "summary");
-        const concepts = filtered.filter((p) => p.page_type === "synthesis");
+        const concepts = filtered.filter(
+            (p) => p.page_type === "synthesis" || p.page_type === "concept" || p.page_type === "entity",
+        );
 
         if (summaries.length > 0) {
             this.renderGroup(this.listEl, MESSAGES.LABEL_WIKI_SUMMARIES, summaries);

--- a/src/views/wiki-view.ts
+++ b/src/views/wiki-view.ts
@@ -1,6 +1,7 @@
 import { ItemView, MarkdownRenderer, setIcon, WorkspaceLeaf } from "obsidian";
 import type LilbeePlugin from "../main";
 import type { WikiPage, WikiPageDetail } from "../types";
+import { CONCEPT_WIKI_PAGE_TYPES, WIKI_PAGE_TYPE } from "../types";
 import { MESSAGES } from "../locales/en";
 import { relativeTime } from "../utils";
 import { CitationModal } from "./citation-modal";
@@ -99,15 +100,8 @@ export class WikiView extends ItemView {
             return;
         }
 
-        // Group by type. The server emits "summary" + "synthesis" +
-        // "concept" + "entity" (lilbee.wiki.shared.SUBDIR_TO_TYPE);
-        // grouping concept/entity/synthesis together as "concepts" keeps
-        // the sidebar layout simple while still surfacing every published
-        // page the server knows about.
-        const summaries = filtered.filter((p) => p.page_type === "summary");
-        const concepts = filtered.filter(
-            (p) => p.page_type === "synthesis" || p.page_type === "concept" || p.page_type === "entity",
-        );
+        const summaries = filtered.filter((p) => p.page_type === WIKI_PAGE_TYPE.SUMMARY);
+        const concepts = filtered.filter((p) => CONCEPT_WIKI_PAGE_TYPES.has(p.page_type));
 
         if (summaries.length > 0) {
             this.renderGroup(this.listEl, MESSAGES.LABEL_WIKI_SUMMARIES, summaries);

--- a/src/wiki-sync.ts
+++ b/src/wiki-sync.ts
@@ -1,5 +1,6 @@
 import type { DataAdapter } from "obsidian";
 import type { WikiPage, WikiPageDetail } from "./types";
+import { PUBLISHED_WIKI_PAGE_TYPES } from "./types";
 import type { LilbeeClient } from "./api";
 
 const MANAGED_MARKER = "lilbee_managed";
@@ -38,16 +39,7 @@ export class WikiSync {
 
     async reconcile(): Promise<{ written: number; removed: number }> {
         const pages = await this.api.wikiList();
-        // Published page types -- everything not in drafts/archive. Keep in
-        // sync with the server-side SUBDIR_TO_TYPE values: summary,
-        // synthesis, concept, entity all represent published wiki content.
-        const publishedPages = pages.filter(
-            (p) =>
-                p.page_type === "summary" ||
-                p.page_type === "synthesis" ||
-                p.page_type === "concept" ||
-                p.page_type === "entity",
-        );
+        const publishedPages = pages.filter((p) => PUBLISHED_WIKI_PAGE_TYPES.has(p.page_type));
 
         await this.ensureFolders();
 

--- a/src/wiki-sync.ts
+++ b/src/wiki-sync.ts
@@ -38,7 +38,16 @@ export class WikiSync {
 
     async reconcile(): Promise<{ written: number; removed: number }> {
         const pages = await this.api.wikiList();
-        const publishedPages = pages.filter((p) => p.page_type === "summary" || p.page_type === "synthesis");
+        // Published page types -- everything not in drafts/archive. Keep in
+        // sync with the server-side SUBDIR_TO_TYPE values: summary,
+        // synthesis, concept, entity all represent published wiki content.
+        const publishedPages = pages.filter(
+            (p) =>
+                p.page_type === "summary" ||
+                p.page_type === "synthesis" ||
+                p.page_type === "concept" ||
+                p.page_type === "entity",
+        );
 
         await this.ensureFolders();
 

--- a/styles.css
+++ b/styles.css
@@ -539,10 +539,7 @@
     border-bottom: none;
 }
 
-/* Catalog action cell: keep "Installed" pill + trash on one row. The td
-   is ~100 px wide so inline layout wraps; flex with justify-end keeps
-   the cluster anchored right and centers the trash button against the
-   pill instead of stacking below it. */
+/* Keep "Installed" pill + trash on one row at narrow column widths. */
 .lilbee-model-catalog td:last-child {
     display: flex;
     align-items: center;

--- a/styles.css
+++ b/styles.css
@@ -539,14 +539,28 @@
     border-bottom: none;
 }
 
+/* Catalog action cell: keep "Installed" pill + trash on one row. The td
+   is ~100 px wide so inline layout wraps; flex with justify-end keeps
+   the cluster anchored right and centers the trash button against the
+   pill instead of stacking below it. */
+.lilbee-model-catalog td:last-child {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--size-4-1, 4px);
+    white-space: nowrap;
+}
+
 .lilbee-installed {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
     padding: 1px var(--size-4-2, 8px);
     border-radius: 999px;
     background-color: var(--text-success);
     color: var(--text-on-accent);
     font-size: var(--font-smallest, 10px);
     font-weight: var(--font-medium, 500);
+    line-height: 1.4;
 }
 
 .lilbee-progress-row {
@@ -594,9 +608,14 @@
     cursor: pointer;
     color: var(--text-muted);
     padding: 2px;
-    margin-left: var(--size-4-2, 8px);
     border-radius: var(--radius-s, 4px);
     vertical-align: middle;
+    flex: 0 0 auto;
+}
+
+.lilbee-model-delete .svg-icon {
+    width: 16px;
+    height: 16px;
 }
 
 .lilbee-model-delete:hover {

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -215,10 +215,18 @@ export class MockElement {
     }
 
     querySelectorAll(selector: string): MockElement[] {
-        if (selector.startsWith(".")) {
-            return this.findAll(selector.slice(1));
+        const seen = new Set<MockElement>();
+        const results: MockElement[] = [];
+        for (const part of selector.split(",")) {
+            const trimmed = part.trim();
+            if (!trimmed.startsWith(".")) continue;
+            for (const el of this.findAll(trimmed.slice(1))) {
+                if (seen.has(el)) continue;
+                seen.add(el);
+                results.push(el);
+            }
         }
-        return [];
+        return results;
     }
 
     createSpan(opts?: { cls?: string; text?: string }): MockElement {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -3538,6 +3538,55 @@ describe("managed mode settings", () => {
             expect(filterInput.style.display).not.toBe("none");
             expect(item.style.display).toBe("");
         });
+
+        it("matches against the description text when the name doesn't include the term", () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            tab.display();
+
+            const container = new MockElement("div") as any;
+            const item = container.createDiv({ cls: "setting-item" });
+            item.createDiv({ cls: "setting-item-name" }).textContent = "Adaptive threshold";
+            item.createDiv({ cls: "setting-item-description" }).textContent = "Cap on top-k retrieval";
+
+            (tab as any).filterSettings(container, "retrieval");
+            expect(item.style.display).toBe("");
+        });
+
+        it("treats null description textContent the same as missing description", () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            tab.display();
+
+            const container = new MockElement("div") as any;
+            const item = container.createDiv({ cls: "setting-item" });
+            item.createDiv({ cls: "setting-item-name" }).textContent = "Server port";
+            const desc = item.createDiv({ cls: "setting-item-description" });
+            // Simulate the element existing with no text -- exercises the
+            // ?.textContent short-circuit branch.
+            desc.textContent = null;
+
+            (tab as any).filterSettings(container, "anything");
+            expect(item.style.display).toBe("none");
+        });
+
+        it("hides containers whose descendants are all hidden", () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            tab.display();
+
+            const container = new MockElement("div") as any;
+            const wrapper = container.createDiv({ cls: "lilbee-chat-container" });
+            const item = wrapper.createDiv({ cls: "setting-item" });
+            item.createDiv({ cls: "setting-item-name" }).textContent = "Active chat model";
+
+            (tab as any).filterSettings(container, "nomatchanywhere");
+            expect(item.style.display).toBe("none");
+            expect(wrapper.style.display).toBe("none");
+        });
     });
 
     describe("LiteLLM base URL onChange", () => {


### PR DESCRIPTION
Four UI bugs, each independent. Pulled out of the demo-reel work so they can ship without waiting on demo iteration.

- **PDF citations open at page 1 instead of the cited page.** Server returns `"pdf"` from `/api/search` and `"application/pdf"` from `/api/source`; the click gate only accepted the MIME, so PDFs fell through to a non-deep-linking path.
- **Wiki sidebar renders empty for new wikis.** Plugin filtered for `synthesis` only; server emits `concept` + `entity` too.
- **Settings catalog: green "Installed" pill visually overlaps the trash icon.** Cell wrapped the trash under the pill at narrow widths.
- **Settings filter input doesn't actually filter most settings.** It only walked top-level children; settings nested in model-task containers (chat, embedding, vision, reranker) were ignored.

All four are visible in the plugin today. Ready to merge.