### PR TITLE
Plugin: dedupe sidebar leaves + name vault root

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "lilbee",
 	"name": "lilbee",
-	"version": "0.6.66b427",
+	"version": "0.6.66b428",
 	"minAppVersion": "1.0.0",
 	"description": "Chat with your vault and verify every answer at the source. Click any citation to preview the cited passage in place.",
 	"author": "tobocop2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-lilbee",
-  "version": "0.6.66b427",
+  "version": "0.6.66b428",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-lilbee",
-      "version": "0.6.66b427",
+      "version": "0.6.66b428",
       "dependencies": {
         "neverthrow": "^8.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-lilbee",
-  "version": "0.6.66b427",
+  "version": "0.6.66b428",
   "private": true,
   "scripts": {
     "build": "node esbuild.config.mjs production",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -2,6 +2,7 @@ import { MODEL_TASK } from "../types";
 
 export const MESSAGES = {
     CONFIRM_REINDEX: (name: string): string => `"${name}" is already indexed. Re-add it?`,
+    LABEL_VAULT_ROOT: "Vault root",
     CONFIRM_SYNC_REBUILD:
         "Rebuilding the index drops every stored document and re-embeds your whole vault from scratch. This can take a while. Continue?",
     BUTTON_SKIP_SETUP: "Skip setup",

--- a/src/main.ts
+++ b/src/main.ts
@@ -292,6 +292,23 @@ export default class LilbeePlugin extends Plugin {
                 void this.openCockpit();
             });
         }
+
+        // Defend against duplicate sidebar leaves persisted in workspace.json
+        // from prior sessions. activateChatView() / openCockpit() are
+        // idempotent for one leaf, but Obsidian restores whatever was saved,
+        // so a workspace that ended up with two chat panes restores both.
+        this.app.workspace.onLayoutReady(() => {
+            this.dedupeLilbeeLeaves();
+        });
+    }
+
+    /** Collapse multiple lilbee-chat / -tasks / -wiki leaves to one of each. */
+    private dedupeLilbeeLeaves(): void {
+        for (const type of [VIEW_TYPE_CHAT, VIEW_TYPE_TASKS, VIEW_TYPE_WIKI]) {
+            const leaves = this.app.workspace.getLeavesOfType(type);
+            for (let i = 1; i < leaves.length; i++) leaves[i].detach();
+        }
+        this.app.workspace.requestSaveLayout?.();
     }
 
     async startManagedServer(onProgress?: ManagedServerProgressHandler): Promise<void> {
@@ -1138,7 +1155,9 @@ export default class LilbeePlugin extends Plugin {
         if (!this.statusBarEl) return;
         if (!this.assertActiveModel()) return;
         const absolutePath = `${this.getVaultBasePath()}/${file.path}`;
-        const name = file.name ?? file.path;
+        // The vault root's name is the empty string and its path is "/", so
+        // `?? file.path` doesn't fall back; both have to be checked.
+        const name = file.name || file.path || MESSAGES.LABEL_VAULT_ROOT;
 
         const isRetry = this.failedAddPaths.has(absolutePath);
         if (!isRetry && !(await this.confirmReindexIfNeeded(name))) return;

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -402,6 +402,46 @@ describe("LilbeePlugin", () => {
         });
     });
 
+    describe("dedupeLilbeeLeaves()", () => {
+        it("detaches duplicate lilbee-chat / -tasks / -wiki leaves and keeps one of each", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const detached: number[] = [];
+            const fakeLeaf = (i: number) => ({ detach: () => detached.push(i) });
+            const leaves: Record<string, ReturnType<typeof fakeLeaf>[]> = {
+                "lilbee-chat": [fakeLeaf(1), fakeLeaf(2), fakeLeaf(3)],
+                "lilbee-tasks": [fakeLeaf(11), fakeLeaf(12)],
+                "lilbee-wiki": [fakeLeaf(21)],
+            };
+            plugin.app.workspace.getLeavesOfType = vi.fn((t: string) => (leaves[t] ?? []) as any);
+            plugin.app.workspace.requestSaveLayout = vi.fn();
+
+            (plugin as any).dedupeLilbeeLeaves();
+
+            expect(detached).toEqual([2, 3, 12]);
+            expect(plugin.app.workspace.requestSaveLayout).toHaveBeenCalled();
+        });
+
+        it("is a no-op when each leaf type has 0 or 1 already", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const detached: number[] = [];
+            const fakeLeaf = (i: number) => ({ detach: () => detached.push(i) });
+            const leaves: Record<string, ReturnType<typeof fakeLeaf>[]> = {
+                "lilbee-chat": [fakeLeaf(1)],
+                "lilbee-tasks": [],
+                "lilbee-wiki": [fakeLeaf(21)],
+            };
+            plugin.app.workspace.getLeavesOfType = vi.fn((t: string) => (leaves[t] ?? []) as any);
+            plugin.app.workspace.requestSaveLayout = vi.fn();
+
+            (plugin as any).dedupeLilbeeLeaves();
+
+            expect(detached).toEqual([]);
+            expect(plugin.app.workspace.requestSaveLayout).toHaveBeenCalled();
+        });
+    });
+
     describe("onunload()", () => {
         it("clears the pending-sync hint timeout if one is active", async () => {
             vi.useFakeTimers();
@@ -1395,6 +1435,30 @@ describe("LilbeePlugin", () => {
             await (plugin as any).addToLilbee({ path: "notes/test.md", name: "test.md" });
 
             expect(plugin.api.addFiles).not.toHaveBeenCalled();
+            mockConfirm.mockRestore();
+        });
+
+        it('addToLilbee labels the vault root as "Vault root" when name + path are empty', async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+            plugin.api.listDocuments = vi.fn().mockResolvedValue({
+                documents: [{ filename: "Vault root", chunk_count: 1, ingested_at: "2026-01-01" }],
+                total: 1,
+                limit: 1,
+                offset: 0,
+            });
+            let capturedMessage = "";
+            const mockConfirm = vi.spyOn(await import("../src/views/confirm-modal"), "ConfirmModal");
+            mockConfirm.mockImplementation((_app: unknown, msg: string) => {
+                capturedMessage = msg;
+                const inst = { open: vi.fn(), result: Promise.resolve(false), close: vi.fn() };
+                return inst as unknown as ConfirmModal;
+            });
+
+            await (plugin as any).addToLilbee({ name: "", path: "" });
+
+            expect(capturedMessage).toContain("Vault root");
             mockConfirm.mockRestore();
         });
 


### PR DESCRIPTION
Two QA-found bugs:

- After workspace restore the plugin could end up with multiple chat / tasks / wiki panes side by side. The plugin now collapses to one of each on layout-ready.
- Adding the vault root showed a "" name in the re-add confirmation. The vault root now reads as "Vault root".

Remaining QA-found bugs that aren't in this PR (filed separately, not plugin-fixable from here):
- Crawl task reports completed without persisting the page — server-side (lilbee).
- Chat mode toggle dispatch — not reproducible without more info.