### PR TITLE
Group the tutorial reels by section and reorder the reel strip

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -83,24 +83,24 @@
       <div class="tutorial">
         <div class="tutorial-watch"><a class="tutorial-cta" href="tutorial/">▶&nbsp; watch the full tutorial reel</a></div>
         <div class="tutorialtabs" role="tablist" aria-label="Tutorial reel">
-          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-rerank"    aria-controls="tutorial-pane-rerank"    aria-selected="true"  tabindex="0">reranking</button>
-          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-ollama"    aria-controls="tutorial-pane-ollama"    aria-selected="false" tabindex="-1">Ollama</button>
-          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-gemini"    aria-controls="tutorial-pane-gemini"    aria-selected="false" tabindex="-1">Gemini</button>
-          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-lmstudio"  aria-controls="tutorial-pane-lmstudio"  aria-selected="false" tabindex="-1">LM Studio</button>
-          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-multipart" aria-controls="tutorial-pane-multipart" aria-selected="false" tabindex="-1">multi-part</button>
-          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-vision"    aria-controls="tutorial-pane-vision"    aria-selected="false" tabindex="-1">scanned PDF</button>
-          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-onlilbee"  aria-controls="tutorial-pane-onlilbee"  aria-selected="false" tabindex="-1">what is lilbee</button>
+          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-onlilbee"  aria-controls="tutorial-pane-onlilbee"  aria-selected="true"  tabindex="0">what is lilbee</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-ask"       aria-controls="tutorial-pane-ask"       aria-selected="false" tabindex="-1">ask &amp; cite</button>
+          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-vision"    aria-controls="tutorial-pane-vision"    aria-selected="false" tabindex="-1">scanned PDF</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-crawl"     aria-controls="tutorial-pane-crawl"     aria-selected="false" tabindex="-1">crawl</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-catalog"   aria-controls="tutorial-pane-catalog"   aria-selected="false" tabindex="-1">catalog</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-download"  aria-controls="tutorial-pane-download"  aria-selected="false" tabindex="-1">download a model</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-models"    aria-controls="tutorial-pane-models"    aria-selected="false" tabindex="-1">model rail</button>
+          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-ollama"    aria-controls="tutorial-pane-ollama"    aria-selected="false" tabindex="-1">Ollama</button>
+          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-lmstudio"  aria-controls="tutorial-pane-lmstudio"  aria-selected="false" tabindex="-1">LM Studio</button>
+          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-gemini"    aria-controls="tutorial-pane-gemini"    aria-selected="false" tabindex="-1">Gemini</button>
+          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-multipart" aria-controls="tutorial-pane-multipart" aria-selected="false" tabindex="-1">multi-part</button>
+          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-rerank"    aria-controls="tutorial-pane-rerank"    aria-selected="false" tabindex="-1">reranking</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-firststart" aria-controls="tutorial-pane-firststart" aria-selected="false" tabindex="-1">first run</button>
-          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-tour"      aria-controls="tutorial-pane-tour"      aria-selected="false" tabindex="-1">tour</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-settings"  aria-controls="tutorial-pane-settings"  aria-selected="false" tabindex="-1">settings</button>
+          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-tour"      aria-controls="tutorial-pane-tour"      aria-selected="false" tabindex="-1">tour</button>
         </div>
 
-        <div class="tutorialpane" role="tabpanel" id="tutorial-pane-rerank" aria-labelledby="tutorial-tab-rerank">
+        <div class="tutorialpane" role="tabpanel" id="tutorial-pane-rerank" aria-labelledby="tutorial-tab-rerank" hidden>
           <div class="tutorial-clip">
             <video src="https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/rerank.webm" controls loop muted autoplay playsinline preload="metadata"></video>
           </div>
@@ -142,7 +142,7 @@
           <p class="tutorial-caption">A scanned, image-only PDF read by a local vision model. The Task Center streams the OCR page by page, then a cited answer reads the support number and publisher straight off the scanned cover, a detail only OCR could surface.</p>
         </div>
 
