### PR TITLE
Managed mode: stop sending stale paste-token + show actionable error

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "lilbee",
 	"name": "lilbee",
-	"version": "0.6.66b426",
+	"version": "0.6.66b427",
 	"minAppVersion": "1.0.0",
 	"description": "Chat with your vault and verify every answer at the source. Click any citation to preview the cited passage in place.",
 	"author": "tobocop2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-lilbee",
-  "version": "0.6.66b426",
+  "version": "0.6.66b427",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-lilbee",
-      "version": "0.6.66b426",
+      "version": "0.6.66b427",
       "dependencies": {
         "neverthrow": "^8.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-lilbee",
-  "version": "0.6.66b426",
+  "version": "0.6.66b427",
   "private": true,
   "scripts": {
     "build": "node esbuild.config.mjs production",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -506,6 +506,8 @@ export const MESSAGES = {
     NOTICE_NO_TOKEN_EXTERNAL:
         "lilbee: no session token — run 'lilbee token' and paste it in Settings → Session token, or set LILBEE_DATA",
     NOTICE_SESSION_TOKEN_INVALID: "lilbee: session token invalid — paste a new one in Settings → Session token",
+    NOTICE_SESSION_TOKEN_INVALID_MANAGED:
+        "lilbee: managed server rejected its own token — restart the server from Settings → Switch to managed server, or open Status for logs",
     NOTICE_QUEUE_FULL: "lilbee: too many tasks queued — wait for some to finish",
     NOTICE_MODEL_ACTIVATED_FULL: (model: string) => `lilbee: ${model} pulled and activated`,
     NOTICE_SET_MODEL: (type: string, model: string) => `${type} set to ${model}`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -520,15 +520,14 @@ export default class LilbeePlugin extends Plugin {
     /**
      * Read the lilbee session token.
      *
-     * Managed mode: reads from the plugin-owned server-data directory.
+     * Managed mode: server-manager's dataDir owns the token. `manualToken`
+     * is only consulted in external mode -- sending an external-mode paste
+     * to the managed server produces a misleading "paste a new token" error.
+     *
      * External mode: auto-discovers the user's data root the same way lilbee
      * itself does (LILBEE_DATA env > .lilbee walk-up > platform default).
      */
     private readCurrentToken(): string | null {
-        // Managed mode owns its own token in the plugin-managed dataDir;
-        // a paste-token (which belongs to external mode) must not be sent
-        // to the managed server, or the server rejects it as stale and
-        // the user sees the misleading "paste a new one" notice.
         if (this.settings.serverMode === SERVER_MODE.MANAGED) {
             return this.serverManager ? readSessionToken(this.serverManager.dataDir) : null;
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ import {
     NOTICE_DURATION_MS,
     NOTICE_ERROR_DURATION_MS,
     NOTICE_PERMANENT,
+    sessionTokenInvalidMessage,
     STREAM_IDLE_TIMEOUT_MS,
     StreamIdleError,
     withIdleTimeout,
@@ -524,11 +525,15 @@ export default class LilbeePlugin extends Plugin {
      * itself does (LILBEE_DATA env > .lilbee walk-up > platform default).
      */
     private readCurrentToken(): string | null {
-        if (this.settings.manualToken) {
-            return this.settings.manualToken;
-        }
+        // Managed mode owns its own token in the plugin-managed dataDir;
+        // a paste-token (which belongs to external mode) must not be sent
+        // to the managed server, or the server rejects it as stale and
+        // the user sees the misleading "paste a new one" notice.
         if (this.settings.serverMode === SERVER_MODE.MANAGED) {
             return this.serverManager ? readSessionToken(this.serverManager.dataDir) : null;
+        }
+        if (this.settings.manualToken) {
+            return this.settings.manualToken;
         }
         const dataRoot = resolveExternalDataRoot(this.getVaultBasePath());
         return readSessionToken(dataRoot);
@@ -1242,8 +1247,9 @@ export default class LilbeePlugin extends Plugin {
                 this.taskQueue.cancel(taskId);
                 this.markAddFailed(retryKeys);
             } else if (err instanceof SessionTokenError) {
-                new Notice(MESSAGES.NOTICE_SESSION_TOKEN_INVALID);
-                this.taskQueue.fail(taskId, MESSAGES.NOTICE_SESSION_TOKEN_INVALID);
+                const msg = sessionTokenInvalidMessage(this.settings.serverMode);
+                new Notice(msg);
+                this.taskQueue.fail(taskId, msg);
                 this.markAddFailed(retryKeys);
             } else {
                 console.error("[lilbee] add failed:", err);
@@ -1696,13 +1702,9 @@ export default class LilbeePlugin extends Plugin {
                 new Notice(MESSAGES.STATUS_SYNC_CANCELLED);
                 this.taskQueue.cancel(taskId);
             } else if (err instanceof SessionTokenError) {
-                // Auto-sync gets 401 when the stored token is stale — e.g. the
-                // server restarted with a new data-dir. Surface the same
-                // actionable notice the manual-sync paths do so the user
-                // knows to paste a fresh token in Settings instead of
-                // wondering why sync silently stopped working.
-                new Notice(MESSAGES.NOTICE_SESSION_TOKEN_INVALID);
-                this.taskQueue.fail(taskId, MESSAGES.NOTICE_SESSION_TOKEN_INVALID);
+                const msg = sessionTokenInvalidMessage(this.settings.serverMode);
+                new Notice(msg);
+                this.taskQueue.fail(taskId, msg);
             } else {
                 console.error("[lilbee] sync failed:", err);
                 new Notice(MESSAGES.STATUS_SYNC_FAILED);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -154,15 +154,22 @@ export function formatRate(bytesPerSecond: number): string {
     return `${formatBytes(bytesPerSecond)}/s`;
 }
 
+/** Pick the right session-token-invalid notice for the active server mode. */
+export function sessionTokenInvalidMessage(serverMode: ServerMode): string {
+    return serverMode === SERVER_MODE.MANAGED
+        ? MESSAGES.NOTICE_SESSION_TOKEN_INVALID_MANAGED
+        : MESSAGES.NOTICE_SESSION_TOKEN_INVALID;
+}
+
 /**
  * Pull a human-readable message out of an unknown thrown value.
  * Centralizes the `err instanceof Error ? err.message : <fallback>` pattern.
  * Stale-session-token errors get a dedicated, actionable message so the user
  * knows exactly where to fix it (see SessionTokenError in api.ts).
  */
-export function errorMessage(err: unknown, fallback: string): string {
+export function errorMessage(err: unknown, fallback: string, serverMode?: ServerMode): string {
     if (err instanceof SessionTokenError) {
-        return MESSAGES.NOTICE_SESSION_TOKEN_INVALID;
+        return sessionTokenInvalidMessage(serverMode ?? SERVER_MODE.EXTERNAL);
     }
     return err instanceof Error ? err.message : fallback;
 }
@@ -179,9 +186,9 @@ export function errorMessage(err: unknown, fallback: string): string {
  * caller (Settings panels, CatalogModal, …) surfaces the same actionable diagnostic
  * without duplicating the parse logic.
  */
-export function noticeForResultError(err: unknown, fallback: string): string {
+export function noticeForResultError(err: unknown, fallback: string, serverMode?: ServerMode): string {
     if (err instanceof SessionTokenError) {
-        return MESSAGES.NOTICE_SESSION_TOKEN_INVALID;
+        return sessionTokenInvalidMessage(serverMode ?? SERVER_MODE.EXTERNAL);
     }
     if (err instanceof Error) {
         const detail = extractServerErrorDetail(err.message);

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -234,7 +234,7 @@ export class ChatView extends ItemView {
                 textarea.value = "";
                 void this.sendMessage(text);
             } catch (err) {
-                const reason = errorMessage(err, MESSAGES.ERROR_UNKNOWN);
+                const reason = errorMessage(err, MESSAGES.ERROR_UNKNOWN, this.plugin.settings.serverMode);
                 new Notice(MESSAGES.ERROR_CHAT_FAILED(reason));
             }
         };
@@ -339,7 +339,7 @@ export class ChatView extends ItemView {
             this.chatModeCurrent = mode;
             this.applyActiveClassToChatModeButtons(mode);
         } catch (err) {
-            const reason = errorMessage(err, MESSAGES.ERROR_UNKNOWN);
+            const reason = errorMessage(err, MESSAGES.ERROR_UNKNOWN, this.plugin.settings.serverMode);
             new Notice(MESSAGES.NOTICE_FAILED_UPDATE(`${MESSAGES.LABEL_CHAT_MODE}: ${reason}`));
         }
     }
@@ -668,7 +668,7 @@ export class ChatView extends ItemView {
             } else {
                 this.renderInlineError(
                     assistantBubble,
-                    MESSAGES.ERROR_CHAT_FAILED(errorMessage(err, MESSAGES.ERROR_UNKNOWN)),
+                    MESSAGES.ERROR_CHAT_FAILED(errorMessage(err, MESSAGES.ERROR_UNKNOWN, this.plugin.settings.serverMode)),
                 );
             }
         } finally {

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -668,7 +668,9 @@ export class ChatView extends ItemView {
             } else {
                 this.renderInlineError(
                     assistantBubble,
-                    MESSAGES.ERROR_CHAT_FAILED(errorMessage(err, MESSAGES.ERROR_UNKNOWN, this.plugin.settings.serverMode)),
+                    MESSAGES.ERROR_CHAT_FAILED(
+                        errorMessage(err, MESSAGES.ERROR_UNKNOWN, this.plugin.settings.serverMode),
+                    ),
                 );
             }
         } finally {

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -6,7 +6,13 @@ import { CATALOG_TAB, SERVER_MODE, SERVER_STATE, SSE_EVENT, WIZARD_STEP, ERROR_N
 import { CatalogModal } from "./catalog-modal";
 import { MESSAGES, FILTERS } from "../locales/en";
 import { renderModelCard } from "../components/model-card";
-import { bindEscapeToClose, percentFromSse, extractSseErrorMessage, getSystemMemoryGB } from "../utils";
+import {
+    bindEscapeToClose,
+    extractSseErrorMessage,
+    getSystemMemoryGB,
+    percentFromSse,
+    sessionTokenInvalidMessage,
+} from "../utils";
 
 type FeaturedModel = CatalogEntry;
 type EmbeddingModel = CatalogEntry;
@@ -647,8 +653,9 @@ export class SetupWizard extends Modal {
             if (err instanceof Error && err.name === ERROR_NAME.ABORT_ERROR) {
                 new Notice(MESSAGES.NOTICE_DOWNLOAD_CANCELLED);
             } else if (err instanceof SessionTokenError) {
-                new Notice(MESSAGES.NOTICE_SESSION_TOKEN_INVALID);
-                statusEl.textContent = MESSAGES.NOTICE_SESSION_TOKEN_INVALID;
+                const msg = sessionTokenInvalidMessage(this.plugin.settings.serverMode);
+                new Notice(msg);
+                statusEl.textContent = msg;
             } else {
                 statusEl.textContent = MESSAGES.ERROR_DOWNLOAD_FAILED;
             }
@@ -809,8 +816,9 @@ export class SetupWizard extends Modal {
             if (err instanceof Error && err.name === ERROR_NAME.ABORT_ERROR) {
                 new Notice(MESSAGES.NOTICE_DOWNLOAD_CANCELLED);
             } else if (err instanceof SessionTokenError) {
-                new Notice(MESSAGES.NOTICE_SESSION_TOKEN_INVALID);
-                statusEl.textContent = MESSAGES.NOTICE_SESSION_TOKEN_INVALID;
+                const msg = sessionTokenInvalidMessage(this.plugin.settings.serverMode);
+                new Notice(msg);
+                statusEl.textContent = msg;
             } else {
                 statusEl.textContent = MESSAGES.ERROR_DOWNLOAD_FAILED;
             }
@@ -892,8 +900,9 @@ export class SetupWizard extends Modal {
             if (err instanceof Error && err.name === ERROR_NAME.ABORT_ERROR) {
                 new Notice(MESSAGES.NOTICE_INDEXING_CANCELLED);
             } else if (err instanceof SessionTokenError) {
-                new Notice(MESSAGES.NOTICE_SESSION_TOKEN_INVALID);
-                progressLabel.textContent = MESSAGES.NOTICE_SESSION_TOKEN_INVALID;
+                const msg = sessionTokenInvalidMessage(this.plugin.settings.serverMode);
+                new Notice(msg);
+                progressLabel.textContent = msg;
             } else {
                 progressLabel.textContent = MESSAGES.ERROR_INDEXING_FAILED;
             }

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -458,6 +458,44 @@ describe("LilbeePlugin", () => {
         });
     });
 
+    describe("readCurrentToken() priority", () => {
+        it("managed mode ignores manualToken and reads from serverManager.dataDir", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const { SERVER_MODE } = await import("../src/types");
+            plugin.settings.serverMode = SERVER_MODE.MANAGED;
+            plugin.settings.manualToken = "stale-from-external-mode";
+            (plugin as any).serverManager = { dataDir: "/some/managed/dir" };
+            const sessionToken = await import("../src/session-token");
+            const spy = vi.spyOn(sessionToken, "readSessionToken").mockReturnValue("managed-token-xyz");
+            try {
+                expect((plugin as any).readCurrentToken()).toBe("managed-token-xyz");
+                expect(spy).toHaveBeenCalledWith("/some/managed/dir");
+            } finally {
+                spy.mockRestore();
+            }
+        });
+
+        it("managed mode returns null when serverManager is absent (even with manualToken set)", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const { SERVER_MODE } = await import("../src/types");
+            plugin.settings.serverMode = SERVER_MODE.MANAGED;
+            plugin.settings.manualToken = "stale-from-external-mode";
+            (plugin as any).serverManager = null;
+            expect((plugin as any).readCurrentToken()).toBeNull();
+        });
+
+        it("external mode still honors manualToken first", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const { SERVER_MODE } = await import("../src/types");
+            plugin.settings.serverMode = SERVER_MODE.EXTERNAL;
+            plugin.settings.manualToken = "pasted-token";
+            expect((plugin as any).readCurrentToken()).toBe("pasted-token");
+        });
+    });
+
     describe("settings initialisation", () => {
         it("settings is a separate object from DEFAULT_SETTINGS", async () => {
             const { default: LilbeePlugin } = await import("../src/main");

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -14,6 +14,7 @@ import {
     noticeServerUnreachableIfApplicable,
     percentFromSse,
     relativeTimeFromIso,
+    sessionTokenInvalidMessage,
     StreamIdleError,
     withIdleTimeout,
 } from "../src/utils";
@@ -214,6 +215,33 @@ describe("errorMessage", () => {
     it("uses ERROR_NAME.SESSION_TOKEN constant for the thrown error name", () => {
         const e = new SessionTokenError(403, "bad");
         expect(e.name).toBe(ERROR_NAME.SESSION_TOKEN);
+    });
+
+    it("returns the managed-mode message when serverMode=managed", () => {
+        const out = errorMessage(new SessionTokenError(401, "stale"), "fallback", SERVER_MODE.MANAGED);
+        expect(out).toBe(MESSAGES.NOTICE_SESSION_TOKEN_INVALID_MANAGED);
+    });
+
+    it("returns the external-mode message when serverMode=external", () => {
+        const out = errorMessage(new SessionTokenError(401, "stale"), "fallback", SERVER_MODE.EXTERNAL);
+        expect(out).toBe(MESSAGES.NOTICE_SESSION_TOKEN_INVALID);
+    });
+});
+
+describe("sessionTokenInvalidMessage", () => {
+    it("picks the managed variant for SERVER_MODE.MANAGED", () => {
+        expect(sessionTokenInvalidMessage(SERVER_MODE.MANAGED)).toBe(MESSAGES.NOTICE_SESSION_TOKEN_INVALID_MANAGED);
+    });
+
+    it("picks the external variant for SERVER_MODE.EXTERNAL", () => {
+        expect(sessionTokenInvalidMessage(SERVER_MODE.EXTERNAL)).toBe(MESSAGES.NOTICE_SESSION_TOKEN_INVALID);
+    });
+});
+
+describe("noticeForResultError with serverMode", () => {
+    it("returns the managed-mode token message for SessionTokenError under managed mode", () => {
+        const out = noticeForResultError(new SessionTokenError(401, "stale"), "fallback", SERVER_MODE.MANAGED);
+        expect(out).toBe(MESSAGES.NOTICE_SESSION_TOKEN_INVALID_MANAGED);
     });
 });
 


### PR DESCRIPTION
Chat (and any other request) in managed mode could fail with a notice telling the user to paste a fresh token in Settings -- which does nothing in managed mode and points at the wrong knob.

The plugin was sending a paste-token from a prior external-mode session to the managed server, which rejects it. The error notice was hard-coded for external mode regardless of the active server.

After this PR:
- Managed mode reads its token from the managed server's data directory only; a stale paste-token is no longer sent.
- The notice in managed mode now points at the managed-server reset action and the Status modal logs instead.