### PR TITLE
Catalog: show model compatibility and block downloads the server can't run

### DIFF
--- a/src/components/model-card.ts
+++ b/src/components/model-card.ts
@@ -1,5 +1,5 @@
 import type { CatalogEntry, HardwareFit, ModelCardOptions } from "../types";
-import { CATALOG_SOURCE, HARDWARE_FIT, MODEL_TASK } from "../types";
+import { CATALOG_SOURCE, HARDWARE_FIT, MODEL_COMPAT, MODEL_TASK } from "../types";
 import { MESSAGES } from "../locales/en";
 import { formatAbbreviatedCount } from "../utils";
 
@@ -27,6 +27,7 @@ export function renderModelCard(container: HTMLElement, entry: CatalogEntry, opt
     card.dataset.repo = entry.hf_repo;
     if (options.isActive) card.addClass("is-selected");
     if (entry.fit && FIT_RAIL_CLASS[entry.fit]) card.addClass(FIT_RAIL_CLASS[entry.fit]);
+    if (entry.compat === MODEL_COMPAT.UNSUPPORTED) card.addClass("is-unsupported");
 
     renderCardHead(card, entry, options);
     renderCardTags(card, entry);
@@ -77,6 +78,29 @@ function renderCardTags(card: HTMLElement, entry: CatalogEntry): void {
     }
     if (entry.source && entry.source !== CATALOG_SOURCE.LOCAL) {
         tags.createEl("span", { text: entry.source, cls: "lilbee-tag lilbee-tag-provider" });
+    }
+    renderCompatTag(tags, entry);
+}
+
+/**
+ * Render the compatibility badge (Unsupported / Unverified) for a model, with a
+ * tooltip naming the architecture when the server reported one. Shared by the
+ * grid card and the catalog list view so both surfaces read identically.
+ */
+export function renderCompatTag(tags: HTMLElement, entry: CatalogEntry): void {
+    const architecture = entry.architecture ?? "";
+    if (entry.compat === MODEL_COMPAT.UNSUPPORTED) {
+        const tag = tags.createEl("span", {
+            text: MESSAGES.LABEL_COMPAT_UNSUPPORTED,
+            cls: "lilbee-tag lilbee-tag-compat is-unsupported",
+        });
+        tag.setAttribute("title", MESSAGES.TOOLTIP_COMPAT_UNSUPPORTED(architecture));
+    } else if (entry.compat === MODEL_COMPAT.UNKNOWN) {
+        const tag = tags.createEl("span", {
+            text: MESSAGES.LABEL_COMPAT_UNKNOWN,
+            cls: "lilbee-tag lilbee-tag-compat is-unknown",
+        });
+        tag.setAttribute("title", MESSAGES.TOOLTIP_COMPAT_UNKNOWN(architecture));
     }
 }
 
@@ -165,6 +189,15 @@ function renderCardActions(card: HTMLElement, entry: CatalogEntry, options: Mode
             const handler = options.onRemove;
             removeBtn.addEventListener("click", () => handler(entry, removeBtn));
         }