-        <div class="tutorialpane" role="tabpanel" id="tutorial-pane-onlilbee" aria-labelledby="tutorial-tab-onlilbee" hidden>
+        <div class="tutorialpane" role="tabpanel" id="tutorial-pane-onlilbee" aria-labelledby="tutorial-tab-onlilbee">
           <div class="tutorial-clip">
             <video src="https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/what_is_lilbee.webm" controls loop muted autoplay playsinline preload="metadata"></video>
           </div>

--- a/site/tutorial/index.html
+++ b/site/tutorial/index.html
@@ -25,7 +25,7 @@
     <p class="tutorial-intro">Every lilbee for Obsidian demo as a video, each with a longer note than the homepage carries. The clips loop and are silent; watch at your own pace.</p>
 
     <nav class="tutorial-toc">
-      <div class="toc-label">in order</div>
+      <div class="toc-label">contents</div>
       <ol id="tutorial-toc"></ol>
     </nav>
 

--- a/site/tutorial/tutorial.css
+++ b/site/tutorial/tutorial.css
@@ -4,8 +4,12 @@
 .tutorial-toc .toc-label { font-size: 12px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent-deep); }
 .tutorial-toc ol { margin: 0.7rem 0 0; padding-left: 1.5rem; }
 .tutorial-toc li { margin: 0.28rem 0; color: var(--ink-3); }
+.tutorial-toc .toc-group { margin: 0.85rem 0 0.15rem -1.5rem; list-style: none; font-size: 12px; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent-deep); }
+.tutorial-toc .toc-group:first-child { margin-top: 0; }
+.tutorial-group { margin: 3.2rem 0 1rem; padding-top: 1.5rem; border-top: 1px solid var(--rule); font-size: 13px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent-deep); }
+.tutorial-group:first-of-type { margin-top: 0.8rem; padding-top: 0; border-top: none; }
 .tutorial-section { margin: 2.4rem 0 2.9rem; scroll-margin-top: 1.5rem; }
-.tutorial-section h2 { margin: 0 0 0.45rem; font-size: 15px; font-weight: 500; letter-spacing: 0.02em; color: var(--accent); }
+.tutorial-section h3 { margin: 0 0 0.45rem; font-size: 15px; font-weight: 500; letter-spacing: 0.02em; color: var(--accent); }
 .tutorial-section p { margin: 0.3rem 0 0.9rem; max-width: 82ch; color: var(--ink-2); font-size: 13px; line-height: 1.6; }
 .tutorial-clip { background: #000; border: 1px solid var(--rule); border-radius: 4px; overflow: hidden; }
 .tutorial-clip video { display: block; width: 100%; background: #000; }

--- a/site/tutorial/tutorial.css
+++ b/site/tutorial/tutorial.css
@@ -6,10 +6,12 @@
 .tutorial-toc li { margin: 0.28rem 0; color: var(--ink-3); }
 .tutorial-toc .toc-group { margin: 0.85rem 0 0.15rem -1.5rem; list-style: none; font-size: 12px; font-weight: 600; letter-spacing: 0.1em; text-transform: uppercase; color: var(--accent-deep); }
 .tutorial-toc .toc-group:first-child { margin-top: 0; }
-.tutorial-group { margin: 3.2rem 0 1rem; padding-top: 1.5rem; border-top: 1px solid var(--rule); font-size: 13px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent-deep); }
+.tutorial-group { margin: 3.2rem 0 1rem; padding-top: 1.5rem; border-top: 1px solid var(--rule); font-size: 13px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--accent-deep); scroll-margin-top: 1.5rem; }
 .tutorial-group:first-of-type { margin-top: 0.8rem; padding-top: 0; border-top: none; }
 .tutorial-section { margin: 2.4rem 0 2.9rem; scroll-margin-top: 1.5rem; }
 .tutorial-section h3 { margin: 0 0 0.45rem; font-size: 15px; font-weight: 500; letter-spacing: 0.02em; color: var(--accent); }
