### PR TITLE
site: prominent reel button + restyle /reel page to match the site

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -80,6 +80,7 @@
       <div class="label">see it</div>
 
       <div class="reel">
+        <div class="reel-watch"><a class="reel-cta" href="https://obsidian.lilbee.sh/reel">▶&nbsp; watch the full demo reel</a></div>
         <div class="reeltabs" role="tablist" aria-label="Demo reel">
           <button type="button" class="reeltab" role="tab" id="reel-tab-onlilbee" aria-controls="reel-pane-onlilbee" aria-selected="true"  tabindex="0">what is lilbee</button>
           <button type="button" class="reeltab" role="tab" id="reel-tab-ask"      aria-controls="reel-pane-ask"      aria-selected="false" tabindex="-1">ask &amp; cite</button>
@@ -147,7 +148,6 @@
           <p class="reel-caption">The palette as an async control surface: fire a crawl, a file add, and a model download back to back without waiting, watch all three run at once in the Task Center, then ask the just-crawled page a cited question.</p>
         </div>
 
-        <p class="reel-more"><kbd>&larr;</kbd>/<kbd>&rarr;</kbd> scrub the tabs. Want the long-form walkthrough? <a href="https://obsidian.lilbee.sh/reel">full demo reel &rarr;</a> (every demo as a video, with longer notes).</p>
       </div>
     </section>
 

--- a/site/reel/index.html
+++ b/site/reel/index.html
@@ -3,59 +3,75 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>lilbee for Obsidian — demo reel</title>
+<title>lilbee for Obsidian demo reel</title>
 <meta name="description" content="Every lilbee for Obsidian demo as a video: ask and cite, crawl the web into your vault, OCR scanned PDFs, the model catalog, downloading a model, settings, and a full tour." />
-<meta property="og:title" content="lilbee for Obsidian — demo reel" />
+<meta property="og:title" content="lilbee for Obsidian demo reel" />
 <meta property="og:description" content="Every lilbee for Obsidian demo as a video." />
 <meta property="og:image" content="https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/what_is_lilbee.contact.png" />
 <link rel="canonical" href="https://obsidian.lilbee.sh/reel/" />
+<link rel="stylesheet" href="../style.css" />
 <style>
