### PR TITLE
Catalog compat pills, model activation, and chat toolbar polish

### DIFF
--- a/src/components/model-card.ts
+++ b/src/components/model-card.ts
@@ -83,9 +83,12 @@ function renderCardTags(card: HTMLElement, entry: CatalogEntry): void {
 }
 
 /**
- * Render the compatibility badge (Unsupported / Unverified) for a model, with a
- * tooltip naming the architecture when the server reported one. Shared by the
- * grid card and the catalog list view so both surfaces read identically.
+ * Render the compatibility badge for a model. Only models the server has
+ * confirmed it can't run get a badge (Unsupported). `unknown` compat just means
+ * the architecture wasn't probed — true for the curated "Our picks" (which
+ * carry no arch metadata) and for un-probed HF search hits — so it renders no
+ * badge, exactly like a supported model. Badging those "Unverified" was noise
+ * and made trusted featured models look broken.
  */
 export function renderCompatTag(tags: HTMLElement, entry: CatalogEntry): void {
     const architecture = entry.architecture ?? "";
@@ -95,12 +98,6 @@ export function renderCompatTag(tags: HTMLElement, entry: CatalogEntry): void {
             cls: "lilbee-tag lilbee-tag-compat is-unsupported",
         });
         tag.setAttribute("title", MESSAGES.TOOLTIP_COMPAT_UNSUPPORTED(architecture));