+    } else if (entry.compat === MODEL_COMPAT.UNSUPPORTED) {
+        // Unsupported models can't run on this server — render the pull action
+        // gated (disabled, secondary look) rather than letting a download that
+        // can never load go through.
+        actions.createEl("button", {
+            text: MESSAGES.BUTTON_PULL,
+            cls: "lilbee-btn lilbee-catalog-pull is-gated",
+            attr: { disabled: "true", title: MESSAGES.TOOLTIP_PULL_UNSUPPORTED },
+        });
     } else {
         const pullBtn = actions.createEl("button", {
             text: MESSAGES.BUTTON_PULL,

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -314,6 +314,17 @@ export const MESSAGES = {
     LABEL_FIT_FITS: "fits",
     LABEL_FIT_TIGHT: "tight",
     LABEL_FIT_WONT_RUN: "won't run",
+    LABEL_COMPAT_UNSUPPORTED: "Unsupported",
+    LABEL_COMPAT_UNKNOWN: "Unverified",
+    TOOLTIP_COMPAT_UNSUPPORTED: (architecture: string) =>
+        architecture
+            ? `Your lilbee server doesn't support this model's architecture (${architecture}).`
+            : "Your lilbee server doesn't support this model's architecture.",
+    TOOLTIP_COMPAT_UNKNOWN: (architecture: string) =>
+        architecture
+            ? `lilbee can't confirm support for this model's architecture (${architecture}) — it may not load.`
+            : "lilbee can't confirm this model will load on your server.",
+    TOOLTIP_PULL_UNSUPPORTED: "This model isn't supported by your lilbee server.",
     LABEL_SWITCH_TO_LIST: "Switch to list view",
     LABEL_SWITCH_TO_GRID: "Switch to grid view",
     LABEL_VIEW_TOGGLE_CTA: "Switch to list view for the full catalog",

--- a/src/types.ts
+++ b/src/types.ts
@@ -155,6 +155,20 @@ export const HARDWARE_FIT = {
     WONT_RUN: "wont_run",
 } as const satisfies Record<string, HardwareFit>;
 
+/**
+ * Whether the connected lilbee server can run a catalog model, derived from its
+ * architecture. `supported` is the common case (no badge); `unsupported` means
+ * the server's runtime can't load it (gate the download); `unknown` means the
+ * server couldn't classify the architecture (surface it, but don't block).
+ */
+export type ModelCompat = "supported" | "unsupported" | "unknown";
+
+export const MODEL_COMPAT = {
+    SUPPORTED: "supported",
+    UNSUPPORTED: "unsupported",
+    UNKNOWN: "unknown",
+} as const satisfies Record<string, ModelCompat>;
+
 export type DiscoverRail = "for_you" | "your_collection" | "fresh";
 
 export const DISCOVER_RAIL = {
@@ -467,6 +481,8 @@ export interface CatalogEntry {
     downloads: number;
     param_count: string;
     fit?: HardwareFit | null;
+    compat?: ModelCompat | null;
+    architecture?: string | null;
     size_variants?: SizeVariant[] | null;
 }
 

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -13,6 +13,7 @@ import {
     CATALOG_SOURCE,
     CATALOG_TAB,
     KEY_STATUS,
+    MODEL_COMPAT,
     MODEL_TASK,
     SSE_EVENT,
     TASK_TYPE,
@@ -34,7 +35,7 @@ import {
     noticeForResultError,
     getRelevantSystemMemoryGB,
 } from "../utils";
-import { renderModelCard } from "../components/model-card";
+import { renderModelCard, renderCompatTag } from "../components/model-card";
 import { renderModelDetail } from "../components/model-detail";
 import { ModelInfoModal } from "./model-info-modal";
 import {
@@ -701,9 +702,11 @@ export class CatalogModal extends Modal {
 
     private renderListRow(listEl: HTMLElement, entry: CatalogEntry): void {
         const row = listEl.createDiv({ cls: "lilbee-catalog-list-row" });
+        if (entry.compat === MODEL_COMPAT.UNSUPPORTED) row.addClass("is-unsupported");
         const nameText = entry.featured ? `★ ${entry.display_name}` : entry.display_name;
         const nameEl = row.createEl("span", { text: nameText, cls: "lilbee-catalog-list-col-name" });
         nameEl.setAttribute("title", entry.display_name);
+        renderCompatTag(nameEl, entry);
         row.createEl("span", { text: entry.task, cls: "lilbee-catalog-list-col-task" });
         row.createEl("span", { text: `${entry.size_gb} GB`, cls: "lilbee-catalog-list-col-size" });
         row.createEl("span", {
@@ -739,6 +742,12 @@ export class CatalogModal extends Modal {
                 cls: "lilbee-catalog-remove",
             });
             removeBtn.addEventListener("click", () => this.handleRemove(entry, removeBtn));
+        } else if (entry.compat === MODEL_COMPAT.UNSUPPORTED) {
+            actionEl.createEl("button", {
+                text: MESSAGES.BUTTON_PULL,
+                cls: "lilbee-catalog-pull is-gated",
+                attr: { disabled: "true", title: MESSAGES.TOOLTIP_PULL_UNSUPPORTED },
+            });
         } else {
             const pullBtn = actionEl.createEl("button", { text: MESSAGES.BUTTON_PULL, cls: "lilbee-catalog-pull" });
             pullBtn.addEventListener("click", () => this.handlePull(entry));
@@ -859,6 +868,13 @@ export class CatalogModal extends Modal {
     }
 
     private handlePull(entry: CatalogEntry): void {
+        // Safety net: every pull path (grid card, list row) funnels through
+        // here, so refuse an unsupported model even if a gated button is ever
+        // bypassed. The buttons are also disabled in the UI.
+        if (entry.compat === MODEL_COMPAT.UNSUPPORTED) {
+            new Notice(MESSAGES.TOOLTIP_PULL_UNSUPPORTED);
+            return;
+        }
         const confirmModal = new ConfirmPullModal(this.app, {
             displayName: entry.display_name,
             sizeGb: entry.size_gb,

--- a/styles.css
+++ b/styles.css
@@ -809,6 +809,15 @@
     background-color: var(--background-modifier-hover);
 }
 
+/* Gated pull (unsupported model): muted, non-interactive, no hover lift. */
+.lilbee-catalog-pull.is-gated,
+.lilbee-catalog-pull.is-gated:hover {
+    color: var(--text-muted);
+    background: transparent;
+    border-color: var(--background-modifier-border);
+    cursor: not-allowed;
+}
+
 .lilbee-catalog-use,
 .lilbee-catalog-remove {
     padding: 4px 12px;
@@ -869,6 +878,11 @@
 .lilbee-model-card.is-fits { --rail: var(--color-green, #4cb37b); }
 .lilbee-model-card.is-tight { --rail: var(--color-orange, #d49340); }
 .lilbee-model-card.is-wont-run { --rail: var(--color-red, #c8392f); }
+
+/* Unsupported models read as dimmed so they're visually de-emphasised against
+ * runnable ones; hover lifts the dim a little so the card stays inspectable. */
+.lilbee-model-card.is-unsupported { opacity: 0.55; }
+.lilbee-model-card.is-unsupported:hover { opacity: 0.85; }
 
 .lilbee-model-card.is-selected {
     --rail: var(--interactive-accent);
@@ -969,6 +983,21 @@
     color: var(--text-faint);
     background: transparent;
     border: 1px dashed color-mix(in srgb, var(--text-faint) 40%, transparent);
+}
+
+.lilbee-tag-compat {
+    text-transform: none;
+    letter-spacing: 0.02em;
+}
+
+.lilbee-tag-compat.is-unsupported {
+    color: var(--color-red, #c8392f);
+    background: color-mix(in srgb, var(--color-red, #c8392f) 14%, transparent);
+}
+
+.lilbee-tag-compat.is-unknown {
+    color: var(--color-orange, #d49340);
+    background: color-mix(in srgb, var(--color-orange, #d49340) 12%, transparent);
 }
 
 /* Specs row: monospace data line, bold size leads, dot separators. */
@@ -1237,6 +1266,14 @@
 
 .lilbee-catalog-list-row:hover {
     background: var(--background-modifier-hover);
+}
+
+.lilbee-catalog-list-row.is-unsupported { opacity: 0.55; }
+.lilbee-catalog-list-row.is-unsupported:hover { opacity: 0.85; }
+
+.lilbee-catalog-list-col-name .lilbee-tag-compat {
+    margin-left: 6px;
+    vertical-align: middle;
 }
 
 .lilbee-catalog-list-col-name {

--- a/tests/components/model-card.test.ts
+++ b/tests/components/model-card.test.ts
@@ -169,6 +169,66 @@ describe("renderModelCard", () => {
         });
     });
 
+    describe("compatibility", () => {
+        it("renders an Unsupported badge and dims the card for compat=unsupported", () => {
+            const c = container();
+            const card = renderModelCard(
+                c,
+                makeEntry({ compat: "unsupported", architecture: "deepseek v4" }),
+                {},
+            ) as unknown as MockElement;
+            expect(card.classList.contains("is-unsupported")).toBe(true);
+            const tag = card.find("lilbee-tag-compat")!;
+            expect(tag.textContent).toBe(MESSAGES.LABEL_COMPAT_UNSUPPORTED);
+            expect(tag.classList.contains("is-unsupported")).toBe(true);
+            expect(tag.getAttribute("title")).toContain("deepseek v4");
+        });
+
+        it("renders an Unverified badge for compat=unknown without dimming the card", () => {
+            const c = container();
+            const card = renderModelCard(
+                c,
+                makeEntry({ compat: "unknown", architecture: "mamba" }),
+                {},
+            ) as unknown as MockElement;
+            expect(card.classList.contains("is-unsupported")).toBe(false);
+            const tag = card.find("lilbee-tag-compat")!;
+            expect(tag.textContent).toBe(MESSAGES.LABEL_COMPAT_UNKNOWN);
+            expect(tag.classList.contains("is-unknown")).toBe(true);
+            expect(tag.getAttribute("title")).toContain("mamba");
+        });
+
+        it("falls back to a generic tooltip when architecture is absent", () => {
+            const c = container();
+            const unsupported = renderModelCard(
+                c,
+                makeEntry({ compat: "unsupported", architecture: null }),
+                {},
+            ) as unknown as MockElement;
+            expect(unsupported.find("lilbee-tag-compat")!.getAttribute("title")).toBe(
+                MESSAGES.TOOLTIP_COMPAT_UNSUPPORTED(""),
+            );
+            const unknown = renderModelCard(
+                container(),
+                makeEntry({ compat: "unknown", architecture: null }),
+                {},
+            ) as unknown as MockElement;
+            expect(unknown.find("lilbee-tag-compat")!.getAttribute("title")).toBe(MESSAGES.TOOLTIP_COMPAT_UNKNOWN(""));
+        });
+
+        it("renders no compat badge for supported or unset compat", () => {
+            const c = container();
+            expect(
+                (renderModelCard(c, makeEntry({ compat: "supported" }), {}) as unknown as MockElement).find(
+                    "lilbee-tag-compat",
+                ),
+            ).toBeNull();
+            expect(
+                (renderModelCard(container(), makeEntry(), {}) as unknown as MockElement).find("lilbee-tag-compat"),
+            ).toBeNull();
+        });
+    });
+
     describe("fit rail", () => {
         it("adds the is-fits modifier when entry.fit is 'fits'", () => {
             const c = container();
@@ -261,6 +321,30 @@ describe("renderModelCard", () => {
             const card = renderModelCard(c, makeEntry(), { showActions: true }) as unknown as MockElement;
             const btn = card.find("lilbee-catalog-pull")!;
             expect(() => btn.trigger("click")).not.toThrow();
+        });
+
+        it("gates the Pull button for unsupported models — disabled, no onPull", () => {
+            const c = container();
+            const entry = makeEntry({ compat: "unsupported" });
+            const onPull = vi.fn();
+            const card = renderModelCard(c, entry, { showActions: true, onPull }) as unknown as MockElement;
+            const btn = card.find("lilbee-catalog-pull")!;
+            expect(btn.classList.contains("is-gated")).toBe(true);
+            expect(btn.getAttribute("disabled")).toBe("true");
+            expect(btn.getAttribute("title")).toBe(MESSAGES.TOOLTIP_PULL_UNSUPPORTED);
+            btn.trigger("click");
+            expect(onPull).not.toHaveBeenCalled();
+        });
+
+        it("keeps the Pull button live for unknown compatibility", () => {
+            const c = container();
+            const entry = makeEntry({ compat: "unknown" });
+            const onPull = vi.fn();
+            const card = renderModelCard(c, entry, { showActions: true, onPull }) as unknown as MockElement;
+            const btn = card.find("lilbee-catalog-pull")!;
+            expect(btn.classList.contains("is-gated")).toBe(false);
+            btn.trigger("click");
+            expect(onPull).toHaveBeenCalledWith(entry, btn);
         });
 
         it("calls onUse when Use button clicked", () => {

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -264,6 +264,32 @@ describe("CatalogModal", () => {
             expect(content.find("lilbee-catalog-pull")).not.toBeNull();
         });
 
+        it("gates the Pull button, dims the row, and badges an unsupported model in list view", async () => {
+            const plugin = makePlugin();
+            plugin.api.catalog.mockResolvedValue(
+                ok(makeCatalogResponse([makeEntry({ compat: "unsupported", architecture: "deepseek v4" })])),
+            );
+            const modal = await openModal(plugin);
+            const content = contentEl(modal);
+            content.find("lilbee-catalog-view-toggle")!.trigger("click");
+            await tick();
+            const row = content.find("lilbee-catalog-list-row")!;
+            expect(row.classList.contains("is-unsupported")).toBe(true);
+            expect(row.find("lilbee-tag-compat")).not.toBeNull();
+            const pull = content.find("lilbee-catalog-pull")!;
+            expect(pull.classList.contains("is-gated")).toBe(true);
+            expect(pull.getAttribute("disabled")).toBe("true");
+        });
+
+        it("handlePull refuses an unsupported model with a Notice (safety net for every pull path)", async () => {
+            const plugin = makePlugin();
+            const modal = await openModal(plugin);
+            (modal as unknown as { handlePull(e: CatalogEntry): void }).handlePull(
+                makeEntry({ compat: "unsupported" }),
+            );
+            expect(Notice.instances.map((n) => n.message)).toContain(MESSAGES.TOOLTIP_PULL_UNSUPPORTED);
+        });
+
         it("renders Use + Remove buttons for installed entries in list view", async () => {
             const plugin = makePlugin();
             plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry({ installed: true })])));


### PR DESCRIPTION
## Problem

The catalog REST API reports per-model compatibility with the connected lilbee server — `supported`, `unsupported`, or `unknown`, alongside the model's architecture — but the plugin's catalog ignored it. A model the server can't run (e.g. a DeepSeek v4 architecture) looked identical to one it can, and its Download button worked, kicking off a download that could never load.

## Solution

Catalog cards and the list view now surface compatibility. Unsupported models are dimmed, carry an "Unsupported" badge, and their Download button is disabled with a tooltip explaining why — the badge tooltip names the model's architecture when the server provides it. Models the server can't classify get an "Unverified" badge but stay downloadable. As a safety net, the pull action itself refuses an unsupported model, so no entry point can start a download that won't run.

Closes bb-9e1m.
