### PR TITLE
Render chat-rail tooltips above the cursor, and match the server's default search depth

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -342,7 +342,9 @@ export interface LilbeeSettings {
 
 export const DEFAULT_SETTINGS: LilbeeSettings = {
     serverUrl: "http://127.0.0.1:7433",
-    topK: 5,
+    // Match the server's default retrieval depth (core config top_k = 12) so the
+    // plugin and a bare `lilbee serve` behave identically out of the box.
+    topK: 12,
     maxDistance: 0.9,
     adaptiveThreshold: false,
     serverMode: "managed",

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -187,6 +187,7 @@ export class ChatView extends ItemView {
 
         const chatChip = rail.createDiv({ cls: "lilbee-model-chip lilbee-toolbar-group" });
         chatChip.setAttribute("aria-label", MESSAGES.TOOLTIP_ROLE_CHAT);
+        chatChip.setAttribute("aria-label-position", "top");
         chatChip.createSpan({ cls: "lilbee-model-chip-dot is-chat is-active" });
         chatChip.createSpan({ cls: "lilbee-model-chip-label", text: MESSAGES.RAIL_LABEL_CHAT });
         this.chatSelectEl = chatChip.createEl("select", {
@@ -196,6 +197,7 @@ export class ChatView extends ItemView {
 
         const embedChip = rail.createDiv({ cls: "lilbee-model-chip lilbee-toolbar-group lilbee-toolbar-group-embed" });
         embedChip.setAttribute("aria-label", MESSAGES.TOOLTIP_ROLE_EMBED);
+        embedChip.setAttribute("aria-label-position", "top");
         embedChip.createSpan({ cls: "lilbee-model-chip-dot is-embed is-active" });
         embedChip.createSpan({ cls: "lilbee-model-chip-label", text: MESSAGES.RAIL_LABEL_EMBED });
         this.embeddingSelectEl = embedChip.createEl("select", {
@@ -389,6 +391,7 @@ export class ChatView extends ItemView {
                 cls: `lilbee-chat-mode-btn${seg.mode === rawMode ? " active" : ""}`,
             });
             btn.setAttribute("aria-label", seg.tooltip);
+            btn.setAttribute("aria-label-position", "top");
             if (noEmbedding) {
                 btn.disabled = true;
                 btn.setAttribute("title", MESSAGES.TOOLTIP_CHAT_MODE_NEEDS_EMBEDDING);
@@ -595,6 +598,7 @@ export class ChatView extends ItemView {
         const options = this.optionalRoleOptions(spec);
         const chip = rail.createDiv({ cls: "lilbee-model-chip lilbee-model-chip-optional" });
         chip.setAttribute("aria-label", spec.tooltip);
+        chip.setAttribute("aria-label-position", "top");
         if (!active) chip.addClass("is-off");
         const dot = chip.createSpan({ cls: `lilbee-model-chip-dot ${spec.dotClass}` });
         if (active) dot.addClass("is-active");

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -584,7 +584,7 @@ describe("LilbeePlugin", () => {
             const plugin = await createPlugin({ serverMode: "external" });
             plugin.loadData = vi.fn().mockResolvedValue(null);
             await plugin.loadSettings();
-            expect(plugin.settings.topK).toBe(5);
+            expect(plugin.settings.topK).toBe(12);
             expect(plugin.settings.serverMode).toBe("managed");
         });
     });

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -41,8 +41,8 @@ describe("DEFAULT_SETTINGS", () => {
         expect(DEFAULT_SETTINGS.serverUrl).toBe("http://127.0.0.1:7433");
     });
 
-    it("has topK of 5", () => {
-        expect(DEFAULT_SETTINGS.topK).toBe(5);
+    it("has topK of 12 (matches the server default)", () => {
+        expect(DEFAULT_SETTINGS.topK).toBe(12);
     });
 
     it("has wikiEnabled defaulting to false", () => {


### PR DESCRIPTION
The model-rail pills and the Search/Chat toggle show hover tooltips, but they rendered below the element — right where the cursor sits — so the pointer covered the text. Setting the tooltip position to top renders each one above its pill or button, clear of the cursor.

Separately, the plugin defaulted topK to 5 while the server's own default retrieval depth is 12. This aligns the plugin default with the server so a fresh install and a bare `lilbee serve` return the same results out of the box.