### PR TITLE
Group hosted models by provider and show progress on server upgrades

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -461,6 +461,7 @@ export const MESSAGES = {
     TITLE_RECOMMENDED: "Recommended",
 
     STATUS_DOWNLOADING: "lilbee: downloading...",
+    STATUS_UPDATE_SIZE: (tag: string, size: string) => `Updating to ${tag} · ${size} download`,
     STATUS_STARTING: "lilbee: starting...",
     STATUS_READY: "lilbee: ready",
     STATUS_READY_EXTERNAL: "lilbee: ready [external]",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,4 @@
-import { App, Notice, PluginSettingTab, setIcon, Setting } from "obsidian";
+import { App, ButtonComponent, Notice, PluginSettingTab, setIcon, Setting } from "obsidian";
 import type LilbeePlugin from "./main";
 import type { ReleaseInfo } from "./binary-manager";
 import {
@@ -56,6 +56,13 @@ const CREDENTIAL_FIELDS = new Set([
 ]);
 
 export { SEPARATOR_KEY, SEPARATOR_LABEL };
+
+/** Elements of the managed-server update progress panel. */
+interface UpdateProgressEls {
+    panel: HTMLElement;
+    phase: HTMLElement;
+    size: HTMLElement;
+}
 
 export class LilbeeSettingTab extends PluginSettingTab {
     plugin: LilbeePlugin;
@@ -234,26 +241,14 @@ export class LilbeeSettingTab extends PluginSettingTab {
             .setName(MESSAGES.LABEL_SERVER_VERSION)
             .setDesc(this.plugin.getSharedLilbeeVersion() || MESSAGES.DESC_SERVER_VERSION_UNKNOWN);
 
+        const progress = this.renderUpdateProgress(containerEl);
+
         let pendingRelease: ReleaseInfo | null = null;
         updateSetting.addButton((checkBtn) =>
             checkBtn.setButtonText(MESSAGES.BUTTON_CHECK_UPDATES).onClick(async () => {
                 if (pendingRelease) {
-                    const release = pendingRelease;
-                    checkBtn.setDisabled(true);
-                    checkBtn.setButtonText(MESSAGES.STATUS_DOWNLOADING);
-                    try {
-                        await this.plugin.updateServer(release, (msg) => {
-                            checkBtn.setButtonText(msg);
-                        });
-                        new Notice(MESSAGES.NOTICE_UPDATED_TO(release.tag));
-                        this.display();
-                    } catch (err) {
-                        // Surface the reason (e.g. not enough disk space), not just a generic failure.
-                        new Notice(errorMessage(err, MESSAGES.ERROR_FAILED_UPDATE));
-                        console.error("[lilbee] update failed:", err);
+                    if (!(await this.runServerUpdate(pendingRelease, checkBtn, progress))) {
                         pendingRelease = null;
-                        checkBtn.setButtonText(MESSAGES.BUTTON_CHECK_UPDATES);
-                        checkBtn.setDisabled(false);
                     }
                     return;
                 }
@@ -285,6 +280,43 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 }
             }),
         );
+    }
+
+    /** Indeterminate progress panel for the managed-server update; hidden until an update runs. */
+    private renderUpdateProgress(containerEl: HTMLElement): UpdateProgressEls {
+        const panel = containerEl.createDiv({ cls: "lilbee-update-progress" });
+        panel.style.display = "none";
+        const bar = panel.createDiv({ cls: "lilbee-progress-bar-container" });
+        bar.createDiv({ cls: "lilbee-progress-bar lilbee-wizard-progress-fill lilbee-wizard-progress-indeterminate" });
+        const phase = panel.createDiv({ cls: "lilbee-update-progress-phase" });
+        const size = panel.createDiv({ cls: "lilbee-update-progress-size" });
+        return { panel, phase, size };
+    }
+
+    /** Download and install a server update, surfacing phase + total download size. Returns false on failure. */
+    private async runServerUpdate(
+        release: ReleaseInfo,
+        checkBtn: ButtonComponent,
+        progress: UpdateProgressEls,
+    ): Promise<boolean> {
+        checkBtn.setDisabled(true);
+        checkBtn.setButtonText(MESSAGES.STATUS_DOWNLOADING);
+        progress.panel.style.display = "";
+        progress.size.setText(MESSAGES.STATUS_UPDATE_SIZE(release.tag, formatBytes(release.sizeBytes)));
+        try {
+            await this.plugin.updateServer(release, (msg) => progress.phase.setText(msg));
+            new Notice(MESSAGES.NOTICE_UPDATED_TO(release.tag));
+            this.display();
+            return true;
+        } catch (err) {
+            // errorMessage carries the server's reason, e.g. insufficient disk space.
+            new Notice(errorMessage(err, MESSAGES.ERROR_FAILED_UPDATE));
+            console.error("[lilbee] update failed:", err);
+            progress.panel.style.display = "none";
+            checkBtn.setButtonText(MESSAGES.BUTTON_CHECK_UPDATES);
+            checkBtn.setDisabled(false);
+            return false;
+        }
     }
 
     private renderSharedRootSetting(containerEl: HTMLElement): void {

--- a/src/views/catalog-helpers.ts
+++ b/src/views/catalog-helpers.ts
@@ -1,6 +1,6 @@
 import type { App } from "obsidian";
-import type { CatalogEntry, CatalogTab, KeyStatus, ModelTask } from "../types";
-import { CATALOG_TAB, HOSTED_SOURCES, KEY_STATUS, MODEL_TASK } from "../types";
+import type { CatalogEntry, CatalogSource, CatalogTab, KeyStatus, ModelTask } from "../types";
+import { CATALOG_SOURCE, CATALOG_TAB, HOSTED_SOURCES, KEY_STATUS, MODEL_TASK } from "../types";
 import { MESSAGES } from "../locales/en";
 
 const DISCOVER_RAIL_LIMIT = 12;
@@ -43,13 +43,29 @@ export function hasReadyHostedRow(rows: CatalogEntry[]): boolean {
     return rows.some(isUsableHostedRow);
 }
 
-/** Selectable hosted rows: local servers always, frontier only with a ready key. Returns [ref, label]. */
+/** Local-server sources (Ollama, LM Studio) lead hosted listings; frontier trails. Lower sorts first. */
+function hostedSourceRank(source: CatalogSource): number {
+    return source === CATALOG_SOURCE.FRONTIER ? 1 : 0;
+}
+
+/** Local-first, then provider, then name — deterministic ordering for hosted rows. */
+function compareHostedRows(a: CatalogEntry, b: CatalogEntry): number {
+    const rankDiff = hostedSourceRank(a.source) - hostedSourceRank(b.source);
+    if (rankDiff !== 0) return rankDiff;
+    const providerDiff = (a.provider ?? "").localeCompare(b.provider ?? "");
+    if (providerDiff !== 0) return providerDiff;
+    return a.display_name.localeCompare(b.display_name);
+}
+
+/** Selectable hosted rows, local-first: local servers always, frontier only with a ready key. Returns [ref, label]. */
 export function hostedOptions(rows: CatalogEntry[]): Array<[string, string]> {
     return rows
         .filter(isUsableHostedRow)
+        .sort(compareHostedRows)
         .map((e) => [e.hf_repo, `${e.display_name}${e.provider ? ` [${e.provider}]` : ""}`]);
 }
 
+/** Hosted rows grouped by provider, local-server groups before frontier, providers alphabetical within a rank. */
 export function groupByProvider(rows: CatalogEntry[]): [string, CatalogEntry[]][] {
     const groups = new Map<string, CatalogEntry[]>();
     for (const row of rows) {
@@ -61,7 +77,12 @@ export function groupByProvider(rows: CatalogEntry[]): [string, CatalogEntry[]][
             groups.set(provider, [row]);
         }
     }
-    return [...groups.entries()];
+    // Each provider maps to one source, so rank the group by its first row's source.
+    return [...groups.entries()].sort(([aProvider, aRows], [bProvider, bRows]) => {
+        const rankDiff = hostedSourceRank(aRows[0].source) - hostedSourceRank(bRows[0].source);
+        if (rankDiff !== 0) return rankDiff;
+        return aProvider.localeCompare(bProvider);
+    });
 }
 
 export function renderProviderPill(parent: HTMLElement, provider: string): HTMLElement {

--- a/styles.css
+++ b/styles.css
@@ -2135,6 +2135,31 @@
     min-width: 200px;
 }
 
+/* Managed-server update: indeterminate bar + phase/size text in the settings tab. */
+.lilbee-update-progress {
+    margin: var(--size-4-2, 8px) 0 var(--size-4-4, 16px);
+}
+
+.lilbee-update-progress .lilbee-progress-bar-container {
+    height: 6px;
+    border-radius: 3px;
+    overflow: hidden;
+    background-color: var(--background-modifier-border);
+}
+
+.lilbee-update-progress-phase {
+    font-size: var(--font-small, 13px);
+    color: var(--text-normal);
+    margin-top: var(--size-4-2, 8px);
+    font-variant-numeric: tabular-nums;
+}
+
+.lilbee-update-progress-size {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-top: 2px;
+}
+
 /* Task Center CTA: styled like a task-type chip, colored by step. Visible
  * the moment a download starts so the user knows their next move if they
  * want to step out of the wizard. */

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -2168,6 +2168,36 @@ describe("managed mode settings", () => {
         expect(Notice.instances.some((n) => n.message.includes("updated to v0.2.0"))).toBe(true);
     });
 
+    it("update progress panel surfaces the phase message and the total download size", async () => {
+        Notice.clear();
+
+        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.1.0" });
+        (plugin as any).checkForUpdate = vi.fn().mockResolvedValue({
+            available: true,
+            release: { tag: "v0.2.0", assetUrl: "https://example.com", variant: "default", sizeBytes: 266000000 },
+        });
+        (plugin as any).updateServer = vi
+            .fn()
+            .mockImplementation(async (_release: any, onProgress?: (msg: string) => void) => {
+                onProgress?.("Downloading...");
+            });
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+
+        const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+        // Stop the post-update re-render so the in-progress panel persists for assertion.
+        const displaySpy = vi.spyOn(tab, "display").mockImplementation(() => {});
+
+        await buttonOnClicks[2](); // check → sets pendingRelease
+        await buttonOnClicks[2](); // update → drives the progress panel
+
+        const panel = tab.containerEl.find("lilbee-update-progress")!;
+        expect(panel.style.display).toBe("");
+        expect(panel.find("lilbee-update-progress-phase")!.textContent).toBe("Downloading...");
+        expect(panel.find("lilbee-update-progress-size")!.textContent).toBe("Updating to v0.2.0 · 266 MB download");
+        displaySpy.mockRestore();
+    });
+
     it("update button does not add duplicate click handlers", async () => {
         Notice.clear();
 
@@ -2191,9 +2221,10 @@ describe("managed mode settings", () => {
         Notice.clear();
 
         const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.1.0" });
-        (plugin as any).checkForUpdate = vi
-            .fn()
-            .mockResolvedValue({ available: true, release: { tag: "v0.2.0", assetUrl: "https://example.com" } });
+        (plugin as any).checkForUpdate = vi.fn().mockResolvedValue({
+            available: true,
+            release: { tag: "v0.2.0", assetUrl: "https://example.com", variant: "default", sizeBytes: 262144000 },
+        });
         (plugin as any).updateServer = vi
             .fn()
             .mockRejectedValue(new Error("Not enough disk space for the lilbee server"));
@@ -2208,6 +2239,8 @@ describe("managed mode settings", () => {
 
         // The notice surfaces the actual reason (e.g. disk space), not just a generic failure.
         expect(Notice.instances.some((n) => n.message.includes("Not enough disk space"))).toBe(true);
+        // A failed update collapses the progress panel rather than leaving a dead bar up.
+        expect(tab.containerEl.find("lilbee-update-progress")!.style.display).toBe("none");
     });
 
     it("check for updates button shows error on failure", async () => {

--- a/tests/views/catalog-helpers.test.ts
+++ b/tests/views/catalog-helpers.test.ts
@@ -83,7 +83,7 @@ describe("catalog-helpers", () => {
     });
 
     describe("hostedOptions", () => {
-        it("includes ollama always and frontier only with a ready key", () => {
+        it("includes ollama always and frontier only with a ready key, local server first", () => {
             const rows = [
                 row({ source: CATALOG_SOURCE.NATIVE, hf_repo: "n/r", display_name: "N" }),
                 row({
@@ -103,14 +103,57 @@ describe("catalog-helpers", () => {
                 row({ source: CATALOG_SOURCE.OLLAMA, hf_repo: "ollama/l", display_name: "Llama", provider: "Ollama" }),
             ];
             expect(hostedOptions(rows)).toEqual([
-                ["gemini/g", "Gemini Flash [Gemini]"],
                 ["ollama/l", "Llama [Ollama]"],
+                ["gemini/g", "Gemini Flash [Gemini]"],
+            ]);
+        });
+
+        it("orders local servers ahead of frontier, then by provider, then by name", () => {
+            const rows = [
+                row({
+                    source: CATALOG_SOURCE.FRONTIER,
+                    hf_repo: "openai/b",
+                    display_name: "GPT-B",
+                    provider: "OpenAI",
+                    key_status: KEY_STATUS.READY,
+                }),
+                row({
+                    source: CATALOG_SOURCE.FRONTIER,
+                    hf_repo: "openai/a",
+                    display_name: "GPT-A",
+                    provider: "OpenAI",
+                    key_status: KEY_STATUS.READY,
+                }),
+                row({
+                    source: CATALOG_SOURCE.FRONTIER,
+                    hf_repo: "gemini/g",
+                    display_name: "Gemini",
+                    provider: "Gemini",
+                    key_status: KEY_STATUS.READY,
+                }),
+                row({ source: CATALOG_SOURCE.LM_STUDIO, hf_repo: "lm/q", display_name: "Qwen", provider: "LM Studio" }),
+                row({ source: CATALOG_SOURCE.OLLAMA, hf_repo: "ollama/l", display_name: "Llama", provider: "Ollama" }),
+            ];
+            expect(hostedOptions(rows).map(([ref]) => ref)).toEqual([
+                "lm/q", // local: "LM Studio" < "Ollama"
+                "ollama/l",
+                "gemini/g", // frontier: "Gemini" < "OpenAI"
+                "openai/a", // same provider → by name "GPT-A" < "GPT-B"
+                "openai/b",
             ]);
         });
 
         it("omits the provider suffix when a hosted row carries none", () => {
             const rows = [row({ source: CATALOG_SOURCE.OLLAMA, hf_repo: "ollama/l", display_name: "Llama" })];
             expect(hostedOptions(rows)).toEqual([["ollama/l", "Llama"]]);
+        });
+
+        it("falls back to name ordering when provider-less rows of the same source are compared", () => {
+            const rows = [
+                row({ source: CATALOG_SOURCE.OLLAMA, hf_repo: "ollama/z", display_name: "Zeta" }),
+                row({ source: CATALOG_SOURCE.OLLAMA, hf_repo: "ollama/a", display_name: "Alpha" }),
+            ];
+            expect(hostedOptions(rows).map(([ref]) => ref)).toEqual(["ollama/a", "ollama/z"]);
         });
 
         it("lists lm_studio rows alongside ollama (both local servers, no key)", () => {
@@ -127,32 +170,30 @@ describe("catalog-helpers", () => {
     });
 
     describe("groupByProvider", () => {
-        it("groups by provider preserving first-seen ordering", () => {
+        it("groups by provider, alphabetical within the same source rank", () => {
             const rows = [
-                row({
-                    source: "frontier",
-                    display_name: "a",
-                    ...({ provider: "OpenAI" } as Partial<CatalogEntry>),
-                }),
-                row({
-                    source: "frontier",
-                    display_name: "b",
-                    ...({ provider: "Anthropic" } as Partial<CatalogEntry>),
-                }),
-                row({
-                    source: "frontier",
-                    display_name: "c",
-                    ...({ provider: "OpenAI" } as Partial<CatalogEntry>),
-                }),
+                row({ source: CATALOG_SOURCE.FRONTIER, display_name: "a", provider: "OpenAI" }),
+                row({ source: CATALOG_SOURCE.FRONTIER, display_name: "b", provider: "Anthropic" }),
+                row({ source: CATALOG_SOURCE.FRONTIER, display_name: "c", provider: "OpenAI" }),
             ];
             const grouped = groupByProvider(rows);
-            expect(grouped.map(([p]) => p)).toEqual(["OpenAI", "Anthropic"]);
-            expect(grouped[0][1].map((r) => r.display_name)).toEqual(["a", "c"]);
-            expect(grouped[1][1].map((r) => r.display_name)).toEqual(["b"]);
+            expect(grouped.map(([p]) => p)).toEqual(["Anthropic", "OpenAI"]);
+            expect(grouped[0][1].map((r) => r.display_name)).toEqual(["b"]);
+            expect(grouped[1][1].map((r) => r.display_name)).toEqual(["a", "c"]);
+        });
+
+        it("ranks local-server groups (Ollama, LM Studio) ahead of frontier groups", () => {
+            const rows = [
+                row({ source: CATALOG_SOURCE.FRONTIER, display_name: "g", provider: "Gemini" }),
+                row({ source: CATALOG_SOURCE.OLLAMA, display_name: "l", provider: "Ollama" }),
+                row({ source: CATALOG_SOURCE.FRONTIER, display_name: "x", provider: "OpenAI" }),
+                row({ source: CATALOG_SOURCE.LM_STUDIO, display_name: "q", provider: "LM Studio" }),
+            ];
+            expect(groupByProvider(rows).map(([p]) => p)).toEqual(["LM Studio", "Ollama", "Gemini", "OpenAI"]);
         });
 
         it("treats missing provider as empty-string group", () => {
-            const rows = [row({ source: "frontier", display_name: "a" })];
+            const rows = [row({ source: CATALOG_SOURCE.FRONTIER, display_name: "a" })];
             const grouped = groupByProvider(rows);
             expect(grouped[0][0]).toBe("");
         });

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -1458,6 +1458,35 @@ describe("CatalogModal", () => {
             expect(content.findAll("lilbee-key-status-pill-needs-key").length).toBe(1);
         });
 
+        it("Hosted tab renders local-server provider headings ahead of frontier ones", async () => {
+            const plugin = makePlugin();
+            plugin.api.catalog.mockResolvedValue(
+                ok(
+                    makeCatalogResponse([
+                        makeFrontierEntry({
+                            hf_repo: "openai/gpt-4o",
+                            display_name: "gpt-4o",
+                            ...({ provider: "OpenAI", key_status: "ready" } as Partial<CatalogEntry>),
+                        }),
+                        makeEntry({
+                            source: "ollama",
+                            hf_repo: "ollama/llama3",
+                            display_name: "llama3",
+                            provider: "Ollama",
+                        }),
+                    ]),
+                ),
+            );
+            const modal = await openModal(plugin);
+            const content = contentEl(modal);
+            findButtons(content)
+                .find((b) => b.textContent === MESSAGES.TAB_FRONTIER)!
+                .trigger("click");
+            await tick();
+            const sectionHeadings = content.findAll("lilbee-catalog-section-heading").map((h) => h.textContent);
+            expect(sectionHeadings).toEqual(["Ollama", "OpenAI"]);
+        });
+
         it("clicking a Ready frontier row sets that model active and closes the modal", async () => {
             const plugin = makePlugin();
             plugin.api.catalog.mockResolvedValue(

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -1374,6 +1374,72 @@ describe("ChatView.onOpen — model selector", () => {
         await view.onClose();
     });
 
+    it("orders the rail's hosted options local-server first (Ollama ahead of frontier)", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        plugin.api.catalog = vi.fn().mockImplementation((p?: { task?: string }) => {
+            if (p?.task === "chat") {
+                return Promise.resolve(
+                    ok({
+                        total: 2,
+                        limit: 50,
+                        offset: 0,
+                        has_more: false,
+                        models: [
+                            {
+                                hf_repo: "gemini/flash",
+                                gguf_filename: "",
+                                display_name: "Gemini Flash",
+                                size_gb: 0,
+                                min_ram_gb: 0,
+                                description: "",
+                                installed: false,
+                                source: "frontier",
+                                task: "chat",
+                                featured: false,
+                                downloads: 0,
+                                quality_tier: "",
+                                param_count: "",
+                                provider: "Gemini",
+                                key_status: "ready",
+                            },
+                            {
+                                hf_repo: "ollama/llama3",
+                                gguf_filename: "",
+                                display_name: "Llama 3",
+                                size_gb: 0,
+                                min_ram_gb: 0,
+                                description: "",
+                                installed: false,
+                                source: "ollama",
+                                task: "chat",
+                                featured: false,
+                                downloads: 0,
+                                quality_tier: "",
+                                param_count: "",
+                                provider: "Ollama",
+                            },
+                        ],
+                    }),
+                );
+            }
+            return Promise.resolve(ok({ total: 0, limit: 50, offset: 0, has_more: false, models: [] }));
+        });
+        plugin.api.installedModels = vi.fn().mockResolvedValue({ models: [] });
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const c = view.containerEl.children[1] as unknown as MockElement;
+        const select = c.find("lilbee-chat-model-select")!;
+        const labels = select.children.filter((ch) => ch.tagName === "OPTION").map((o) => o.textContent);
+        const idxOllama = labels.indexOf("Llama 3 [Ollama]");
+        const idxFrontier = labels.indexOf("Gemini Flash [Gemini]");
+        expect(idxOllama).toBeGreaterThanOrEqual(0);
+        expect(idxFrontier).toBeGreaterThan(idxOllama);
+        await view.onClose();
+    });
+
     it("lists a ready hosted (frontier) model and marks it selected when active", async () => {
         Notice.clear();
         const plugin = makePlugin();

--- a/tests/views/model-picker-modal.test.ts
+++ b/tests/views/model-picker-modal.test.ts
@@ -137,7 +137,7 @@ describe("ModelPickerModal", () => {
         const headers = contentEl(modal)
             .findAll("lilbee-model-picker-section-header")
             .map((h) => h.textContent);
-        expect(headers).toEqual([MESSAGES.MODEL_PICKER_LOCAL_HEADING, "OpenAI", "Anthropic"]);
+        expect(headers).toEqual([MESSAGES.MODEL_PICKER_LOCAL_HEADING, "Anthropic", "OpenAI"]);
     });
 
     it("renders ollama rows with a provider pill and no key pill, and defaults a key-less frontier row to Needs key", async () => {
@@ -154,8 +154,8 @@ describe("ModelPickerModal", () => {
         const modal = await openPicker(plugin);
         await tick();
         const content = contentEl(modal);
-        // Ollama always surfaces the hosted set (no key needed).
-        expect(content.findAll("lilbee-provider-pill").map((p) => p.textContent)).toEqual(["OpenAI", "Ollama"]);
+        // Ollama always surfaces the hosted set (no key needed) and, as a local server, leads the frontier row.
+        expect(content.findAll("lilbee-provider-pill").map((p) => p.textContent)).toEqual(["Ollama", "OpenAI"]);
         // Only the frontier row carries a key-status pill; it defaults to Needs key.
         const keyPills = content.findAll("lilbee-key-status-pill");
         expect(keyPills).toHaveLength(1);


### PR DESCRIPTION
Two fixes to the managed-server experience that surfaced during demo recording on b437.

## Hosted catalog grouping

The Hosted sub-tab (renamed from Frontier) rendered as a near-flat list dominated by the long Gemini/frontier set, with Ollama and LM Studio pushed to the bottom. Now hosted models are grouped under a clear per-provider heading, and the providers you run locally — Ollama and LM Studio — always sort ahead of the frontier providers, with providers ordered alphabetically within each group so the listing is stable. The same local-first ordering now applies wherever hosted models are offered: the chat rail's model dropdown, the model-picker, and the settings dropdowns.

## Server upgrade progress

Upgrading the managed lilbee server from settings showed nothing but an indeterminate spinner, even though the binary is around 266 MB — no way to tell whether it was working or stalled. The update now opens a progress panel showing the download size and the current phase (stopping, downloading, starting) with an animated bar, matching how the first-run download presents itself. Live byte-level percentage isn't available on this download path, so the panel leads with the total size for scale and reports each phase as it happens.

All checks pass: lint, formatting, and the full Vitest suite at 100% coverage.