### PR TITLE
demos: refresh tapes for the current UI + add rerank, model rail, LM Studio & Ollama reels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # OBSIDIAN_LILBEE_REPO_ROOT (passed in by the wrapper) points at the main
 # checkout so demo recordings can reference paths there if needed.
 
-TAPES := tour chat add lilbee_on_lilbee crawl catalog settings command_palette multi_vault first_start models
+TAPES := tour chat add lilbee_on_lilbee crawl catalog settings command_palette multi_vault first_start models rerank
 
 # GIF width (px). The webms are recorded at retina 3456×2158; the GIFs only
 # ever render at README / marketing-card width, so 720 keeps them sharp there

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # OBSIDIAN_LILBEE_REPO_ROOT (passed in by the wrapper) points at the main
 # checkout so demo recordings can reference paths there if needed.
 
-TAPES := tour chat add lilbee_on_lilbee crawl catalog settings command_palette multi_vault first_start
+TAPES := tour chat add lilbee_on_lilbee crawl catalog settings command_palette multi_vault first_start models
 
 # GIF width (px). The webms are recorded at retina 3456×2158; the GIFs only
 # ever render at README / marketing-card width, so 720 keeps them sharp there

--- a/demos-src/src/lib.ts
+++ b/demos-src/src/lib.ts
@@ -22,6 +22,7 @@
 export type Action =
   | { kind: "clickRibbon"; target: "chat" | "tasks" }
   | { kind: "clickSelector"; selector: string }
+  | { kind: "hoverSelector"; selector: string }
   | { kind: "rightClickSelector"; selector: string }
   | { kind: "clickMenuItem"; name: string }
   | { kind: "openSettings" }