-  :root { color-scheme: dark; }
-  * { box-sizing: border-box; }
-  body { margin: 0; background: #15171a; color: #e7e9ec; font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }
-  header { padding: 34px 32px 18px; border-bottom: 1px solid #2a2e34; }
-  header h1 { margin: 0 0 6px; font-size: 24px; font-weight: 650; }
-  header p { margin: 0; color: #9aa1ab; font-size: 14px; }
-  header a { color: #8ab4ff; text-decoration: none; }
-  header a:hover { text-decoration: underline; }
-  main { max-width: 1100px; margin: 0 auto; padding: 28px 32px 80px; display: grid; gap: 40px; }
-  .demo { background: #1c1f24; border: 1px solid #2a2e34; border-radius: 12px; overflow: hidden; }
-  .demo-head { padding: 16px 20px 6px; }
-  .demo-head h2 { margin: 0; font-size: 18px; font-weight: 600; }
-  .demo p.desc { margin: 0 20px 14px; color: #b6bcc5; font-size: 14px; }
-  video { display: block; width: 100%; background: #000; border-top: 1px solid #2a2e34; }
-  footer { max-width: 1100px; margin: 0 auto; padding: 0 32px 60px; color: #7f8792; font-size: 13px; }
-  footer a { color: #8ab4ff; text-decoration: none; }
+  .reel-h1 { margin: 2rem 0 0.5rem; font-size: 22px; font-weight: 500; letter-spacing: 0.01em; color: var(--ink); }
+  .reel-intro { margin: 0.4rem 0 2rem; max-width: 74ch; color: var(--ink-2); font-size: 13px; line-height: 1.6; }
+  .reel-toc { margin: 0 0 2.6rem; padding: 1.1rem 1.3rem; background: var(--bg-card); border: 1px solid var(--rule); border-radius: 4px; }
+  .reel-toc .toc-label { font-size: 12px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent-deep); }
+  .reel-toc ol { margin: 0.7rem 0 0; padding-left: 1.5rem; }
+  .reel-toc li { margin: 0.28rem 0; color: var(--ink-3); }
+  .reel-section { margin: 2.4rem 0 2.9rem; scroll-margin-top: 1.5rem; }
+  .reel-section h2 { margin: 0 0 0.45rem; font-size: 15px; font-weight: 500; letter-spacing: 0.02em; color: var(--accent); }
+  .reel-section p { margin: 0.3rem 0 0.9rem; max-width: 82ch; color: var(--ink-2); font-size: 13px; line-height: 1.6; }
+  .reel-frame { background: #000; border: 1px solid var(--rule); border-radius: 4px; overflow: hidden; }
+  .reel-frame video { display: block; width: 100%; background: #000; }
+  .reel-foot { margin: 3rem 0 1rem; color: var(--ink-3); font-size: 12.5px; }
 </style>
 </head>
 <body>
-<header>
-  <h1>lilbee for Obsidian — demo reel</h1>
-  <p>Every demo as a video, longer notes below each one. <a href="https://obsidian.lilbee.sh/">&larr; back to the project site</a></p>
-</header>
-<main id="demos"></main>
-<footer>Recorded on a 2021 M1 Pro, 32&nbsp;GB RAM. lilbee runs entirely on your machine. <a href="https://github.com/tobocop2/obsidian-lilbee">Source &rarr;</a></footer>
+<div class="layout">
+  <main class="main">
+
+    <div class="topstrip">
+      <div><span class="badge">lilbee for Obsidian</span> <span>demo reel</span></div>
+      <div><a class="pill" href="https://obsidian.lilbee.sh/">&larr; back to the site</a></div>
+    </div>
+
+    <h1 class="reel-h1">Demo reel</h1>
+    <p class="reel-intro">Every lilbee for Obsidian demo as a video, each with a longer note than the homepage carries. The clips loop and are silent; watch at your own pace.</p>
+
+    <nav class="reel-toc">
+      <div class="toc-label">in order</div>
+      <ol id="reel-toc"></ol>
+    </nav>
+
+    <div id="demos"></div>
+
+    <p class="reel-foot">Recorded on a 2021 M1 Pro, 32&nbsp;GB RAM. lilbee runs entirely on your machine. <a href="https://obsidian.lilbee.sh/">&larr; back to the site</a> &nbsp;&middot;&nbsp; <a href="https://github.com/tobocop2/obsidian-lilbee">GitHub</a></p>
+
+  </main>
+</div>
 <script>
   const GH = "https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/";
   const demos = [
-    { name: "what_is_lilbee", title: "What is lilbee", desc: "Add lilbee's own README to your library and watch it ingest, then ask “what is lilbee in one sentence?” — a cited answer straight from the README, and the citation opens it at the source." },
-    { name: "add", title: "Ask & cite your documents", desc: "Add a PDF from the command palette, watch the Task Center index it, then ask a question and get a cited answer. Click the citation and the source preview opens at the exact page." },
-    { name: "crawl", title: "Crawl the web into your vault", desc: "Crawl a Wikipedia page into your vault, ask when the 9C1 police package was introduced, and jump from the citation straight to the cited section of the rendered source." },
-    { name: "vision", title: "Scanned PDFs, read by OCR", desc: "A scanned, image-only PDF read by a local vision model. The Task Center streams the OCR page by page, then a cited answer reads the support number and publisher straight off the scanned cover — a detail only OCR could surface." },
-    { name: "catalog", title: "Model catalog", desc: "Browse the model catalog without leaving Obsidian: Chat, Embed, Vision, and Rerank tabs, each pulled live from Hugging Face Hub. Models the bundled engine can't run are flagged before you pull." },
-    { name: "download_model", title: "Download and use a model", desc: "Search the catalog for a small chat model, watch the download stream start to finish in the Task Center, then activate it, switch to Chat mode, and use it — the full pull-and-use loop without leaving Obsidian." },
-    { name: "settings", title: "Settings", desc: "50+ settings: search depth, reranking, sampling, parsers, the wiki. Sane defaults; tune the moment you want to." },
-    { name: "tour", title: "Tour: the palette as an async control surface", desc: "Fire a crawl, a file add, and a model download back to back without waiting, watch all three run at once in the Task Center, then ask the just-crawled page a cited question." },
+    { id: "what-is-lilbee", name: "what_is_lilbee", title: "What is lilbee", desc: "Add lilbee's own README to your library and watch it ingest, then ask “what is lilbee in one sentence?” and get a cited answer straight from the README. The citation opens it at the source." },
+    { id: "ask", name: "add", title: "Ask &amp; cite your documents", desc: "Add a PDF from the command palette, watch the Task Center index it, then ask a question and get a cited answer. Click the citation and the source preview opens at the exact page." },
+    { id: "crawl", name: "crawl", title: "Crawl the web into your vault", desc: "Crawl a Wikipedia page into your vault, ask when the 9C1 police package was introduced, and jump from the citation straight to the cited section of the rendered source." },
+    { id: "scanned-pdf", name: "vision", title: "Scanned PDFs, read by OCR", desc: "A scanned, image-only PDF read by a local vision model. The Task Center streams the OCR page by page, then a cited answer reads the support number and publisher straight off the scanned cover, a detail only OCR could surface." },
+    { id: "catalog", name: "catalog", title: "Model catalog", desc: "Browse the model catalog without leaving Obsidian: Chat, Embed, Vision, and Rerank tabs, each pulled live from Hugging Face Hub. Models the bundled engine can't run are flagged before you pull." },
+    { id: "download", name: "download_model", title: "Download and use a model", desc: "Search the catalog for a small chat model, watch the download stream start to finish in the Task Center, then activate it, switch to Chat mode, and use it, the full pull-and-use loop without leaving Obsidian." },
+    { id: "settings", name: "settings", title: "Settings", desc: "50+ settings: search depth, reranking, sampling, parsers, the wiki. Sane defaults; tune the moment you want to." },
+    { id: "tour", name: "tour", title: "Tour: the palette as an async control surface", desc: "Fire a crawl, a file add, and a model download back to back without waiting, watch all three run at once in the Task Center, then ask the just-crawled page a cited question." },
   ];
-  const main = document.getElementById("demos");
+  const toc = document.getElementById("reel-toc");
+  const list = document.getElementById("demos");
   for (const d of demos) {
-    const el = document.createElement("section");
-    el.className = "demo";
-    el.innerHTML =
-      '<div class="demo-head"><h2>' + d.title + "</h2></div>" +
-      '<p class="desc">' + d.desc + "</p>" +
-      '<video src="' + GH + d.name + '.webm" controls loop muted autoplay playsinline preload="metadata"></video>';
-    main.appendChild(el);
+    toc.insertAdjacentHTML("beforeend", '<li><a href="#' + d.id + '">' + d.title + "</a></li>");
+    const sec = document.createElement("section");
+    sec.className = "reel-section";
+    sec.id = d.id;
+    sec.innerHTML =
+      "<h2>" + d.title + "</h2>" +
+      "<p>" + d.desc + "</p>" +
+      '<div class="reel-frame"><video src="' + GH + d.name + '.webm" controls loop muted autoplay playsinline preload="metadata"></video></div>';
+    list.appendChild(sec);
   }
 </script>
 </body>

--- a/site/style.css
+++ b/site/style.css
@@ -347,10 +347,28 @@ h1.sr {
 }
 .reel-caption em { color: var(--accent); font-style: normal; font-weight: 500; }
 
-.reel-more {
-  margin-top: 1.1rem;
-  font-size: 12.5px;
-  color: var(--ink-3);
+.reel-watch {
+  text-align: center;
+  margin-bottom: 1.3rem;
+}
+.reel-cta {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--mono);
+  font-size: 13.5px;
+  letter-spacing: 0.03em;
+  color: var(--accent);
+  background: transparent;
+  border: 1px solid var(--rule-2);
+  border-radius: 4px;
+  padding: 0.6rem 1.25rem;
+  text-decoration: none;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+}
+.reel-cta:hover {
+  border-color: var(--accent-deep);
+  background: rgba(124, 58, 237, 0.10);
+  color: var(--accent-hot);
 }
 
 /* install ------------------------------------------------------------ */
@@ -406,7 +424,7 @@ h1.sr {
 .extras { font-size: 13px; margin-top: 0.9rem; color: var(--ink-3); }
 .extras a { color: var(--ink-2); }
 
-/* the difference — two-column comparison ----------------------------- */
+/* the difference: two-column comparison ----------------------------- */
 .shape { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
 .shape-box {
   background: var(--bg-card);


### PR DESCRIPTION
## Problem
The 'full demo reel' link was a small grey inline text link under the tabbed previews, and used jargon ('scrub the tabs'). The standalone /reel page was a generic dark theme that didn't match the site's mono/violet aesthetic.

## Solution
Replace the inline link with a mono outline button centered above the tabs, and drop the hint line. Rebuild the /reel page to mirror the tutorial-reel format (topstrip, intro, table of contents, numbered sections) using the site's own stylesheet and tokens. Also removes the remaining em dashes from the site.