+.tutorial-group a, .tutorial-section h3 a, .tutorial-toc .toc-group a { color: inherit; text-decoration: none; }
+.tutorial-group a:hover, .tutorial-section h3 a:hover, .tutorial-toc .toc-group a:hover { text-decoration: underline; }
 .tutorial-section p { margin: 0.3rem 0 0.9rem; max-width: 82ch; color: var(--ink-2); font-size: 13px; line-height: 1.6; }
 .tutorial-clip { background: #000; border: 1px solid var(--rule); border-radius: 4px; overflow: hidden; }
 .tutorial-clip video { display: block; width: 100%; background: #000; }

--- a/site/tutorial/tutorial.js
+++ b/site/tutorial/tutorial.js
@@ -1,6 +1,7 @@
 const GH = "https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/";
 const groups = [
   {
+    id: "what-it-is",
     heading: "What it is",
     reels: [
       { id: "what-is-lilbee", name: "what_is_lilbee", title: "What is lilbee", desc: "Add lilbee's own README to your library and watch it ingest, then ask “what is lilbee in one sentence?” and get a cited answer straight from the README. The citation opens it at the source." },
@@ -8,6 +9,7 @@ const groups = [
     ],
   },
   {
+    id: "feed-it-anything",
     heading: "Feed it anything",
     reels: [
       { id: "scanned-pdf", name: "vision", title: "Scanned PDFs, read by OCR", desc: "A scanned, image-only PDF read by a local vision model. The Task Center streams the OCR page by page, then a cited answer reads the support number and publisher straight off the scanned cover, a detail only OCR could surface." },
@@ -15,6 +17,7 @@ const groups = [
     ],
   },
   {
+    id: "models-managed-for-you",
     heading: "Models, managed for you",
     reels: [
       { id: "catalog", name: "catalog", title: "Model catalog", desc: "Browse the model catalog without leaving Obsidian: Chat, Embed, Vision, and Rerank tabs, each pulled live from Hugging Face Hub. Models that won't run on your hardware are flagged before you pull." },
@@ -23,6 +26,7 @@ const groups = [
     ],
   },
   {
+    id: "bring-your-own-models",
     heading: "Bring your own models",
     reels: [
       { id: "ollama", name: "ollama", title: "Use your Ollama models for both roles", desc: "Already running Ollama? Point lilbee at it and pick one of its models for embedding and another for chat, straight from the catalog's Hosted tab, so it's clear Ollama powers both halves of the pipeline. Add the Crown Victoria manual, watch it index in the Task Center, then ask a question and get a cited answer served end to end by Ollama." },
@@ -31,6 +35,7 @@ const groups = [
     ],
   },
   {
+    id: "answer-quality",
     heading: "Answer quality",
     reels: [
       { id: "multipart", name: "multipart", title: "Multi-part questions, each fact cited", desc: "One prompt, two unrelated facts from different sections of a manual, a bulb part number and the engine's firing order. A local model answers both in a single reply and cites each one to the page it came from." },
@@ -38,6 +43,7 @@ const groups = [
     ],
   },
   {
+    id: "set-up-and-tune",
     heading: "Set up &amp; tune",
     reels: [
       { id: "first-start", name: "first_start", title: "First run: install to first cited answer", desc: "Brand-new to lilbee, on a fresh vault. Install it through BRAT, walk the setup wizard (pick a chat model and an embedder, run the first sync), then ask a question and get a cited answer from your own notes, with a click-through to the source. The whole onboarding in one take." },
@@ -49,10 +55,11 @@ const groups = [
 const toc = document.getElementById("tutorial-toc");
 const list = document.getElementById("demos");
 for (const g of groups) {
-  toc.insertAdjacentHTML("beforeend", '<li class="toc-group">' + g.heading + "</li>");
+  toc.insertAdjacentHTML("beforeend", '<li class="toc-group"><a href="#' + g.id + '">' + g.heading + "</a></li>");
   const groupHeading = document.createElement("h2");
   groupHeading.className = "tutorial-group";
-  groupHeading.innerHTML = g.heading;
+  groupHeading.id = g.id;
+  groupHeading.innerHTML = '<a href="#' + g.id + '">' + g.heading + "</a>";
   list.appendChild(groupHeading);
   for (const d of g.reels) {
     toc.insertAdjacentHTML("beforeend", '<li><a href="#' + d.id + '">' + d.title + "</a></li>");
@@ -60,7 +67,7 @@ for (const g of groups) {
     sec.className = "tutorial-section";
     sec.id = d.id;
     sec.innerHTML =
-      "<h3>" + d.title + "</h3>" +
+      '<h3><a href="#' + d.id + '">' + d.title + "</a></h3>" +
       "<p>" + d.desc + "</p>" +
       '<div class="tutorial-clip"><video src="' + GH + d.name + '.webm" controls loop muted autoplay playsinline preload="metadata"></video></div>';
     list.appendChild(sec);

--- a/site/tutorial/tutorial.js
+++ b/site/tutorial/tutorial.js
@@ -1,31 +1,68 @@
 const GH = "https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/";
-const demos = [
-  { id: "rerank", name: "rerank", title: "Reranking, before and after", desc: "The same question asked twice, with reranking off and then on, against eight short build notes. The note that holds the fix is written around the cause (voltage sag, cable gauge), not the question's keywords, so plain vector search ranks it just out of the top results and the model gives the wrong fix. Turn reranking on and a cross-encoder re-scores the candidates by true relevance, promotes that note into context, and the answer corrects itself. Both answers stay on screen, so you see the before and after." },
-  { id: "ollama", name: "ollama", title: "Use your Ollama models for both roles", desc: "Already running Ollama? Point lilbee at it and pick one of its models for embedding and another for chat, straight from the catalog's Hosted tab, so it's clear Ollama powers both halves of the pipeline. Add the Crown Victoria manual, watch it index in the Task Center, then ask a question and get a cited answer served end to end by Ollama." },
-  { id: "gemini", name: "gemini", title: "Bring your own frontier key", desc: "lilbee also drives hosted frontier models when you bring your own key. Open the catalog's Hosted tab, pick a free-tier Gemini model for chat, and keep embedding local. The answer comes from Gemini and still cites your own manual, with a click-through to the page." },
-  { id: "lmstudio", name: "lmstudio", title: "Use your LM Studio models for both roles", desc: "The same as the Ollama reel, with LM Studio's local server. Pick its embedder and chat model from the Hosted tab, index the manual, and get a cited answer powered end to end by LM Studio." },
-  { id: "multipart", name: "multipart", title: "Multi-part questions, each fact cited", desc: "One prompt, two unrelated facts from different sections of a manual, a bulb part number and the engine's firing order. A local model answers both in a single reply and cites each one to the page it came from." },
-  { id: "scanned-pdf", name: "vision", title: "Scanned PDFs, read by OCR", desc: "A scanned, image-only PDF read by a local vision model. The Task Center streams the OCR page by page, then a cited answer reads the support number and publisher straight off the scanned cover, a detail only OCR could surface." },
-  { id: "what-is-lilbee", name: "what_is_lilbee", title: "What is lilbee", desc: "Add lilbee's own README to your library and watch it ingest, then ask “what is lilbee in one sentence?” and get a cited answer straight from the README. The citation opens it at the source." },
-  { id: "ask", name: "add", title: "Ask &amp; cite your documents", desc: "Add a PDF from the command palette, watch the Task Center index it, then ask a question and get a cited answer. Click the citation and the source preview opens at the exact page." },
-  { id: "crawl", name: "crawl", title: "Crawl the web into your vault", desc: "Crawl a Wikipedia page into your vault and ask it a question, then jump from the citation straight to the cited section of the rendered source." },
-  { id: "catalog", name: "catalog", title: "Model catalog", desc: "Browse the model catalog without leaving Obsidian: Chat, Embed, Vision, and Rerank tabs, each pulled live from Hugging Face Hub. Models that won't run on your hardware are flagged before you pull." },
-  { id: "download", name: "download_model", title: "Download and use a model", desc: "Search the catalog for a small chat model, watch the download stream start to finish in the Task Center, then activate it, switch to Chat mode, and use it, the full pull-and-use loop without leaving Obsidian." },
-  { id: "models", name: "models", title: "The model rail, role by role", desc: "The chat rail carries four roles, each its own model: chat writes the answers, embedding indexes your notes, vision reads scanned PDFs, reranking sharpens the results. Hover each pill to see what it does, then flip between Search (answers from your vault, cited) and Chat (the model directly, no retrieval)." },
-  { id: "first-start", name: "first_start", title: "First run: install to first cited answer", desc: "Brand-new to lilbee, on a fresh vault. Install it through BRAT, walk the setup wizard (pick a chat model and an embedder, run the first sync), then ask a question and get a cited answer from your own notes, with a click-through to the source. The whole onboarding in one take." },
-  { id: "tour", name: "tour", title: "Tour: the palette as an async control surface", desc: "Fire a crawl, a file add, and a model download back to back without waiting, watch all three run at once in the Task Center, then ask the just-crawled page a cited question." },
-  { id: "settings", name: "settings", title: "Settings", desc: "50+ settings: search depth, reranking, sampling, parsers, the wiki. Sane defaults; tune the moment you want to." },
+const groups = [
+  {
+    heading: "What it is",
+    reels: [
+      { id: "what-is-lilbee", name: "what_is_lilbee", title: "What is lilbee", desc: "Add lilbee's own README to your library and watch it ingest, then ask “what is lilbee in one sentence?” and get a cited answer straight from the README. The citation opens it at the source." },
+      { id: "ask", name: "add", title: "Ask &amp; cite your documents", desc: "Add a PDF from the command palette, watch the Task Center index it, then ask a question and get a cited answer. Click the citation and the source preview opens at the exact page." },
+    ],
+  },
+  {
+    heading: "Feed it anything",
+    reels: [
+      { id: "scanned-pdf", name: "vision", title: "Scanned PDFs, read by OCR", desc: "A scanned, image-only PDF read by a local vision model. The Task Center streams the OCR page by page, then a cited answer reads the support number and publisher straight off the scanned cover, a detail only OCR could surface." },
+      { id: "crawl", name: "crawl", title: "Crawl the web into your vault", desc: "Crawl a Wikipedia page into your vault and ask it a question, then jump from the citation straight to the cited section of the rendered source." },
+    ],
+  },
+  {
+    heading: "Models, managed for you",
+    reels: [
+      { id: "catalog", name: "catalog", title: "Model catalog", desc: "Browse the model catalog without leaving Obsidian: Chat, Embed, Vision, and Rerank tabs, each pulled live from Hugging Face Hub. Models that won't run on your hardware are flagged before you pull." },
+      { id: "download", name: "download_model", title: "Download and use a model", desc: "Search the catalog for a small chat model, watch the download stream start to finish in the Task Center, then activate it, switch to Chat mode, and use it, the full pull-and-use loop without leaving Obsidian." },
+      { id: "models", name: "models", title: "The model rail, role by role", desc: "The chat rail carries four roles, each its own model: chat writes the answers, embedding indexes your notes, vision reads scanned PDFs, reranking sharpens the results. Hover each pill to see what it does, then flip between Search (answers from your vault, cited) and Chat (the model directly, no retrieval)." },
+    ],
+  },
+  {
+    heading: "Bring your own models",
+    reels: [
+      { id: "ollama", name: "ollama", title: "Use your Ollama models for both roles", desc: "Already running Ollama? Point lilbee at it and pick one of its models for embedding and another for chat, straight from the catalog's Hosted tab, so it's clear Ollama powers both halves of the pipeline. Add the Crown Victoria manual, watch it index in the Task Center, then ask a question and get a cited answer served end to end by Ollama." },
+      { id: "lmstudio", name: "lmstudio", title: "Use your LM Studio models for both roles", desc: "The same as the Ollama reel, with LM Studio's local server. Pick its embedder and chat model from the Hosted tab, index the manual, and get a cited answer powered end to end by LM Studio." },
+      { id: "gemini", name: "gemini", title: "Bring your own frontier key", desc: "lilbee also drives hosted frontier models when you bring your own key. Open the catalog's Hosted tab, pick a free-tier Gemini model for chat, and keep embedding local. The answer comes from Gemini and still cites your own manual, with a click-through to the page." },
+    ],
+  },
+  {
+    heading: "Answer quality",
+    reels: [
+      { id: "multipart", name: "multipart", title: "Multi-part questions, each fact cited", desc: "One prompt, two unrelated facts from different sections of a manual, a bulb part number and the engine's firing order. A local model answers both in a single reply and cites each one to the page it came from." },
+      { id: "rerank", name: "rerank", title: "Reranking, before and after", desc: "The same question asked twice, with reranking off and then on, against eight short build notes. The note that holds the fix is written around the cause (voltage sag, cable gauge), not the question's keywords, so plain vector search ranks it just out of the top results and the model gives the wrong fix. Turn reranking on and a cross-encoder re-scores the candidates by true relevance, promotes that note into context, and the answer corrects itself. Both answers stay on screen, so you see the before and after." },
+    ],
+  },
+  {
+    heading: "Set up &amp; tune",
+    reels: [
+      { id: "first-start", name: "first_start", title: "First run: install to first cited answer", desc: "Brand-new to lilbee, on a fresh vault. Install it through BRAT, walk the setup wizard (pick a chat model and an embedder, run the first sync), then ask a question and get a cited answer from your own notes, with a click-through to the source. The whole onboarding in one take." },
+      { id: "settings", name: "settings", title: "Settings", desc: "50+ settings: search depth, reranking, sampling, parsers, the wiki. Sane defaults; tune the moment you want to." },
+      { id: "tour", name: "tour", title: "Tour: the palette as an async control surface", desc: "Fire a crawl, a file add, and a model download back to back without waiting, watch all three run at once in the Task Center, then ask the just-crawled page a cited question." },
+    ],
+  },
 ];
 const toc = document.getElementById("tutorial-toc");
 const list = document.getElementById("demos");
-for (const d of demos) {
-  toc.insertAdjacentHTML("beforeend", '<li><a href="#' + d.id + '">' + d.title + "</a></li>");
-  const sec = document.createElement("section");
-  sec.className = "tutorial-section";
-  sec.id = d.id;
-  sec.innerHTML =
-    "<h2>" + d.title + "</h2>" +
-    "<p>" + d.desc + "</p>" +
-    '<div class="tutorial-clip"><video src="' + GH + d.name + '.webm" controls loop muted autoplay playsinline preload="metadata"></video></div>';
-  list.appendChild(sec);
+for (const g of groups) {
+  toc.insertAdjacentHTML("beforeend", '<li class="toc-group">' + g.heading + "</li>");
+  const groupHeading = document.createElement("h2");
+  groupHeading.className = "tutorial-group";
+  groupHeading.innerHTML = g.heading;
+  list.appendChild(groupHeading);
+  for (const d of g.reels) {
+    toc.insertAdjacentHTML("beforeend", '<li><a href="#' + d.id + '">' + d.title + "</a></li>");
+    const sec = document.createElement("section");
+    sec.className = "tutorial-section";
+    sec.id = d.id;
+    sec.innerHTML =
+      "<h3>" + d.title + "</h3>" +
+      "<p>" + d.desc + "</p>" +
+      '<div class="tutorial-clip"><video src="' + GH + d.name + '.webm" controls loop muted autoplay playsinline preload="metadata"></video></div>';
+    list.appendChild(sec);
+  }
 }


### PR DESCRIPTION
## Problem
The reels were ordered "most exciting first," which opened on reranking — an advanced retrieval concept that means nothing to a first-time visitor — and pushed the orientation reels (what is lilbee, first run) deep into the list. The flat strip also gave no sense of how the reels relate.

## Solution
Group the tutorial page into six sections with headings, and order the sections as a story: **What it is → Feed it anything → Models, managed for you → Bring your own models → Answer quality → Set up & tune**. Native model management sits above bring-your-own (mirroring the README framing), and the model-freedom reels sit above answer quality. The tutorial table of contents is grouped to match.

The homepage reel strip is reordered into the same sequence (no section labels there — it's a single tab row). It now opens on "what is lilbee" instead of reranking.

Reel titles on the tutorial page move from `h2` to `h3` under the new `h2` group headings; CSS adds the group-heading and grouped-TOC styles. Site-only change, no plugin code.