-    } else if (entry.compat === MODEL_COMPAT.UNKNOWN) {
-        const tag = tags.createEl("span", {
-            text: MESSAGES.LABEL_COMPAT_UNKNOWN,
-            cls: "lilbee-tag lilbee-tag-compat is-unknown",
-        });
-        tag.setAttribute("title", MESSAGES.TOOLTIP_COMPAT_UNKNOWN(architecture));
     }
 }
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -297,15 +297,10 @@ export const MESSAGES = {
     LABEL_FIT_TIGHT: "tight",
     LABEL_FIT_WONT_RUN: "won't run",
     LABEL_COMPAT_UNSUPPORTED: "Unsupported",
-    LABEL_COMPAT_UNKNOWN: "Unverified",
     TOOLTIP_COMPAT_UNSUPPORTED: (architecture: string) =>
         architecture
             ? `Your lilbee server doesn't support this model's architecture (${architecture}).`
             : "Your lilbee server doesn't support this model's architecture.",
-    TOOLTIP_COMPAT_UNKNOWN: (architecture: string) =>
-        architecture
-            ? `lilbee can't confirm support for this model's architecture (${architecture}) — it may not load.`
-            : "lilbee can't confirm this model will load on your server.",
     TOOLTIP_PULL_UNSUPPORTED: "This model isn't supported by your lilbee server.",
     LABEL_SWITCH_TO_LIST: "Switch to list view",
     LABEL_SWITCH_TO_GRID: "Switch to grid view",

--- a/src/utils/model-ref.ts
+++ b/src/utils/model-ref.ts
@@ -9,6 +9,19 @@ const STRIP_SUFFIXES = [/-GGUF$/i, /-Instruct$/i, /-Chat$/i, /-v\d+(\.\d+)*$/i, 
 
 const META_PREFIX = /^Meta-/;
 
+/**
+ * Build the ref to send when activating a catalog entry. A multi-quant GGUF
+ * repo (e.g. "bartowski/SmolLM2-360M-Instruct-GGUF") has no single default
+ * file, so the server rejects the bare repo with "not available"; send the
+ * concrete "<repo>/<filename>.gguf" instead. Falls back to the bare repo when
+ * the filename is missing or a glob (sharded/pattern entries).
+ */
+export function nativeModelRef(hfRepo: string, ggufFilename: string | null | undefined): string {
+    const f = ggufFilename ?? "";
+    if (f && f.endsWith(".gguf") && !f.includes("*")) return `${hfRepo}/${f}`;
+    return hfRepo;
+}
+
 /** Strip the trailing `/<filename>.gguf` from a full HF ref so it matches a `CatalogEntry.hf_repo`. */
 export function extractHfRepo(ref: string): string {
     if (!ref.endsWith(".gguf")) return ref;

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -21,7 +21,7 @@ import {
     ERROR_NAME,
 } from "../types";
 import { MESSAGES, FILTERS, CATALOG_FILTERS } from "../locales/en";
-import { extractHfRepo } from "../utils/model-ref";
+import { extractHfRepo, nativeModelRef } from "../utils/model-ref";
 import { ConfirmModal } from "./confirm-modal";
 import { ConfirmPullModal } from "./confirm-pull-modal";
 import {
@@ -853,17 +853,21 @@ export class CatalogModal extends Modal {
     }
 
     private async setActiveFor(entry: CatalogEntry): ReturnType<typeof this.plugin.api.setChatModel> {
+        // Activate by the concrete GGUF file ref, not the bare repo: multi-quant
+        // repos have no single default file and the server rejects the bare repo
+        // with "not available", surfacing a spurious "Failed to set" toast.
+        const ref = nativeModelRef(entry.hf_repo, entry.gguf_filename);
         if (entry.task === MODEL_TASK.EMBEDDING) {
-            return this.plugin.api.setEmbeddingModel(entry.hf_repo);
+            return this.plugin.api.setEmbeddingModel(ref);
         }
         if (entry.task === MODEL_TASK.RERANK) {
-            return this.plugin.api.setRerankerModel(entry.hf_repo);
+            return this.plugin.api.setRerankerModel(ref);
         }
         if (entry.task === MODEL_TASK.VISION) {
-            return this.plugin.api.setVisionModel(entry.hf_repo);
+            return this.plugin.api.setVisionModel(ref);
         }
-        const result = await this.plugin.api.setChatModel(entry.hf_repo);
-        if (result.isOk()) this.plugin.activeModel = entry.hf_repo;
+        const result = await this.plugin.api.setChatModel(ref);
+        if (result.isOk()) this.plugin.activeModel = ref;
         return result;
     }
 

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -197,10 +197,9 @@ export class ChatView extends ItemView {
         saveBtn.setAttribute("aria-label", MESSAGES.LABEL_SAVE_VAULT);
         saveBtn.addEventListener("click", () => this.saveToVault());
 
-        const clearBtn = toolbar.createEl("button", {
-            text: MESSAGES.BUTTON_CLEAR_CHAT,
-            cls: "lilbee-chat-clear",
-        });
+        const clearBtn = toolbar.createEl("button", { cls: "lilbee-chat-clear" });
+        setIcon(clearBtn, "eraser");
+        clearBtn.setAttribute("aria-label", MESSAGES.BUTTON_CLEAR_CHAT);
         clearBtn.addEventListener("click", () => this.clearChat());
     }
 

--- a/styles.css
+++ b/styles.css
@@ -164,6 +164,19 @@
     display: flex;
     align-items: center;
     gap: 2px;
+    /* Let the model/embed groups shrink so a narrow chat panel (e.g. beside the
+       Task Center) yields space to the toolbar actions instead of clipping. */
+    min-width: 0;
+}
+
+/* Native selects size to their widest option, which bloats the toolbar; cap
+   and shrink them so the row fits and the selected value truncates gracefully. */
+.lilbee-chat-model-select,
+.lilbee-embed-model-select {
+    min-width: 0;
+    max-width: 150px;
+    flex-shrink: 1;
+    text-overflow: ellipsis;
 }
 
 .lilbee-embed-browse {
@@ -599,16 +612,23 @@
     background-color: var(--background-modifier-hover);
 }
 
-.lilbee-chat-save {
+.lilbee-chat-save,
+.lilbee-chat-clear {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     background: none;
     border: none;
     cursor: pointer;
     color: var(--text-muted);
     padding: 2px var(--size-4-2, 8px);
     border-radius: var(--radius-s, 4px);
+    /* Pinned action icons: never shrink or clip behind the Task Center edge. */
+    flex: 0 0 auto;
 }
 
-.lilbee-chat-save:hover {
+.lilbee-chat-save:hover,
+.lilbee-chat-clear:hover {
     background-color: var(--background-modifier-hover);
     color: var(--text-normal);
 }

--- a/tests/components/model-card.test.ts
+++ b/tests/components/model-card.test.ts
@@ -184,7 +184,7 @@ describe("renderModelCard", () => {
             expect(tag.getAttribute("title")).toContain("deepseek v4");
         });
 
-        it("renders an Unverified badge for compat=unknown without dimming the card", () => {
+        it("renders no badge for compat=unknown (un-probed arch is not surfaced)", () => {
             const c = container();
             const card = renderModelCard(
                 c,
@@ -192,10 +192,7 @@ describe("renderModelCard", () => {
                 {},
             ) as unknown as MockElement;
             expect(card.classList.contains("is-unsupported")).toBe(false);
-            const tag = card.find("lilbee-tag-compat")!;
-            expect(tag.textContent).toBe(MESSAGES.LABEL_COMPAT_UNKNOWN);
-            expect(tag.classList.contains("is-unknown")).toBe(true);
-            expect(tag.getAttribute("title")).toContain("mamba");
+            expect(card.find("lilbee-tag-compat")).toBeNull();
         });
 
         it("falls back to a generic tooltip when architecture is absent", () => {
@@ -208,12 +205,6 @@ describe("renderModelCard", () => {
             expect(unsupported.find("lilbee-tag-compat")!.getAttribute("title")).toBe(
                 MESSAGES.TOOLTIP_COMPAT_UNSUPPORTED(""),
             );
-            const unknown = renderModelCard(
-                container(),
-                makeEntry({ compat: "unknown", architecture: null }),
-                {},
-            ) as unknown as MockElement;
-            expect(unknown.find("lilbee-tag-compat")!.getAttribute("title")).toBe(MESSAGES.TOOLTIP_COMPAT_UNKNOWN(""));
         });
 
         it("renders no compat badge for supported or unset compat", () => {

--- a/tests/utils/model-ref.test.ts
+++ b/tests/utils/model-ref.test.ts
@@ -1,5 +1,23 @@
 import { describe, expect, it } from "vitest";
-import { cleanDisplayName, displayLabelForRef, extractHfRepo } from "../../src/utils/model-ref";
+import { cleanDisplayName, displayLabelForRef, extractHfRepo, nativeModelRef } from "../../src/utils/model-ref";
+
+describe("nativeModelRef", () => {
+    it("builds the full file ref when a concrete .gguf filename is present", () => {
+        expect(nativeModelRef("bartowski/SmolLM2-360M-Instruct-GGUF", "SmolLM2-360M-Instruct-Q4_K_M.gguf")).toBe(
+            "bartowski/SmolLM2-360M-Instruct-GGUF/SmolLM2-360M-Instruct-Q4_K_M.gguf",
+        );
+    });
+
+    it("falls back to the bare repo for a glob filename", () => {
+        expect(nativeModelRef("Qwen/Qwen3-8B-GGUF", "*Q4_K_M.gguf")).toBe("Qwen/Qwen3-8B-GGUF");
+    });
+
+    it("falls back to the bare repo when the filename is missing", () => {
+        expect(nativeModelRef("Qwen/Qwen3-8B-GGUF", "")).toBe("Qwen/Qwen3-8B-GGUF");
+        expect(nativeModelRef("Qwen/Qwen3-8B-GGUF", null)).toBe("Qwen/Qwen3-8B-GGUF");
+        expect(nativeModelRef("Qwen/Qwen3-8B-GGUF", undefined)).toBe("Qwen/Qwen3-8B-GGUF");
+    });
+});
 
 describe("displayLabelForRef", () => {
     it("returns empty string for empty input", () => {

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -798,6 +798,32 @@ describe("CatalogModal", () => {
             expect(plugin.api.setEmbeddingModel).toHaveBeenCalledWith("Qwen/Qwen3-8B-GGUF");
         });
 
+        it("activates by the concrete GGUF file ref when the filename is not a glob", async () => {
+            const plugin = makePlugin();
+            plugin.api.setChatModel = vi.fn().mockResolvedValue(ok(undefined));
+            plugin.api.catalog.mockResolvedValue(
+                ok(
+                    makeCatalogResponse([
+                        makeEntry({
+                            installed: true,
+                            hf_repo: "bartowski/SmolLM2-360M-Instruct-GGUF",
+                            gguf_filename: "SmolLM2-360M-Instruct-Q4_K_M.gguf",
+                        }),
+                    ]),
+                ),
+            );
+            const modal = await openModal(plugin);
+            const content = contentEl(modal);
+            const useBtn = findButtons(content).find((b) => b.textContent === MESSAGES.BUTTON_USE)!;
+            useBtn.trigger("click");
+            await tick();
+            await tick();
+            // Bare repo would 422 on the server (no default quant); send the full ref.
+            expect(plugin.api.setChatModel).toHaveBeenCalledWith(
+                "bartowski/SmolLM2-360M-Instruct-GGUF/SmolLM2-360M-Instruct-Q4_K_M.gguf",
+            );
+        });
+
         it("4u1: handleUse refreshes the Settings tab on success", async () => {
             const plugin = makePlugin();
             plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry({ installed: true })])));

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -288,11 +288,12 @@ describe("ChatView.onOpen — DOM structure", () => {
         expect(container.find("lilbee-chat-toolbar")).not.toBeNull();
     });
 
-    it("creates a clear button inside the toolbar", () => {
+    it("creates a clear icon button inside the toolbar", () => {
         const clearBtn = container.find("lilbee-chat-clear");
         expect(clearBtn).not.toBeNull();
         expect(clearBtn!.tagName).toBe("BUTTON");
-        expect(clearBtn!.textContent).toBe("Clear chat");
+        // Icon button (matches the save action), with the label on aria-label.
+        expect(clearBtn!.getAttribute("aria-label")).toBe("Clear chat");
     });
 
     it("creates a paperclip add-file button inside the input area", () => {


### PR DESCRIPTION
## Problem

Reviewing the demo reel surfaced three catalog/chat UI bugs:

- The featured "Our picks" carry no architecture, so their compat defaulted to *unknown* and rendered an "Unverified" badge — lilbee's own trusted picks looked broken.
- Activating a just-pulled model used the bare repo (`entry.hf_repo`). Multi-quant GGUF repos (e.g. `bartowski/SmolLM2-360M-Instruct-GGUF`) have no single default file, so the server rejects the bare repo and a spurious "Failed to set" toast appears.
- The chat toolbar crammed two wide native model selects, the mode/scope toggles, and a text "Clear chat" button into one non-wrapping row. In a narrow chat panel (beside the Task Center) the row overflowed and clipped "Clear chat".

## Solution

- Only badge models the server has confirmed it can't run (Unsupported). Supported and unknown both render no badge; drops the unused Unverified label/tooltip.
- Activate by the concrete `<repo>/<filename>.gguf` ref via a new `nativeModelRef` helper, falling back to the bare repo for glob/sharded filenames.
- Make Clear an icon button matching Save (label on aria-label), pin both actions so they never shrink, and cap + shrink the native selects so the toolbar fits and the selected value truncates gracefully.

100% coverage retained; new tests for `nativeModelRef`, the full-ref activation path, the no-badge-for-unknown rendering, and the clear icon button.