### PR TITLE
Refresh the chat rail when a model is switched from the catalog

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "lilbee",
 	"name": "lilbee",
-	"version": "0.6.66b438",
+	"version": "0.6.66b439",
 	"minAppVersion": "1.0.0",
 	"description": "Chat with your vault and verify every answer at the source. Click any citation to preview the cited passage in place.",
 	"author": "tobocop2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-lilbee",
-  "version": "0.6.66b438",
+  "version": "0.6.66b439",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-lilbee",
-      "version": "0.6.66b438",
+      "version": "0.6.66b439",
       "dependencies": {
         "neverthrow": "^8.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-lilbee",
-  "version": "0.6.66b438",
+  "version": "0.6.66b439",
   "private": true,
   "scripts": {
     "build": "node esbuild.config.mjs production",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1704,6 +1704,15 @@ export default class LilbeePlugin extends Plugin {
         }
     }
 
+    // Re-sync the model rail in every open chat view after a model is switched
+    // elsewhere (e.g. the catalog), so the pills don't show a stale selection.
+    refreshOpenChatRails(): void {
+        for (const leaf of this.app.workspace.getLeavesOfType(VIEW_TYPE_CHAT)) {
+            const view = leaf.view;
+            if (view instanceof ChatView) view.refreshRail();
+        }
+    }
+
     async activateWikiView(): Promise<void> {
         const existing = this.app.workspace.getLeavesOfType(VIEW_TYPE_WIKI);
         if (existing.length > 0) {

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -604,6 +604,7 @@ export class CatalogModal extends Modal {
         }
         this.plugin.fetchActiveModel();
         this.plugin.refreshSettingsTab();
+        this.plugin.refreshOpenChatRails();
         new Notice(MESSAGES.NOTICE_MODEL_ACTIVATED(this.activatedRefFor(row)));
         this.close();
     }
@@ -848,6 +849,7 @@ export class CatalogModal extends Modal {
 
         this.plugin.fetchActiveModel();
         this.plugin.refreshSettingsTab();
+        this.plugin.refreshOpenChatRails();
         new Notice(MESSAGES.NOTICE_MODEL_ACTIVATED(this.activatedRefFor(entry)));
         this.resetAndFetch();
     }
@@ -950,6 +952,7 @@ export class CatalogModal extends Modal {
 
         this.plugin.fetchActiveModel();
         this.plugin.refreshSettingsTab();
+        this.plugin.refreshOpenChatRails();
         new Notice(MESSAGES.NOTICE_MODEL_ACTIVATED_FULL(this.activatedRefFor(entry)));
         this.resetAndFetch();
     }

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -755,6 +755,12 @@ export class ChatView extends ItemView {
         this.fetchAndFillSelectors();
     }
 
+    // Re-sync the rail pills with the server's active models, for callers
+    // outside this view (e.g. the catalog) that switch a model.
+    refreshRail(): void {
+        this.refreshModelSelector();
+    }
+
     private clearChat(): void {
         this.history = [];
         if (this.messagesEl) this.messagesEl.empty();

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -5,6 +5,7 @@ import { SSE_EVENT } from "../src/types";
 import { FileProgressTracker } from "../src/main";
 import { MESSAGES } from "../src/locales/en";
 import { ConfirmModal } from "../src/views/confirm-modal";
+import { ChatView } from "../src/views/chat-view";
 vi.mock("../src/api", () => ({
     SessionTokenError: class SessionTokenError extends Error {
         readonly status: number;
@@ -735,6 +736,23 @@ describe("LilbeePlugin", () => {
             plugin.app.workspace.getRightLeaf = vi.fn().mockReturnValue(null);
 
             await expect((plugin as any).activateChatView()).resolves.not.toThrow();
+        });
+    });
+
+    describe("refreshOpenChatRails()", () => {
+        it("refreshes ChatView rails and skips non-chat views", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+
+            const refreshRail = vi.fn();
+            const chatView = Object.assign(Object.create(ChatView.prototype), { refreshRail });
+            const otherView = {};
+            plugin.app.workspace.getLeavesOfType = vi.fn().mockReturnValue([{ view: chatView }, { view: otherView }]);
+
+            (plugin as any).refreshOpenChatRails();
+
+            expect(plugin.app.workspace.getLeavesOfType).toHaveBeenCalledWith("lilbee-chat");
+            expect(refreshRail).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -76,6 +76,7 @@ function makePlugin(overrides: Record<string, unknown> = {}) {
         saveSettings: vi.fn().mockResolvedValue(undefined),
         fetchActiveModel: vi.fn(),
         refreshSettingsTab: vi.fn(),
+        refreshOpenChatRails: vi.fn(),
         taskQueue: new TaskQueue(),
         ...overrides,
     };

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -4207,6 +4207,17 @@ describe("ChatView — null-element guard branches", () => {
         expect(spy).toHaveBeenCalled();
     });
 
+    it("refreshRail re-syncs the rail via refreshModelSelector", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+        const spy = vi.spyOn(view as any, "refreshModelSelector").mockImplementation(() => {});
+        view.refreshRail();
+        expect(spy).toHaveBeenCalled();
+    });
+
     it("clearChat no-ops when messagesEl is null", async () => {
         Notice.clear();
         const plugin = makePlugin();


### PR DESCRIPTION
## Problem
Activating a model from the catalog updated the server and the settings tab, but not the model rail in an open chat view. The chat/embedding/vision/reranker pills kept showing the previously selected model until the chat was closed and reopened, so the rail could disagree with what was actually active.

## Solution
Add `refreshOpenChatRails()` on the plugin, which re-syncs the rail in every open chat view, and call it at the catalog's three model-activation sites (next to the existing `refreshSettingsTab()` calls). `ChatView.refreshRail()` exposes the existing selector refresh. Tests cover both new methods and coverage stays at 100%. Bumps the beta to 0.6.66b439.