### PR TITLE
Demos: make targets that drive the gh-pages recording harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.PHONY: build test lint format format-check demo demo-prep demo-publish
+
+build:  ## esbuild → main.js
+	npm run build
+
+test:  ## vitest with v8 coverage (100% required)
+	npm test
+
+lint:  ## eslint src/ tests/
+	npm run lint
+
+format:  ## prettier --write
+	npm run format
+
+format-check:  ## prettier --check
+	npm run format:check
+
+demo-prep:  ## Stage harness deps via the gh-pages worktree
+	bash scripts/demo.sh prep
+
+demo:  ## Record every demo tape via the gh-pages worktree
+	bash scripts/demo.sh render
+
+demo-publish:  ## Commit + push refreshed renders on gh-pages
+	bash scripts/demo.sh publish

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Thin wrapper around the demo recording pipeline that lives on the
+# gh-pages branch (so main stays clean). Worktrees gh-pages, runs the
+# corresponding `make` target there, leaves the worktree in place for
+# the next call.
+#
+# Usage:
+#   scripts/demo.sh prep      # install harness deps + verify deps
+#   scripts/demo.sh render    # records every tape into demos-src/output/
+#   scripts/demo.sh publish   # copies + commits webms onto gh-pages
+
+set -euo pipefail
+
+WORKTREE="${OBSIDIAN_LILBEE_GH_PAGES_WORKTREE:-/tmp/obsidian-lilbee-gh-pages}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+if [ ! -d "$WORKTREE" ]; then
+    git -C "$REPO_ROOT" fetch origin gh-pages >/dev/null
+    git -C "$REPO_ROOT" worktree add "$WORKTREE" origin/gh-pages
+fi
+
+git -C "$WORKTREE" fetch origin gh-pages >/dev/null 2>&1 || true
+git -C "$WORKTREE" checkout gh-pages
+git -C "$WORKTREE" pull --ff-only origin gh-pages >/dev/null 2>&1 || true
+
+export OBSIDIAN_LILBEE_REPO_ROOT="$REPO_ROOT"
+
+case "${1:-render}" in
+    prep)
+        make -C "$WORKTREE" demo-prep
+        ;;
+    render)
+        make -C "$WORKTREE" demo
+        ;;
+    publish)
+        make -C "$WORKTREE" demo-publish
+        ;;
+    *)
+        echo "usage: $0 {prep|render|publish}" >&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
## Problem

The obsidian-lilbee demo reels (10 webms used in the marketing site) had nowhere to live: the harness was floating in an untracked sibling directory and the rendered output was on no remote. main also had no entry point for running the demo pipeline.

## Solution

Same pattern as lilbee. main carries a thin wrapper (\`scripts/demo.sh\`) and a top-level Makefile. The wrapper worktrees the \`gh-pages\` branch where the actual harness (\`demos-src/\`) and the rendered output (\`demos/\`) already live.

```
make demo-prep      install harness deps + verify ffmpeg/pyautogui
make demo           record every tape (CDP + pyautogui) into demos/
make demo-publish   commit refreshed demos/ on gh-pages
```