### PR TITLE
Fix the rerank and multipart reels

### DIFF
--- a/demos-src/src/lib.ts
+++ b/demos-src/src/lib.ts
@@ -76,6 +76,9 @@ export type Storyboard = {
   layout: LayoutName;
   /** Doc names to remove from the corpus before recording (so ingest demos start fresh). */
   freshIngest?: string[];
+  /** Empty the whole index before recording, for a fresh-vault demo that adds a
+   * doc on camera: the Add is a clean first ingest and retrieval sees only it. */
+  emptyIndex?: boolean;
   /** HF repo of a model to uninstall before recording, so a download demo
    * triggers a real pull on every take. */
   freshModel?: string;
@@ -113,6 +116,7 @@ export type StoryboardOptions = {
   window?: [number, number];
   layout?: LayoutName;
   freshIngest?: string[];
+  emptyIndex?: boolean;
   freshModel?: string;
   clearTaskCenter?: boolean;
   clearChat?: boolean;
@@ -134,6 +138,7 @@ export function storyboard(name: string, opts: StoryboardOptions): Storyboard {
     window: { w: opts.window?.[0] ?? 1400, h: opts.window?.[1] ?? 900 },
     layout: opts.layout ?? "chat-and-tasks",
     freshIngest: opts.freshIngest,
+    emptyIndex: opts.emptyIndex,
     freshModel: opts.freshModel,
     clearTaskCenter: opts.clearTaskCenter,
     clearChat: opts.clearChat,

--- a/demos-src/src/preflight.ts
+++ b/demos-src/src/preflight.ts
@@ -51,6 +51,12 @@ export type PreflightOptions = {
   ctx: ObsidianContext;
   layout: LayoutName;
   freshIngest?: string[];
+  /** Empty the whole index before recording. For a "fresh vault" demo that adds
+   * a document on camera: the on-camera Add becomes a genuine first ingest (no
+   * "already indexed" prompt) and retrieval sees only what the demo adds. Leaves
+   * the embedder untouched, so the store must already be bound to the embedder
+   * the demo records with (native nomic for the all-local reels). */
+  emptyIndex?: boolean;
   /** HF repo to uninstall before recording so a download demo pulls fresh. */
   freshModel?: string;
   clearTaskCenter?: boolean;
@@ -231,7 +237,27 @@ export async function preflight(opts: PreflightOptions): Promise<void> {
   });
   }
 
-  // 4. Fresh ingest cleanup
+  // 4. Empty the whole index (fresh-vault demos add a doc on camera; this makes
+  // that Add a clean first ingest and keeps retrieval to just what's added).
+  // delete_files:true so the managed copy is gone too — the vault originals stay.
+  if (opts.emptyIndex) {
+    await ctx.page.evaluate(async () => {
+      const p = (globalThis as unknown as { app: { plugins: { plugins: { lilbee: { settings: { serverUrl: string; manualToken?: string }; api?: { baseUrl: string; token?: string | null } } } } } }).app.plugins.plugins.lilbee;
+      const base = p.api?.baseUrl ?? p.settings.serverUrl;
+      const auth = { "Content-Type": "application/json", Authorization: "Bearer " + (p.api?.token ?? p.settings.manualToken ?? "") };
+      const r = await fetch(base + "/api/documents", { headers: auth }).then((res) => res.json()).catch(() => ({ documents: [] }));
+      const names = Array.isArray(r.documents) ? r.documents.map((d: { filename: string }) => d.filename) : [];
+      if (names.length) {
+        await fetch(base + "/api/documents/remove", {
+          method: "POST",
+          headers: auth,
+          body: JSON.stringify({ names, delete_files: true }),
+        }).catch(() => {});
+      }
+    });
+  }
+
+  // 4a. Fresh ingest cleanup
   for (const name of freshIngest) {
     await ctx.page.evaluate(
       async ([n]) => {

--- a/demos-src/src/record.ts
+++ b/demos-src/src/record.ts
@@ -130,6 +130,7 @@ export async function record(storyboard: Storyboard): Promise<void> {
       ctx,
       layout: storyboard.layout,
       freshIngest: storyboard.freshIngest,
+      emptyIndex: storyboard.emptyIndex,
       freshModel: storyboard.freshModel,
       clearTaskCenter: storyboard.clearTaskCenter,
       clearChat: storyboard.clearChat,

--- a/demos-src/tapes/multipart.ts
+++ b/demos-src/tapes/multipart.ts
@@ -25,6 +25,9 @@ export default storyboard("multipart", {
   window: [1400, 900],
   layout: "explorer-chat-tasks",
   clearTaskCenter: true,
+  // Fresh vault: empty the index first so the on-camera Add is a genuine first
+  // ingest (no "already indexed" prompt) and retrieval sees only the manual.
+  emptyIndex: true,
   // Qwen3 8B is the answering model; preload so the on-camera answer is warm.
   pinChatModel: "Qwen/Qwen3-8B-GGUF/Qwen3-8B-Q4_K_M.gguf",
   preloadChatModel: true,

--- a/demos-src/tapes/rerank.ts
+++ b/demos-src/tapes/rerank.ts
@@ -29,7 +29,7 @@
  * Requires the server pre-seeded with ONLY the 8 Crown Vic Build notes (the
  * other reels use the manual). The setup beats below pin top_k/context/expansion.
  */
-import { beat, clickSelector, clickSend, fillChat, key, runJs, storyboard, waitChatIdle } from "../src/lib.ts";
+import { beat, clickSend, fillChat, runJs, storyboard, waitChatIdle } from "../src/lib.ts";
 
 const QUESTION =
   "At idle with the light bar and laptop running, the radio resets and the headlights dim. What is the fix on this build?";
@@ -102,13 +102,24 @@ export default storyboard("rerank", {
       `),
       { holdMs: 200 },
     ),
-    // Turn reranking on via the rail pill.
-    beat("Open the Rerank picker", clickSelector(".lilbee-rerank-model-select"), {
-      holdMs: 800,
-      caption: "Turn reranking on — a cross-encoder re-scores the candidates by true relevance.",
-    }),
-    beat("Highlight the reranker", key("down"), { holdMs: 500 }),
-    beat("Choose it", key("enter"), { holdMs: 900 }),
+    // Turn reranking on by flipping the rail pill directly. A native <select>
+    // opens an OS popup the window capture can't see, so click-then-arrow-keys
+    // reads as the cursor sitting on the pill doing nothing; setting the value +
+    // change updates the visible pill instantly and fires the plugin's handler.
+    beat(
+      "Turn reranking on",
+      runJs(`
+        const sel = document.querySelector(".lilbee-rerank-model-select");
+        if (sel) {
+          const o = [...sel.options].find(o => /bge/i.test(o.text));
+          if (o) { sel.value = o.value; sel.dispatchEvent(new Event("change", { bubbles: true })); }
+        }
+      `),
+      {
+        holdMs: 900,
+        caption: "Turn reranking on — a cross-encoder re-scores the candidates by true relevance.",
+      },
+    ),
     beat("Ensure the reranker is active", setReranker(RERANK_MODEL), { holdMs: 700 }),
     // The first rerank call loads the cross-encoder; that cold call skips the
     // rerank pass, so warm it with a hidden throwaway query before the visible


### PR DESCRIPTION
Two reel fixes, no re-recording yet.

The rerank reel turned reranking on by clicking the native rerank `<select>` and arrow-keying through it. A native select opens an OS popup the window capture can't see, so on camera the cursor just sat on the pill for ~2 seconds before the chip flipped — it read as lingering. It now flips the rail pill directly (set value + change), so the chip switches to the bge reranker instantly, with the existing reranker API call kept as a safety net.

The multipart reel adds the manual on camera, but nothing guaranteed an empty index, so it hit the "already indexed — re-add?" prompt and the tape never clicked through it. New `emptyIndex` preflight option clears the index before recording, so the on-camera Add is a genuine first ingest with no prompt, and retrieval sees only the manual — what the tape's own header always intended. multipart sets it; it's available to the other fresh-vault reels too.

record.ts carries one line here (the emptyIndex passthrough); its caption change already landed in #126.