### PR TITLE
Route unresolvable-model chat errors to the setup wizard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ src/
 - **Error handling** — wrap all API calls in try/catch, show `new Notice(message)` on failure.
 - **Constants** — named constants for magic numbers (`MAX_EXCERPT_CHARS`, `SEARCH_DEBOUNCE_MS`). Use `as const` objects for string literal sets (`SSE_EVENT`, `JSON_HEADERS`, `SERVER_STATE`, `SERVER_MODE`, `MODEL_TASK`, `CAPABILITY`, `TASK_TYPE`, …, all in `types.ts`). Never compare against raw string literals when a constant exists.
 - **Obsidian DOM helpers** — use `createDiv()`, `createEl()`, `setText()`, `addClass()`. No `innerHTML`.
+- **Comments state what, not a story** — a comment names a non-obvious invariant or constraint in one line. Cut the narration and justification: not "the server emits this without a code, so it's matched on the substring it always carries", just "substring the server includes when the litellm extra is missing". Avoid multi-sentence comment blocks that explain the reasoning behind the code; prefer a clear name and no comment. Same for JSDoc: describe what a function is, not the chain of consequences that motivated it.
 - **Import order** — obsidian imports first, then local modules.
 - **Strict TypeScript** — `noImplicitAny`, `strictNullChecks` enabled in tsconfig.
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -549,6 +549,7 @@ export const MESSAGES = {
     ERROR_SERVER_UNREACHABLE: "Could not connect to lilbee server. Is it running?",
     ERROR_STREAM: (msg: string) => `lilbee: ${msg}`,
     ERROR_CHAT_FAILED: (reason: string) => `Chat failed: ${reason}`,
+    NOTICE_MODEL_UNAVAILABLE_SETUP: "Your model isn't available. Opening setup so you can pick a working one.",
     ERROR_RATE_LIMITED: (retryAfterSeconds: number | null) =>
         retryAfterSeconds !== null
             ? `lilbee is busy with another request. Try again in ${retryAfterSeconds} seconds.`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -246,27 +246,14 @@ export function isRoleMismatchDetail(detail: string): boolean {
     return detail.includes("Set it via PUT /api/models/");
 }
 
-/**
- * SSE error `code` values (server-side `ProviderErrorKind`) that mean the
- * configured model or its backend can't be reached or resolved: the local
- * model server (Ollama / LM Studio) is down, or the model no longer exists.
- * `auth` is excluded — a missing API key is a settings problem, not something
- * the model-pull setup wizard resolves.
- */
+// Server error codes meaning the model or its backend is unreachable or gone.
+// `auth` is excluded: a missing API key is a settings issue, not a setup one.
 const MODEL_UNAVAILABLE_CODES: ReadonlySet<string> = new Set(["connection", "server", "not_found"]);
 
-/**
- * Sentinel in the server's error message when the optional `litellm` extra
- * isn't installed, which makes every remote (Ollama/LM Studio/API) model
- * unusable. The server emits this without a structured `code`, so it is
- * matched on the install-hint substring it always carries.
- */
+// Substring the server includes when the optional litellm extra is missing.
 const LITELLM_MISSING_MARKER = "lilbee[litellm]";
 
-/**
- * Pull the structured `code` out of an SSE `error` payload, or null when the
- * payload is a bare string, has no `code`, or `code` isn't a string.
- */
+/** The structured `code` from an SSE error payload, or null. */
 export function extractSseErrorCode(data: unknown): string | null {
     if (data && typeof data === "object" && "code" in data) {
         const code = (data as { code?: unknown }).code;
@@ -275,11 +262,7 @@ export function extractSseErrorCode(data: unknown): string | null {
     return null;
 }
 
-/**
- * True when a chat error means the configured model/provider is unavailable
- * (local server down, model not found, or the litellm extra missing) rather
- * than a transient or content failure. Such errors route the user to setup.
- */
+/** Whether a chat error means the model/provider is unavailable, so the user is routed to setup. */
 export function isModelUnavailableError(code: string | null, message: string): boolean {
     if (code !== null && MODEL_UNAVAILABLE_CODES.has(code)) return true;
     return message.includes(LITELLM_MISSING_MARKER);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -247,6 +247,45 @@ export function isRoleMismatchDetail(detail: string): boolean {
 }
 
 /**
+ * SSE error `code` values (server-side `ProviderErrorKind`) that mean the
+ * configured model or its backend can't be reached or resolved: the local
+ * model server (Ollama / LM Studio) is down, or the model no longer exists.
+ * `auth` is excluded — a missing API key is a settings problem, not something
+ * the model-pull setup wizard resolves.
+ */
+const MODEL_UNAVAILABLE_CODES: ReadonlySet<string> = new Set(["connection", "server", "not_found"]);
+
+/**
+ * Sentinel in the server's error message when the optional `litellm` extra
+ * isn't installed, which makes every remote (Ollama/LM Studio/API) model
+ * unusable. The server emits this without a structured `code`, so it is
+ * matched on the install-hint substring it always carries.
+ */
+const LITELLM_MISSING_MARKER = "lilbee[litellm]";
+
+/**
+ * Pull the structured `code` out of an SSE `error` payload, or null when the
+ * payload is a bare string, has no `code`, or `code` isn't a string.
+ */
+export function extractSseErrorCode(data: unknown): string | null {
+    if (data && typeof data === "object" && "code" in data) {
+        const code = (data as { code?: unknown }).code;
+        if (typeof code === "string") return code;
+    }
+    return null;
+}
+
+/**
+ * True when a chat error means the configured model/provider is unavailable
+ * (local server down, model not found, or the litellm extra missing) rather
+ * than a transient or content failure. Such errors route the user to setup.
+ */
+export function isModelUnavailableError(code: string | null, message: string): boolean {
+    if (code !== null && MODEL_UNAVAILABLE_CODES.has(code)) return true;
+    return message.includes(LITELLM_MISSING_MARKER);
+}
+
+/**
  * Compute a percent (0–100) from a server SSE progress payload.
  * Accepts `{percent, current, total}` shape and prefers `percent` if present;
  * otherwise derives from `current/total`. Returns undefined when neither is usable

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -36,9 +36,12 @@ import {
     percentFromSse,
     errorMessage,
     extractSseErrorMessage,
+    extractSseErrorCode,
+    isModelUnavailableError,
     noticeForResultError,
     getRelevantSystemMemoryGB,
 } from "../utils";
+import { SetupWizard } from "./setup-wizard";
 import { hostedOptions, isUsableHostedRow } from "./catalog-helpers";
 
 interface OpenDialogResult {
@@ -896,6 +899,10 @@ export class ChatView extends ItemView {
                     text: MESSAGES.ERROR_STREAM(errMsg),
                 });
                 new Notice(MESSAGES.ERROR_STREAM(errMsg));
+                if (isModelUnavailableError(extractSseErrorCode(event.data), errMsg)) {
+                    new Notice(MESSAGES.NOTICE_MODEL_UNAVAILABLE_SETUP);
+                    new SetupWizard(this.app, this.plugin).open();
+                }
                 break;
             }
         }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -5,6 +5,8 @@ import {
     ensureUrlScheme,
     errorMessage,
     extractServerErrorDetail,
+    extractSseErrorCode,
+    isModelUnavailableError,
     formatBytes,
     formatRate,
     formatElapsed,
@@ -308,6 +310,46 @@ describe("isRoleMismatchDetail", () => {
         // a generic "see PUT /api/models/ for options") must NOT be misclassified as a
         // role-mismatch. The sentinel is the `Set it via PUT /api/models/` prefix.
         expect(isRoleMismatchDetail("Auth failed — see PUT /api/models/ docs for the right endpoint.")).toBe(false);
+    });
+});
+
+describe("extractSseErrorCode", () => {
+    it("returns the string code from a structured error payload", () => {
+        expect(extractSseErrorCode({ message: "down", code: "connection" })).toBe("connection");
+    });
+
+    it("returns null when the payload has no code", () => {
+        expect(extractSseErrorCode({ message: "down" })).toBeNull();
+    });
+
+    it("returns null when code is not a string", () => {
+        expect(extractSseErrorCode({ message: "down", code: 503 })).toBeNull();
+    });
+
+    it("returns null for a bare-string payload", () => {
+        expect(extractSseErrorCode("something went wrong")).toBeNull();
+    });
+
+    it("returns null for a non-object payload", () => {
+        expect(extractSseErrorCode(null)).toBeNull();
+    });
+});
+
+describe("isModelUnavailableError", () => {
+    it.each(["connection", "server", "not_found"])("treats the %s code as model-unavailable", (code) => {
+        expect(isModelUnavailableError(code, "")).toBe(true);
+    });
+
+    it("treats the litellm-missing message as model-unavailable even without a code", () => {
+        expect(isModelUnavailableError(null, "Remote and API models need the lilbee[litellm] extra.")).toBe(true);
+    });
+
+    it("does not route auth errors to setup (API key is a settings problem)", () => {
+        expect(isModelUnavailableError("auth", "missing key")).toBe(false);
+    });
+
+    it("returns false for an unrelated error with no marker", () => {
+        expect(isModelUnavailableError(null, "the model produced no output")).toBe(false);
     });
 });
 

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -60,6 +60,10 @@ vi.mock("../../src/views/confirm-modal", () => ({
         close: vi.fn(),
     })),
 }));
+const { setupWizardOpen } = vi.hoisted(() => ({ setupWizardOpen: vi.fn() }));
+vi.mock("../../src/views/setup-wizard", () => ({
+    SetupWizard: vi.fn().mockImplementation(() => ({ open: setupWizardOpen })),
+}));
 import type { SSEEvent, Source } from "../../src/types";
 import { TaskQueue } from "../../src/task-queue";
 
@@ -1040,6 +1044,49 @@ describe("ChatView.sendMessage — error event", () => {
         const history = (view as any).history;
         expect(history.length).toBe(1);
         expect(history[0].role).toBe("user");
+    });
+});
+
+describe("ChatView.sendMessage — model-unavailable error routes to setup", () => {
+    it("opens the SetupWizard and notifies when the error reports the provider is unavailable", async () => {
+        Notice.clear();
+        setupWizardOpen.mockClear();
+        const plugin = makePlugin();
+        const { mockFn, done } = makeStream([
+            { event: SSE_EVENT.ERROR, data: { message: "connection refused", code: "connection" } },
+        ]);
+        plugin.api.chatStream = mockFn;
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const textarea = container.find("lilbee-chat-textarea")!;
+        textarea.value = "hello";
+
+        container.find("lilbee-chat-send")!.trigger("click");
+        await done;
+        await tick();
+
+        expect(setupWizardOpen).toHaveBeenCalledTimes(1);
+        expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_MODEL_UNAVAILABLE_SETUP)).toBe(true);
+    });
+
+    it("does not open the SetupWizard for an ordinary chat error", async () => {
+        Notice.clear();
+        setupWizardOpen.mockClear();
+        const plugin = makePlugin();
+        const { mockFn, done } = makeStream([{ event: SSE_EVENT.ERROR, data: "something went wrong" }]);
+        plugin.api.chatStream = mockFn;
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const textarea = container.find("lilbee-chat-textarea")!;
+        textarea.value = "hello";
+
+        container.find("lilbee-chat-send")!.trigger("click");
+        await done;
+        await tick();
+
+        expect(setupWizardOpen).not.toHaveBeenCalled();
     });
 });
 


### PR DESCRIPTION
## Problem

When a user uninstalls Ollama (or the `litellm` extra), the configured chat model can no longer be served. The lilbee server already reports this with a structured SSE error code (`connection`/`server`/`not_found`, or the litellm-missing install hint), but the plugin only read the error `message` and showed a generic inline failure with no way forward. The user was left stuck in a broken chat with no path back to a working setup.

## Solution

The plugin now consumes the SSE error `code`, classifies model/provider-unavailable failures, and opens the Setup Wizard with a clear notice so the user can pick a working model. Ordinary chat errors are unaffected. Auth errors are intentionally left out since a missing API key is a settings concern, not something the model-pull wizard resolves. Mirrors the lilbee TUI fix (tobocop2/lilbee#307).

Unit suite green at 100% coverage.