### PR TITLE
Settings: separate Ollama and LM Studio URLs

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -254,7 +254,8 @@ export const MESSAGES = {
     LABEL_GEMINI_API_KEY: "Gemini API key",
     DESC_GEMINI_API_KEY: "For Gemini models via litellm",
     LABEL_HF_TOKEN: "HuggingFace token",
-    LABEL_LITELLM_BASE_URL: "External AI endpoint",
+    LABEL_OLLAMA_BASE_URL: "Ollama URL",
+    LABEL_LM_STUDIO_BASE_URL: "LM Studio URL",
     LABEL_DELETE_MODEL: "Delete model",
     LABEL_GENERATION_HELP: "Fine-tune AI responses. Defaults work well for most users.",
     LABEL_ADVANCED_HELP:
@@ -418,7 +419,10 @@ export const MESSAGES = {
     DESC_LLM_PROVIDER_EXTERNAL: "External (OpenAI, Claude, etc.)",
     DESC_API_KEY: "Your API key for external AI services (OpenAI, Anthropic, etc.). Stored securely on the server.",
     DESC_HF_TOKEN: "Needed for some models. Get one free at huggingface.co/settings/tokens",
-    DESC_LITELLM_BASE_URL: "The URL of your external AI service. Only needed when using the External backend.",
+    DESC_OLLAMA_BASE_URL:
+        "Where your Ollama server is listening. Leave blank for the default (http://localhost:11434).",
+    DESC_LM_STUDIO_BASE_URL:
+        "Where your LM Studio server is listening. Leave blank for the default (http://localhost:1234/v1).",
     DESC_REINDEX_WARNING: "Changing {field} will require re-indexing all documents. Continue?",
     DESC_EMBEDDING_REINDEX_WARNING: "Changing the embedding model will require re-indexing all documents. Continue?",
 
@@ -585,8 +589,8 @@ export const MESSAGES = {
     NOTICE_FAILED_SAVE_KEY: "lilbee: failed to save API key",
     NOTICE_LLM_UPDATED: "lilbee: LLM provider updated",
     NOTICE_FAILED_LLM: "lilbee: failed to update LLM provider",
-    NOTICE_LITELLM_UPDATED: "lilbee: LiteLLM URL updated",
-    NOTICE_FAILED_LITELLM: "lilbee: failed to update LiteLLM URL",
+    NOTICE_LOCAL_SERVER_URL_UPDATED: "lilbee: local server URL updated",
+    NOTICE_FAILED_LOCAL_SERVER_URL: "lilbee: failed to update local server URL",
     NOTICE_EMBEDDING_UPDATED: "lilbee: embedding model updated",
     NOTICE_FAILED_EMBEDDING: "lilbee: failed to update embedding model",
     NOTICE_UPDATED_TO: (version: string) => `lilbee: updated to ${version}`,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1754,8 +1754,6 @@ export class LilbeeSettingTab extends PluginSettingTab {
 
         this.renderRerankCandidatesField(details);
 
-        const litellmContainer = details.createDiv({ cls: "lilbee-litellm-container" });
-
         const llmSetting = new Setting(details)
             .setName(MESSAGES.LABEL_LLM_PROVIDER)
             .setDesc(MESSAGES.DESC_LLM_PROVIDER)
@@ -1769,7 +1767,6 @@ export class LilbeeSettingTab extends PluginSettingTab {
                         try {
                             await this.plugin.api.updateConfig({ llm_provider: value });
                             new Notice(MESSAGES.NOTICE_LLM_UPDATED);
-                            litellmContainer.style.display = value === "litellm" ? "" : "none";
                         } catch {
                             new Notice(MESSAGES.NOTICE_FAILED_LLM);
                         }
@@ -1842,26 +1839,46 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 text.inputEl.type = "password";
             });
 
-        litellmContainer.style.display = "none";
-        const litellmSetting = new Setting(litellmContainer)
-            .setName(MESSAGES.LABEL_LITELLM_BASE_URL)
-            .setDesc(MESSAGES.DESC_LITELLM_BASE_URL)
-            .addText((text) => {
-                text.setPlaceholder("http://localhost:11434")
-                    .setValue("")
-                    .onChange(async (value) => {
-                        const trimmed = value.trim();
-                        if (trimmed === "") return;
-                        try {
-                            await this.plugin.api.updateConfig({ litellm_base_url: trimmed });
-                            new Notice(MESSAGES.NOTICE_LITELLM_UPDATED);
-                        } catch {
-                            new Notice(MESSAGES.NOTICE_FAILED_LITELLM);
-                        }
-                    });
-                this.serverConfigInputs.set("litellm_base_url", text.inputEl as unknown as HTMLInputElement);
-            });
-        this.appendResetAffordance(litellmSetting, "litellm_base_url", MESSAGES.LABEL_LITELLM_BASE_URL);
+        const localServerFields: {
+            label: string;
+            desc: string;
+            configKey: string;
+            placeholder: string;
+        }[] = [
+            {
+                label: MESSAGES.LABEL_OLLAMA_BASE_URL,
+                desc: MESSAGES.DESC_OLLAMA_BASE_URL,
+                configKey: "ollama_base_url",
+                placeholder: "http://localhost:11434",
+            },
+            {
+                label: MESSAGES.LABEL_LM_STUDIO_BASE_URL,
+                desc: MESSAGES.DESC_LM_STUDIO_BASE_URL,
+                configKey: "lm_studio_base_url",
+                placeholder: "http://localhost:1234/v1",
+            },
+        ];
+        for (const field of localServerFields) {
+            const setting = new Setting(details)
+                .setName(field.label)
+                .setDesc(field.desc)
+                .addText((text) => {
+                    text.setPlaceholder(field.placeholder)
+                        .setValue("")
+                        .onChange(async (value) => {
+                            const trimmed = value.trim();
+                            if (trimmed === "") return;
+                            try {
+                                await this.plugin.api.updateConfig({ [field.configKey]: trimmed });
+                                new Notice(MESSAGES.NOTICE_LOCAL_SERVER_URL_UPDATED);
+                            } catch {
+                                new Notice(MESSAGES.NOTICE_FAILED_LOCAL_SERVER_URL);
+                            }
+                        });
+                    this.serverConfigInputs.set(field.configKey, text.inputEl as unknown as HTMLInputElement);
+                });
+            this.appendResetAffordance(setting, field.configKey, field.label);
+        }
 
         const cockpitSetting = new Setting(details)
             .setName(MESSAGES.LABEL_AUTO_OPEN_COCKPIT)

--- a/tests/locales/en.test.ts
+++ b/tests/locales/en.test.ts
@@ -149,8 +149,11 @@ describe("MESSAGES", () => {
             expect(MESSAGES.DESC_HF_TOKEN).toBe(
                 "Needed for some models. Get one free at huggingface.co/settings/tokens",
             );
-            expect(MESSAGES.DESC_LITELLM_BASE_URL).toBe(
-                "The URL of your external AI service. Only needed when using the External backend.",
+            expect(MESSAGES.DESC_OLLAMA_BASE_URL).toBe(
+                "Where your Ollama server is listening. Leave blank for the default (http://localhost:11434).",
+            );
+            expect(MESSAGES.DESC_LM_STUDIO_BASE_URL).toBe(
+                "Where your LM Studio server is listening. Leave blank for the default (http://localhost:1234/v1).",
             );
             expect(MESSAGES.DESC_WIKI_PRUNE_RAW).toBe(
                 "After wiki summaries are created, remove the original text chunks that were summarized",

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -466,8 +466,9 @@ describe("LilbeeSettingTab", () => {
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
             // sharedRoot + 9 generation + 5 retrieval-advanced + 4 ingest + 2 worker-pool
-            // + 10 crawling + wikiVaultFolder + rerank_candidates + hfToken + litellm = 35
-            expect(textOnChanges.length).toBe(35);
+            // + 10 crawling + wikiVaultFolder + rerank_candidates + hfToken
+            // + ollama URL + lm_studio URL = 36
+            expect(textOnChanges.length).toBe(36);
         });
     });
 
@@ -3725,17 +3726,28 @@ describe("managed mode settings", () => {
         });
     });
 
-    describe("LiteLLM base URL onChange", () => {
-        const LITELLM_IDX = 34;
+    describe("Local server URL onChange", () => {
+        const OLLAMA_IDX = 34;
+        const LM_STUDIO_IDX = 35;
 
-        it("calls updateConfig on non-empty value", async () => {
+        it("calls updateConfig with ollama_base_url on non-empty value", async () => {
             const plugin = makePlugin();
             mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
-            await textOnChanges[LITELLM_IDX]("http://localhost:4000");
-            expect(plugin.api.updateConfig).toHaveBeenCalledWith({ litellm_base_url: "http://localhost:4000" });
+            await textOnChanges[OLLAMA_IDX]("http://localhost:4000");
+            expect(plugin.api.updateConfig).toHaveBeenCalledWith({ ollama_base_url: "http://localhost:4000" });
+        });
+
+        it("calls updateConfig with lm_studio_base_url on non-empty value", async () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const { textOnChanges } = captureSettingCallbacks(() => tab.display());
+
+            await textOnChanges[LM_STUDIO_IDX]("http://localhost:1234/v1");
+            expect(plugin.api.updateConfig).toHaveBeenCalledWith({ lm_studio_base_url: "http://localhost:1234/v1" });
         });
 
         it("skips empty value", async () => {
@@ -3744,7 +3756,7 @@ describe("managed mode settings", () => {
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
-            await textOnChanges[LITELLM_IDX]("  ");
+            await textOnChanges[OLLAMA_IDX]("  ");
             expect(plugin.api.updateConfig).not.toHaveBeenCalled();
         });
 
@@ -3755,8 +3767,10 @@ describe("managed mode settings", () => {
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
 
-            await textOnChanges[LITELLM_IDX]("http://localhost:4000");
-            expect(Notice.instances.some((n: any) => n.message.includes("failed to update LiteLLM URL"))).toBe(true);
+            await textOnChanges[OLLAMA_IDX]("http://localhost:4000");
+            expect(Notice.instances.some((n: any) => n.message.includes("failed to update local server URL"))).toBe(
+                true,
+            );
         });
     });
 
@@ -4121,7 +4135,7 @@ describe("managed mode settings", () => {
             expect(plugin.api.updateConfig).toHaveBeenCalledWith({ llm_provider: "litellm" });
         });
 
-        it("hides litellm container when provider is not litellm", async () => {
+        it("calls updateConfig when provider is set to auto", async () => {
             const plugin = makePlugin();
             mockChatPicker(plugin);
             const tab = makeTab(plugin);
@@ -4168,7 +4182,8 @@ describe("managed mode settings", () => {
 
             // Layout (text-input order via addText): 0=port, 1-9=gen, 10-14=retrieval-advanced,
             // 15-18=ingest, 19-20=worker-pool, 21-30=crawling, 31=wikiVaultFolder,
-            // 32=rerank_candidates, 33-35=apiKeys (openai, anthropic, gemini), 36=hfToken, 37=litellm.
+            // 32=rerank_candidates, 33-35=apiKeys (openai, anthropic, gemini), 36=hfToken,
+            // 37=ollama URL, 38=lm_studio URL.
             expect(inputs[33].type).toBe("password");
             expect(inputs[34].type).toBe("password");
             expect(inputs[35].type).toBe("password");


### PR DESCRIPTION
## Problem

The settings had a single "External AI endpoint" field that was hidden behind the backend dropdown and wrote a config key the server no longer recognizes, so it never actually took effect. With lilbee now able to talk to Ollama and LM Studio at the same time, one combined field can't express both.

## Solution

The single field is replaced by two always-visible fields under "Local servers", one for the Ollama URL and one for the LM Studio URL, each showing its default as a placeholder and offering a reset. They apply whenever you use a model from that server, so they're no longer tied to the backend dropdown.

Pairs with the lilbee change in tobocop2/lilbee#310, which adds the matching `ollama_base_url` / `lm_studio_base_url` config.