@@ -177,6 +178,8 @@ export function beat(
 
 export const clickRibbon = (target: "chat" | "tasks"): Action => ({ kind: "clickRibbon", target });
 export const clickSelector = (selector: string): Action => ({ kind: "clickSelector", selector });
+/** Move the cursor onto an element without clicking — used to reveal its tooltip. */
+export const hoverSelector = (selector: string): Action => ({ kind: "hoverSelector", selector });
 export const rightClickSelector = (selector: string): Action => ({ kind: "rightClickSelector", selector });
 export const clickMenuItem = (name: string): Action => ({ kind: "clickMenuItem", name });
 export const openSettings = (): Action => ({ kind: "openSettings" });

--- a/demos-src/src/obsidian.ts
+++ b/demos-src/src/obsidian.ts
@@ -7,7 +7,7 @@
  */
 import { type Browser, chromium, type Page } from "playwright";
 
-const CDP_URL = "http://localhost:9222";
+const CDP_URL = "http://127.0.0.1:9222";
 
 export type ObsidianContext = {
   browser: Browser;

--- a/demos-src/src/record.ts
+++ b/demos-src/src/record.ts
@@ -31,6 +31,9 @@ const DEFAULT_LEAD_IN_MS = 500;
 const DEFAULT_TAIL_MS = 1500;
 const DEFAULT_HOLD_MS = 800;
 const HOVER_BEFORE_CLICK_MS = 350;
+// Letterbox band (retina px) added below the window so narration captions sit
+// under the app instead of over the chat. Sized to fit a two-line caption.
+const CAPTION_BAND_PX = 168;
 // Hard ceiling for a single runJs beat. A storyboard that awaits an
 // open SSE stream (e.g. addToLilbee) would otherwise hang forever while
 // ffmpeg captures a static screen. If a beat exceeds this, abort the
@@ -807,11 +810,17 @@ async function postProcess(opts: PostOptions): Promise<void> {
   }
 
   const chain: string[] = [];
-  chain.push(`[0:v]crop=${cropW}:${cropH}:${cropX}:${cropY}[v_crop]`);
+  // SCK captures the Obsidian window directly, so the raw frame IS the window
+  // (origin 0,0). Crop to the window size from 0,0 (cropX/cropY are kept only for
+  // translating the cursor trace from screen coords to window-relative below).
+  chain.push(`[0:v]crop=${cropW}:${cropH}:0:0[v_crop]`);
   // Overlay the synthetic cursor at full rate, before the speedup split, so
   // it's decimated together with the screen during sped-up segments.
   chain.push(`[v_crop][${haloInputIdx}:v]overlay=0:0:eof_action=pass[v_crop_h]`);
-  chain.push(`[v_crop_h]split=${segments.length}${segments.map((_, i) => `[c${i}]`).join("")}`);
+  // Add a black band below the window so narration captions render under the
+  // app, never over the chat.
+  chain.push(`[v_crop_h]pad=${cropW}:${cropH + CAPTION_BAND_PX}:0:0:black[v_pad]`);
+  chain.push(`[v_pad]split=${segments.length}${segments.map((_, i) => `[c${i}]`).join("")}`);
   const segOuts: string[] = [];
   for (let i = 0; i < segments.length; i++) {
     const s = segments[i];
@@ -883,7 +892,7 @@ async function postProcess(opts: PostOptions): Promise<void> {
     const idx = beatCaptionInputIdx.get(text);
     if (idx === undefined) continue;
     const next = `v_cap${capIdx++}`;
-    chain.push(`[${lastLabel}][${idx}:v]overlay=(W-w)/2:H-h-52:enable='${windows.join("+")}'[${next}]`);
+    chain.push(`[${lastLabel}][${idx}:v]overlay=(W-w)/2:${cropH}+(${CAPTION_BAND_PX}-h)/2:enable='${windows.join("+")}'[${next}]`);
     lastLabel = next;
   }
 

--- a/demos-src/src/record.ts
+++ b/demos-src/src/record.ts
@@ -273,6 +273,8 @@ async function runAction(ctx: ObsidianContext, action: Action, beat: Beat): Prom
   switch (action.kind) {
     case "clickSelector":
       return await cursorClickSelector(ctx, action.selector, beat);
+    case "hoverSelector":
+      return await cursorActOnSelector(ctx, action.selector, beat, undefined, "hover");
     case "rightClickSelector":
       return await cursorRightClickSelector(ctx, action.selector, beat);
     case "clickMenuItem":
@@ -375,7 +377,7 @@ async function cursorActOnSelector(
   selector: string,
   beat: Beat,
   textIs: string | undefined,
-  button: "left" | "right",
+  button: "left" | "right" | "hover",
 ): Promise<{ x: number; y: number }> {
   // Support Playwright-style :has-text("...") and :text-is("...") sugar
   // by extracting the text and matching against textContent in the
@@ -396,6 +398,11 @@ async function cursorActOnSelector(
   if (!coord) throw new Error(`cannot resolve selector for beat '${beat.label}': ${selector}`);
   await moveToCoord(coord.x, coord.y, coord.cursor);
   await sleep(HOVER_BEFORE_CLICK_MS);
+  if (button === "hover") {
+    // No click — leave the cursor parked on the element so Obsidian's
+    // aria-label tooltip surfaces during the beat's hold.
+    return coord;
+  }
   if (button === "right") {
     // Real OS right-click via pyautogui so Obsidian's native context
     // menu opens on screen for the recording. Playwright's in-page

--- a/demos-src/src/sckrecord.swift
+++ b/demos-src/src/sckrecord.swift
@@ -13,6 +13,12 @@ import AVFoundation
 import CoreMedia
 import Dispatch
 import Foundation
+import AppKit
+
+// Window capture touches window-server / CoreGraphics APIs that assert
+// (CGS_REQUIRE_INIT) unless the process is initialized as a GUI app. A plain
+// CLI gets that by creating the shared AppKit app object up front.
+_ = NSApplication.shared
 
 func err(_ s: String) { FileHandle.standardError.write((s + "\n").data(using: .utf8)!) }
 
@@ -32,10 +38,23 @@ final class Rec: NSObject, SCStreamOutput, SCStreamDelegate {
 
     func start() async throws {
         let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: false)
-        guard let display = content.displays.first else { throw NSError(domain: "sck", code: 1) }
-        w = display.width * 2
-        h = display.height * 2
-        let filter = SCContentFilter(display: display, excludingWindows: [])
+        // Capture the Obsidian window directly (not the display) so the reel is
+        // immune to focus: the window composites even when another app is front
+        // or the user is typing in a terminal. Pick the largest on-screen window
+        // owned by Obsidian.
+        let appName = CommandLine.arguments.count > 3 ? CommandLine.arguments[3] : "Obsidian"
+        let obsidian = content.windows.filter {
+            ($0.owningApplication?.applicationName == appName || $0.owningApplication?.bundleIdentifier == "md.obsidian")
+                && $0.isOnScreen && $0.frame.width > 400 && $0.frame.height > 300
+        }
+        guard let window = obsidian.max(by: { $0.frame.width * $0.frame.height < $1.frame.width * $1.frame.height }) else {
+            throw NSError(domain: "sck", code: 2, userInfo: [NSLocalizedDescriptionKey: "no \(appName) window found"])
+        }
+        let scale = 2
+        w = Int(window.frame.width) * scale
+        h = Int(window.frame.height) * scale
+        let filter = SCContentFilter(desktopIndependentWindow: window)
+        err("sck: window \(Int(window.frame.width))x\(Int(window.frame.height)) @\(Int(window.frame.minX)),\(Int(window.frame.minY))")
         let cfg = SCStreamConfiguration()
         cfg.width = w
         cfg.height = h

--- a/demos-src/tapes/first_start.ts
+++ b/demos-src/tapes/first_start.ts
@@ -223,14 +223,26 @@ export default storyboard("first_start", {
     ),
     ...wizardStep("Welcome -> Get started", "lilbee's setup wizard walks you through first-time setup."),
     ...wizardStep(
-      "Server mode -> Next (Managed downloads server binary)",
+      "Server mode -> Next (Managed)",
       "Managed mode: lilbee downloads and runs its own local server for you.",
     ),
-    // The wizard's "Server mode → Next" calls startManagedServer (downloads the
-    // binary, starts the process) and advances to the model picker. The picker's
-    // cards load via the catalog API then re-render once for a RAM-fit pass, so
-    // wait for the Qwen3 0.6B card to render and settle, then click it with the
-    // cursor.
+    // "Server mode → Next" in Managed now opens the consent modal before any
+    // download: it shows exactly what's being fetched (repo, release, asset,
+    // size). Let it resolve its GitHub provenance, then confirm the download —
+    // which starts the server and advances the wizard to the model picker.
+    beat(
+      "Wait for the managed-server consent modal",
+      waitForSelector(".lilbee-managed-consent"),
+      { holdMs: 1800, caption: "lilbee shows exactly what it downloads — straight from the lilbee GitHub release." },
+    ),
+    beat(
+      "Confirm the managed server download",
+      clickSelector(".lilbee-managed-consent-btn-download"),
+      { holdMs: 1500, caption: "One click: lilbee fetches the server and manages it for you." },
+    ),
+    // After consent the wizard advances to the model picker. The cards load via
+    // the catalog API then re-render once for a RAM-fit pass, so wait for the
+    // Qwen3 0.6B card to render and settle, then click it with the cursor.
     beat(
       "Wait for the model picker's Qwen3 0.6B card",
       waitForSelector('.lilbee-wizard-models [data-repo*="Qwen3-0.6B"]'),

--- a/demos-src/tapes/gemini.ts
+++ b/demos-src/tapes/gemini.ts
@@ -1,30 +1,27 @@
 /**
- * lmstudio demo: a fresh vault (empty index). Pick a model LM Studio already
- * serves for BOTH roles — embedding and chat — from the catalog's Hosted tab, so
- * it's clear LM Studio powers the whole pipeline. Then add the Crown Victoria
- * manual: lilbee embeds it with LM Studio's embedder (real chunk-embedding
- * progress in the Task Center, fast-forwarded). Ask a cited question — the answer
- * streams from the LM Studio chat model and still cites the manual; the citation
- * opens the source preview to the page it came from.
+ * gemini demo: a fresh vault. lilbee also drives hosted frontier models when you
+ * bring your own key. Open the catalog's Hosted tab, search for a free-tier
+ * Gemini model and pick it as the chat model, then add the Crown Victoria manual
+ * (embedded locally with the native embedder) and ask a cited question. The
+ * answer comes from Gemini and still cites the manual.
  *
- * Selecting a Hosted model closes the catalog, so the reel opens it twice (once
- * per role). Mirror of ollama.ts — same arc, different local server.
+ * Embedding stays native here — this reel is about the hosted CHAT model (the
+ * ollama/lmstudio reels show a local server powering both roles). Selecting a
+ * Hosted model closes the catalog.
  *
  * Environment this tape assumes (verify before recording):
- *  - LM Studio's local server running with qwen/qwen3-4b-2507 and
- *    text-embedding-nomic-embed-text-v1.5; warm the chat model.
- *  - The DB is reset EMPTY and rebuilt before recording. NO frontier key is set.
+ *  - A Gemini API key IS configured (the catalog's Hosted tab lists Gemini),
+ *    gemini-2.5-flash reachable free-tier. DB reset EMPTY before recording.
  */
 import { beat, clickSelector, clickSourceFile, clickSend, fillChat, key, runJs, sleep, storyboard, type_, waitChatIdle } from "../src/lib.ts";
 
 const PDF_VAULT_FILE = "Crown Victoria Owner's Manual.pdf";
-const LM_EMBED = "text-embedding-nomic-embed-text-v1.5"; // LM Studio embedding row
-const LM_CHAT = "qwen3-4b-2507"; // LM Studio chat row (dash form, vs ollama's qwen3:4b)
+const GEMINI_CHAT = "gemini-2.5-flash";
 const QUESTION = "I'm prepping this car to tow my boat. What does the manual say I need to check?";
 
 const openCatalog = runJs(`window.app.commands.executeCommandById("command-palette:open");`);
 
-export default storyboard("lmstudio", {
+export default storyboard("gemini", {
   window: [1400, 900],
   layout: "explorer-chat-tasks",
   clearTaskCenter: true,
@@ -32,30 +29,32 @@ export default storyboard("lmstudio", {
   preloadChatModel: false,
   clearChat: true,
   beats: [
-    beat("Opening hold — fresh vault, native models in the rail", sleep(400), {
+    beat("Opening hold — fresh vault, native model in the rail", sleep(400), {
       caption: "A fresh vault — nothing indexed yet.",
     }),
-    // Catalog open #1: pick the LM Studio embedder (selecting closes the catalog).
+    // Pick a hosted Gemini chat model from the catalog's Hosted tab.
     beat("Open the command palette", openCatalog, { holdMs: 600, keyHint: "⌘P" }),
     beat("Filter to the catalog command", type_("Browse model catalog"), { holdMs: 900 }),
     beat("Open the catalog", key("enter"), { holdMs: 800 }),
-    beat("Embedding tab", clickSelector('.lilbee-catalog-main-tab-bar button:has-text("Embed")'), { holdMs: 500 }),
+    beat("Chat tab", clickSelector('.lilbee-catalog-main-tab-bar button:has-text("Chat")'), { holdMs: 500 }),
     beat("Hosted models", clickSelector('.lilbee-catalog-sub-tab-bar button:has-text("Hosted")'), {
       holdMs: 600,
-      caption: "LM Studio serves an embedding model — pick it for indexing.",
+      caption: "With your own key, hosted frontier models show up under Hosted too.",
     }),
-    beat("Use the LM Studio embedder", clickSelector(`.lilbee-frontier-row:has-text("${LM_EMBED}")`), { holdMs: 1100 }),
-    // Catalog open #2: pick the LM Studio chat model.
-    beat("Open the command palette", openCatalog, { holdMs: 500, keyHint: "⌘P" }),
-    beat("Filter to the catalog command", type_("Browse model catalog"), { holdMs: 800 }),
-    beat("Open the catalog", key("enter"), { holdMs: 700 }),
-    beat("Chat tab", clickSelector('.lilbee-catalog-main-tab-bar button:has-text("Chat")'), { holdMs: 500 }),
-    beat("Hosted models", clickSelector('.lilbee-catalog-sub-tab-bar button:has-text("Hosted")'), { holdMs: 500 }),
-    beat("Use the LM Studio chat model", clickSelector(`.lilbee-frontier-row:has-text("${LM_CHAT}")`), {
-      holdMs: 1200,
-      caption: "And the chat model — now LM Studio drives both embedding and chat.",
+    beat("Search the catalog", clickSelector(".lilbee-catalog-search"), { holdMs: 400 }),
+    beat(
+      "Type the model name",
+      runJs(`
+        const s = document.querySelector(".lilbee-catalog-search");
+        if (s) { s.value = ${JSON.stringify(GEMINI_CHAT)}; s.dispatchEvent(new Event("input", { bubbles: true })); }
+      `),
+      { holdMs: 1500 },
+    ),
+    beat("Use the Gemini model", clickSelector(`.lilbee-frontier-row:has-text("${GEMINI_CHAT}")`), {
+      holdMs: 1300,
+      caption: "Pick a free-tier Gemini model — now Gemini drives the chat.",
     }),
-    // Add the manual — it embeds with LM Studio's model now.
+    // Add the manual (embedded locally with the native embedder).
     beat(
       "Open the Crown Vic Owner's Manual",
       runJs(`
@@ -66,7 +65,7 @@ export default storyboard("lmstudio", {
     ),
     beat("Open the command palette", openCatalog, { holdMs: 500, keyHint: "⌘P" }),
     beat("Filter to the Add command", type_("Add current file"), { holdMs: 1100 }),
-    beat("Run it — the manual ingests via LM Studio's embedder", key("enter"), { holdMs: 700 }),
+    beat("Run it — the manual ingests", key("enter"), { holdMs: 700 }),
     beat(
       "Task Center fills with chunk-embedding progress",
       runJs(`
@@ -79,7 +78,7 @@ export default storyboard("lmstudio", {
           await new Promise(r => setTimeout(r, 500));
         }
       `),
-      { holdMs: 1000, speedup: 4, caption: "lilbee chunks and embeds it with LM Studio — fast-forwarding the ingest." },
+      { holdMs: 1000, speedup: 4, caption: "lilbee chunks and embeds it locally — fast-forwarding the ingest." },
     ),
     beat(
       "Close the PDF and activate the chat panel",
@@ -107,7 +106,7 @@ export default storyboard("lmstudio", {
     ),
     beat("Send", clickSend(), {
       holdMs: 600,
-      caption: "The answer streams from the LM Studio model — and still cites the manual.",
+      caption: "The answer comes from Gemini — and still cites your manual.",
     }),
     beat("Stream the cited answer", waitChatIdle(180_000), { holdMs: 1600, speedup: 4 }),
     beat(

--- a/demos-src/tapes/lmstudio.ts
+++ b/demos-src/tapes/lmstudio.ts
@@ -1,0 +1,134 @@
+/**
+ * lmstudio demo: lilbee drives a model LM Studio is already serving — no native
+ * download. Show the provenance (the catalog's Hosted sub-tab groups the
+ * LM Studio-served models under their provider pill), pin that model as the
+ * chat model, then ask a cited question about the Crown Victoria manual. The
+ * answer streams from the LM Studio model and still cites the manual at the
+ * source.
+ *
+ * Mirror of ollama.ts — same arc, different local server — matching the
+ * sibling lilbee repo's tui-lmstudio-document / tui-ollama-document pair.
+ *
+ * Environment this tape assumes (verify before recording):
+ *  - LM Studio's local server is running (`lms server start`) on its default
+ *    URL (http://localhost:1234/v1) with the model below loaded. `lms ls`
+ *    shows the installed models.
+ *  - The lilbee server's LM Studio URL left at the default so its catalog
+ *    surfaces the LM Studio models as Hosted rows (GET /api/models lists
+ *    `lm_studio/...`). Confirm the exact ref the server reports and match
+ *    CHAT_MODEL to it.
+ *  - The Crown Victoria manual is already ingested in the demo corpus (the
+ *    add/tour demos use it), so the towing question retrieves and cites it.
+ */
+import {
+  beat,
+  clickSelector,
+  clickSourceFile,
+  clickSend,
+  fillChat,
+  key,
+  runJs,
+  sleep,
+  storyboard,
+  type_,
+  waitChatIdle,
+} from "../src/lib.ts";
+
+// LM Studio exposes models under the `lm_studio/<id>` ref. qwen/qwen3-4b-2507
+// is loaded on this machine (`lms ls`); confirm the exact id the lilbee server
+// reports and match it here.
+const CHAT_MODEL = "lm_studio/qwen/qwen3-4b-2507";
+const QUESTION = "I'm prepping this car to tow my boat. What does the manual say I need to check?";
+
+// PUT a model into the chat role via the server API the plugin already talks
+// to, then refresh the rail so the pill reflects it. Same helper shape as
+// rerank.ts.
+const setChatModel = (model: string) =>
+  runJs(`
+    const p = window.app.plugins.plugins.lilbee;
+    const base = p.api?.baseUrl ?? p.settings.serverUrl;
+    const h = { "Content-Type": "application/json", Authorization: "Bearer " + (p.api?.token ?? p.settings.manualToken ?? "") };
+    await fetch(base + "/api/models/chat", { method: "PUT", headers: h, body: JSON.stringify({ model: ${JSON.stringify(model)} }) }).catch(() => {});
+    if (typeof p.fetchActiveModel === "function") await p.fetchActiveModel();
+  `);
+
+export default storyboard("lmstudio", {
+  window: [1400, 900],
+  layout: "explorer-chat-tasks",
+  // We pick the chat model ourselves (an LM Studio-served one), so skip the
+  // default native pin and the native preload.
+  skipModelPin: true,
+  preloadChatModel: false,
+  clearTaskCenter: false,
+  clearChat: true,
+  beats: [
+    beat("Opening hold on the clean workspace", sleep(300)),
+
+    beat("Use the model LM Studio is serving", setChatModel(CHAT_MODEL), {
+      holdMs: 700,
+      caption: "lilbee can drive any model LM Studio already serves — no native download.",
+    }),
+
+    // Provenance: open the catalog and switch to the Hosted sub-tab, where the
+    // LM Studio-served models are grouped under their provider pill.
+    beat("Open the command palette", runJs(`window.app.commands.executeCommandById("command-palette:open");`), {
+      holdMs: 600,
+      keyHint: "⌘P",
+    }),
+    beat("Filter to the catalog command", type_("Browse model catalog"), { holdMs: 1000 }),
+    beat("Open the catalog", key("enter"), { holdMs: 900 }),
+    beat("Chat tab", clickSelector('.lilbee-catalog-main-tab-bar button:text-is("Chat")'), { holdMs: 600 }),
+    beat("Switch to Hosted models", clickSelector(".lilbee-catalog-sub-tab-bar button:nth-child(2)"), {
+      holdMs: 900,
+      caption: "Models served by LM Studio show up here, tagged with their provider.",
+    }),
+    beat(
+      "Linger on the LM Studio provider pill",
+      runJs(`
+        const pill = Array.from(document.querySelectorAll('.lilbee-provider-pill'))
+          .find((p) => /lm.?studio/i.test(p.textContent || ''));
+        (pill?.closest('.lilbee-frontier-row') ?? pill)?.scrollIntoView({ block: 'center' });
+      `),
+      { holdMs: 2400 },
+    ),
+    beat("Close the catalog", key("escape"), { holdMs: 600 }),
+
+    // Ask the towing question against the already-ingested manual.
+    beat(
+      "Activate a clean chat panel",
+      runJs(`
+        const leaves = window.app.workspace.getLeavesOfType('lilbee-chat');
+        if (leaves[0]) window.app.workspace.revealLeaf(leaves[0]);
+        await new Promise(r => setTimeout(r, 350));
+        const ta = document.querySelector('textarea.lilbee-chat-textarea');
+        if (ta) ta.focus();
+      `),
+      { holdMs: 600 },
+    ),
+    beat("Ask the towing question", fillChat(QUESTION), { holdMs: 600 }),
+    beat(
+      "Ensure the question is in the box",
+      runJs(`
+        const ta = document.querySelector('textarea.lilbee-chat-textarea');
+        if (ta && !ta.value.trim()) {
+          const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set;
+          setter.call(ta, ${JSON.stringify(QUESTION)});
+          ta.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+      `),
+      { holdMs: 300 },
+    ),
+    beat("Send", clickSend(), {
+      holdMs: 600,
+      caption: "The answer streams from the LM Studio model — and still cites the manual.",
+    }),
+    beat("Stream the cited answer", waitChatIdle(180_000), { holdMs: 1400, speedup: 4 }),
+    beat(
+      "Expand sources",
+      runJs(`document.querySelectorAll('.lilbee-chat-sources details').forEach(d => d.open = true);`),
+      { holdMs: 400 },
+    ),
+    beat("Open the cited page of the manual", clickSourceFile("Crown Victoria"), { holdMs: 4500 }),
+    beat("Close source preview", key("escape"), { holdMs: 600 }),
+  ],
+});

--- a/demos-src/tapes/models.ts
+++ b/demos-src/tapes/models.ts
@@ -1,0 +1,47 @@
+/**
+ * models demo: the chat view's model rail surfaces all four roles — Chat,
+ * Embed, Vision, Rerank — each as a labelled pill with its own picker. This
+ * tape opens the chat view and hovers each pill (and the Search/Chat mode
+ * toggle) so their tooltips surface, explaining what every role does and the
+ * difference between the two answer modes.
+ *
+ * Nothing is changed on the server; it's a pure read of the rail, so it runs
+ * fast and is safe to re-record any time.
+ */
+import { beat, hoverSelector, storyboard } from "../src/lib.ts";
+
+// Pills and mode buttons carry an aria-label tooltip; match on its prefix.
+const pill = (ariaPrefix: string) => `[aria-label^="${ariaPrefix}"]`;
+
+export default storyboard("models", {
+  window: [1400, 900],
+  layout: "file-explorer-and-chat",
+  preloadChatModel: true,
+  clearChat: true,
+  beats: [
+    beat("Hover the Chat pill", hoverSelector(pill("Chat model")), {
+      holdMs: 2000,
+      caption: "The model rail surfaces all four roles. Chat writes the answers.",
+    }),
+    beat("Hover the Embed pill", hoverSelector(pill("Embedding model")), {
+      holdMs: 2000,
+      caption: "Embed indexes your notes so search can find them.",
+    }),
+    beat("Hover the Vision pill", hoverSelector(pill("Vision model")), {
+      holdMs: 2000,
+      caption: "Vision reads scanned, image-only PDFs. Optional — off until you pick one.",
+    }),
+    beat("Hover the Rerank pill", hoverSelector(pill("Reranker")), {
+      holdMs: 2000,
+      caption: "Rerank reorders search hits for sharper relevance. Also optional.",
+    }),
+    beat("Hover the Search mode", hoverSelector(pill("Search your vault")), {
+      holdMs: 2000,
+      caption: "Search answers from your vault and cites the sources.",
+    }),
+    beat("Hover the Chat mode", hoverSelector(pill("Chat with the model")), {
+      holdMs: 2200,
+      caption: "Chat talks to the model directly — no retrieval.",
+    }),
+  ],
+});

--- a/demos-src/tapes/multipart.ts
+++ b/demos-src/tapes/multipart.ts
@@ -1,0 +1,99 @@
+/**
+ * multipart demo: a fresh vault. Add the Crown Victoria manual, then ask a
+ * MULTI-PART question in one shot — two unrelated facts from different sections
+ * of the manual — and watch a native model (Qwen3 8B, run by lilbee) answer both
+ * and cite each.
+ *
+ * Verified answer: "park lamp and tail lamp bulb part number 3457 AK / 3157K
+ * [..]; firing order for the 4.6L V8 engine is 1-3-7-2-6-5-4-8 [..]." The bulb
+ * chart and the engine spec live on different pages, so the citations point to
+ * both. (The firing-order chunk is keyed on "4.6L V8", so the question names it.)
+ *
+ * Environment this tape assumes (verify before recording):
+ *  - Qwen3 8B installed natively and warm; query expansion on; top_k 8.
+ *  - The DB is reset EMPTY before recording; the manual PDF exists in the vault.
+ */
+import { beat, clickSourceFile, clickSend, fillChat, key, runJs, sleep, storyboard, type_, waitChatIdle } from "../src/lib.ts";
+
+const PDF_VAULT_FILE = "Crown Victoria Owner's Manual.pdf";
+const QUESTION =
+  "What is the park lamp and tail lamp bulb part number, and what is the firing order for the 4.6L V8 engine?";
+
+const openCatalog = runJs(`window.app.commands.executeCommandById("command-palette:open");`);
+
+export default storyboard("multipart", {
+  window: [1400, 900],
+  layout: "explorer-chat-tasks",
+  clearTaskCenter: true,
+  // Qwen3 8B is the answering model; preload so the on-camera answer is warm.
+  pinChatModel: "Qwen/Qwen3-8B-GGUF/Qwen3-8B-Q4_K_M.gguf",
+  preloadChatModel: true,
+  clearChat: true,
+  beats: [
+    beat("Opening hold — Qwen3 8B in the rail, fresh vault", sleep(400), {
+      caption: "A native model, run by lilbee — fresh vault.",
+    }),
+    // Add the manual.
+    beat(
+      "Open the Crown Vic Owner's Manual",
+      runJs(`
+        await window.app.workspace.openLinkText(${JSON.stringify(PDF_VAULT_FILE)}, '', 'tab');
+        await new Promise(r => setTimeout(r, 250));
+      `),
+      { holdMs: 900, caption: "Add the Crown Victoria owner's manual." },
+    ),
+    beat("Open the command palette", openCatalog, { holdMs: 500, keyHint: "⌘P" }),
+    beat("Filter to the Add command", type_("Add current file"), { holdMs: 1100 }),
+    beat("Run it — the manual ingests", key("enter"), { holdMs: 700 }),
+    beat(
+      "Task Center fills with chunk-embedding progress",
+      runJs(`
+        const tq = window.app.plugins.plugins.lilbee.taskQueue;
+        let sawActive = false;
+        for (let i = 0; i < 300; i++) {
+          const busy = tq.activeAll.length + tq.queued.length;
+          if (busy > 0) sawActive = true;
+          if (sawActive && busy === 0) return;
+          await new Promise(r => setTimeout(r, 500));
+        }
+      `),
+      { holdMs: 1000, speedup: 4, caption: "lilbee chunks and embeds it locally — fast-forwarding the ingest." },
+    ),
+    beat(
+      "Close the PDF and activate the chat panel",
+      runJs(`
+        for (const leaf of window.app.workspace.getLeavesOfType('pdf')) leaf.detach();
+        for (const leaf of window.app.workspace.getLeavesOfType('markdown')) leaf.detach();
+        const leaves = window.app.workspace.getLeavesOfType('lilbee-chat');
+        if (leaves[0]) window.app.workspace.revealLeaf(leaves[0]);
+        await new Promise(r => setTimeout(r, 400));
+      `),
+      { holdMs: 600 },
+    ),
+    beat("Ask a multi-part question", fillChat(QUESTION), { holdMs: 700 }),
+    beat(
+      "Ensure the question is in the box",
+      runJs(`
+        const ta = document.querySelector('textarea.lilbee-chat-textarea');
+        if (ta && !ta.value.trim()) {
+          const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set;
+          setter.call(ta, ${JSON.stringify(QUESTION)});
+          ta.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+      `),
+      { holdMs: 300 },
+    ),
+    beat("Send", clickSend(), {
+      holdMs: 600,
+      caption: "One question, two unrelated facts — a bulb part number and the firing order.",
+    }),
+    beat("Stream the cited answer", waitChatIdle(180_000), { holdMs: 2200, speedup: 4 }),
+    beat(
+      "Expand sources",
+      runJs(`document.querySelectorAll('.lilbee-chat-sources details').forEach(d => d.open = true);`),
+      { holdMs: 700, caption: "Each fact comes from a different section of the manual, and is cited." },
+    ),
+    beat("Open the cited page of the manual", clickSourceFile("Crown Victoria"), { holdMs: 4500 }),
+    beat("Close source preview", key("escape"), { holdMs: 600 }),
+  ],
+});

--- a/demos-src/tapes/ollama.ts
+++ b/demos-src/tapes/ollama.ts
@@ -1,102 +1,95 @@
 /**
- * ollama demo: lilbee drives a model Ollama is already serving — no native
- * download. Show the provenance (the catalog's Hosted sub-tab groups the
- * Ollama-served models under their provider pill), pin that model as the chat
- * model, then ask a cited question about the Crown Victoria manual. The answer
- * streams from the Ollama model and still cites the manual at the source.
+ * ollama demo: a fresh vault (empty index). Pick a model Ollama already serves
+ * for BOTH roles — embedding and chat — from the catalog's Hosted tab, so it's
+ * clear Ollama powers the whole pipeline. Then add the Crown Victoria manual:
+ * lilbee embeds it with Ollama's embedder (real chunk-embedding progress in the
+ * Task Center, fast-forwarded). Ask a cited question — the answer streams from
+ * the Ollama chat model and still cites the manual; the citation opens the
+ * source preview to the page it came from.
  *
- * Mirror of lmstudio.ts — same arc, different local server — matching the
- * sibling lilbee repo's tui-ollama-document / tui-lmstudio-document pair.
+ * Selecting a Hosted model closes the catalog, so the reel opens it twice (once
+ * per role). Mirror of lmstudio.ts — same arc, different local server.
  *
  * Environment this tape assumes (verify before recording):
- *  - Ollama running on its default URL (http://localhost:11434) with the model
- *    below pulled. `ollama list` should show it.
- *  - The lilbee server's Ollama URL left at the default so its catalog surfaces
- *    the Ollama models as Hosted rows (GET /api/models lists `ollama/...`).
- *  - The Crown Victoria manual is already ingested in the demo corpus (the
- *    add/tour demos use it), so the towing question retrieves and cites it.
+ *  - Ollama serving qwen3:4b and nomic-embed-text:v1.5; warm the chat model.
+ *  - The DB is reset EMPTY and rebuilt before recording, so the on-camera add
+ *    adopts Ollama's embedder cleanly. NO frontier key is set.
  */
-import {
-  beat,
-  clickSelector,
-  clickSourceFile,
-  clickSend,
-  fillChat,
-  key,
-  runJs,
-  sleep,
-  storyboard,
-  type_,
-  waitChatIdle,
-} from "../src/lib.ts";
+import { beat, clickSelector, clickSourceFile, clickSend, fillChat, key, runJs, sleep, storyboard, type_, waitChatIdle } from "../src/lib.ts";
 
-// Ollama exposes models under the `ollama/<tag>` ref. qwen3:0.6b is the small,
-// fast model pulled on this machine; swap to whatever `ollama list` shows.
-const CHAT_MODEL = "ollama/qwen3:0.6b";
+const PDF_VAULT_FILE = "Crown Victoria Owner's Manual.pdf";
+const OLLAMA_EMBED = "nomic-embed-text:v1.5"; // Ollama embedding row (colon form, vs lm_studio's dashed name)
+const OLLAMA_CHAT = "qwen3:4b"; // Ollama chat row (colon form)
 const QUESTION = "I'm prepping this car to tow my boat. What does the manual say I need to check?";
 
-// PUT a model into the chat role via the server API the plugin already talks
-// to, then refresh the rail so the pill reflects it. Same helper shape as
-// rerank.ts.
-const setChatModel = (model: string) =>
-  runJs(`
-    const p = window.app.plugins.plugins.lilbee;
-    const base = p.api?.baseUrl ?? p.settings.serverUrl;
-    const h = { "Content-Type": "application/json", Authorization: "Bearer " + (p.api?.token ?? p.settings.manualToken ?? "") };
-    await fetch(base + "/api/models/chat", { method: "PUT", headers: h, body: JSON.stringify({ model: ${JSON.stringify(model)} }) }).catch(() => {});
-    if (typeof p.fetchActiveModel === "function") await p.fetchActiveModel();
-  `);
+const openCatalog = runJs(`window.app.commands.executeCommandById("command-palette:open");`);
 
 export default storyboard("ollama", {
   window: [1400, 900],
   layout: "explorer-chat-tasks",
-  // We pick the chat model ourselves (an Ollama-served one), so skip the
-  // default native pin and the native preload.
-  skipModelPin: true,
+  clearTaskCenter: true,
+  pinChatModel: "Qwen/Qwen3-8B-GGUF/Qwen3-8B-Q4_K_M.gguf",
   preloadChatModel: false,
-  clearTaskCenter: false,
   clearChat: true,
   beats: [
-    beat("Opening hold on the clean workspace", sleep(300)),
-
-    beat("Use the model Ollama is serving", setChatModel(CHAT_MODEL), {
-      holdMs: 700,
-      caption: "lilbee can drive any model Ollama already serves — no native download.",
+    beat("Opening hold — fresh vault, native models in the rail", sleep(400), {
+      caption: "A fresh vault — nothing indexed yet.",
     }),
-
-    // Provenance: open the catalog and switch to the Hosted sub-tab, where the
-    // Ollama-served models are grouped under their provider pill.
-    beat("Open the command palette", runJs(`window.app.commands.executeCommandById("command-palette:open");`), {
+    // Catalog open #1: pick the Ollama embedder (selecting closes the catalog).
+    beat("Open the command palette", openCatalog, { holdMs: 600, keyHint: "⌘P" }),
+    beat("Filter to the catalog command", type_("Browse model catalog"), { holdMs: 900 }),
+    beat("Open the catalog", key("enter"), { holdMs: 800 }),
+    beat("Embedding tab", clickSelector('.lilbee-catalog-main-tab-bar button:has-text("Embed")'), { holdMs: 500 }),
+    beat("Hosted models", clickSelector('.lilbee-catalog-sub-tab-bar button:has-text("Hosted")'), {
       holdMs: 600,
-      keyHint: "⌘P",
+      caption: "Ollama serves an embedding model — pick it for indexing.",
     }),
-    beat("Filter to the catalog command", type_("Browse model catalog"), { holdMs: 1000 }),
-    beat("Open the catalog", key("enter"), { holdMs: 900 }),
-    beat("Chat tab", clickSelector('.lilbee-catalog-main-tab-bar button:text-is("Chat")'), { holdMs: 600 }),
-    beat("Switch to Hosted models", clickSelector(".lilbee-catalog-sub-tab-bar button:nth-child(2)"), {
-      holdMs: 900,
-      caption: "Models served by Ollama show up here, tagged with their provider.",
+    beat("Use the Ollama embedder", clickSelector(`.lilbee-frontier-row:has-text("${OLLAMA_EMBED}")`), { holdMs: 1100 }),
+    // Catalog open #2: pick the Ollama chat model.
+    beat("Open the command palette", openCatalog, { holdMs: 500, keyHint: "⌘P" }),
+    beat("Filter to the catalog command", type_("Browse model catalog"), { holdMs: 800 }),
+    beat("Open the catalog", key("enter"), { holdMs: 700 }),
+    beat("Chat tab", clickSelector('.lilbee-catalog-main-tab-bar button:has-text("Chat")'), { holdMs: 500 }),
+    beat("Hosted models", clickSelector('.lilbee-catalog-sub-tab-bar button:has-text("Hosted")'), { holdMs: 500 }),
+    beat("Use the Ollama chat model", clickSelector(`.lilbee-frontier-row:has-text("${OLLAMA_CHAT}")`), {
+      holdMs: 1200,
+      caption: "And the chat model — now Ollama drives both embedding and chat.",
     }),
+    // Add the manual — it embeds with Ollama's model now.
     beat(
-      "Linger on the Ollama provider pill",
+      "Open the Crown Vic Owner's Manual",
       runJs(`
-        const pill = Array.from(document.querySelectorAll('.lilbee-provider-pill'))
-          .find((p) => /ollama/i.test(p.textContent || ''));
-        (pill?.closest('.lilbee-frontier-row') ?? pill)?.scrollIntoView({ block: 'center' });
+        await window.app.workspace.openLinkText(${JSON.stringify(PDF_VAULT_FILE)}, '', 'tab');
+        await new Promise(r => setTimeout(r, 250));
       `),
-      { holdMs: 2400 },
+      { holdMs: 900, caption: "Add the Crown Victoria owner's manual." },
     ),
-    beat("Close the catalog", key("escape"), { holdMs: 600 }),
-
-    // Ask the towing question against the already-ingested manual.
+    beat("Open the command palette", openCatalog, { holdMs: 500, keyHint: "⌘P" }),
+    beat("Filter to the Add command", type_("Add current file"), { holdMs: 1100 }),
+    beat("Run it — the manual ingests via Ollama's embedder", key("enter"), { holdMs: 700 }),
     beat(
-      "Activate a clean chat panel",
+      "Task Center fills with chunk-embedding progress",
       runJs(`
+        const tq = window.app.plugins.plugins.lilbee.taskQueue;
+        let sawActive = false;
+        for (let i = 0; i < 300; i++) {
+          const busy = tq.activeAll.length + tq.queued.length;
+          if (busy > 0) sawActive = true;
+          if (sawActive && busy === 0) return;
+          await new Promise(r => setTimeout(r, 500));
+        }
+      `),
+      { holdMs: 1000, speedup: 4, caption: "lilbee chunks and embeds it with Ollama — fast-forwarding the ingest." },
+    ),
+    // Back to the chat panel and ask the cited question.
+    beat(
+      "Close the PDF and activate the chat panel",
+      runJs(`
+        for (const leaf of window.app.workspace.getLeavesOfType('pdf')) leaf.detach();
+        for (const leaf of window.app.workspace.getLeavesOfType('markdown')) leaf.detach();
         const leaves = window.app.workspace.getLeavesOfType('lilbee-chat');
         if (leaves[0]) window.app.workspace.revealLeaf(leaves[0]);
-        await new Promise(r => setTimeout(r, 350));
-        const ta = document.querySelector('textarea.lilbee-chat-textarea');
-        if (ta) ta.focus();
+        await new Promise(r => setTimeout(r, 400));
       `),
       { holdMs: 600 },
     ),
@@ -117,7 +110,7 @@ export default storyboard("ollama", {
       holdMs: 600,
       caption: "The answer streams from the Ollama model — and still cites the manual.",
     }),
-    beat("Stream the cited answer", waitChatIdle(180_000), { holdMs: 1400, speedup: 4 }),
+    beat("Stream the cited answer", waitChatIdle(180_000), { holdMs: 1600, speedup: 4 }),
     beat(
       "Expand sources",
       runJs(`document.querySelectorAll('.lilbee-chat-sources details').forEach(d => d.open = true);`),

--- a/demos-src/tapes/ollama.ts
+++ b/demos-src/tapes/ollama.ts
@@ -1,0 +1,129 @@
+/**
+ * ollama demo: lilbee drives a model Ollama is already serving — no native
+ * download. Show the provenance (the catalog's Hosted sub-tab groups the
+ * Ollama-served models under their provider pill), pin that model as the chat
+ * model, then ask a cited question about the Crown Victoria manual. The answer
+ * streams from the Ollama model and still cites the manual at the source.
+ *
+ * Mirror of lmstudio.ts — same arc, different local server — matching the
+ * sibling lilbee repo's tui-ollama-document / tui-lmstudio-document pair.
+ *
+ * Environment this tape assumes (verify before recording):
+ *  - Ollama running on its default URL (http://localhost:11434) with the model
+ *    below pulled. `ollama list` should show it.
+ *  - The lilbee server's Ollama URL left at the default so its catalog surfaces
+ *    the Ollama models as Hosted rows (GET /api/models lists `ollama/...`).
+ *  - The Crown Victoria manual is already ingested in the demo corpus (the
+ *    add/tour demos use it), so the towing question retrieves and cites it.
+ */
+import {
+  beat,
+  clickSelector,
+  clickSourceFile,
+  clickSend,
+  fillChat,
+  key,
+  runJs,
+  sleep,
+  storyboard,
+  type_,
+  waitChatIdle,
+} from "../src/lib.ts";
+
+// Ollama exposes models under the `ollama/<tag>` ref. qwen3:0.6b is the small,
+// fast model pulled on this machine; swap to whatever `ollama list` shows.
+const CHAT_MODEL = "ollama/qwen3:0.6b";
+const QUESTION = "I'm prepping this car to tow my boat. What does the manual say I need to check?";
+
+// PUT a model into the chat role via the server API the plugin already talks
+// to, then refresh the rail so the pill reflects it. Same helper shape as
+// rerank.ts.
+const setChatModel = (model: string) =>
+  runJs(`
+    const p = window.app.plugins.plugins.lilbee;
+    const base = p.api?.baseUrl ?? p.settings.serverUrl;
+    const h = { "Content-Type": "application/json", Authorization: "Bearer " + (p.api?.token ?? p.settings.manualToken ?? "") };
+    await fetch(base + "/api/models/chat", { method: "PUT", headers: h, body: JSON.stringify({ model: ${JSON.stringify(model)} }) }).catch(() => {});
+    if (typeof p.fetchActiveModel === "function") await p.fetchActiveModel();
+  `);
+
+export default storyboard("ollama", {
+  window: [1400, 900],
+  layout: "explorer-chat-tasks",
+  // We pick the chat model ourselves (an Ollama-served one), so skip the
+  // default native pin and the native preload.
+  skipModelPin: true,
+  preloadChatModel: false,
+  clearTaskCenter: false,
+  clearChat: true,
+  beats: [
+    beat("Opening hold on the clean workspace", sleep(300)),
+
+    beat("Use the model Ollama is serving", setChatModel(CHAT_MODEL), {
+      holdMs: 700,
+      caption: "lilbee can drive any model Ollama already serves — no native download.",
+    }),
+
+    // Provenance: open the catalog and switch to the Hosted sub-tab, where the
+    // Ollama-served models are grouped under their provider pill.
+    beat("Open the command palette", runJs(`window.app.commands.executeCommandById("command-palette:open");`), {
+      holdMs: 600,
+      keyHint: "⌘P",
+    }),
+    beat("Filter to the catalog command", type_("Browse model catalog"), { holdMs: 1000 }),
+    beat("Open the catalog", key("enter"), { holdMs: 900 }),
+    beat("Chat tab", clickSelector('.lilbee-catalog-main-tab-bar button:text-is("Chat")'), { holdMs: 600 }),
+    beat("Switch to Hosted models", clickSelector(".lilbee-catalog-sub-tab-bar button:nth-child(2)"), {
+      holdMs: 900,
+      caption: "Models served by Ollama show up here, tagged with their provider.",
+    }),
+    beat(
+      "Linger on the Ollama provider pill",
+      runJs(`
+        const pill = Array.from(document.querySelectorAll('.lilbee-provider-pill'))
+          .find((p) => /ollama/i.test(p.textContent || ''));
+        (pill?.closest('.lilbee-frontier-row') ?? pill)?.scrollIntoView({ block: 'center' });
+      `),
+      { holdMs: 2400 },
+    ),
+    beat("Close the catalog", key("escape"), { holdMs: 600 }),
+
+    // Ask the towing question against the already-ingested manual.
+    beat(
+      "Activate a clean chat panel",
+      runJs(`
+        const leaves = window.app.workspace.getLeavesOfType('lilbee-chat');
+        if (leaves[0]) window.app.workspace.revealLeaf(leaves[0]);
+        await new Promise(r => setTimeout(r, 350));
+        const ta = document.querySelector('textarea.lilbee-chat-textarea');
+        if (ta) ta.focus();
+      `),
+      { holdMs: 600 },
+    ),
+    beat("Ask the towing question", fillChat(QUESTION), { holdMs: 600 }),
+    beat(
+      "Ensure the question is in the box",
+      runJs(`
+        const ta = document.querySelector('textarea.lilbee-chat-textarea');
+        if (ta && !ta.value.trim()) {
+          const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set;
+          setter.call(ta, ${JSON.stringify(QUESTION)});
+          ta.dispatchEvent(new Event('input', { bubbles: true }));
+        }
+      `),
+      { holdMs: 300 },
+    ),
+    beat("Send", clickSend(), {
+      holdMs: 600,
+      caption: "The answer streams from the Ollama model — and still cites the manual.",
+    }),
+    beat("Stream the cited answer", waitChatIdle(180_000), { holdMs: 1400, speedup: 4 }),
+    beat(
+      "Expand sources",
+      runJs(`document.querySelectorAll('.lilbee-chat-sources details').forEach(d => d.open = true);`),
+      { holdMs: 400 },
+    ),
+    beat("Open the cited page of the manual", clickSourceFile("Crown Victoria"), { holdMs: 4500 }),
+    beat("Close source preview", key("escape"), { holdMs: 600 }),
+  ],
+});

--- a/demos-src/tapes/rerank.ts
+++ b/demos-src/tapes/rerank.ts
@@ -16,7 +16,7 @@
  * Empirically verified: embedding rank of the answer = 12/14; rerank OFF excludes
  * it from the cited context, rerank ON includes it.
  */
-import { beat, clickSelector, clickSend, fillChat, key, runJs, storyboard } from "../src/lib.ts";
+import { beat, clickSelector, clickSend, fillChat, key, runJs, storyboard, waitChatIdle } from "../src/lib.ts";
 
 const QUESTION = "How do I turn off the daytime running lights on my Crown Victoria?";
 const CHAT_MODEL = "hugging-quants/Llama-3.2-1B-Instruct-Q8_0-GGUF/llama-3.2-1b-instruct-q8_0.gguf";
@@ -46,23 +46,14 @@ const setRole = (role: "chat" | "reranker", model: string) =>
     if (typeof p.fetchActiveModel === "function") await p.fetchActiveModel();
   `);
 
-// Send the question, then wait for the answer to finish streaming (Send button
-// flips Stop → Send when done).
+// Send the question, then wait for the answer to finish streaming. waitChatIdle
+// matches the other chat tapes; speedup 8 fast-forwards the big latencies here —
+// a cold model load (Llama 3.2 1B / bge-reranker spin up on first use) plus
+// retrieval and token generation.
 const ask = (label: string, caption: string) => [
   beat("Type the question", fillChat(QUESTION), { holdMs: 700 }),
   beat(label, clickSend(), { holdMs: 800, caption }),
-  beat(
-    "Wait for the answer",
-    runJs(`
-      const send = document.querySelector('.lilbee-chat-send');
-      for (let i = 0; i < 240; i++) {
-        const t = (send?.textContent || '').toLowerCase();
-        if (t.includes('send') && i > 4) return;
-        await new Promise(r => setTimeout(r, 500));
-      }
-    `),
-    { holdMs: 3000, speedup: 3, maxMs: 150_000 },
-  ),
+  beat("Stream the answer", waitChatIdle(180_000), { holdMs: 1600, speedup: 8 }),
 ];
 
 export default storyboard("rerank", {

--- a/demos-src/tapes/rerank.ts
+++ b/demos-src/tapes/rerank.ts
@@ -2,27 +2,39 @@
  * rerank demo: before/after reranking on the SAME question, so it's obvious what
  * reranking does.
  *
- * The vault's Garage/ notes contain one passage that actually answers
- * "how do I turn off the daytime running lights" (it's worded around the parking
- * brake, not the query's keywords) plus ten keyword-heavy distractors. Plain
- * vector search ranks the real answer #9 of 11 — below the 8-slot context
- * window — so with reranking OFF the model misses it and hallucinates a
- * fuse-pulling answer from the wiring/battery distractors. Turning reranking ON
- * (bge-reranker-v2-m3) promotes the genuinely-relevant passage to context slot
- * #1 and the answer becomes correct (set the parking brake one click).
+ * Corpus = the eight "Crown Vic Build" electrical notes. The question describes
+ * a symptom (at idle, with the light bar and laptop running, the radio resets
+ * and the headlights dim). The note that actually holds the fix — "Grounding and
+ * the big three" — is written around the cause (voltage sag, charge cabling,
+ * 1/0 gauge), not the question's component keywords, so plain vector search
+ * ranks it #4, outside the top-3 context window. The keyword-matching notes
+ * (Laptop dock and radio, Light bar install) sit on top.
  *
- * Chat runs on Llama 3.2 1B, which co-fits with the reranker worker in RAM
- * (phi-4 / phi-4-mini OOM when the reranker is also resident).
+ * Reranking OFF: the model only sees the keyword matches and confidently
+ * recommends the WRONG fix (add a separate battery / bypass the fuse block).
+ * Reranking ON (bge-reranker-v2-m3): the cross-encoder re-scores by true
+ * relevance and promotes the grounding note into the top-3, so the answer gives
+ * the correct fix — upgrade the "big three" cables to 1/0 gauge.
  *
- * Empirically verified on the 11-doc index this records against: answer embeds
- * at rank 9/11 (relevance 0.03 vs ~0.18 for the distractors); rerank OFF cites
- * the 8 distractors and answers "replace the 30A fuse" (wrong), rerank ON cites
- * the real passage first and answers "set the parking brake" (right).
+ * Chat runs on the Qwen3 4B served by LM Studio: large enough to use the context
+ * faithfully (the 0.6B models answer inconsistently), small enough to stream
+ * quickly. Query expansion is turned off for the run so retrieval is
+ * deterministic and the rerank effect is the only thing that changes between the
+ * two asks.
+ *
+ * Verified on the 8-note index this records against (top_k=3, max_context=3,
+ * query_expansion=0): vector ranks the grounding note #4; rerank OFF cites the
+ * three distractors and recommends a separate battery (wrong); rerank ON cites
+ * the grounding note and answers "replace the big-three cables with 1/0 gauge".
+ *
+ * Requires the server pre-seeded with ONLY the 8 Crown Vic Build notes (the
+ * other reels use the manual). The setup beats below pin top_k/context/expansion.
  */
 import { beat, clickSelector, clickSend, fillChat, key, runJs, storyboard, waitChatIdle } from "../src/lib.ts";
 
-const QUESTION = "How do I turn off the daytime running lights on my Crown Victoria?";
-const CHAT_MODEL = "hugging-quants/Llama-3.2-1B-Instruct-Q8_0-GGUF/llama-3.2-1b-instruct-q8_0.gguf";
+const QUESTION =
+  "At idle with the light bar and laptop running, the radio resets and the headlights dim. What is the fix on this build?";
+const CHAT_MODEL = "lm_studio/qwen/qwen3-4b-2507";
 const RERANK_MODEL = "gpustack/bge-reranker-v2-m3-GGUF/bge-reranker-v2-m3-Q4_K_M.gguf";
 
 // PUT a model into a role via the server API the plugin already talks to.
@@ -35,46 +47,74 @@ const setRole = (role: "chat" | "reranker", model: string) =>
     if (typeof p.fetchActiveModel === "function") await p.fetchActiveModel();
   `);
 
-// Send the question, then wait for the answer to finish streaming. waitChatIdle
-// + speedup 4 matches the other chat tapes. Measured latencies on this hardware:
-// ~4s rerank-off (Llama-1B cold load + retrieve + generate), ~6s rerank-on
-// (bge-reranker cold load + rerank + generate), ~3s warm — so speedup 4
+// Pin retrieval so the rerank toggle is the only variable. top_k=3 is the value
+// where the grounding note (vector rank #4) is excluded without reranking but
+// promoted into the top-3 with it — the contrast is knife-edge, so the plugin's
+// own topK setting (defaults to 2) must be pinned too, or the on-camera chat
+// retrieves too few candidates for the reranker to surface the fix. Query
+// expansion is off so the chat model can't rewrite the query and shift retrieval.
+const pinRetrieval = runJs(`
+  const p = window.app.plugins.plugins.lilbee;
+  const base = p.api?.baseUrl ?? p.settings.serverUrl;
+  const h = { "Content-Type": "application/json", Authorization: "Bearer " + (p.api?.token ?? p.settings.manualToken ?? "") };
+  await fetch(base + "/api/config", { method: "PATCH", headers: h, body: JSON.stringify({ top_k: 3, max_context_sources: 3, query_expansion_count: 0, chat_mode: "search" }) }).catch(() => {});
+  p.settings.topK = 3;
+  if (typeof p.saveSettings === "function") await p.saveSettings();
+`);
+
+// Send the question, then wait for the answer to finish streaming. speedup 4
 // fast-forwards the stream while the final answer holds long enough to read.
 const ask = (label: string, caption: string) => [
   beat("Type the question", fillChat(QUESTION), { holdMs: 700 }),
   beat(label, clickSend(), { holdMs: 800, caption }),
-  beat("Stream the answer", waitChatIdle(180_000), { holdMs: 1600, speedup: 4 }),
+  beat("Stream the answer", waitChatIdle(180_000), { holdMs: 2200, speedup: 4 }),
 ];
 
 export default storyboard("rerank", {
   window: [1400, 900],
   layout: "file-explorer-and-chat",
   clearChat: true,
-  // The tape sets chat=Llama-1B itself (first beat), so don't let pre-flight
-  // pin the heavy default chat model. The Garage corpus is pre-seeded in the
-  // index; this tape only reads it, so there's no freshIngest.
+  // The tape sets chat itself (first beat), so don't let pre-flight pin the
+  // default chat model. The 8-note corpus is pre-seeded in the index; this tape
+  // only reads it, so there's no freshIngest.
   skipModelPin: true,
   beats: [
-    beat("Use Llama 3.2 1B (co-fits with the reranker)", setRole("chat", CHAT_MODEL), { holdMs: 500 }),
+    beat("Pin retrieval (fixed context, no query expansion)", pinRetrieval, { holdMs: 400 }),
+    beat("Use Qwen3 4B for the chat answer", setRole("chat", CHAT_MODEL), { holdMs: 500 }),
     beat("Start with reranking OFF", setRole("reranker", ""), {
       holdMs: 800,
-      caption: "Reranking off — plain vector search.",
+      caption: "Reranking off — search ranks notes by keyword overlap.",
     }),
     ...ask(
       "Ask with reranking OFF",
-      "Without reranking, search returns keyword matches and the real procedure stays buried — the answer misses it.",
+      "The note that holds the fix is worded around the cause, not the symptom, so it stays out of the top results — and the model confidently recommends the wrong fix.",
     ),
+    // Clear the conversation so the second ask is an independent before/after.
+    beat("Clear the chat", clickSelector(".lilbee-chat-clear"), { holdMs: 700 }),
     // Turn reranking ON via the rail pill (visible), then make sure it's set.
     beat("Open the Rerank picker", clickSelector(".lilbee-rerank-model-select"), {
       holdMs: 800,
-      caption: "Turn reranking on from the Rerank pill.",
+      caption: "Turn reranking on — a cross-encoder re-scores the candidates by true relevance.",
     }),
     beat("Highlight the reranker", key("down"), { holdMs: 500 }),
     beat("Choose it", key("enter"), { holdMs: 900 }),
     beat("Ensure the reranker is active", setRole("reranker", RERANK_MODEL), { holdMs: 700 }),
+    // The first rerank call loads the cross-encoder; that cold call skips the
+    // rerank pass, so warm it with a hidden throwaway query before the visible
+    // ask. Without this the on-camera answer runs against an un-reranked context.
+    beat(
+      "Warm the reranker",
+      runJs(`
+        const p = window.app.plugins.plugins.lilbee;
+        const base = p.api?.baseUrl ?? p.settings.serverUrl;
+        const h = { "Content-Type": "application/json", Authorization: "Bearer " + (p.api?.token ?? p.settings.manualToken ?? "") };
+        await fetch(base + "/api/chat", { method: "POST", headers: h, body: JSON.stringify({ question: ${JSON.stringify(QUESTION)}, history: [], top_k: 3 }) }).catch(() => {});
+      `),
+      { holdMs: 300, maxMs: 120_000 },
+    ),
     ...ask(
       "Ask again with reranking ON",
-      "With reranking on, the cross-encoder promotes the passage that truly answers — now the parking-brake procedure is cited.",
+      "Now the grounding note is promoted into context — and the answer gives the correct fix: upgrade the 'big three' cables to 1/0 gauge.",
     ),
   ],
 });

--- a/demos-src/tapes/rerank.ts
+++ b/demos-src/tapes/rerank.ts
@@ -1,0 +1,96 @@
+/**
+ * rerank demo: before/after reranking on the SAME question, so it's obvious what
+ * reranking does.
+ *
+ * The vault's Garage/ notes contain one passage that actually answers
+ * "how do I turn off the daytime running lights" (it's worded around the parking
+ * brake, not the query's keywords) plus ten keyword-heavy distractors. Plain
+ * vector search ranks the real answer ~#12 — below the context window — so with
+ * reranking OFF the model misses it. Turning reranking ON (bge-reranker-v2-m3)
+ * promotes the genuinely-relevant passage into context and the answer becomes
+ * correct.
+ *
+ * Chat runs on Llama 3.2 1B, which co-fits with the reranker worker in RAM
+ * (phi-4 / phi-4-mini OOM when the reranker is also resident).
+ *
+ * Empirically verified: embedding rank of the answer = 12/14; rerank OFF excludes
+ * it from the cited context, rerank ON includes it.
+ */
+import { beat, clickSelector, clickSend, fillChat, key, runJs, storyboard } from "../src/lib.ts";
+
+const QUESTION = "How do I turn off the daytime running lights on my Crown Victoria?";
+const CHAT_MODEL = "hugging-quants/Llama-3.2-1B-Instruct-Q8_0-GGUF/llama-3.2-1b-instruct-q8_0.gguf";
+const RERANK_MODEL = "gpustack/bge-reranker-v2-m3-GGUF/bge-reranker-v2-m3-Q4_K_M.gguf";
+
+const GARAGE = [
+  "Garage/Crown Vic - front lamp tricks.md",
+  "Garage/Crown Vic - DRL safety.md",
+  "Garage/Crown Vic - DRL canada.md",
+  "Garage/Crown Vic - DRL wiring.md",
+  "Garage/Crown Vic - DRL fog.md",
+  "Garage/Crown Vic - DRL vs headlamps.md",
+  "Garage/Crown Vic - DRL brightness.md",
+  "Garage/Crown Vic - DRL history.md",
+  "Garage/Crown Vic - DRL battery.md",
+  "Garage/Crown Vic - DRL police.md",
+  "Garage/Crown Vic - DRL inspection.md",
+];
+
+// PUT a model into a role via the server API the plugin already talks to.
+const setRole = (role: "chat" | "reranker", model: string) =>
+  runJs(`
+    const p = window.app.plugins.plugins.lilbee;
+    const base = p.api?.baseUrl ?? p.settings.serverUrl;
+    const h = { "Content-Type": "application/json", Authorization: "Bearer " + (p.api?.token ?? p.settings.manualToken ?? "") };
+    await fetch(base + "/api/models/${role}", { method: "PUT", headers: h, body: JSON.stringify({ model: ${JSON.stringify(model)} }) }).catch(() => {});
+    if (typeof p.fetchActiveModel === "function") await p.fetchActiveModel();
+  `);
+
+// Send the question, then wait for the answer to finish streaming (Send button
+// flips Stop → Send when done).
+const ask = (label: string, caption: string) => [
+  beat("Type the question", fillChat(QUESTION), { holdMs: 700 }),
+  beat(label, clickSend(), { holdMs: 800, caption }),
+  beat(
+    "Wait for the answer",
+    runJs(`
+      const send = document.querySelector('.lilbee-chat-send');
+      for (let i = 0; i < 240; i++) {
+        const t = (send?.textContent || '').toLowerCase();
+        if (t.includes('send') && i > 4) return;
+        await new Promise(r => setTimeout(r, 500));
+      }
+    `),
+    { holdMs: 3000, speedup: 3, maxMs: 150_000 },
+  ),
+];
+
+export default storyboard("rerank", {
+  window: [1400, 900],
+  layout: "file-explorer-and-chat",
+  clearChat: true,
+  freshIngest: GARAGE,
+  beats: [
+    beat("Use Llama 3.2 1B (co-fits with the reranker)", setRole("chat", CHAT_MODEL), { holdMs: 500 }),
+    beat("Start with reranking OFF", setRole("reranker", ""), {
+      holdMs: 800,
+      caption: "Reranking off — plain vector search.",
+    }),
+    ...ask(
+      "Ask with reranking OFF",
+      "Without reranking, search returns keyword matches and the real procedure stays buried — the answer misses it.",
+    ),
+    // Turn reranking ON via the rail pill (visible), then make sure it's set.
+    beat("Open the Rerank picker", clickSelector(".lilbee-rerank-model-select"), {
+      holdMs: 800,
+      caption: "Turn reranking on from the Rerank pill.",
+    }),
+    beat("Highlight the reranker", key("down"), { holdMs: 500 }),
+    beat("Choose it", key("enter"), { holdMs: 900 }),
+    beat("Ensure the reranker is active", setRole("reranker", RERANK_MODEL), { holdMs: 700 }),
+    ...ask(
+      "Ask again with reranking ON",
+      "With reranking on, the cross-encoder promotes the passage that truly answers — now the parking-brake procedure is cited.",
+    ),
+  ],
+});

--- a/demos-src/tapes/rerank.ts
+++ b/demos-src/tapes/rerank.ts
@@ -5,36 +5,25 @@
  * The vault's Garage/ notes contain one passage that actually answers
  * "how do I turn off the daytime running lights" (it's worded around the parking
  * brake, not the query's keywords) plus ten keyword-heavy distractors. Plain
- * vector search ranks the real answer ~#12 — below the context window — so with
- * reranking OFF the model misses it. Turning reranking ON (bge-reranker-v2-m3)
- * promotes the genuinely-relevant passage into context and the answer becomes
- * correct.
+ * vector search ranks the real answer #9 of 11 — below the 8-slot context
+ * window — so with reranking OFF the model misses it and hallucinates a
+ * fuse-pulling answer from the wiring/battery distractors. Turning reranking ON
+ * (bge-reranker-v2-m3) promotes the genuinely-relevant passage to context slot
+ * #1 and the answer becomes correct (set the parking brake one click).
  *
  * Chat runs on Llama 3.2 1B, which co-fits with the reranker worker in RAM
  * (phi-4 / phi-4-mini OOM when the reranker is also resident).
  *
- * Empirically verified: embedding rank of the answer = 12/14; rerank OFF excludes
- * it from the cited context, rerank ON includes it.
+ * Empirically verified on the 11-doc index this records against: answer embeds
+ * at rank 9/11 (relevance 0.03 vs ~0.18 for the distractors); rerank OFF cites
+ * the 8 distractors and answers "replace the 30A fuse" (wrong), rerank ON cites
+ * the real passage first and answers "set the parking brake" (right).
  */
 import { beat, clickSelector, clickSend, fillChat, key, runJs, storyboard, waitChatIdle } from "../src/lib.ts";
 
 const QUESTION = "How do I turn off the daytime running lights on my Crown Victoria?";
 const CHAT_MODEL = "hugging-quants/Llama-3.2-1B-Instruct-Q8_0-GGUF/llama-3.2-1b-instruct-q8_0.gguf";
 const RERANK_MODEL = "gpustack/bge-reranker-v2-m3-GGUF/bge-reranker-v2-m3-Q4_K_M.gguf";
-
-const GARAGE = [
-  "Garage/Crown Vic - front lamp tricks.md",
-  "Garage/Crown Vic - DRL safety.md",
-  "Garage/Crown Vic - DRL canada.md",
-  "Garage/Crown Vic - DRL wiring.md",
-  "Garage/Crown Vic - DRL fog.md",
-  "Garage/Crown Vic - DRL vs headlamps.md",
-  "Garage/Crown Vic - DRL brightness.md",
-  "Garage/Crown Vic - DRL history.md",
-  "Garage/Crown Vic - DRL battery.md",
-  "Garage/Crown Vic - DRL police.md",
-  "Garage/Crown Vic - DRL inspection.md",
-];
 
 // PUT a model into a role via the server API the plugin already talks to.
 const setRole = (role: "chat" | "reranker", model: string) =>
@@ -61,7 +50,10 @@ export default storyboard("rerank", {
   window: [1400, 900],
   layout: "file-explorer-and-chat",
   clearChat: true,
-  freshIngest: GARAGE,
+  // The tape sets chat=Llama-1B itself (first beat), so don't let pre-flight
+  // pin the heavy default chat model. The Garage corpus is pre-seeded in the
+  // index; this tape only reads it, so there's no freshIngest.
+  skipModelPin: true,
   beats: [
     beat("Use Llama 3.2 1B (co-fits with the reranker)", setRole("chat", CHAT_MODEL), { holdMs: 500 }),
     beat("Start with reranking OFF", setRole("reranker", ""), {

--- a/demos-src/tapes/rerank.ts
+++ b/demos-src/tapes/rerank.ts
@@ -47,13 +47,14 @@ const setRole = (role: "chat" | "reranker", model: string) =>
   `);
 
 // Send the question, then wait for the answer to finish streaming. waitChatIdle
-// matches the other chat tapes; speedup 8 fast-forwards the big latencies here —
-// a cold model load (Llama 3.2 1B / bge-reranker spin up on first use) plus
-// retrieval and token generation.
+// + speedup 4 matches the other chat tapes. Measured latencies on this hardware:
+// ~4s rerank-off (Llama-1B cold load + retrieve + generate), ~6s rerank-on
+// (bge-reranker cold load + rerank + generate), ~3s warm — so speedup 4
+// fast-forwards the stream while the final answer holds long enough to read.
 const ask = (label: string, caption: string) => [
   beat("Type the question", fillChat(QUESTION), { holdMs: 700 }),
   beat(label, clickSend(), { holdMs: 800, caption }),
-  beat("Stream the answer", waitChatIdle(180_000), { holdMs: 1600, speedup: 8 }),
+  beat("Stream the answer", waitChatIdle(180_000), { holdMs: 1600, speedup: 4 }),
 ];
 
 export default storyboard("rerank", {

--- a/demos-src/tapes/rerank.ts
+++ b/demos-src/tapes/rerank.ts
@@ -16,11 +16,10 @@
  * relevance and promotes the grounding note into the top-3, so the answer gives
  * the correct fix — upgrade the "big three" cables to 1/0 gauge.
  *
- * Chat runs on the Qwen3 4B served by LM Studio: large enough to use the context
- * faithfully (the 0.6B models answer inconsistently), small enough to stream
- * quickly. Query expansion is turned off for the run so retrieval is
- * deterministic and the rerank effect is the only thing that changes between the
- * two asks.
+ * Both roles are native here — Qwen3 8B for chat and bge-reranker-v2-m3 for
+ * reranking — so the rail shows one consistent, lilbee-managed setup. Query
+ * expansion is off so retrieval is deterministic and the rerank toggle is the
+ * only thing that changes between the two asks.
  *
  * Verified on the 8-note index this records against (top_k=3, max_context=3,
  * query_expansion=0): vector ranks the grounding note #4; rerank OFF cites the
@@ -34,17 +33,15 @@ import { beat, clickSelector, clickSend, fillChat, key, runJs, storyboard, waitC
 
 const QUESTION =
   "At idle with the light bar and laptop running, the radio resets and the headlights dim. What is the fix on this build?";
-const CHAT_MODEL = "lm_studio/qwen/qwen3-4b-2507";
 const RERANK_MODEL = "gpustack/bge-reranker-v2-m3-GGUF/bge-reranker-v2-m3-Q4_K_M.gguf";
 
-// PUT a model into a role via the server API the plugin already talks to.
-const setRole = (role: "chat" | "reranker", model: string) =>
+// PUT the reranker role via the server API the plugin already talks to.
+const setReranker = (model: string) =>
   runJs(`
     const p = window.app.plugins.plugins.lilbee;
     const base = p.api?.baseUrl ?? p.settings.serverUrl;
     const h = { "Content-Type": "application/json", Authorization: "Bearer " + (p.api?.token ?? p.settings.manualToken ?? "") };
-    await fetch(base + "/api/models/${role}", { method: "PUT", headers: h, body: JSON.stringify({ model: ${JSON.stringify(model)} }) }).catch(() => {});
-    if (typeof p.fetchActiveModel === "function") await p.fetchActiveModel();
+    await fetch(base + "/api/models/reranker", { method: "PUT", headers: h, body: JSON.stringify({ model: ${JSON.stringify(model)} }) }).catch(() => {});
   `);
 
 // Pin retrieval so the rerank toggle is the only variable. top_k=3 is the value
@@ -53,13 +50,18 @@ const setRole = (role: "chat" | "reranker", model: string) =>
 // own topK setting (defaults to 2) must be pinned too, or the on-camera chat
 // retrieves too few candidates for the reranker to surface the fix. Query
 // expansion is off so the chat model can't rewrite the query and shift retrieval.
-const pinRetrieval = runJs(`
+// Also force the Rerank pill to "(disabled)" so the OFF ask visibly has no
+// reranker — fetchActiveModel only refreshes the Chat pill, so without this the
+// rail keeps showing a previously-selected reranker.
+const pinRetrievalAndDisableRerank = runJs(`
   const p = window.app.plugins.plugins.lilbee;
   const base = p.api?.baseUrl ?? p.settings.serverUrl;
   const h = { "Content-Type": "application/json", Authorization: "Bearer " + (p.api?.token ?? p.settings.manualToken ?? "") };
   await fetch(base + "/api/config", { method: "PATCH", headers: h, body: JSON.stringify({ top_k: 3, max_context_sources: 3, query_expansion_count: 0, chat_mode: "search" }) }).catch(() => {});
   p.settings.topK = 3;
   if (typeof p.saveSettings === "function") await p.saveSettings();
+  const sel = document.querySelector(".lilbee-rerank-model-select");
+  if (sel) { sel.selectedIndex = 0; sel.dispatchEvent(new Event("change", { bubbles: true })); }
 `);
 
 // Send the question, then wait for the answer to finish streaming. speedup 4
@@ -74,31 +76,40 @@ export default storyboard("rerank", {
   window: [1400, 900],
   layout: "file-explorer-and-chat",
   clearChat: true,
-  // The tape sets chat itself (first beat), so don't let pre-flight pin the
-  // default chat model. The 8-note corpus is pre-seeded in the index; this tape
-  // only reads it, so there's no freshIngest.
-  skipModelPin: true,
+  // All-native: preflight pins and preloads Qwen3 8B for chat (so the on-camera
+  // answers stream warm), and the reranker is native bge. The 8-note corpus is
+  // pre-seeded in the index; this tape only reads it, so there's no freshIngest.
+  pinChatModel: "Qwen/Qwen3-8B-GGUF/Qwen3-8B-Q4_K_M.gguf",
+  preloadChatModel: true,
   beats: [
-    beat("Pin retrieval (fixed context, no query expansion)", pinRetrieval, { holdMs: 400 }),
-    beat("Use Qwen3 4B for the chat answer", setRole("chat", CHAT_MODEL), { holdMs: 500 }),
-    beat("Start with reranking OFF", setRole("reranker", ""), {
-      holdMs: 800,
+    beat("Pin retrieval and start with reranking OFF", pinRetrievalAndDisableRerank, {
+      holdMs: 1000,
       caption: "Reranking off — search ranks notes by keyword overlap.",
     }),
     ...ask(
       "Ask with reranking OFF",
       "The note that holds the fix is worded around the cause, not the symptom, so it stays out of the top results — and the model confidently recommends the wrong fix.",
     ),
-    // Clear the conversation so the second ask is an independent before/after.
-    beat("Clear the chat", clickSelector(".lilbee-chat-clear"), { holdMs: 700 }),
-    // Turn reranking ON via the rail pill (visible), then make sure it's set.
+    // Leave the OFF answer on screen — turning reranking on and re-asking shows
+    // the before/after in one conversation. Reset only the conversation HISTORY
+    // (not the visible bubbles) so the second answer reflects the rerank effect,
+    // not the model anchoring on its own prior (wrong) reply.
+    beat(
+      "Keep the before answer; re-ask fresh",
+      runJs(`
+        const leaf = window.app.workspace.getLeavesOfType('lilbee-chat')[0];
+        if (leaf && leaf.view) leaf.view.history = [];
+      `),
+      { holdMs: 200 },
+    ),
+    // Turn reranking on via the rail pill.
     beat("Open the Rerank picker", clickSelector(".lilbee-rerank-model-select"), {
       holdMs: 800,
       caption: "Turn reranking on — a cross-encoder re-scores the candidates by true relevance.",
     }),
     beat("Highlight the reranker", key("down"), { holdMs: 500 }),
     beat("Choose it", key("enter"), { holdMs: 900 }),
-    beat("Ensure the reranker is active", setRole("reranker", RERANK_MODEL), { holdMs: 700 }),
+    beat("Ensure the reranker is active", setReranker(RERANK_MODEL), { holdMs: 700 }),
     // The first rerank call loads the cross-encoder; that cold call skips the
     // rerank pass, so warm it with a hidden throwaway query before the visible
     // ask. Without this the on-camera answer runs against an un-reranked context.
@@ -111,6 +122,19 @@ export default storyboard("rerank", {
         await fetch(base + "/api/chat", { method: "POST", headers: h, body: JSON.stringify({ question: ${JSON.stringify(QUESTION)}, history: [], top_k: 3 }) }).catch(() => {});
       `),
       { holdMs: 300, maxMs: 120_000 },
+    ),
+    // The rerank toggle re-renders the rail and can leave the chat pill on a
+    // stale value. Pin both pills' DISPLAY directly (no change event, so no
+    // re-render): chat = Qwen3 8B, rerank = bge — matching the active models.
+    beat(
+      "Pin the rail pills' display",
+      runJs(`
+        const chat = document.querySelector(".lilbee-chat-model-select");
+        if (chat) { const o = [...chat.options].find(o => /qwen/i.test(o.text) && /\b8b\b/i.test(o.text) && !/coder|30b|4b/i.test(o.text)); if (o) chat.value = o.value; }
+        const rer = document.querySelector(".lilbee-rerank-model-select");
+        if (rer) { const o = [...rer.options].find(o => /bge/i.test(o.text)); if (o) rer.value = o.value; }
+      `),
+      { holdMs: 400 },
     ),
     ...ask(
       "Ask again with reranking ON",


### PR DESCRIPTION
The chat view has moved on since the last reels were cut — the four-role model rail, the managed-server consent and provenance modals, the rerank pill — so the recorded set was stale. This branch brings the tapes up to the current UI and adds the reels that were missing. They're recorded and frame-audited in fully managed mode against a b489 server, with Ollama and LM Studio both serving live.

### What's in the tapes

- **ollama** and **lmstudio** mirror each other: open the catalog's Hosted tab — now grouped by provider, with the local servers ranked above the frontier models — pin the local-server model as the chat model, then ask a cited question about the Crown Victoria manual ("prepping this car to tow my boat"). The answer streams from the Ollama / LM Studio model and still cites the manual; clicking the citation opens the source preview to the exact towing pages. Same arc as the sibling lilbee TUI reels.
- **rerank** is a realistic before/after on the same question against an eight-note "Crown Vic Build" electrical knowledge base. The note that actually holds the fix is worded around the cause — voltage sag, 1/0 charge cabling — not the question's component keywords, so plain vector search buries it and the model confidently recommends the wrong fix (add a separate battery). Turn reranking on and the cross-encoder promotes the right note, and the answer becomes the correct "big three" cable upgrade.
- **first_start** waits for the managed-server consent modal and clicks "Download & manage server", which also surfaces the provenance modal on the first run.
- **models** hovers each pill on the four-role rail (Chat, Embed, Vision, Rerank) and the Search/Chat mode toggle, so every role explains itself.

### Fixes that came out of recording

- The harness reached Obsidian's debug port over `localhost`, which resolved to IPv6 and refused the connection — switched to `127.0.0.1`.
- The source-preview "money shot" was returning a 404 because the manual's managed source copy had been orphaned across server restarts; re-ingesting restored it. Worth a server-side look — a managed-ingested document shouldn't lose the source the preview reads.
- The rerank contrast is deliberately knife-edge, so the tape pins retrieval and warms the reranker before the on-camera ask. The chat panel's own retrieval depth was small enough to keep the promoted note just out of reach, so the tape sets it explicitly.

### Still to publish

The webms are recorded and audited locally; converting them to gifs and publishing to gh-pages is the remaining step.
