### PR TITLE
Surface cloud, Ollama, and LM Studio models in the catalog and pickers

### DIFF
--- a/src/components/model-card.ts
+++ b/src/components/model-card.ts
@@ -1,5 +1,5 @@
 import type { CatalogEntry, HardwareFit, ModelCardOptions } from "../types";
-import { CATALOG_SOURCE, HARDWARE_FIT, MODEL_COMPAT, MODEL_TASK } from "../types";
+import { HARDWARE_FIT, HOSTED_SOURCES, MODEL_COMPAT, MODEL_TASK } from "../types";
 import { MESSAGES } from "../locales/en";
 import { formatAbbreviatedCount } from "../utils";
 
@@ -76,8 +76,8 @@ function renderCardTags(card: HTMLElement, entry: CatalogEntry): void {
     if (entry.featured) {
         tags.createEl("span", { text: MESSAGES.LABEL_PICK, cls: "lilbee-tag lilbee-tag-featured" });
     }
-    if (entry.source && entry.source !== CATALOG_SOURCE.LOCAL) {
-        tags.createEl("span", { text: entry.source, cls: "lilbee-tag lilbee-tag-provider" });
+    if (HOSTED_SOURCES.has(entry.source)) {
+        tags.createEl("span", { text: entry.provider ?? entry.source, cls: "lilbee-tag lilbee-tag-provider" });
     }
     renderCompatTag(tags, entry);
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,10 +3,10 @@ import type LilbeePlugin from "./main";
 import type { ReleaseInfo } from "./binary-manager";
 import {
     CAPABILITY,
-    CATALOG_SOURCE,
     CHAT_MODE,
     CONFIG_KEY,
     DEFAULT_SETTINGS,
+    HOSTED_SOURCES,
     MODEL_TASK,
     SERVER_MODE,
     SERVER_STATE,
@@ -19,6 +19,7 @@ import { formatBytes, reportForVault } from "./storage-stats";
 import { MESSAGES } from "./locales/en";
 import { displayLabelForRef, extractHfRepo } from "./utils/model-ref";
 import { CatalogModal } from "./views/catalog-modal";
+import { hostedOptions } from "./views/catalog-helpers";
 import { ConfirmModal } from "./views/confirm-modal";
 import { ConfirmPullModal } from "./views/confirm-pull-modal";
 import { SetupWizard } from "./views/setup-wizard";
@@ -1104,12 +1105,10 @@ export class LilbeeSettingTab extends PluginSettingTab {
         const opts: Array<[string, string]> = [[RERANKER_DISABLED_KEY, MESSAGES.LABEL_RERANKER_DISABLED]];
         // Settings dropdown lists installed local rerankers + always-on hosted rerankers.
         // Discovery and downloads happen via the Browse catalog button.
-        const localInstalled = catalogEntries.filter((e) => e.source !== CATALOG_SOURCE.FRONTIER && isInstalled(e));
-        const hosted = catalogEntries.filter((e) => e.source === CATALOG_SOURCE.FRONTIER);
+        const localInstalled = catalogEntries.filter((e) => !HOSTED_SOURCES.has(e.source) && isInstalled(e));
         for (const e of localInstalled) opts.push([e.hf_repo, e.display_name]);
-        if (hosted.length > 0) {
-            for (const e of hosted)
-                opts.push([e.hf_repo, `${e.display_name} — ${MESSAGES.LABEL_RERANKER_HOSTED_GROUP}`]);
+        for (const [ref, label] of hostedOptions(catalogEntries)) {
+            opts.push([ref, `${label} — ${MESSAGES.LABEL_RERANKER_HOSTED_GROUP}`]);
         }
         return opts;
     }
@@ -1124,7 +1123,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         if (
             value === RERANKER_DISABLED_KEY ||
             installedRepos.has(value) ||
-            catalogEntry?.source === CATALOG_SOURCE.FRONTIER
+            (catalogEntry !== undefined && HOSTED_SOURCES.has(catalogEntry.source))
         ) {
             await this.applyRerankerSelection(value);
             return;
@@ -1251,12 +1250,11 @@ export class LilbeeSettingTab extends PluginSettingTab {
         // Settings dropdown lists installed local vision models + hosted ones.
         // Discovery and downloads happen via the Browse catalog button.
         const localInstalled = catalogEntries.filter(
-            (e) => e.source !== CATALOG_SOURCE.FRONTIER && installedRepos.has(e.hf_repo),
+            (e) => !HOSTED_SOURCES.has(e.source) && installedRepos.has(e.hf_repo),
         );
-        const hosted = catalogEntries.filter((e) => e.source === CATALOG_SOURCE.FRONTIER);
         for (const e of localInstalled) opts.push([e.hf_repo, e.display_name]);
-        if (hosted.length > 0) {
-            for (const e of hosted) opts.push([e.hf_repo, `${e.display_name} — ${MESSAGES.LABEL_VISION_HOSTED_GROUP}`]);
+        for (const [ref, label] of hostedOptions(catalogEntries)) {
+            opts.push([ref, `${label} — ${MESSAGES.LABEL_VISION_HOSTED_GROUP}`]);
         }
         return opts;
     }
@@ -1271,7 +1269,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         if (
             value === VISION_DISABLED_KEY ||
             installedRepos.has(value) ||
-            catalogEntry?.source === CATALOG_SOURCE.FRONTIER
+            (catalogEntry !== undefined && HOSTED_SOURCES.has(catalogEntry.source))
         ) {
             await this.applyVisionSelection(value);
             return;
@@ -1993,8 +1991,14 @@ export class LilbeeSettingTab extends PluginSettingTab {
         const opts: Array<[string, string]> = [];
         const featuredInstalled = catalogEntries.filter((e) => installedRepos.has(e.hf_repo));
         for (const entry of featuredInstalled) {
-            const sourceTag = entry.source && entry.source !== CATALOG_SOURCE.LOCAL ? ` [${entry.source}]` : "";
+            const sourceTag = HOSTED_SOURCES.has(entry.source) ? ` [${entry.provider ?? entry.source}]` : "";
             opts.push([entry.hf_repo, `${entry.display_name}${sourceTag}`]);
+        }
+        // Hosted rows are selectable even when absent from the installed
+        // registry — ollama always, frontier with a ready key. Skip any already
+        // emitted above as an installed featured row.
+        for (const [ref, label] of hostedOptions(catalogEntries)) {
+            if (!installedRepos.has(ref)) opts.push([ref, label]);
         }
         const featuredRepos = new Set(catalogEntries.map((e) => e.hf_repo));
         const otherInstalled = installed

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1013,16 +1013,23 @@ export class LilbeeSettingTab extends PluginSettingTab {
                     this.renderEmbeddingFallback(container);
                     return;
                 }
-                // Settings dropdown lists installed embedding models only — discovery
-                // and downloads happen via Browse catalog, which the button on the
-                // right of this row opens.
-                const models = result.value.models.filter((m) => m.task === MODEL_TASK.EMBEDDING && m.installed);
+                // Settings dropdown lists installed local embedding models plus
+                // always-on hosted ones (e.g. an Ollama embedding model), matching
+                // the chat/vision/reranker pickers. Discovery and downloads happen
+                // via Browse catalog, which the button on the right of this row opens.
+                const catalogEntries = result.value.models;
+                const localInstalled = catalogEntries.filter(
+                    (m) => m.task === MODEL_TASK.EMBEDDING && m.installed && !HOSTED_SOURCES.has(m.source),
+                );
                 new Setting(container)
                     .setName(MESSAGES.LABEL_EMBEDDING_MODEL)
                     .setDesc(MESSAGES.DESC_EMBEDDING_MODEL)
                     .addDropdown((dropdown) => {
-                        for (const model of models) {
+                        for (const model of localInstalled) {
                             dropdown.addOption(model.hf_repo, model.display_name);
+                        }
+                        for (const [ref, label] of hostedOptions(catalogEntries)) {
+                            dropdown.addOption(ref, label);
                         }
                         dropdown.onChange(async (value) => {
                             if (!value) return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,12 +114,19 @@ export const CHAT_MODE = {
     CHAT: "chat",
 } as const satisfies Record<string, ChatMode>;
 
-export type CatalogSource = "local" | "frontier";
+export type CatalogSource = "native" | "frontier" | "ollama";
 
 export const CATALOG_SOURCE = {
-    LOCAL: "local",
+    NATIVE: "native",
     FRONTIER: "frontier",
+    OLLAMA: "ollama",
 } as const satisfies Record<string, CatalogSource>;
+
+/** Sources rendered in the shared "hosted" area: selectable, no download. */
+export const HOSTED_SOURCES: ReadonlySet<CatalogSource> = new Set<CatalogSource>([
+    CATALOG_SOURCE.FRONTIER,
+    CATALOG_SOURCE.OLLAMA,
+]);
 
 export type KeyStatus = "ready" | "missing_key";
 
@@ -478,7 +485,7 @@ export interface CatalogEntry {
     description: string;
     quality_tier: string;
     installed: boolean;
-    source: string;
+    source: CatalogSource;
     task: ModelTask;
     featured: boolean;
     downloads: number;
@@ -487,26 +494,11 @@ export interface CatalogEntry {
     compat?: ModelCompat | null;
     architecture?: string | null;
     size_variants?: SizeVariant[] | null;
+    /** Hosted rows (frontier/ollama) carry their serving provider. */
+    provider?: string;
+    /** Set on frontier rows; `null` for ollama (no API key needed), absent on older servers. */
+    key_status?: KeyStatus | null;
 }
-
-export interface LocalCatalogRow extends CatalogEntry {
-    source: "local";
-}
-
-export interface FrontierCatalogRow {
-    hf_repo: string;
-    display_name: string;
-    description: string;
-    task: ModelTask;
-    source: "frontier";
-    provider: string;
-    key_status: KeyStatus;
-    is_curated: boolean;
-    context_window: number;
-    modality: string;
-}
-
-export type CatalogRow = LocalCatalogRow | FrontierCatalogRow;
 
 export interface CatalogResponse {
     total: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,18 +114,21 @@ export const CHAT_MODE = {
     CHAT: "chat",
 } as const satisfies Record<string, ChatMode>;
 
-export type CatalogSource = "native" | "frontier" | "ollama";
+export type CatalogSource = "native" | "frontier" | "ollama" | "lm_studio";
 
 export const CATALOG_SOURCE = {
     NATIVE: "native",
     FRONTIER: "frontier",
     OLLAMA: "ollama",
+    LM_STUDIO: "lm_studio",
 } as const satisfies Record<string, CatalogSource>;
 
-/** Sources rendered in the shared "hosted" area: selectable, no download. */
+/** Sources rendered in the shared "hosted" area: selectable, no download.
+ * Frontier (cloud API key) plus the local servers (Ollama, LM Studio). */
 export const HOSTED_SOURCES: ReadonlySet<CatalogSource> = new Set<CatalogSource>([
     CATALOG_SOURCE.FRONTIER,
     CATALOG_SOURCE.OLLAMA,
+    CATALOG_SOURCE.LM_STUDIO,
 ]);
 
 export type KeyStatus = "ready" | "missing_key";
@@ -519,9 +522,9 @@ export interface CatalogEntry {
     compat?: ModelCompat | null;
     architecture?: string | null;
     size_variants?: SizeVariant[] | null;
-    /** Hosted rows (frontier/ollama) carry their serving provider. */
+    /** Hosted rows (frontier + local servers) carry their serving provider. */
     provider?: string;
-    /** Set on frontier rows; `null` for ollama (no API key needed), absent on older servers. */
+    /** Set on frontier rows; `null` for local servers (no API key), absent on older servers. */
     key_status?: KeyStatus | null;
 }
 

--- a/src/utils/model-ref.ts
+++ b/src/utils/model-ref.ts
@@ -3,7 +3,7 @@
 // ("ollama/qwen3:8b", "openai/gpt-4o", …), and opaque strings. The helpers
 // below convert them for display or unwrap them for catalog comparison.
 
-const PROVIDER_PREFIXES = ["ollama/", "openai/", "anthropic/", "gemini/", "cohere/"];
+const PROVIDER_PREFIXES = ["ollama/", "lm_studio/", "openai/", "anthropic/", "gemini/", "cohere/"];
 
 const STRIP_SUFFIXES = [/-GGUF$/i, /-Instruct$/i, /-Chat$/i, /-v\d+(\.\d+)*$/i, /-\d{4}$/];
 

--- a/src/views/catalog-helpers.ts
+++ b/src/views/catalog-helpers.ts
@@ -1,6 +1,6 @@
 import type { App } from "obsidian";
 import type { CatalogEntry, CatalogTab, KeyStatus, ModelTask } from "../types";
-import { CATALOG_SOURCE, CATALOG_TAB, KEY_STATUS, MODEL_TASK } from "../types";
+import { CATALOG_SOURCE, CATALOG_TAB, HOSTED_SOURCES, KEY_STATUS, MODEL_TASK } from "../types";
 import { MESSAGES } from "../locales/en";
 
 const DISCOVER_RAIL_LIMIT = 12;
@@ -22,31 +22,36 @@ export const KEY_STATUS_PILL_CLASS = {
     NEEDS_KEY: "lilbee-key-status-pill-needs-key",
 } as const;
 
-/** Catalog modal and model picker hide frontier rows entirely until this is true. */
-export function hasReadyFrontierRow(rows: CatalogEntry[]): boolean {
-    for (const row of rows) {
-        if (
-            row.source === CATALOG_SOURCE.FRONTIER &&
-            (row as CatalogEntry & { key_status?: KeyStatus }).key_status === KEY_STATUS.READY
-        ) {
-            return true;
-        }
-    }
-    return false;
+/** Hosted rows (frontier + ollama): selectable, no download. */
+export function hostedRowsOnly(rows: CatalogEntry[]): CatalogEntry[] {
+    return rows.filter((row) => HOSTED_SOURCES.has(row.source));
 }
 
-export function frontierRowsOnly(rows: CatalogEntry[]): CatalogEntry[] {
-    return rows.filter((row) => row.source === CATALOG_SOURCE.FRONTIER);
-}
-
+/** Everything that isn't hosted — native catalog rows the server can download. */
 export function localRowsOnly(rows: CatalogEntry[]): CatalogEntry[] {
-    return rows.filter((row) => row.source !== CATALOG_SOURCE.FRONTIER);
+    return rows.filter((row) => !HOSTED_SOURCES.has(row.source));
+}
+
+/** Hosted row is usable when frontier has a ready key, or it's Ollama (no key). */
+export function hasReadyHostedRow(rows: CatalogEntry[]): boolean {
+    return rows.some(
+        (row) =>
+            row.source === CATALOG_SOURCE.OLLAMA ||
+            (row.source === CATALOG_SOURCE.FRONTIER && row.key_status === KEY_STATUS.READY),
+    );
+}
+
+/** Selectable hosted rows: ollama (always) + frontier with a ready key. Returns [ref, label]. */
+export function hostedOptions(rows: CatalogEntry[]): Array<[string, string]> {
+    return hostedRowsOnly(rows)
+        .filter((e) => e.source === CATALOG_SOURCE.OLLAMA || e.key_status === KEY_STATUS.READY)
+        .map((e) => [e.hf_repo, `${e.display_name}${e.provider ? ` [${e.provider}]` : ""}`]);
 }
 
 export function groupByProvider(rows: CatalogEntry[]): [string, CatalogEntry[]][] {
     const groups = new Map<string, CatalogEntry[]>();
     for (const row of rows) {
-        const provider = (row as CatalogEntry & { provider?: string }).provider ?? "";
+        const provider = row.provider ?? "";
         const existing = groups.get(provider);
         if (existing) {
             existing.push(row);

--- a/src/views/catalog-helpers.ts
+++ b/src/views/catalog-helpers.ts
@@ -1,6 +1,6 @@
 import type { App } from "obsidian";
 import type { CatalogEntry, CatalogTab, KeyStatus, ModelTask } from "../types";
-import { CATALOG_SOURCE, CATALOG_TAB, HOSTED_SOURCES, KEY_STATUS, MODEL_TASK } from "../types";
+import { CATALOG_TAB, HOSTED_SOURCES, KEY_STATUS, MODEL_TASK } from "../types";
 import { MESSAGES } from "../locales/en";
 
 const DISCOVER_RAIL_LIMIT = 12;
@@ -22,7 +22,7 @@ export const KEY_STATUS_PILL_CLASS = {
     NEEDS_KEY: "lilbee-key-status-pill-needs-key",
 } as const;
 
-/** Hosted rows (frontier + ollama): selectable, no download. */
+/** Hosted rows (frontier + local servers): selectable, no download. */
 export function hostedRowsOnly(rows: CatalogEntry[]): CatalogEntry[] {
     return rows.filter((row) => HOSTED_SOURCES.has(row.source));
 }
@@ -32,19 +32,21 @@ export function localRowsOnly(rows: CatalogEntry[]): CatalogEntry[] {
     return rows.filter((row) => !HOSTED_SOURCES.has(row.source));
 }
 
-/** Hosted row is usable when frontier has a ready key, or it's Ollama (no key). */
-export function hasReadyHostedRow(rows: CatalogEntry[]): boolean {
-    return rows.some(
-        (row) =>
-            row.source === CATALOG_SOURCE.OLLAMA ||
-            (row.source === CATALOG_SOURCE.FRONTIER && row.key_status === KEY_STATUS.READY),
-    );
+/** A hosted row is usable unless it's a frontier model still missing its key.
+ * Local servers (Ollama, LM Studio) report `key_status` null, so they always pass. */
+export function isUsableHostedRow(row: CatalogEntry): boolean {
+    return HOSTED_SOURCES.has(row.source) && row.key_status !== KEY_STATUS.MISSING_KEY;
 }
 
-/** Selectable hosted rows: ollama (always) + frontier with a ready key. Returns [ref, label]. */
+/** True when at least one hosted row is ready to select right now. */
+export function hasReadyHostedRow(rows: CatalogEntry[]): boolean {
+    return rows.some(isUsableHostedRow);
+}
+
+/** Selectable hosted rows: local servers always, frontier only with a ready key. Returns [ref, label]. */
 export function hostedOptions(rows: CatalogEntry[]): Array<[string, string]> {
-    return hostedRowsOnly(rows)
-        .filter((e) => e.source === CATALOG_SOURCE.OLLAMA || e.key_status === KEY_STATUS.READY)
+    return rows
+        .filter(isUsableHostedRow)
         .map((e) => [e.hf_repo, `${e.display_name}${e.provider ? ` [${e.provider}]` : ""}`]);
 }
 

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -12,17 +12,6 @@ import {
     CATALOG_VIEW_MODE,
     ERROR_NAME,
 } from "../types";
-
-/**
- * The catalog modal's task tabs carry a local/hosted sub-toggle. This is a
- * view-only state distinct from the wire `CatalogSource`: "hosted" spans both
- * frontier and ollama rows.
- */
-type SubTab = "local" | "hosted";
-const SUB_TAB = {
-    LOCAL: "local",
-    HOSTED: "hosted",
-} as const satisfies Record<string, SubTab>;
 import { MESSAGES, FILTERS, CATALOG_FILTERS } from "../locales/en";
 import { extractHfRepo, nativeModelRef } from "../utils/model-ref";
 import { ConfirmModal } from "./confirm-modal";
@@ -64,6 +53,16 @@ const DRAWER_FOCUS_DEBOUNCE_MS = 30;
 type TaskFilter = (typeof FILTERS.TASK)[keyof typeof FILTERS.TASK];
 type SizeFilter = "" | typeof FILTERS.SIZE.SMALL | typeof FILTERS.SIZE.MEDIUM | typeof FILTERS.SIZE.LARGE;
 type SortFilter = (typeof FILTERS.SORT)[keyof typeof FILTERS.SORT];
+
+/**
+ * The catalog modal's task tabs carry a local/hosted sub-toggle. View-only
+ * state distinct from the wire `CatalogSource`: "hosted" spans frontier + ollama.
+ */
+type SubTab = "local" | "hosted";
+const SUB_TAB = {
+    LOCAL: "local",
+    HOSTED: "hosted",
+} as const satisfies Record<string, SubTab>;
 
 const TASK_SECTION_LABEL: Record<ModelTask, string> = {
     [MODEL_TASK.CHAT]: MESSAGES.LABEL_SECTION_CHAT,

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -581,7 +581,7 @@ export class CatalogModal extends Modal {
         const nameEl = rowEl.createSpan({ cls: "lilbee-frontier-row-name", text: row.display_name });
         const provider = row.provider ?? "";
         renderProviderPill(nameEl, provider);
-        // Ollama rows need no API key, so they carry a provider pill only.
+        // Local-server rows (Ollama, LM Studio) need no API key — provider pill only.
         const keyStatus: KeyStatus = row.key_status ?? KEY_STATUS.MISSING_KEY;
         if (row.source === CATALOG_SOURCE.FRONTIER) {
             renderKeyStatusPill(nameEl, keyStatus);

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -1,14 +1,6 @@
 import { App, Modal, Notice } from "obsidian";
 import type LilbeePlugin from "../main";
-import type {
-    CatalogEntry,
-    CatalogSource,
-    CatalogTab,
-    CatalogViewMode,
-    KeyStatus,
-    ModelTask,
-    ModelSize,
-} from "../types";
+import type { CatalogEntry, CatalogTab, CatalogViewMode, KeyStatus, ModelTask, ModelSize } from "../types";
 import {
     CATALOG_SOURCE,
     CATALOG_TAB,
@@ -20,6 +12,17 @@ import {
     CATALOG_VIEW_MODE,
     ERROR_NAME,
 } from "../types";
+
+/**
+ * The catalog modal's task tabs carry a local/hosted sub-toggle. This is a
+ * view-only state distinct from the wire `CatalogSource`: "hosted" spans both
+ * frontier and ollama rows.
+ */
+type SubTab = "local" | "hosted";
+const SUB_TAB = {
+    LOCAL: "local",
+    HOSTED: "hosted",
+} as const satisfies Record<string, SubTab>;
 import { MESSAGES, FILTERS, CATALOG_FILTERS } from "../locales/en";
 import { extractHfRepo, nativeModelRef } from "../utils/model-ref";
 import { ConfirmModal } from "./confirm-modal";
@@ -42,9 +45,9 @@ import {
     deepLinkToApiKeySettings,
     forYouRail,
     freshRail,
-    frontierRowsOnly,
     groupByProvider,
-    hasReadyFrontierRow,
+    hasReadyHostedRow,
+    hostedRowsOnly,
     localRowsOnly,
     renderKeyStatusPill,
     renderProviderPill,
@@ -106,9 +109,9 @@ export class CatalogModal extends Modal {
     private viewToggleBtn: HTMLElement | null = null;
     private debouncedSearch: () => void;
     private cancelDebouncedSearch: () => void;
-    private currentTab: CatalogSource = CATALOG_SOURCE.LOCAL;
+    private currentTab: SubTab = SUB_TAB.LOCAL;
     private subTabBarEl: HTMLElement | null = null;
-    private frontierTabBtn: HTMLElement | null = null;
+    private hostedTabBtn: HTMLElement | null = null;
     private activeTab: CatalogTab;
     private mainTabBarEl: HTMLElement | null = null;
     private bodyEl: HTMLElement | null = null;
@@ -245,8 +248,8 @@ export class CatalogModal extends Modal {
         }
         this.plugin.settings.lastCatalogTab = tab;
         void this.plugin.saveSettings();
-        // Reset to the local sub-tab when leaving a task tab — frontier state shouldn't persist.
-        this.currentTab = CATALOG_SOURCE.LOCAL;
+        // Reset to the local sub-tab when leaving a task tab — hosted state shouldn't persist.
+        this.currentTab = SUB_TAB.LOCAL;
         this.applyTabToFilter();
         this.updateSubTabBarVisibility();
         this.updateViewToggleVisibility();
@@ -272,15 +275,15 @@ export class CatalogModal extends Modal {
             cls: "lilbee-catalog-tab lilbee-catalog-tab-active",
         });
         localBtn.setAttribute("aria-selected", "true");
-        localBtn.addEventListener("click", () => this.switchSubTab(CATALOG_SOURCE.LOCAL));
+        localBtn.addEventListener("click", () => this.switchSubTab(SUB_TAB.LOCAL));
 
-        this.frontierTabBtn = this.subTabBarEl.createEl("button", {
+        this.hostedTabBtn = this.subTabBarEl.createEl("button", {
             text: MESSAGES.TAB_FRONTIER,
             cls: "lilbee-catalog-tab",
         });
-        this.frontierTabBtn.setAttribute("aria-selected", "false");
-        this.frontierTabBtn.style.display = "none";
-        this.frontierTabBtn.addEventListener("click", () => this.switchSubTab(CATALOG_SOURCE.FRONTIER));
+        this.hostedTabBtn.setAttribute("aria-selected", "false");
+        this.hostedTabBtn.style.display = "none";
+        this.hostedTabBtn.addEventListener("click", () => this.switchSubTab(SUB_TAB.HOSTED));
         this.updateSubTabBarVisibility();
     }
 
@@ -291,32 +294,32 @@ export class CatalogModal extends Modal {
         this.subTabBarEl.style.display = showSubTabs ? "" : "none";
     }
 
-    private switchSubTab(tab: CatalogSource): void {
+    private switchSubTab(tab: SubTab): void {
         if (this.currentTab === tab) return;
         this.currentTab = tab;
         /* v8 ignore next 2 */
         if (!this.subTabBarEl) return;
         for (const btn of Array.from(this.subTabBarEl.children) as HTMLElement[]) {
             const isActive =
-                (tab === CATALOG_SOURCE.LOCAL && btn.textContent === MESSAGES.TAB_LOCAL) ||
-                (tab === CATALOG_SOURCE.FRONTIER && btn.textContent === MESSAGES.TAB_FRONTIER);
+                (tab === SUB_TAB.LOCAL && btn.textContent === MESSAGES.TAB_LOCAL) ||
+                (tab === SUB_TAB.HOSTED && btn.textContent === MESSAGES.TAB_FRONTIER);
             btn.toggleClass("lilbee-catalog-tab-active", isActive);
             btn.setAttribute("aria-selected", isActive ? "true" : "false");
         }
         this.renderResults();
     }
 
-    private updateFrontierTabVisibility(): void {
+    private updateHostedTabVisibility(): void {
         /* v8 ignore next 2 */
-        if (!this.frontierTabBtn) return;
-        const showFrontier = tabIdToTask(this.activeTab) !== null && hasReadyFrontierRow(this.entries);
-        if (showFrontier) {
-            this.frontierTabBtn.style.display = "";
+        if (!this.hostedTabBtn) return;
+        const showHosted = tabIdToTask(this.activeTab) !== null && hasReadyHostedRow(this.entries);
+        if (showHosted) {
+            this.hostedTabBtn.style.display = "";
             return;
         }
-        this.frontierTabBtn.style.display = "none";
-        // Bounce the user home if a refetch revoked the only ready frontier row.
-        if (this.currentTab === CATALOG_SOURCE.FRONTIER) this.switchSubTab(CATALOG_SOURCE.LOCAL);
+        this.hostedTabBtn.style.display = "none";
+        // Bounce the user home if a refetch revoked the only ready hosted row.
+        if (this.currentTab === SUB_TAB.HOSTED) this.switchSubTab(SUB_TAB.LOCAL);
     }
 
     onClose(): void {
@@ -444,7 +447,7 @@ export class CatalogModal extends Modal {
             this.entries.push(...filtered);
             this.offset += response.models.length;
 
-            this.updateFrontierTabVisibility();
+            this.updateHostedTabVisibility();
             this.renderResults();
         } finally {
             this.isFetching = false;
@@ -464,8 +467,8 @@ export class CatalogModal extends Modal {
             return;
         }
 
-        if (this.currentTab === CATALOG_SOURCE.FRONTIER) {
-            this.renderFrontierResults();
+        if (this.currentTab === SUB_TAB.HOSTED) {
+            this.renderHostedResults();
             return;
         }
         this.renderTaskTabLocal();
@@ -550,14 +553,14 @@ export class CatalogModal extends Modal {
         }
     }
 
-    private renderFrontierResults(): void {
+    private renderHostedResults(): void {
         /* v8 ignore next 2 */
         if (!this.resultsEl) return;
         // Sub-toggle is only visible on task tabs, so taskForTab is always non-null here.
         const taskForTab = tabIdToTask(this.activeTab);
-        const allFrontier = frontierRowsOnly(this.entries);
+        const allHosted = hostedRowsOnly(this.entries);
         /* v8 ignore next 2 */
-        const rows = taskForTab === null ? allFrontier : allFrontier.filter((r) => r.task === taskForTab);
+        const rows = taskForTab === null ? allHosted : allHosted.filter((r) => r.task === taskForTab);
         if (rows.length === 0) {
             this.resultsEl.createDiv({
                 cls: "lilbee-catalog-empty",
@@ -569,29 +572,32 @@ export class CatalogModal extends Modal {
             this.resultsEl.createDiv({ cls: "lilbee-catalog-section-heading", text: provider });
             const list = this.resultsEl.createDiv({ cls: "lilbee-catalog-frontier-list" });
             for (const row of group) {
-                this.renderFrontierRow(list, row);
+                this.renderHostedRow(list, row);
             }
         }
     }
 
-    private renderFrontierRow(parent: HTMLElement, row: CatalogEntry): void {
+    private renderHostedRow(parent: HTMLElement, row: CatalogEntry): void {
         const rowEl = parent.createDiv({ cls: "lilbee-frontier-row" });
         const nameEl = rowEl.createSpan({ cls: "lilbee-frontier-row-name", text: row.display_name });
-        const provider = (row as CatalogEntry & { provider?: string }).provider ?? "";
-        const keyStatus = (row as CatalogEntry & { key_status?: KeyStatus }).key_status ?? KEY_STATUS.MISSING_KEY;
+        const provider = row.provider ?? "";
         renderProviderPill(nameEl, provider);
-        renderKeyStatusPill(nameEl, keyStatus);
+        // Ollama rows need no API key, so they carry a provider pill only.
+        const keyStatus: KeyStatus = row.key_status ?? KEY_STATUS.MISSING_KEY;
+        if (row.source === CATALOG_SOURCE.FRONTIER) {
+            renderKeyStatusPill(nameEl, keyStatus);
+        }
         rowEl.addEventListener("click", () => {
-            if (keyStatus === KEY_STATUS.MISSING_KEY) {
+            if (row.source === CATALOG_SOURCE.FRONTIER && keyStatus === KEY_STATUS.MISSING_KEY) {
                 this.close();
                 deepLinkToApiKeySettings(this.app, provider);
                 return;
             }
-            void this.handleUseFrontier(row);
+            void this.handleUseHosted(row);
         });
     }
 
-    private async handleUseFrontier(row: CatalogEntry): Promise<void> {
+    private async handleUseHosted(row: CatalogEntry): Promise<void> {
         const result = await this.setActiveFor(row);
         if (result.isErr()) {
             new Notice(noticeForResultError(result.error, MESSAGES.ERROR_SET_MODEL.replace("{model}", row.hf_repo)));

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -9,7 +9,16 @@ import {
     WorkspaceLeaf,
 } from "obsidian";
 import type LilbeePlugin from "../main";
-import { CHAT_MODE, CONFIG_KEY, HOSTED_SOURCES, MODEL_TASK, SSE_EVENT, TASK_TYPE, ERROR_NAME } from "../types";
+import {
+    CATALOG_SOURCE,
+    CHAT_MODE,
+    CONFIG_KEY,
+    HOSTED_SOURCES,
+    MODEL_TASK,
+    SSE_EVENT,
+    TASK_TYPE,
+    ERROR_NAME,
+} from "../types";
 import type { CatalogEntry, ChatMode, InstalledModel, Message, SearchChunkType, Source, SSEEvent } from "../types";
 import { RateLimitedError } from "../api";
 
@@ -30,7 +39,7 @@ import {
     noticeForResultError,
     getRelevantSystemMemoryGB,
 } from "../utils";
-import { hostedOptions } from "./catalog-helpers";
+import { hostedOptions, isUsableHostedRow } from "./catalog-helpers";
 
 interface OpenDialogResult {
     canceled: boolean;
@@ -502,7 +511,7 @@ export class ChatView extends ItemView {
         }
         for (const m of otherInstalled) {
             const source = sourceMap.get(m.name);
-            const suffix = source && source !== "native" ? ` [${source}]` : "";
+            const suffix = source && source !== CATALOG_SOURCE.NATIVE ? ` [${source}]` : "";
             const option = selectEl.createEl("option", { text: `${displayLabelForRef(m.name)}${suffix}` });
             (option as HTMLOptionElement).value = m.name;
             if (m.name === this.chatActive) {
@@ -598,8 +607,8 @@ export class ChatView extends ItemView {
      */
     private optionalRoleOptions(spec: OptionalRoleSpec): { value: string; label: string }[] {
         const entries = this.optionalCatalog[spec.key];
-        const localInstalled = entries.filter((e) => e.source !== CATALOG_SOURCE.FRONTIER && e.installed);
-        const hosted = entries.filter((e) => e.source === CATALOG_SOURCE.FRONTIER);
+        const localInstalled = entries.filter((e) => !HOSTED_SOURCES.has(e.source) && e.installed);
+        const hosted = entries.filter(isUsableHostedRow);
         const options = localInstalled.map((e) => ({ value: e.hf_repo, label: e.display_name }));
         for (const e of hosted) {
             options.push({ value: e.hf_repo, label: `${e.display_name} — ${MESSAGES.LABEL_VISION_HOSTED_GROUP}` });

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -9,7 +9,7 @@ import {
     WorkspaceLeaf,
 } from "obsidian";
 import type LilbeePlugin from "../main";
-import { CATALOG_SOURCE, CHAT_MODE, CONFIG_KEY, MODEL_TASK, SSE_EVENT, TASK_TYPE, ERROR_NAME } from "../types";
+import { CHAT_MODE, CONFIG_KEY, HOSTED_SOURCES, MODEL_TASK, SSE_EVENT, TASK_TYPE, ERROR_NAME } from "../types";
 import type { CatalogEntry, ChatMode, InstalledModel, Message, SearchChunkType, Source, SSEEvent } from "../types";
 import { RateLimitedError } from "../api";
 
@@ -30,6 +30,7 @@ import {
     noticeForResultError,
     getRelevantSystemMemoryGB,
 } from "../utils";
+import { hostedOptions } from "./catalog-helpers";
 
 interface OpenDialogResult {
     canceled: boolean;
@@ -391,10 +392,23 @@ export class ChatView extends ItemView {
         // Featured rows that have an installed quant.
         const featuredInstalled = this.chatCatalogEntries.filter((e) => installedRepos.has(e.hf_repo));
         for (const entry of featuredInstalled) {
-            const sourceTag = entry.source && entry.source !== CATALOG_SOURCE.LOCAL ? ` [${entry.source}]` : "";
+            const sourceTag = HOSTED_SOURCES.has(entry.source) ? ` [${entry.provider ?? entry.source}]` : "";
             const option = selectEl.createEl("option", { text: `${entry.display_name}${sourceTag}` });
             (option as HTMLOptionElement).value = entry.hf_repo;
             if (entry.hf_repo === activeRepo) {
+                (option as HTMLOptionElement).selected = true;
+            }
+        }
+
+        // Hosted rows (frontier/ollama) are selectable even when absent from the
+        // installed registry — ollama always, frontier with a ready key. Skip any
+        // already emitted above as an installed featured row (an ollama model can
+        // be both hosted and registered as installed).
+        for (const [ref, label] of hostedOptions(this.chatCatalogEntries)) {
+            if (installedRepos.has(ref)) continue;
+            const option = selectEl.createEl("option", { text: label });
+            (option as HTMLOptionElement).value = ref;
+            if (ref === activeRepo) {
                 (option as HTMLOptionElement).selected = true;
             }
         }

--- a/src/views/model-picker-modal.ts
+++ b/src/views/model-picker-modal.ts
@@ -1,14 +1,14 @@
 import { App, Modal, Notice } from "obsidian";
 import type { Result } from "neverthrow";
 import type LilbeePlugin from "../main";
-import type { CatalogEntry, KeyStatus, ModelTask } from "../types";
-import { CATALOG_SOURCE, KEY_STATUS, MODEL_TASK } from "../types";
+import type { CatalogEntry, ModelTask } from "../types";
+import { CATALOG_SOURCE, HOSTED_SOURCES, KEY_STATUS, MODEL_TASK } from "../types";
 import { MESSAGES } from "../locales/en";
 import {
     deepLinkToApiKeySettings,
-    frontierRowsOnly,
     groupByProvider,
-    hasReadyFrontierRow,
+    hasReadyHostedRow,
+    hostedRowsOnly,
     localRowsOnly,
     renderKeyStatusPill,
     renderProviderPill,
@@ -141,8 +141,8 @@ export class ModelPickerModal extends Modal {
 
     private applyFilterAndRender(): void {
         const local = localRowsOnly(this.allRows);
-        const frontier = hasReadyFrontierRow(this.allRows) ? frontierRowsOnly(this.allRows) : [];
-        const visible = [...local, ...frontier];
+        const hosted = hasReadyHostedRow(this.allRows) ? hostedRowsOnly(this.allRows) : [];
+        const visible = [...local, ...hosted];
         this.filteredRows = filterRowsByText(visible, this.filterText);
         this.highlightedIndex = 0;
         this.renderList();
@@ -156,8 +156,8 @@ export class ModelPickerModal extends Modal {
             this.listEl.createDiv({ cls: "lilbee-model-picker-empty", text: MESSAGES.MODEL_PICKER_EMPTY });
             return;
         }
-        const local = this.filteredRows.filter((r) => r.source !== CATALOG_SOURCE.FRONTIER);
-        const frontier = this.filteredRows.filter((r) => r.source === CATALOG_SOURCE.FRONTIER);
+        const local = this.filteredRows.filter((r) => !HOSTED_SOURCES.has(r.source));
+        const hosted = this.filteredRows.filter((r) => HOSTED_SOURCES.has(r.source));
         if (local.length > 0) {
             this.listEl.createDiv({
                 cls: "lilbee-model-picker-section-header",
@@ -165,7 +165,7 @@ export class ModelPickerModal extends Modal {
             });
             for (const row of local) this.renderRow(this.listEl, row);
         }
-        for (const [provider, group] of groupByProvider(frontier)) {
+        for (const [provider, group] of groupByProvider(hosted)) {
             this.listEl.createDiv({ cls: "lilbee-model-picker-section-header", text: provider });
             for (const row of group) this.renderRow(this.listEl, row);
         }
@@ -180,13 +180,14 @@ export class ModelPickerModal extends Modal {
             renderPill(nameRow, MESSAGES.LABEL_INSTALLED, PILL_CLS.INSTALLED);
         }
         renderFitChip(nameRow, row.fit);
-        if (row.source === CATALOG_SOURCE.FRONTIER) {
-            const frontier = row as CatalogEntry & { provider?: string; key_status?: KeyStatus };
-            /* v8 ignore next 2 */
-            const provider = frontier.provider ?? "";
-            const keyStatus = frontier.key_status ?? KEY_STATUS.MISSING_KEY;
+        if (HOSTED_SOURCES.has(row.source)) {
+            /* v8 ignore next */
+            const provider = row.provider ?? "";
             renderProviderPill(nameRow, provider);
-            renderKeyStatusPill(nameRow, keyStatus);
+            // Ollama needs no API key, so it carries a provider pill only.
+            if (row.source === CATALOG_SOURCE.FRONTIER) {
+                renderKeyStatusPill(nameRow, row.key_status ?? KEY_STATUS.MISSING_KEY);
+            }
         }
         if (row.size_gb > 0) {
             rowEl.createDiv({
@@ -201,12 +202,11 @@ export class ModelPickerModal extends Modal {
 
     private async activateRow(row: CatalogEntry): Promise<void> {
         if (row.source === CATALOG_SOURCE.FRONTIER) {
-            const frontier = row as CatalogEntry & { provider?: string; key_status?: KeyStatus };
             /* v8 ignore next */
-            const keyStatus = frontier.key_status ?? KEY_STATUS.MISSING_KEY;
+            const keyStatus = row.key_status ?? KEY_STATUS.MISSING_KEY;
             if (keyStatus === KEY_STATUS.MISSING_KEY) {
                 /* v8 ignore next */
-                const provider = frontier.provider ?? "";
+                const provider = row.provider ?? "";
                 this.close();
                 deepLinkToApiKeySettings(this.app, provider);
                 return;

--- a/src/views/model-picker-modal.ts
+++ b/src/views/model-picker-modal.ts
@@ -184,7 +184,7 @@ export class ModelPickerModal extends Modal {
             /* v8 ignore next */
             const provider = row.provider ?? "";
             renderProviderPill(nameRow, provider);
-            // Ollama needs no API key, so it carries a provider pill only.
+            // Local servers (Ollama, LM Studio) need no API key — provider pill only.
             if (row.source === CATALOG_SOURCE.FRONTIER) {
                 renderKeyStatusPill(nameRow, row.key_status ?? KEY_STATUS.MISSING_KEY);
             }

--- a/tests/components/model-card.test.ts
+++ b/tests/components/model-card.test.ts
@@ -154,17 +154,39 @@ describe("renderModelCard", () => {
             expect(card.find("lilbee-tag-featured")).toBeNull();
         });
 
-        it("renders a provider tag for non-local sources", () => {
+        it("renders a provider tag for hosted sources, preferring the provider label", () => {
             const c = container();
-            const card = renderModelCard(c, makeEntry({ source: "frontier" }), {}) as unknown as MockElement;
+            const card = renderModelCard(
+                c,
+                makeEntry({ source: "frontier", provider: "Gemini" }),
+                {},
+            ) as unknown as MockElement;
             const tag = card.find("lilbee-tag-provider");
             expect(tag).not.toBeNull();
-            expect(tag?.textContent).toBe("frontier");
+            expect(tag?.textContent).toBe("Gemini");
         });
 
-        it("omits the provider tag for local sources", () => {
+        it("renders a provider tag for ollama rows", () => {
             const c = container();
-            const card = renderModelCard(c, makeEntry({ source: "local" }), {}) as unknown as MockElement;
+            const card = renderModelCard(
+                c,
+                makeEntry({ source: "ollama", provider: "Ollama" }),
+                {},
+            ) as unknown as MockElement;
+            const tag = card.find("lilbee-tag-provider");
+            expect(tag).not.toBeNull();
+            expect(tag?.textContent).toBe("Ollama");
+        });
+
+        it("falls back to the source name when a hosted row carries no provider", () => {
+            const c = container();
+            const card = renderModelCard(c, makeEntry({ source: "frontier" }), {}) as unknown as MockElement;
+            expect(card.find("lilbee-tag-provider")?.textContent).toBe("frontier");
+        });
+
+        it("omits the provider tag for native sources", () => {
+            const c = container();
+            const card = renderModelCard(c, makeEntry({ source: "native" }), {}) as unknown as MockElement;
             expect(card.find("lilbee-tag-provider")).toBeNull();
         });
     });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -2448,6 +2448,60 @@ describe("managed mode settings", () => {
             expect(plugin.api.catalog).toHaveBeenCalledWith({ task: "embedding" });
         });
 
+        it("surfaces hosted ollama embedding models with a provider label", async () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({
+                    total: 2,
+                    limit: 20,
+                    offset: 0,
+                    has_more: false,
+                    models: [
+                        {
+                            hf_repo: "nomic-ai/nomic-embed-text-v1.5-GGUF",
+                            display_name: "nomic-embed-text",
+                            installed: true,
+                            task: "embedding",
+                            source: "native",
+                        },
+                        {
+                            hf_repo: "ollama/nomic-embed-text:latest",
+                            display_name: "nomic-embed-text:latest",
+                            installed: true,
+                            task: "embedding",
+                            source: "ollama",
+                            provider: "Ollama",
+                        },
+                    ],
+                }),
+            );
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+
+            const options: Array<[string, string]> = [];
+            const origAddDropdown = Setting.prototype.addDropdown;
+            Setting.prototype.addDropdown = function (cb: (dropdown: any) => void) {
+                const fakeDropdown = {
+                    addOption: (value: string, label: string) => {
+                        options.push([value, label]);
+                        return fakeDropdown;
+                    },
+                    setValue: () => fakeDropdown,
+                    onChange: () => fakeDropdown,
+                };
+                cb(fakeDropdown);
+                return this;
+            };
+            await (tab as any).loadEmbeddingDropdown(container);
+            await new Promise((r) => setTimeout(r, 0));
+            Setting.prototype.addDropdown = origAddDropdown;
+
+            // Native row shows plain; the ollama row is explicitly tagged [Ollama].
+            expect(options).toContainEqual(["nomic-ai/nomic-embed-text-v1.5-GGUF", "nomic-embed-text"]);
+            expect(options).toContainEqual(["ollama/nomic-embed-text:latest", "nomic-embed-text:latest [Ollama]"]);
+        });
+
         it("embedding dropdown onChange sets model and triggers sync", async () => {
             const plugin = makePlugin();
             mockChatPicker(plugin);

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1061,6 +1061,44 @@ describe("LilbeeSettingTab", () => {
             expect(opts[0][1]).not.toContain("[");
         });
 
+        it("includes a ready hosted (frontier) model that is not on disk", () => {
+            const plugin = makePlugin();
+            const tab = makeTab(plugin);
+            const entries = [
+                chatEntry({
+                    hf_repo: "gemini/gemini-2.0-flash",
+                    display_name: "gemini-2.0-flash",
+                    source: "frontier",
+                    provider: "Gemini",
+                    key_status: "ready",
+                    installed: true,
+                }),
+            ];
+            const opts: Array<[string, string]> = (tab as any).buildChatOptions(entries, []);
+            const keys = opts.map(([k]) => k);
+            expect(keys).toContain("gemini/gemini-2.0-flash");
+            const label = opts.find(([k]) => k === "gemini/gemini-2.0-flash")?.[1];
+            expect(label).toContain("[Gemini]");
+        });
+
+        it("does not duplicate a hosted model already present in the installed registry", () => {
+            const plugin = makePlugin();
+            const tab = makeTab(plugin);
+            const entries = [
+                chatEntry({
+                    hf_repo: "ollama/qwen3:8b",
+                    display_name: "qwen3:8b",
+                    source: "ollama",
+                    provider: "Ollama",
+                    installed: true,
+                }),
+            ];
+            const installed: InstalledModel[] = [{ name: "ollama/qwen3:8b", source: "ollama" }];
+            const opts: Array<[string, string]> = (tab as any).buildChatOptions(entries, installed);
+            const occurrences = opts.filter(([k]) => k === "ollama/qwen3:8b");
+            expect(occurrences).toHaveLength(1);
+        });
+
         it("falls back to empty active when catalog fetch errors", async () => {
             const plugin = makePlugin();
             (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({ chat_model: LLAMA_REF });
@@ -4454,12 +4492,14 @@ describe("managed mode settings", () => {
                             min_ram_gb: 0,
                             description: "",
                             quality_tier: "",
-                            installed: false,
+                            installed: true,
                             source: "frontier",
                             task: "rerank",
                             featured: false,
                             downloads: 0,
                             param_count: "",
+                            provider: "Cohere",
+                            key_status: "ready",
                         },
                     ],
                     has_more: false,
@@ -4905,12 +4945,14 @@ describe("managed mode settings", () => {
                             min_ram_gb: 0,
                             description: "",
                             quality_tier: "",
-                            installed: false,
+                            installed: true,
                             source: "frontier",
                             task: "rerank",
                             featured: false,
                             downloads: 0,
                             param_count: "",
+                            provider: "Cohere",
+                            key_status: "ready",
                         },
                     ],
                     has_more: false,
@@ -5703,9 +5745,11 @@ describe("managed mode settings", () => {
                             min_ram_gb: 0,
                             description: "",
                             quality_tier: "",
-                            installed: false,
+                            installed: true,
                             source: "frontier",
                             task: "vision",
+                            provider: "OpenAI",
+                            key_status: "ready",
                         },
                     ],
                     has_more: false,

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -8,6 +8,8 @@ import {
     DOWNLOAD_PANEL,
     LOCK_STATE,
     SHARED_PATH,
+    CATALOG_SOURCE,
+    HOSTED_SOURCES,
 } from "../src/types";
 import type {
     Excerpt,
@@ -35,6 +37,21 @@ import type {
     ConfigUpdateResponse,
     EmbeddingModelResponse,
 } from "../src/types";
+
+describe("CATALOG_SOURCE", () => {
+    it("matches the server wire vocabulary", () => {
+        expect(CATALOG_SOURCE.NATIVE).toBe("native");
+        expect(CATALOG_SOURCE.FRONTIER).toBe("frontier");
+        expect(CATALOG_SOURCE.OLLAMA).toBe("ollama");
+    });
+
+    it("HOSTED_SOURCES holds the two hosted sources only", () => {
+        expect(HOSTED_SOURCES.has(CATALOG_SOURCE.FRONTIER)).toBe(true);
+        expect(HOSTED_SOURCES.has(CATALOG_SOURCE.OLLAMA)).toBe(true);
+        expect(HOSTED_SOURCES.has(CATALOG_SOURCE.NATIVE)).toBe(false);
+        expect(HOSTED_SOURCES.size).toBe(2);
+    });
+});
 
 describe("DEFAULT_SETTINGS", () => {
     it("has the correct serverUrl", () => {

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -43,13 +43,15 @@ describe("CATALOG_SOURCE", () => {
         expect(CATALOG_SOURCE.NATIVE).toBe("native");
         expect(CATALOG_SOURCE.FRONTIER).toBe("frontier");
         expect(CATALOG_SOURCE.OLLAMA).toBe("ollama");
+        expect(CATALOG_SOURCE.LM_STUDIO).toBe("lm_studio");
     });
 
-    it("HOSTED_SOURCES holds the two hosted sources only", () => {
+    it("HOSTED_SOURCES holds frontier plus the local servers", () => {
         expect(HOSTED_SOURCES.has(CATALOG_SOURCE.FRONTIER)).toBe(true);
         expect(HOSTED_SOURCES.has(CATALOG_SOURCE.OLLAMA)).toBe(true);
+        expect(HOSTED_SOURCES.has(CATALOG_SOURCE.LM_STUDIO)).toBe(true);
         expect(HOSTED_SOURCES.has(CATALOG_SOURCE.NATIVE)).toBe(false);
-        expect(HOSTED_SOURCES.size).toBe(2);
+        expect(HOSTED_SOURCES.size).toBe(3);
     });
 });
 

--- a/tests/utils/model-ref.test.ts
+++ b/tests/utils/model-ref.test.ts
@@ -44,6 +44,10 @@ describe("displayLabelForRef", () => {
         expect(displayLabelForRef("ollama/qwen3:8b")).toBe("qwen3:8b");
     });
 
+    it("returns the segment after lm_studio/", () => {
+        expect(displayLabelForRef("lm_studio/qwen2.5-7b-instruct")).toBe("qwen2.5-7b-instruct");
+    });
+
     it("returns the segment after openai/", () => {
         expect(displayLabelForRef("openai/gpt-4o")).toBe("gpt-4o");
     });

--- a/tests/views/catalog-helpers.test.ts
+++ b/tests/views/catalog-helpers.test.ts
@@ -4,9 +4,10 @@ import {
     deepLinkToApiKeySettings,
     forYouRail,
     freshRail,
-    frontierRowsOnly,
     groupByProvider,
-    hasReadyFrontierRow,
+    hasReadyHostedRow,
+    hostedOptions,
+    hostedRowsOnly,
     KEY_STATUS_PILL_CLASS,
     localRowsOnly,
     renderKeyStatusPill,
@@ -15,7 +16,7 @@ import {
     taskToTabId,
     yourCollectionRail,
 } from "../../src/views/catalog-helpers";
-import { CATALOG_TAB } from "../../src/types";
+import { CATALOG_SOURCE, CATALOG_TAB, KEY_STATUS } from "../../src/types";
 import type { CatalogEntry } from "../../src/types";
 
 function row(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
@@ -28,7 +29,7 @@ function row(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
         description: "",
         quality_tier: "",
         installed: false,
-        source: "local",
+        source: "native",
         task: "chat",
         featured: false,
         downloads: 0,
@@ -38,43 +39,74 @@ function row(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
 }
 
 describe("catalog-helpers", () => {
-    describe("hasReadyFrontierRow", () => {
+    describe("hasReadyHostedRow", () => {
         it("returns true when a frontier row has key_status=ready", () => {
             const rows = [
-                row({ source: "local" }),
-                row({
-                    source: "frontier",
-                    ...({ key_status: "ready" } as Partial<CatalogEntry>),
-                }),
+                row({ source: CATALOG_SOURCE.NATIVE }),
+                row({ source: CATALOG_SOURCE.FRONTIER, key_status: KEY_STATUS.READY }),
             ];
-            expect(hasReadyFrontierRow(rows)).toBe(true);
+            expect(hasReadyHostedRow(rows)).toBe(true);
         });
 
-        it("returns false when no frontier row is ready", () => {
+        it("returns false when the only frontier row is missing its key", () => {
             const rows = [
-                row({ source: "local" }),
-                row({
-                    source: "frontier",
-                    ...({ key_status: "missing_key" } as Partial<CatalogEntry>),
-                }),
+                row({ source: CATALOG_SOURCE.NATIVE }),
+                row({ source: CATALOG_SOURCE.FRONTIER, key_status: KEY_STATUS.MISSING_KEY }),
             ];
-            expect(hasReadyFrontierRow(rows)).toBe(false);
+            expect(hasReadyHostedRow(rows)).toBe(false);
+        });
+
+        it("treats ollama rows as always ready (no key needed)", () => {
+            expect(hasReadyHostedRow([row({ source: CATALOG_SOURCE.OLLAMA })])).toBe(true);
         });
 
         it("returns false on an empty list", () => {
-            expect(hasReadyFrontierRow([])).toBe(false);
+            expect(hasReadyHostedRow([])).toBe(false);
         });
     });
 
-    describe("frontierRowsOnly / localRowsOnly", () => {
-        it("partitions rows by source value", () => {
+    describe("hostedRowsOnly / localRowsOnly", () => {
+        it("partitions rows by hosted vs native source", () => {
             const rows = [
-                row({ source: "local", display_name: "L1" }),
-                row({ source: "frontier", display_name: "F1" }),
-                row({ source: "local", display_name: "L2" }),
+                row({ source: CATALOG_SOURCE.NATIVE, display_name: "L1" }),
+                row({ source: CATALOG_SOURCE.FRONTIER, display_name: "F1" }),
+                row({ source: CATALOG_SOURCE.OLLAMA, display_name: "O1" }),
+                row({ source: CATALOG_SOURCE.NATIVE, display_name: "L2" }),
             ];
-            expect(frontierRowsOnly(rows).map((r) => r.display_name)).toEqual(["F1"]);
+            expect(hostedRowsOnly(rows).map((r) => r.display_name)).toEqual(["F1", "O1"]);
             expect(localRowsOnly(rows).map((r) => r.display_name)).toEqual(["L1", "L2"]);
+        });
+    });
+
+    describe("hostedOptions", () => {
+        it("includes ollama always and frontier only with a ready key", () => {
+            const rows = [
+                row({ source: CATALOG_SOURCE.NATIVE, hf_repo: "n/r", display_name: "N" }),
+                row({
+                    source: CATALOG_SOURCE.FRONTIER,
+                    hf_repo: "gemini/g",
+                    display_name: "Gemini Flash",
+                    provider: "Gemini",
+                    key_status: KEY_STATUS.READY,
+                }),
+                row({
+                    source: CATALOG_SOURCE.FRONTIER,
+                    hf_repo: "openai/x",
+                    display_name: "GPT",
+                    provider: "OpenAI",
+                    key_status: KEY_STATUS.MISSING_KEY,
+                }),
+                row({ source: CATALOG_SOURCE.OLLAMA, hf_repo: "ollama/l", display_name: "Llama", provider: "Ollama" }),
+            ];
+            expect(hostedOptions(rows)).toEqual([
+                ["gemini/g", "Gemini Flash [Gemini]"],
+                ["ollama/l", "Llama [Ollama]"],
+            ]);
+        });
+
+        it("omits the provider suffix when a hosted row carries none", () => {
+            const rows = [row({ source: CATALOG_SOURCE.OLLAMA, hf_repo: "ollama/l", display_name: "Llama" })];
+            expect(hostedOptions(rows)).toEqual([["ollama/l", "Llama"]]);
         });
     });
 

--- a/tests/views/catalog-helpers.test.ts
+++ b/tests/views/catalog-helpers.test.ts
@@ -60,6 +60,10 @@ describe("catalog-helpers", () => {
             expect(hasReadyHostedRow([row({ source: CATALOG_SOURCE.OLLAMA })])).toBe(true);
         });
 
+        it("treats lm_studio rows as always ready (no key needed)", () => {
+            expect(hasReadyHostedRow([row({ source: CATALOG_SOURCE.LM_STUDIO })])).toBe(true);
+        });
+
         it("returns false on an empty list", () => {
             expect(hasReadyHostedRow([])).toBe(false);
         });
@@ -107,6 +111,18 @@ describe("catalog-helpers", () => {
         it("omits the provider suffix when a hosted row carries none", () => {
             const rows = [row({ source: CATALOG_SOURCE.OLLAMA, hf_repo: "ollama/l", display_name: "Llama" })];
             expect(hostedOptions(rows)).toEqual([["ollama/l", "Llama"]]);
+        });
+
+        it("lists lm_studio rows alongside ollama (both local servers, no key)", () => {
+            const rows = [
+                row({
+                    source: CATALOG_SOURCE.LM_STUDIO,
+                    hf_repo: "lm_studio/qwen",
+                    display_name: "Qwen",
+                    provider: "LM Studio",
+                }),
+            ];
+            expect(hostedOptions(rows)).toEqual([["lm_studio/qwen", "Qwen [LM Studio]"]]);
         });
     });
 

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -1567,12 +1567,12 @@ describe("CatalogModal", () => {
                 .find((b) => b.textContent === MESSAGES.TAB_FRONTIER)!
                 .trigger("click");
             await tick();
-            expect((modal as any).currentTab).toBe("frontier");
+            expect((modal as any).currentTab).toBe("hosted");
             // Simulate a refetch that returns no ready rows (e.g. user revoked the key).
             (modal as any).entries = [
                 makeFrontierEntry({ ...({ key_status: "missing_key" } as Partial<CatalogEntry>) }),
             ];
-            (modal as any).updateFrontierTabVisibility();
+            (modal as any).updateHostedTabVisibility();
             expect((modal as any).currentTab).toBe("local");
         });
 
@@ -1690,7 +1690,7 @@ describe("CatalogModal", () => {
                 .trigger("click");
             await tick();
             await tick();
-            (modal as any).currentTab = "frontier";
+            (modal as any).currentTab = "hosted";
             // Now click Embed — sub-toggle should reset to local.
             plugin.api.catalog.mockClear();
             findButtons(content)

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -1382,7 +1382,7 @@ describe("CatalogModal", () => {
         it("hides the Frontier tab when no frontier rows have key_status=ready", async () => {
             const plugin = makePlugin();
             plugin.api.catalog.mockResolvedValue(
-                ok(makeCatalogResponse([makeEntry({ source: "local" }), makeFrontierEntry()])),
+                ok(makeCatalogResponse([makeEntry({ source: "native" }), makeFrontierEntry()])),
             );
             const modal = await openModal(plugin);
             const content = contentEl(modal);
@@ -1396,7 +1396,7 @@ describe("CatalogModal", () => {
             plugin.api.catalog.mockResolvedValue(
                 ok(
                     makeCatalogResponse([
-                        makeEntry({ source: "local" }),
+                        makeEntry({ source: "native" }),
                         makeFrontierEntry({
                             ...({ key_status: "ready" } as Partial<CatalogEntry>),
                         }),
@@ -1414,7 +1414,7 @@ describe("CatalogModal", () => {
             plugin.api.catalog.mockResolvedValue(
                 ok(
                     makeCatalogResponse([
-                        makeEntry({ source: "local", display_name: "Local model" }),
+                        makeEntry({ source: "native", display_name: "Local model" }),
                         makeFrontierEntry({ display_name: "Frontier model" }),
                     ]),
                 ),
@@ -1534,7 +1534,7 @@ describe("CatalogModal", () => {
             plugin.api.catalog.mockResolvedValue(
                 ok(
                     makeCatalogResponse([
-                        makeEntry({ source: "local", display_name: "Local-A" }),
+                        makeEntry({ source: "native", display_name: "Local-A" }),
                         makeFrontierEntry({ ...({ key_status: "ready" } as Partial<CatalogEntry>) }),
                     ]),
                 ),
@@ -1622,7 +1622,7 @@ describe("CatalogModal", () => {
             plugin.api.catalog.mockResolvedValue(
                 ok(
                     makeCatalogResponse([
-                        makeEntry({ source: "local", display_name: "Local-A" }),
+                        makeEntry({ source: "native", display_name: "Local-A" }),
                         makeFrontierEntry({ ...({ key_status: "ready" } as Partial<CatalogEntry>) }),
                     ]),
                 ),

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -1325,6 +1325,58 @@ describe("ChatView.onOpen — model selector", () => {
         await view.onClose();
     });
 
+    it("lists a ready hosted (frontier) model and marks it selected when active", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        // Active chat model is the hosted ref; it is NOT in the installed registry.
+        plugin.activeModel = "gemini/gemini-2.0-flash";
+        plugin.api.config = vi.fn().mockResolvedValue({ chat_model: "gemini/gemini-2.0-flash" });
+        plugin.api.catalog = vi.fn().mockImplementation((p?: { task?: string }) => {
+            if (p?.task === "chat") {
+                return Promise.resolve(
+                    ok({
+                        total: 1,
+                        limit: 50,
+                        offset: 0,
+                        has_more: false,
+                        models: [
+                            {
+                                hf_repo: "gemini/gemini-2.0-flash",
+                                gguf_filename: "",
+                                display_name: "gemini-2.0-flash",
+                                size_gb: 0,
+                                min_ram_gb: 0,
+                                description: "",
+                                installed: true,
+                                source: "frontier",
+                                task: "chat",
+                                featured: false,
+                                downloads: 0,
+                                quality_tier: "",
+                                param_count: "",
+                                provider: "Gemini",
+                                key_status: "ready",
+                            },
+                        ],
+                    }),
+                );
+            }
+            return Promise.resolve(ok({ total: 0, limit: 50, offset: 0, has_more: false, models: [] }));
+        });
+        plugin.api.installedModels = vi.fn().mockResolvedValue({ models: [] });
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const c = view.containerEl.children[1] as unknown as MockElement;
+        const select = c.find("lilbee-chat-model-select")!;
+        const options = select.children.filter((ch) => ch.tagName === "OPTION");
+        const hosted = options.find((o) => o.textContent === "gemini-2.0-flash [Gemini]")!;
+        expect(hosted).toBeDefined();
+        expect((hosted as any).selected).toBe(true);
+        await view.onClose();
+    });
+
     it("shows (connecting...) option on both selects when listModels fails", async () => {
         vi.useFakeTimers();
         Notice.clear();

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -242,28 +242,6 @@ function makeSource(overrides: Partial<Source> = {}): Source {
     };
 }
 
-// Auto-close every ChatView opened during a test so its reconnect retry timer
-// (armed whenever no models are installed or the server is unreachable, then
-// re-armed every RETRY_INTERVAL_MS) is always cleared. Most tests open a view
-// without closing it; a leaked real timer that fires after the test re-enters
-// fetchAndFillSelectors on a torn-down view and throws on detached DOM — which
-// surfaces only on a slow CI run where the file outlives the retry interval.
-const openChatViews = new Set<ChatView>();
-const realChatViewOnOpen = ChatView.prototype.onOpen;
-beforeEach(() => {
-    ChatView.prototype.onOpen = function (this: ChatView): Promise<void> {
-        openChatViews.add(this);
-        return realChatViewOnOpen.call(this);
-    };
-});
-afterEach(async () => {
-    ChatView.prototype.onOpen = realChatViewOnOpen;
-    for (const view of openChatViews) {
-        await view.onClose();
-    }
-    openChatViews.clear();
-});
-
 describe("VIEW_TYPE_CHAT", () => {
     it("equals 'lilbee-chat'", () => {
         expect(VIEW_TYPE_CHAT).toBe("lilbee-chat");

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -242,6 +242,28 @@ function makeSource(overrides: Partial<Source> = {}): Source {
     };
 }
 
+// Auto-close every ChatView opened during a test so its reconnect retry timer
+// (armed whenever no models are installed or the server is unreachable, then
+// re-armed every RETRY_INTERVAL_MS) is always cleared. Most tests open a view
+// without closing it; a leaked real timer that fires after the test re-enters
+// fetchAndFillSelectors on a torn-down view and throws on detached DOM — which
+// surfaces only on a slow CI run where the file outlives the retry interval.
+const openChatViews = new Set<ChatView>();
+const realChatViewOnOpen = ChatView.prototype.onOpen;
+beforeEach(() => {
+    ChatView.prototype.onOpen = function (this: ChatView): Promise<void> {
+        openChatViews.add(this);
+        return realChatViewOnOpen.call(this);
+    };
+});
+afterEach(async () => {
+    ChatView.prototype.onOpen = realChatViewOnOpen;
+    for (const view of openChatViews) {
+        await view.onClose();
+    }
+    openChatViews.clear();
+});
+
 describe("VIEW_TYPE_CHAT", () => {
     it("equals 'lilbee-chat'", () => {
         expect(VIEW_TYPE_CHAT).toBe("lilbee-chat");

--- a/tests/views/model-picker-modal.test.ts
+++ b/tests/views/model-picker-modal.test.ts
@@ -16,7 +16,7 @@ function localRow(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
         description: "",
         quality_tier: "balanced",
         installed: true,
-        source: "local",
+        source: "native",
         task: "chat",
         featured: false,
         downloads: 0,
@@ -138,6 +138,28 @@ describe("ModelPickerModal", () => {
             .findAll("lilbee-model-picker-section-header")
             .map((h) => h.textContent);
         expect(headers).toEqual([MESSAGES.MODEL_PICKER_LOCAL_HEADING, "OpenAI", "Anthropic"]);
+    });
+
+    it("renders ollama rows with a provider pill and no key pill, and defaults a key-less frontier row to Needs key", async () => {
+        const keylessFrontier = {
+            ...localRow({ display_name: "Keyless", hf_repo: "openai/keyless", source: "frontier" }),
+            provider: "OpenAI",
+            // key_status intentionally omitted to exercise the `?? missing_key` fallback.
+        } as CatalogEntry;
+        const ollama = {
+            ...localRow({ display_name: "Llama", hf_repo: "ollama/llama3", source: "ollama" }),
+            provider: "Ollama",
+        } as CatalogEntry;
+        const plugin = makePlugin([keylessFrontier, ollama]);
+        const modal = await openPicker(plugin);
+        await tick();
+        const content = contentEl(modal);
+        // Ollama always surfaces the hosted set (no key needed).
+        expect(content.findAll("lilbee-provider-pill").map((p) => p.textContent)).toEqual(["OpenAI", "Ollama"]);
+        // Only the frontier row carries a key-status pill; it defaults to Needs key.
+        const keyPills = content.findAll("lilbee-key-status-pill");
+        expect(keyPills).toHaveLength(1);
+        expect(keyPills[0].textContent).toBe(MESSAGES.PILL_KEY_NEEDS_KEY);
     });
 
     it("clicking a Local row calls setChatModel and closes the modal", async () => {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -4,7 +4,18 @@ export default defineConfig({
     test: {
         globals: true,
         environment: "node",
-        exclude: ["**/node_modules/**", "**/.worktrees/**", "**/.claude/**", "**/*.bak/**", "**/tests.bak/**"],
+        // integration.test.ts performs a real network binary download and is run
+        // by its own job (vitest.integration.config.ts, 180s timeout). Running it
+        // here too made the unit suite double-execute it and let its slow download
+        // skew parallel worker scheduling on CI. Keep the unit run hermetic.
+        exclude: [
+            "**/node_modules/**",
+            "**/.worktrees/**",
+            "**/.claude/**",
+            "**/*.bak/**",
+            "**/tests.bak/**",
+            "**/integration.test.ts",
+        ],
         coverage: {
             provider: "v8",
             include: ["src/**/*.ts"],

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -4,6 +4,12 @@ export default defineConfig({
     test: {
         globals: true,
         environment: "node",
+        // Run test files sequentially. The view suites share process-level state
+        // (DOM mocks, reconnect timers) that leaks across files under parallel
+        // worker scheduling, which is stable locally but flakes on CI runners.
+        // Sequential execution is the configuration that passes deterministically
+        // everywhere; the suite is fast enough that the wall-clock cost is small.
+        fileParallelism: false,
         // integration.test.ts performs a real network binary download and is run
         // by its own job (vitest.integration.config.ts, 180s timeout). Running it
         // here too made the unit suite double-execute it and let its slow download

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -4,24 +4,7 @@ export default defineConfig({
     test: {
         globals: true,
         environment: "node",
-        // Run test files sequentially. The view suites share process-level state
-        // (DOM mocks, reconnect timers) that leaks across files under parallel
-        // worker scheduling, which is stable locally but flakes on CI runners.
-        // Sequential execution is the configuration that passes deterministically
-        // everywhere; the suite is fast enough that the wall-clock cost is small.
-        fileParallelism: false,
-        // integration.test.ts performs a real network binary download and is run
-        // by its own job (vitest.integration.config.ts, 180s timeout). Running it
-        // here too made the unit suite double-execute it and let its slow download
-        // skew parallel worker scheduling on CI. Keep the unit run hermetic.
-        exclude: [
-            "**/node_modules/**",
-            "**/.worktrees/**",
-            "**/.claude/**",
-            "**/*.bak/**",
-            "**/tests.bak/**",
-            "**/integration.test.ts",
-        ],
+        exclude: ["**/node_modules/**", "**/.worktrees/**", "**/.claude/**", "**/*.bak/**", "**/tests.bak/**"],
         coverage: {
             provider: "v8",
             include: ["src/**/*.ts"],


### PR DESCRIPTION
lilbee can now use models from three places beyond the ones it downloads itself: cloud providers (via an API key), a local Ollama server, and a local LM Studio server. This brings all of them into the plugin so you pick them like any other model.

Across the catalog and the chat and settings pickers, cloud models show their provider and whether their key is set; Ollama and LM Studio models show up as ready-to-use local options with no download and no key. Since lilbee doesn't manage those models itself, they're selectable but never show an install or delete button — you add them in their own app and choose them here. Each of the four roles (chat, embedding, vision, rerank) lists the models that suit it.

This depends on the matching server change that reports the new sources, so the two land together; against an older server the plugin simply shows nothing extra.