### PR TITLE
Open the model rail pickers as in-window menus instead of native dropdowns

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -218,6 +218,7 @@ export default class LilbeePlugin extends Plugin {
     private previousServerMode: ServerMode = SERVER_MODE.MANAGED;
     private startingServer = false;
     private serverStartFailed = false;
+    private unloaded = false;
     taskQueue: TaskQueue = new TaskQueue();
     /** Paths whose most-recent add failed — retry skips the reindex confirm. */
     private failedAddPaths = new Set<string>();
@@ -387,6 +388,8 @@ export default class LilbeePlugin extends Plugin {
             const binaryPath = await this.ensureBinaryWithUi(onProgress);
             if (binaryPath === null) return;
             await this.recordLilbeeVersionAfterDownload();
+            // A spawn after unload would leak a server no plugin instance tracks.
+            if (this.unloaded) return;
 
             try {
                 this.serverManager = this.buildServerManager(binaryPath, registry, sharedRoot);
@@ -1080,6 +1083,7 @@ export default class LilbeePlugin extends Plugin {
     }
 
     onunload(): void {
+        this.unloaded = true;
         if (this.pendingHintTimeout) {
             clearTimeout(this.pendingHintTimeout);
             this.pendingHintTimeout = null;

--- a/src/server-manager.ts
+++ b/src/server-manager.ts
@@ -149,6 +149,10 @@ export class ServerManager {
         this.setState(SERVER_STATE.STARTING);
         this._stderrLines = [];
 
+        // A leftover server.port from a previous run would be adopted as this
+        // child's port, so it must be gone before the spawn.
+        this.cleanupPortFile();
+
         // No --port: the server binds 0, the kernel picks a free port, and
         // the chosen value is written to data/server.port for us to read.
         const args = ["serve", "--host", "127.0.0.1", "--data-dir", this.opts.dataDir];
@@ -166,6 +170,8 @@ export class ServerManager {
             this.crashCount = 0;
             this.setState(SERVER_STATE.READY);
         } catch {
+            // Kill the child we spawned so it doesn't outlive the failure and block retries.
+            await this.stop();
             this.setState(SERVER_STATE.ERROR);
         }
     }

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -32,7 +32,6 @@ import type {
 import { RateLimitedError } from "../api";
 
 import { renderAggregatedSourceChips } from "./results";
-import { SEPARATOR_KEY, SEPARATOR_LABEL } from "../settings";
 import { displayLabelForRef, extractHfRepo } from "../utils/model-ref";
 import { ConfirmPullModal } from "./confirm-pull-modal";
 import { ConfirmModal } from "./confirm-modal";
@@ -77,13 +76,25 @@ const RAIL_BROWSE_KEY = "__lilbee_browse__";
 /** Option value that turns an optional role off (matches the server's empty model ref). */
 const RAIL_DISABLED_KEY = "";
 
+/** One pickable entry in a rail role's menu. */
+interface RailOption {
+    value: string;
+    label: string;
+    checked: boolean;
+}
+
+/** Label shown on a chip trigger: the checked option, else the first (matching a native select). */
+function railTriggerLabel(options: RailOption[]): string {
+    return (options.find((o) => o.checked) ?? options[0])?.label ?? "";
+}
+
 /** Static description of an optional rail role (Vision, Rerank). Dynamic state lives on the view. */
 interface OptionalRoleSpec {
     key: "vision" | "rerank";
     task: typeof MODEL_TASK.VISION | typeof MODEL_TASK.RERANK;
     label: string;
     dotClass: string;
-    selectClass: string;
+    triggerClass: string;
     disabledLabel: string;
     tooltip: string;
     configKey: string;
@@ -97,7 +108,7 @@ const OPTIONAL_ROLE_SPECS: OptionalRoleSpec[] = [
         task: MODEL_TASK.VISION,
         label: MESSAGES.RAIL_LABEL_VISION,
         dotClass: "is-vision",
-        selectClass: "lilbee-vision-model-select",
+        triggerClass: "lilbee-vision-model-select",
         disabledLabel: MESSAGES.LABEL_VISION_DISABLED,
         tooltip: MESSAGES.TOOLTIP_ROLE_VISION,
         configKey: "vision_model",
@@ -109,7 +120,7 @@ const OPTIONAL_ROLE_SPECS: OptionalRoleSpec[] = [
         task: MODEL_TASK.RERANK,
         label: MESSAGES.RAIL_LABEL_RERANK,
         dotClass: "is-rerank",
-        selectClass: "lilbee-rerank-model-select",
+        triggerClass: "lilbee-rerank-model-select",
         disabledLabel: MESSAGES.LABEL_RERANKER_DISABLED,
         tooltip: MESSAGES.TOOLTIP_ROLE_RERANK,
         configKey: "reranker_model",
@@ -143,8 +154,8 @@ export class ChatView extends ItemView {
     private chatCatalogEntries: CatalogEntry[] = [];
     private chatInstalled: InstalledModel[] = [];
     private chatActive = "";
-    private chatSelectEl: HTMLSelectElement | null = null;
-    private embeddingSelectEl: HTMLSelectElement | null = null;
+    private chatTriggerTextEl: HTMLElement | null = null;
+    private embeddingTriggerTextEl: HTMLElement | null = null;
     private embeddingModels: CatalogEntry[] = [];
     private activeEmbeddingModel = "";
     private chatModeContainer: HTMLElement | null = null;
@@ -212,20 +223,18 @@ export class ChatView extends ItemView {
         chatChip.setAttribute("aria-label-position", "top");
         chatChip.createSpan({ cls: "lilbee-model-chip-dot is-chat is-active" });
         chatChip.createSpan({ cls: "lilbee-model-chip-label", text: MESSAGES.RAIL_LABEL_CHAT });
-        this.chatSelectEl = chatChip.createEl("select", {
-            cls: "lilbee-chat-model-select lilbee-model-chip-select",
-        }) as HTMLSelectElement;
-        this.attachChatListener(this.chatSelectEl);
+        this.chatTriggerTextEl = this.createRailTrigger(chatChip, "lilbee-chat-model-select", (event) =>
+            this.openChatMenu(event),
+        );
 
         const embedChip = rail.createDiv({ cls: "lilbee-model-chip lilbee-toolbar-group lilbee-toolbar-group-embed" });
         embedChip.setAttribute("aria-label", MESSAGES.TOOLTIP_ROLE_EMBED);
         embedChip.setAttribute("aria-label-position", "top");
         embedChip.createSpan({ cls: "lilbee-model-chip-dot is-embed is-active" });
         embedChip.createSpan({ cls: "lilbee-model-chip-label", text: MESSAGES.RAIL_LABEL_EMBED });
-        this.embeddingSelectEl = embedChip.createEl("select", {
-            cls: "lilbee-embed-model-select lilbee-model-chip-select",
-        }) as HTMLSelectElement;
-        this.attachEmbeddingListener(this.embeddingSelectEl);
+        this.embeddingTriggerTextEl = this.createRailTrigger(embedChip, "lilbee-embed-model-select", (event) =>
+            this.openEmbeddingMenu(event),
+        );
 
         // Optional roles (Vision, Rerank) are chips in the same wrapping rail.
         this.optionalRailEl = rail.createDiv({ cls: "lilbee-model-rail-optional" });
@@ -353,11 +362,10 @@ export class ChatView extends ItemView {
                     this.retryTimer = null;
                 }
                 this.retryCount = 0;
-                if (this.chatSelectEl) this.chatSelectEl.empty();
                 this.chatCatalogEntries = chatCatalogResult.isOk() ? chatCatalogResult.value.models : [];
                 this.chatInstalled = chatInstalled.models;
                 this.chatActive = serverConfig ? String(serverConfig["chat_model"] ?? "") : "";
-                if (this.chatSelectEl) this.fillSelectOptions(this.chatSelectEl);
+                this.chatTriggerTextEl?.setText(railTriggerLabel(this.chatOptionGroups().flat()));
 
                 this.fillEmbeddingSelector(embeddingResult, serverConfig);
                 this.fillOptionalRoleData(
@@ -378,14 +386,13 @@ export class ChatView extends ItemView {
                 this.retryCount++;
                 const connecting = this.retryCount < ChatView.OFFLINE_THRESHOLD;
                 const label = connecting ? MESSAGES.LABEL_CONNECTING : MESSAGES.LABEL_OFFLINE;
-                if (this.chatSelectEl) {
-                    this.chatSelectEl.empty();
-                    this.chatSelectEl.createEl("option", { text: label });
-                }
-                if (this.embeddingSelectEl) {
-                    this.embeddingSelectEl.empty();
-                    this.embeddingSelectEl.createEl("option", { text: label });
-                }
+                // Clear option state so the menus offer nothing while unreachable.
+                this.chatCatalogEntries = [];
+                this.chatInstalled = [];
+                this.embeddingModels = [];
+                this.activeEmbeddingModel = "";
+                this.chatTriggerTextEl?.setText(label);
+                this.embeddingTriggerTextEl?.setText(label);
                 if (this.retryCount === ChatView.OFFLINE_THRESHOLD) {
                     new Notice(MESSAGES.ERROR_SERVER_UNREACHABLE);
                 }
@@ -452,141 +459,182 @@ export class ChatView extends ItemView {
         embeddingResult: import("neverthrow").Result<import("../types").CatalogResponse, Error> | null,
         serverConfig: Record<string, unknown> | null,
     ): void {
-        if (!this.embeddingSelectEl) return;
-        this.embeddingSelectEl.empty();
-
-        const activeModel = serverConfig ? String(serverConfig["embedding_model"] ?? "") : "";
-        this.activeEmbeddingModel = activeModel;
-
-        const models =
+        this.activeEmbeddingModel = serverConfig ? String(serverConfig["embedding_model"] ?? "") : "";
+        this.embeddingModels =
             embeddingResult && embeddingResult.isOk() ? embeddingResult.value.models.filter((m) => m.installed) : [];
-        this.embeddingModels = models;
-
-        for (const model of models) {
-            const option = this.embeddingSelectEl.createEl("option", { text: model.display_name });
-            (option as HTMLOptionElement).value = model.hf_repo;
-            if (model.hf_repo === extractHfRepo(activeModel)) {
-                (option as HTMLOptionElement).selected = true;
-            }
-        }
-
-        if (models.length === 0 && activeModel) {
-            const option = this.embeddingSelectEl.createEl("option", { text: displayLabelForRef(activeModel) });
-            (option as HTMLOptionElement).value = activeModel;
-            (option as HTMLOptionElement).selected = true;
-        }
+        this.embeddingTriggerTextEl?.setText(railTriggerLabel(this.embeddingOptions()));
     }
 
-    private fillSelectOptions(selectEl: HTMLSelectElement): void {
-        const sourceMap = new Map(this.chatInstalled.map((m) => [m.name, m.source]));
+    /** Embedding menu entries: installed builds, or the bare active ref when none are installed. */
+    private embeddingOptions(): RailOption[] {
+        const activeRepo = extractHfRepo(this.activeEmbeddingModel);
+        const options = this.embeddingModels.map((m) => ({
+            value: m.hf_repo,
+            label: m.display_name,
+            checked: m.hf_repo === activeRepo,
+        }));
+        if (options.length === 0 && this.activeEmbeddingModel) {
+            options.push({
+                value: this.activeEmbeddingModel,
+                label: displayLabelForRef(this.activeEmbeddingModel),
+                checked: true,
+            });
+        }
+        return options;
+    }
+
+    /** Chat menu entries: [featured installed + hosted rows, other installed builds]. */
+    private chatOptionGroups(): RailOption[][] {
+        return [this.chatPrimaryOptions(), this.chatOtherOptions()];
+    }
+
+    /** Featured rows that have an installed quant, then hosted rows not already listed. */
+    private chatPrimaryOptions(): RailOption[] {
         const installedRepos = new Set(this.chatInstalled.map((m) => extractHfRepo(m.name)));
         const activeRepo = extractHfRepo(this.chatActive);
-
-        // Featured rows that have an installed quant.
-        const featuredInstalled = this.chatCatalogEntries.filter((e) => installedRepos.has(e.hf_repo));
-        for (const entry of featuredInstalled) {
+        const primary: RailOption[] = [];
+        for (const entry of this.chatCatalogEntries.filter((e) => installedRepos.has(e.hf_repo))) {
             const sourceTag = HOSTED_SOURCES.has(entry.source) ? ` [${entry.provider ?? entry.source}]` : "";
-            const option = selectEl.createEl("option", { text: `${entry.display_name}${sourceTag}` });
-            (option as HTMLOptionElement).value = entry.hf_repo;
-            if (entry.hf_repo === activeRepo) {
-                (option as HTMLOptionElement).selected = true;
-            }
+            primary.push({
+                value: entry.hf_repo,
+                label: `${entry.display_name}${sourceTag}`,
+                checked: entry.hf_repo === activeRepo,
+            });
         }
-
         // Hosted rows (frontier/ollama) are selectable even when absent from the
         // installed registry — ollama always, frontier with a ready key. Skip any
         // already emitted above as an installed featured row (an ollama model can
         // be both hosted and registered as installed).
         for (const [ref, label] of hostedOptions(this.chatCatalogEntries)) {
             if (installedRepos.has(ref)) continue;
-            const option = selectEl.createEl("option", { text: label });
-            (option as HTMLOptionElement).value = ref;
-            if (ref === activeRepo) {
-                (option as HTMLOptionElement).selected = true;
-            }
+            primary.push({ value: ref, label, checked: ref === activeRepo });
         }
-
-        // Anything installed that isn't in the featured catalog (manually pulled, ollama/, openai/, …).
-        const featuredRepos = new Set(this.chatCatalogEntries.map((e) => e.hf_repo));
-        const otherInstalled = this.chatInstalled
-            .filter((m) => !featuredRepos.has(extractHfRepo(m.name)))
-            .sort((a, b) => a.name.localeCompare(b.name));
-        // Only emit the separator when it's actually dividing two
-        // sections. Without this guard, an empty featured catalog (e.g.
-        // server still warming up) lets the separator be the first
-        // option, which browsers render as the dropdown's displayed
-        // value — "—— Other... ——" instead of the real active model.
-        if (featuredInstalled.length > 0 && otherInstalled.length > 0) {
-            const sep = selectEl.createEl("option", { text: SEPARATOR_LABEL });
-            (sep as HTMLOptionElement).value = SEPARATOR_KEY;
-            (sep as HTMLOptionElement).disabled = true;
-        }
-        for (const m of otherInstalled) {
-            const source = sourceMap.get(m.name);
-            const suffix = source && source !== CATALOG_SOURCE.NATIVE ? ` [${source}]` : "";
-            const option = selectEl.createEl("option", { text: `${displayLabelForRef(m.name)}${suffix}` });
-            (option as HTMLOptionElement).value = m.name;
-            if (m.name === this.chatActive) {
-                (option as HTMLOptionElement).selected = true;
-            }
-        }
+        return primary;
     }
 
-    private attachChatListener(el: HTMLSelectElement): void {
-        el.addEventListener("change", () => {
-            if (!el.value || el.value === SEPARATOR_KEY) return;
-            const uninstalled = this.chatCatalogEntries.find((e) => e.hf_repo === el.value && !e.installed);
-            if (uninstalled) {
-                const modal = new ConfirmPullModal(this.plugin.app, {
-                    displayName: uninstalled.display_name,
-                    sizeGb: uninstalled.size_gb,
-                    minRamGb: uninstalled.min_ram_gb,
-                    systemMemGb: getRelevantSystemMemoryGB(this.plugin.settings.serverMode),
-                });
-                modal.open();
-                void modal.result.then((confirmed) => {
-                    if (confirmed) {
-                        void this.autoPullAndSet(uninstalled);
-                    }
-                });
+    /** Installed builds that aren't in the featured catalog (manually pulled, ollama/, openai/, …). */
+    private chatOtherOptions(): RailOption[] {
+        const sourceMap = new Map(this.chatInstalled.map((m) => [m.name, m.source]));
+        const featuredRepos = new Set(this.chatCatalogEntries.map((e) => e.hf_repo));
+        return this.chatInstalled
+            .filter((m) => !featuredRepos.has(extractHfRepo(m.name)))
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((m) => {
+                const source = sourceMap.get(m.name);
+                const suffix = source && source !== CATALOG_SOURCE.NATIVE ? ` [${source}]` : "";
+                return {
+                    value: m.name,
+                    label: `${displayLabelForRef(m.name)}${suffix}`,
+                    checked: m.name === this.chatActive,
+                };
+            });
+    }
+
+    private openChatMenu(event: MouseEvent): void {
+        this.openRailMenu(event, this.chatTriggerTextEl, this.chatOptionGroups(), (value) =>
+            this.handleChatSelection(value),
+        );
+    }
+
+    private handleChatSelection(value: string): void {
+        const uninstalled = this.chatCatalogEntries.find((e) => e.hf_repo === value && !e.installed);
+        if (uninstalled) {
+            const modal = new ConfirmPullModal(this.plugin.app, {
+                displayName: uninstalled.display_name,
+                sizeGb: uninstalled.size_gb,
+                minRamGb: uninstalled.min_ram_gb,
+                systemMemGb: getRelevantSystemMemoryGB(this.plugin.settings.serverMode),
+            });
+            modal.open();
+            void modal.result.then((confirmed) => {
+                if (confirmed) {
+                    void this.autoPullAndSet(uninstalled);
+                }
+            });
+            return;
+        }
+        void this.plugin.api.setChatModel(value).then((result) => {
+            if (result.isOk()) {
+                // Keep the menu's checkmark in sync without waiting for a refetch.
+                this.chatActive = value;
+                this.plugin.activeModel = value;
+                this.plugin.fetchActiveModel();
+                this.plugin.refreshSettingsTab();
+            } else {
+                new Notice(MESSAGES.ERROR_SWITCH_MODEL);
+            }
+        });
+    }
+
+    private openEmbeddingMenu(event: MouseEvent): void {
+        this.openRailMenu(event, this.embeddingTriggerTextEl, [this.embeddingOptions()], (value) =>
+            this.handleEmbeddingSelection(value),
+        );
+    }
+
+    private handleEmbeddingSelection(value: string): void {
+        const previous = this.activeEmbeddingModel;
+        const modal = new ConfirmModal(this.plugin.app, MESSAGES.DESC_EMBEDDING_REINDEX_WARNING);
+        modal.open();
+        void modal.result.then(async (confirmed) => {
+            if (!confirmed) {
+                this.revertEmbeddingTrigger(previous);
                 return;
             }
-            this.plugin.api.setChatModel(el.value).then((result) => {
-                if (result.isOk()) {
-                    this.plugin.activeModel = el.value;
-                    this.plugin.fetchActiveModel();
-                    this.plugin.refreshSettingsTab();
-                } else {
-                    new Notice(MESSAGES.ERROR_SWITCH_MODEL);
-                }
-            });
+            const result = await this.plugin.api.setEmbeddingModel(value);
+            if (result.isErr()) {
+                new Notice(noticeForResultError(result.error, MESSAGES.NOTICE_FAILED_EMBEDDING));
+                this.revertEmbeddingTrigger(previous);
+                return;
+            }
+            this.activeEmbeddingModel = value;
+            new Notice(MESSAGES.NOTICE_EMBEDDING_UPDATED);
+            new Notice(MESSAGES.NOTICE_REINDEX_REQUIRED);
+            this.plugin.refreshSettingsTab();
+            void this.plugin.triggerSync();
         });
     }
 
-    private attachEmbeddingListener(el: HTMLSelectElement): void {
-        el.addEventListener("change", () => {
-            if (!el.value) return;
-            const previous = this.activeEmbeddingModel;
-            const modal = new ConfirmModal(this.plugin.app, MESSAGES.DESC_EMBEDDING_REINDEX_WARNING);
-            modal.open();
-            void modal.result.then(async (confirmed) => {
-                if (!confirmed) {
-                    this.revertEmbeddingSelect(previous);
-                    return;
-                }
-                const result = await this.plugin.api.setEmbeddingModel(el.value);
-                if (result.isErr()) {
-                    new Notice(noticeForResultError(result.error, MESSAGES.NOTICE_FAILED_EMBEDDING));
-                    this.revertEmbeddingSelect(previous);
-                    return;
-                }
-                this.activeEmbeddingModel = el.value;
-                new Notice(MESSAGES.NOTICE_EMBEDDING_UPDATED);
-                new Notice(MESSAGES.NOTICE_REINDEX_REQUIRED);
-                this.plugin.refreshSettingsTab();
-                void this.plugin.triggerSync();
-            });
+    /** Chip trigger button: current model text + caret; click opens the role's menu. */
+    private createRailTrigger(
+        chip: HTMLElement,
+        cls: string,
+        onOpen: (event: MouseEvent, textEl: HTMLElement) => void,
+    ): HTMLElement {
+        const trigger = chip.createEl("button", { cls: `lilbee-model-chip-select ${cls}` });
+        const text = trigger.createSpan({ cls: "lilbee-model-chip-select-text" });
+        setIcon(trigger.createSpan({ cls: "lilbee-model-chip-select-caret" }), "chevron-down");
+        trigger.addEventListener("click", (event) => onOpen(event, text));
+        return text;
+    }
+
+    /** In-window menu of rail options; the checked entry is the active one. */
+    private openRailMenu(
+        event: MouseEvent,
+        textEl: HTMLElement | null,
+        groups: RailOption[][],
+        onPick: (value: string) => void,
+    ): void {
+        const nonEmpty = groups.filter((group) => group.length > 0);
+        if (nonEmpty.length === 0) return;
+        const menu = new Menu();
+        nonEmpty.forEach((group, index) => {
+            if (index > 0) menu.addSeparator();
+            for (const opt of group) {
+                menu.addItem((item) => {
+                    item.setTitle(opt.label)
+                        .setChecked(opt.checked)
+                        .onClick(() => {
+                            // Re-picking the active item is a no-op (matches a native select's change event).
+                            if (opt.checked) return;
+                            // Browse opens the catalog; the chip keeps showing the current model.
+                            if (opt.value !== RAIL_BROWSE_KEY) textEl?.setText(opt.label);
+                            onPick(opt.value);
+                        });
+                });
+            }
         });
+        this.showMenu(menu, event);
     }
 
     /** Store the latest per-task catalog + active model for the optional roles, then re-render. */
@@ -628,9 +676,22 @@ export class ChatView extends ItemView {
         return options;
     }
 
+    /** Full menu entry list for an optional role: Disabled, role-capable models, Browse catalog. */
+    private optionalRoleMenuOptions(spec: OptionalRoleSpec): RailOption[] {
+        const active = this.optionalActive[spec.key];
+        const activeRepo = extractHfRepo(active);
+        // "Disabled" turns the role off (model ref ""); the role stays visible
+        // even with nothing installed, and "Browse catalog" downloads one.
+        const options: RailOption[] = [{ value: RAIL_DISABLED_KEY, label: spec.disabledLabel, checked: !active }];
+        for (const opt of this.optionalRoleOptions(spec)) {
+            options.push({ ...opt, checked: opt.value === active || opt.value === activeRepo });
+        }
+        options.push({ value: RAIL_BROWSE_KEY, label: MESSAGES.RAIL_BROWSE_CATALOG, checked: false });
+        return options;
+    }
+
     private renderOptionalRoleRow(rail: HTMLElement, spec: OptionalRoleSpec): void {
         const active = this.optionalActive[spec.key];
-        const options = this.optionalRoleOptions(spec);
         const chip = rail.createDiv({ cls: "lilbee-model-chip lilbee-model-chip-optional" });
         chip.setAttribute("aria-label", spec.tooltip);
         chip.setAttribute("aria-label-position", "top");
@@ -639,59 +700,39 @@ export class ChatView extends ItemView {
         if (active) dot.addClass("is-active");
         chip.createSpan({ cls: "lilbee-model-chip-label", text: spec.label });
 
-        const select = chip.createEl("select", {
-            cls: `lilbee-model-chip-select ${spec.selectClass}`,
-        }) as HTMLSelectElement;
-        // "Disabled" turns the role off (model ref ""); the role stays visible
-        // even with nothing installed, and "Browse catalog" downloads one.
-        const disabled = select.createEl("option", { text: spec.disabledLabel });
-        (disabled as HTMLOptionElement).value = RAIL_DISABLED_KEY;
-        if (!active) (disabled as HTMLOptionElement).selected = true;
-
-        const activeRepo = extractHfRepo(active);
-        for (const opt of options) {
-            const option = select.createEl("option", { text: opt.label });
-            (option as HTMLOptionElement).value = opt.value;
-            if (opt.value === active || opt.value === activeRepo) {
-                (option as HTMLOptionElement).selected = true;
-            }
-        }
-        const browse = select.createEl("option", { text: MESSAGES.RAIL_BROWSE_CATALOG });
-        (browse as HTMLOptionElement).value = RAIL_BROWSE_KEY;
-        this.attachOptionalRoleListener(select, spec);
+        const textEl = this.createRailTrigger(chip, spec.triggerClass, (event, text) =>
+            this.openRailMenu(event, text, [this.optionalRoleMenuOptions(spec)], (value) =>
+                this.handleOptionalRoleSelection(spec, value),
+            ),
+        );
+        textEl.setText(railTriggerLabel(this.optionalRoleMenuOptions(spec)));
     }
 
-    private attachOptionalRoleListener(el: HTMLSelectElement, spec: OptionalRoleSpec): void {
-        el.addEventListener("change", () => {
-            if (el.value === RAIL_BROWSE_KEY) {
-                new CatalogModal(this.app, this.plugin, spec.task).open();
-                // Reset selection so reopening the catalog stays possible.
-                el.value = this.optionalActive[spec.key];
+    private handleOptionalRoleSelection(spec: OptionalRoleSpec, value: string): void {
+        if (value === RAIL_BROWSE_KEY) {
+            new CatalogModal(this.app, this.plugin, spec.task).open();
+            return;
+        }
+        // RAIL_DISABLED_KEY disables the role; any other value activates it.
+        void spec.setActive(this.plugin.api, value).then((result) => {
+            if (result.isErr()) {
+                new Notice(MESSAGES.NOTICE_FAILED_UPDATE(spec.failNotice));
                 return;
             }
-            // el.value === "" disables the role; any other value activates it.
-            void spec.setActive(this.plugin.api, el.value).then((result) => {
-                if (result.isErr()) {
-                    new Notice(MESSAGES.NOTICE_FAILED_UPDATE(spec.failNotice));
-                    return;
-                }
-                this.optionalActive[spec.key] = el.value;
-                this.fillOptionalRoles();
-                this.plugin.fetchActiveModel();
-                this.plugin.refreshSettingsTab();
-            });
+            this.optionalActive[spec.key] = value;
+            this.fillOptionalRoles();
+            this.plugin.fetchActiveModel();
+            this.plugin.refreshSettingsTab();
         });
     }
 
-    private revertEmbeddingSelect(previousValue: string): void {
-        if (!this.embeddingSelectEl) return;
-        // HTMLSelectElement.value is a no-op if no option matches — which
-        // silently blanks the picker. Guard so the previous value only wins
-        // when it actually exists in the current option set; otherwise fall
-        // back to a server refresh so the picker can't get stuck empty.
-        const hasOption = Array.from(this.embeddingSelectEl.options).some((opt) => opt.value === previousValue);
-        if (hasOption) {
-            this.embeddingSelectEl.value = previousValue;
+    private revertEmbeddingTrigger(previousValue: string): void {
+        if (!this.embeddingTriggerTextEl) return;
+        // Restore the previous label only when that value still exists in the
+        // option set; otherwise fall back to a server refresh.
+        const option = this.embeddingOptions().find((opt) => opt.value === previousValue);
+        if (option) {
+            this.embeddingTriggerTextEl.setText(option.label);
             return;
         }
         void this.fetchAndFillSelectors();
@@ -755,19 +796,13 @@ export class ChatView extends ItemView {
             this.plugin.refreshSettingsTab();
         }
         this.plugin.fetchActiveModel();
-        this.refreshModelSelector();
-    }
-
-    private refreshModelSelector(): void {
-        if (this.chatSelectEl) this.chatSelectEl.empty();
-        if (this.embeddingSelectEl) this.embeddingSelectEl.empty();
         this.fetchAndFillSelectors();
     }
 
     // Re-sync the rail pills with the server's active models, for callers
     // outside this view (e.g. the catalog) that switch a model.
     refreshRail(): void {
-        this.refreshModelSelector();
+        this.fetchAndFillSelectors();
     }
 
     private clearChat(): void {
@@ -973,11 +1008,11 @@ export class ChatView extends ItemView {
                     new CrawlModal(this.app, this.plugin).open();
                 });
         });
-        // Belt-and-braces ESC dismissal. Obsidian's Menu is supposed to close
-        // on ESC, but in QA the popover stayed open — the textarea kept
-        // focus, so the keypress never reached the menu. Routing the ESC
-        // listener through the document with capture=true catches it before
-        // any input handler can swallow it.
+        this.showMenu(menu, event);
+    }
+
+    /** Show a menu with capture-phase ESC dismissal (a focused input can otherwise swallow the keypress). */
+    private showMenu(menu: Menu, event: MouseEvent): void {
         const onKey = (e: KeyboardEvent) => {
             if (e.key === "Escape") {
                 e.preventDefault();
@@ -986,6 +1021,13 @@ export class ChatView extends ItemView {
         };
         document.addEventListener("keydown", onKey, true);
         menu.onHide(() => document.removeEventListener("keydown", onKey, true));
+        // Keyboard-synthesized clicks (detail 0) carry no coordinates; anchor to the trigger instead.
+        const trigger = event.detail === 0 ? (event.currentTarget as HTMLElement | null) : null;
+        if (trigger) {
+            const rect = trigger.getBoundingClientRect();
+            menu.showAtPosition({ x: rect.left, y: rect.bottom });
+            return;
+        }
         menu.showAtMouseEvent(event);
     }
 

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -4,6 +4,7 @@ import {
     MarkdownRenderer,
     Menu,
     Notice,
+    Platform,
     setIcon,
     type TFile,
     WorkspaceLeaf,
@@ -1011,16 +1012,28 @@ export class ChatView extends ItemView {
         this.showMenu(menu, event);
     }
 
-    /** Show a menu with capture-phase ESC dismissal (a focused input can otherwise swallow the keypress). */
+    /** The core "Native menus" appearance setting; unset falls back to the platform default (native on macOS). */
+    private prefersNativeMenu(): boolean {
+        const vault = this.app.vault as unknown as { getConfig?: (key: string) => unknown };
+        const value = vault.getConfig?.("nativeMenus");
+        return typeof value === "boolean" ? value : Platform.isMacOS;
+    }
+
+    /** Show a menu, native when the vault prefers it; the in-window menu gets capture-phase ESC dismissal. */
     private showMenu(menu: Menu, event: MouseEvent): void {
-        const onKey = (e: KeyboardEvent) => {
-            if (e.key === "Escape") {
-                e.preventDefault();
-                menu.hide();
-            }
-        };
-        document.addEventListener("keydown", onKey, true);
-        menu.onHide(() => document.removeEventListener("keydown", onKey, true));
+        const useNative = this.prefersNativeMenu();
+        menu.setUseNativeMenu(useNative);
+        if (!useNative) {
+            // Capture-phase ESC: a focused input can otherwise swallow the keypress.
+            const onKey = (e: KeyboardEvent) => {
+                if (e.key === "Escape") {
+                    e.preventDefault();
+                    menu.hide();
+                }
+            };
+            document.addEventListener("keydown", onKey, true);
+            menu.onHide(() => document.removeEventListener("keydown", onKey, true));
+        }
         // Keyboard-synthesized clicks (detail 0) carry no coordinates; anchor to the trigger instead.
         const trigger = event.detail === 0 ? (event.currentTarget as HTMLElement | null) : null;
         if (trigger) {

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -72,6 +72,9 @@ export const electronDialog = {
 
 export const VIEW_TYPE_CHAT = "lilbee-chat";
 
+/** Within this distance of the bottom the view counts as pinned and follows the stream. */
+const SCROLL_FOLLOW_THRESHOLD_PX = 80;
+
 /** Sentinel option value: selecting it opens the catalog instead of switching models. */
 const RAIL_BROWSE_KEY = "__lilbee_browse__";
 /** Option value that turns an optional role off (matches the server's empty model ref). */
@@ -839,13 +842,12 @@ export class ChatView extends ItemView {
             const elapsed = Date.now() - spinnerCreatedAt;
             const delay = Math.max(0, SPINNER_MIN_DISPLAY_MS - elapsed);
             setTimeout(() => {
-                if (spinner.parentElement) spinner.remove();
-                textEl.style.display = "";
+                // Revealing the hidden content grows the bubble; keep the view pinned.
+                void this.renderFollowing(() => {
+                    if (spinner.parentElement) spinner.remove();
+                    textEl.style.display = "";
+                });
             }, delay);
-        };
-
-        const scrollToBottom = (): void => {
-            if (this.messagesEl) this.messagesEl.scrollTop = this.messagesEl.scrollHeight;
         };
 
         const scheduleRender = (): void => {
@@ -853,7 +855,7 @@ export class ChatView extends ItemView {
             state.renderPending = true;
             requestAnimationFrame(() => {
                 state.renderPending = false;
-                void this.renderMarkdown(textEl, state.fullContent).then(scrollToBottom);
+                void this.renderFollowing(() => this.renderMarkdown(textEl, state.fullContent));
             });
         };
 
@@ -923,16 +925,21 @@ export class ChatView extends ItemView {
             case SSE_EVENT.DONE: {
                 revealContent();
                 const rendered = state.fullContent;
-                if (state.reasoningContent) {
-                    const details = assistantBubble.createEl("details", { cls: "lilbee-reasoning" });
-                    details.createEl("summary", { text: MESSAGES.LABEL_REASONING });
-                    const content = details.createDiv({ cls: "lilbee-reasoning-content" });
-                    void MarkdownRenderer.render(this.app, state.reasoningContent, content, "", this.plugin);
-                    details.removeAttribute("open");
-                }
-                this.renderBannerIfPresent(event.data, assistantBubble);
-                void this.renderMarkdown(textEl, rendered);
-                if (state.sources.length > 0) this.renderSources(assistantBubble, state.sources);
+                // Reasoning, banner, and sources all grow the bubble after the
+                // last token; render them inside one follow so the view ends
+                // pinned to the bottom.
+                void this.renderFollowing(async () => {
+                    if (state.reasoningContent) {
+                        const details = assistantBubble.createEl("details", { cls: "lilbee-reasoning" });
+                        details.createEl("summary", { text: MESSAGES.LABEL_REASONING });
+                        const content = details.createDiv({ cls: "lilbee-reasoning-content" });
+                        void MarkdownRenderer.render(this.app, state.reasoningContent, content, "", this.plugin);
+                        details.removeAttribute("open");
+                    }
+                    this.renderBannerIfPresent(event.data, assistantBubble);
+                    await this.renderMarkdown(textEl, rendered);
+                    if (state.sources.length > 0) this.renderSources(assistantBubble, state.sources);
+                });
                 this.history.push({ role: "assistant", content: rendered });
                 break;
             }
@@ -964,6 +971,22 @@ export class ChatView extends ItemView {
                 }
                 break;
             }
+        }
+    }
+
+    /** True when the message list is scrolled to (or near) the bottom. */
+    private isNearBottom(): boolean {
+        const el = this.messagesEl;
+        if (!el) return false;
+        return el.scrollHeight - el.scrollTop - el.clientHeight < SCROLL_FOLLOW_THRESHOLD_PX;
+    }
+
+    /** Run a DOM-growing render; re-pin the view to the bottom only if it was pinned before. */
+    private async renderFollowing(run: () => Promise<void> | void): Promise<void> {
+        const follow = this.isNearBottom();
+        await run();
+        if (follow && this.messagesEl) {
+            this.messagesEl.scrollTop = this.messagesEl.scrollHeight;
         }
     }
 

--- a/styles.css
+++ b/styles.css
@@ -180,16 +180,6 @@
     min-width: 0;
 }
 
-/* Native selects size to their widest option, which bloats the toolbar; cap
-   and shrink them so the row fits and the selected value truncates gracefully. */
-.lilbee-chat-model-select,
-.lilbee-embed-model-select {
-    min-width: 0;
-    max-width: 150px;
-    flex-shrink: 1;
-    text-overflow: ellipsis;
-}
-
 .lilbee-embed-browse {
     font-size: var(--font-smallest, 10px);
     padding: 2px 6px;
@@ -4026,17 +4016,53 @@
     color: var(--text-faint);
 }
 
-/* The select shows just the model name, borderless inside the chip, and
-   truncates — overriding the 150px cap the old horizontal toolbar used. */
-.lilbee-model-chip-select {
+/* Chip trigger: current model name + caret, borderless; opens an in-window menu.
+   button-prefixed to outrank Obsidian's button:not(.clickable-icon) defaults. */
+button.lilbee-model-chip-select {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
     flex: 0 1 auto;
     min-width: 0;
     max-width: 130px;
+    height: auto;
     font-size: 11px;
-    background: transparent;
+    font-weight: 400;
+    background-color: transparent;
     border: none;
+    box-shadow: none;
     color: var(--text-muted);
     padding: 0;
+    cursor: pointer;
+}
+
+button.lilbee-model-chip-select:hover {
+    background-color: transparent;
+    box-shadow: none;
+    color: var(--text-normal);
+}
+
+/* Restore the focus ring the base rule's box-shadow reset would otherwise suppress. */
+button.lilbee-model-chip-select:focus-visible {
+    box-shadow: 0 0 0 3px var(--background-modifier-border-focus);
+}
+
+.lilbee-model-chip-select-text {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.lilbee-model-chip-select-caret {
+    display: inline-flex;
+    flex: 0 0 auto;
+    color: var(--text-faint);
+}
+
+.lilbee-model-chip-select-caret .svg-icon {
+    width: 10px;
+    height: 10px;
 }
 
 /* "Browse more" is pushed to the far right of the rail (margin-left:auto) so it

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -176,10 +176,8 @@ export class MockElement {
         if (i >= 0) handlers.splice(i, 1);
     }
 
-    // HTMLSelectElement.options — return children whose tagName is OPTION.
-    // Real-DOM HTMLSelectElement exposes the live HTMLOptionsCollection via
-    // this property; views that iterate it (e.g. chat-view.revertEmbeddingSelect)
-    // need the same surface in tests.
+    // HTMLSelectElement.options — children whose tagName is OPTION, matching
+    // the surface views that iterate a select's options expect.
     get options(): MockElement[] {
         return this.children.filter((c) => c.tagName === "OPTION");
     }
@@ -400,35 +398,78 @@ export class FuzzySuggestModal<T> {
     }
 }
 
-class MockMenuItem {
-    setTitle(_title: string): this {
+export class MockMenuItem {
+    title = "";
+    icon: string | null = null;
+    checked: boolean | null = null;
+    private clickHandler: ((evt?: MouseEvent | KeyboardEvent) => void) | null = null;
+
+    setTitle(title: string): this {
+        this.title = title;
         return this;
     }
-    setIcon(_icon: string): this {
+    setIcon(icon: string): this {
+        this.icon = icon;
         return this;
     }
-    onClick(cb: () => void): this {
-        cb();
+    setChecked(checked: boolean | null): this {
+        this.checked = checked;
         return this;
+    }
+    onClick(cb: (evt?: MouseEvent | KeyboardEvent) => void): this {
+        this.clickHandler = cb;
+        return this;
+    }
+    // Test helper: invoke the registered click handler.
+    click(): void {
+        this.clickHandler?.();
     }
 }
 
+/** Marker pushed by Menu.addSeparator so tests can assert on grouping. */
+export class MockMenuSeparator {}
+
 export class Menu {
-    private _items: MockMenuItem[] = [];
+    // Test helpers mirroring Notice.instances: grab the most recent menu.
+    static instances: Menu[] = [];
+    static clear(): void {
+        Menu.instances = [];
+    }
+
+    items: Array<MockMenuItem | MockMenuSeparator> = [];
+    visible = false;
+    position: { x: number; y: number } | null = null;
     private _hideCallbacks: Array<() => void> = [];
+
+    constructor() {
+        Menu.instances.push(this);
+    }
 
     addItem(cb: (item: MockMenuItem) => void): this {
         const item = new MockMenuItem();
         cb(item);
-        this._items.push(item);
+        this.items.push(item);
         return this;
     }
 
-    showAtMouseEvent(_event: unknown): void {
-        /* noop */
+    addSeparator(): this {
+        this.items.push(new MockMenuSeparator());
+        return this;
+    }
+
+    showAtMouseEvent(_event: unknown): this {
+        this.visible = true;
+        return this;
+    }
+
+    showAtPosition(position: { x: number; y: number }): this {
+        this.visible = true;
+        this.position = position;
+        return this;
     }
 
     hide(): this {
+        this.visible = false;
         for (const cb of this._hideCallbacks) cb();
         this._hideCallbacks = [];
         return this;
@@ -436,6 +477,16 @@ export class Menu {
 
     onHide(cb: () => void): void {
         this._hideCallbacks.push(cb);
+    }
+
+    // Test helper: clickable items in order, separators excluded.
+    get menuItems(): MockMenuItem[] {
+        return this.items.filter((i): i is MockMenuItem => i instanceof MockMenuItem);
+    }
+
+    // Test helper: first item whose title matches.
+    itemTitled(title: string): MockMenuItem | null {
+        return this.menuItems.find((i) => i.title === title) ?? null;
     }
 }
 

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -45,6 +45,10 @@ export class MockElement {
     placeholder: string = "";
     title: string = "";
     parentElement: MockElement | null = null;
+    // Scroll geometry — tests set scrollHeight/clientHeight to simulate overflow.
+    scrollTop: number = 0;
+    scrollHeight: number = 0;
+    clientHeight: number = 0;
 
     constructor(tag = "div") {
         this.tagName = tag.toUpperCase();

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -8,6 +8,11 @@
 
 import { vi } from "vitest";
 
+// Mutable so tests can simulate either platform; reset isMacOS in afterEach when changed.
+export const Platform = {
+    isMacOS: false,
+};
+
 export class MockElement {
     tagName: string;
     private _textContent: string = "";
@@ -291,6 +296,8 @@ export class App {
     vault = {
         on: vi.fn().mockReturnValue({ id: "mock-vault-event" }),
         offref: vi.fn(),
+        // Undocumented-but-stable Obsidian API for appearance settings; null means unset.
+        getConfig: vi.fn().mockReturnValue(null),
         adapter: {
             getBasePath: vi.fn().mockReturnValue("/test/vault"),
             // Obsidian's real DataAdapter surfaces these; tests that copy
@@ -439,6 +446,7 @@ export class Menu {
     items: Array<MockMenuItem | MockMenuSeparator> = [];
     visible = false;
     position: { x: number; y: number } | null = null;
+    useNativeMenu: boolean | null = null;
     private _hideCallbacks: Array<() => void> = [];
 
     constructor() {
@@ -454,6 +462,11 @@ export class Menu {
 
     addSeparator(): this {
         this.items.push(new MockMenuSeparator());
+        return this;
+    }
+
+    setUseNativeMenu(useNativeMenu: boolean): this {
+        this.useNativeMenu = useNativeMenu;
         return this;
     }
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -4401,6 +4401,30 @@ describe("LilbeePlugin", () => {
             expect(phases).toContain("ready");
         });
 
+        it("startManagedServer aborted by unload mid-download never spawns a server", async () => {
+            let releaseBinary!: (path: string) => void;
+            mockEnsureBinary.mockImplementationOnce(() => new Promise((r) => (releaseBinary = r)));
+
+            const plugin = await createPlugin({ setupCompleted: false, serverMode: "managed" });
+            plugin.loadData = vi.fn().mockResolvedValue({ setupCompleted: false, serverMode: "managed" });
+            await plugin.onload();
+
+            const { ServerManager } = await import("../src/server-manager");
+            (ServerManager as unknown as ReturnType<typeof vi.fn>).mockClear();
+            mockServerStart.mockClear();
+
+            const startPromise = plugin.startManagedServer();
+            await flush();
+            // The plugin unloads (e.g. a reload) while the binary download is in flight.
+            plugin.onunload();
+            releaseBinary("/fake/bin/lilbee");
+            await startPromise;
+            await flush();
+
+            expect(ServerManager).not.toHaveBeenCalled();
+            expect(mockServerStart).not.toHaveBeenCalled();
+        });
+
         it("startManagedServer onProgress emits 'error' phase when ensureBinary rejects", async () => {
             mockBinaryExists.mockReturnValueOnce(false);
             mockEnsureBinary.mockRejectedValueOnce(new Error("boom"));

--- a/tests/server-manager.test.ts
+++ b/tests/server-manager.test.ts
@@ -177,6 +177,8 @@ describe("ServerManager", () => {
 
             const startPromise = mgr.start();
             await vi.advanceTimersByTimeAsync(120_000);
+            // The failure path stops the child; advance past the stop grace period.
+            await vi.advanceTimersByTimeAsync(6_000);
             await startPromise;
 
             expect(mgr.state).toBe("error");
@@ -190,6 +192,7 @@ describe("ServerManager", () => {
 
             const startPromise = mgr.start();
             await vi.advanceTimersByTimeAsync(120_000);
+            await vi.advanceTimersByTimeAsync(6_000);
             await startPromise;
 
             expect(mgr.serverUrl).toBe("");
@@ -215,6 +218,7 @@ describe("ServerManager", () => {
             const startPromise = mgr.start();
             // 120 attempts * 1000ms each = 120000ms
             await vi.advanceTimersByTimeAsync(120_000);
+            await vi.advanceTimersByTimeAsync(6_000);
             await startPromise;
 
             expect(mgr.state).toBe("error");
@@ -226,9 +230,44 @@ describe("ServerManager", () => {
 
             const startPromise = mgr.start();
             await vi.advanceTimersByTimeAsync(120_000);
+            await vi.advanceTimersByTimeAsync(6_000);
             await startPromise;
 
             expect(mgr.state).toBe("error");
+        }, 15_000);
+
+        it("removes a stale port file before spawning so the old port is never adopted", async () => {
+            const mgr = new ServerManager(defaultOpts());
+
+            const startPromise = mgr.start();
+            await vi.advanceTimersByTimeAsync(1000);
+            await startPromise;
+
+            expect(unlinkSyncSpy).toHaveBeenCalledWith("/tmp/data/data/server.port");
+            // Cleanup happens before the child is spawned.
+            expect(unlinkSyncSpy.mock.invocationCallOrder[0]).toBeLessThan(spawnSpy.mock.invocationCallOrder[0]);
+        });
+
+        it("kills the spawned child on discovery failure so a retry can start clean", async () => {
+            existsSyncSpy.mockReturnValue(false);
+            const mgr = new ServerManager(defaultOpts());
+
+            const startPromise = mgr.start();
+            await vi.advanceTimersByTimeAsync(126_000);
+            await startPromise;
+
+            expect(mgr.state).toBe("error");
+            expect(child.kill).toHaveBeenCalled();
+            expect((mgr as any).child).toBeNull();
+
+            // With the failed child gone, a retry spawns a fresh server.
+            existsSyncSpy.mockReturnValue(true);
+            const retryPromise = mgr.start();
+            await vi.advanceTimersByTimeAsync(1000);
+            await retryPromise;
+
+            expect(spawnSpy).toHaveBeenCalledTimes(2);
+            expect(mgr.state).toBe("ready");
         }, 15_000);
     });
 
@@ -449,6 +488,8 @@ describe("ServerManager", () => {
             // Port file vanished between start and stop — e.g. the server
             // unlinked it on shutdown before our stop() ran the check.
             existsSyncSpy.mockReturnValue(false);
+            // Only stop()'s cleanup is under test, not start()'s pre-spawn unlink.
+            unlinkSyncSpy.mockClear();
 
             const stopPromise = mgr.stop();
             await vi.advanceTimersByTimeAsync(50);

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -17,7 +17,7 @@ if (typeof globalThis.document === "undefined") {
     };
 }
 
-import { Menu, MockMenuItem, MockMenuSeparator, Notice, WorkspaceLeaf } from "../__mocks__/obsidian";
+import { Menu, MockMenuItem, MockMenuSeparator, Notice, Platform, WorkspaceLeaf } from "../__mocks__/obsidian";
 import { MockElement } from "../__mocks__/obsidian";
 import { ChatView, VIEW_TYPE_CHAT, VaultFilePickerModal, electronDialog } from "../../src/views/chat-view";
 import { ok, err } from "neverthrow";
@@ -1598,6 +1598,83 @@ describe("ChatView.onOpen — model selector", () => {
         await tick();
 
         expect(plugin.refreshSettingsTab).not.toHaveBeenCalled();
+    });
+
+    it("renders in-window with ESC dismissal when native menus are off", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        (view.app.vault as any).getConfig = vi.fn().mockReturnValue(false);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const menu = openRailMenu(container, "lilbee-chat-model-select")!;
+        expect(menu.useNativeMenu).toBe(false);
+    });
+
+    it("renders natively when the vault's Native menus setting is on", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        (view.app.vault as any).getConfig = vi.fn().mockReturnValue(true);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const menu = openRailMenu(container, "lilbee-chat-model-select")!;
+        expect(menu.useNativeMenu).toBe(true);
+        expect((view.app.vault as any).getConfig).toHaveBeenCalledWith("nativeMenus");
+    });
+
+    it("defaults to native on macOS when the setting is unset", async () => {
+        Notice.clear();
+        Platform.isMacOS = true;
+        try {
+            const plugin = makePlugin();
+            const view = new ChatView(makeLeaf(), plugin);
+            await view.onOpen();
+            await tick();
+
+            const container = view.containerEl.children[1] as unknown as MockElement;
+            const menu = openRailMenu(container, "lilbee-chat-model-select")!;
+            expect(menu.useNativeMenu).toBe(true);
+        } finally {
+            Platform.isMacOS = false;
+        }
+    });
+
+    it("defaults to the in-window menu when the vault has no getConfig API", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        (view.app.vault as any).getConfig = undefined;
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const menu = openRailMenu(container, "lilbee-chat-model-select")!;
+        expect(menu.useNativeMenu).toBe(false);
+    });
+
+    it("skips the document ESC listener for native menus", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        (view.app.vault as any).getConfig = vi.fn().mockReturnValue(true);
+        await view.onOpen();
+        await tick();
+
+        const addSpy = vi.fn();
+        const origAdd = document.addEventListener;
+        document.addEventListener = addSpy as typeof document.addEventListener;
+        try {
+            const container = view.containerEl.children[1] as unknown as MockElement;
+            openRailMenu(container, "lilbee-chat-model-select");
+            expect(addSpy).not.toHaveBeenCalled();
+        } finally {
+            document.addEventListener = origAdd;
+        }
     });
 
     it("keyboard activation (detail 0) anchors the menu to the chip instead of the mouse", async () => {

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -4241,7 +4241,7 @@ describe("ChatView — null-element guard branches", () => {
         expect((view as any).sending).toBe(false);
     });
 
-    it("sendMessage scrollToBottom no-ops when messagesEl becomes null mid-stream", async () => {
+    it("sendMessage scroll-follow no-ops when messagesEl becomes null mid-stream", async () => {
         Notice.clear();
         const plugin = makePlugin();
         const { mockFn, done } = makeStream([
@@ -4253,7 +4253,7 @@ describe("ChatView — null-element guard branches", () => {
         await view.onOpen();
         const messagesEl = (view as any).messagesEl as MockElement;
         const sendPromise = (view as any).sendMessage("hi");
-        // Drop messagesEl so the deferred scrollToBottom (797) hits its false branch.
+        // Drop messagesEl so the deferred renderFollowing hits its null-element branch.
         (view as any).messagesEl = null;
         await sendPromise;
         await done;
@@ -4354,6 +4354,76 @@ describe("ChatView — vault file picker enqueues the chosen file", () => {
         // The arrow (file) => this.enqueueAddFile(file) runs enqueueAddFile → addToLilbee.
         expect((plugin as any).addToLilbee).toHaveBeenCalledWith(file);
         spy.mockRestore();
+    });
+});
+
+describe("ChatView.sendMessage — sticky auto-scroll", () => {
+    async function streamWith(
+        events: SSEEvent[],
+        geometry: { scrollTop: number; scrollHeight: number; clientHeight: number },
+    ): Promise<MockElement> {
+        Notice.clear();
+        const plugin = makePlugin();
+        const { mockFn, done } = makeStream(events);
+        plugin.api.chatStream = mockFn;
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const messagesEl = container.find("lilbee-chat-messages")!;
+        container.find("lilbee-chat-textarea")!.value = "follow me";
+        container.find("lilbee-chat-send")!.trigger("click");
+        // Applied after the send (which pins unconditionally) so the geometry
+        // describes the view's state while the answer streams.
+        Object.assign(messagesEl, geometry);
+        await done;
+        await tick();
+        await tick();
+        return messagesEl;
+    }
+
+    it("follows the stream to the bottom when the view is pinned near it", async () => {
+        const messagesEl = await streamWith(
+            [
+                { event: SSE_EVENT.TOKEN, data: "hello" },
+                { event: SSE_EVENT.DONE, data: {} },
+            ],
+            // 1000 - 480 - 500 = 20px from the bottom — within the follow threshold.
+            { scrollTop: 480, scrollHeight: 1000, clientHeight: 500 },
+        );
+        expect(messagesEl.scrollTop).toBe(messagesEl.scrollHeight);
+    });
+
+    it("ends pinned to the bottom after DONE renders sources and reasoning", async () => {
+        const messagesEl = await streamWith(
+            [
+                { event: SSE_EVENT.TOKEN, data: "hello" },
+                { event: SSE_EVENT.REASONING, data: "thinking" },
+                { event: SSE_EVENT.SOURCES, data: [makeSource()] },
+                { event: SSE_EVENT.DONE, data: {} },
+            ],
+            { scrollTop: 480, scrollHeight: 1000, clientHeight: 500 },
+        );
+        expect(messagesEl.scrollTop).toBe(messagesEl.scrollHeight);
+    });
+
+    it("does not yank the view back down when the user scrolled up mid-stream", async () => {
+        const messagesEl = await streamWith(
+            [
+                { event: SSE_EVENT.TOKEN, data: "hello" },
+                { event: SSE_EVENT.DONE, data: {} },
+            ],
+            // 1000 - 100 - 500 = 400px above the bottom — reading older content.
+            { scrollTop: 100, scrollHeight: 1000, clientHeight: 500 },
+        );
+        expect(messagesEl.scrollTop).toBe(100);
+    });
+
+    it("isNearBottom is false when messagesEl is null", async () => {
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        (view as any).messagesEl = null;
+        expect((view as any).isNearBottom()).toBe(false);
     });
 });
 

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -17,7 +17,7 @@ if (typeof globalThis.document === "undefined") {
     };
 }
 
-import { Notice, WorkspaceLeaf } from "../__mocks__/obsidian";
+import { Menu, MockMenuItem, MockMenuSeparator, Notice, WorkspaceLeaf } from "../__mocks__/obsidian";
 import { MockElement } from "../__mocks__/obsidian";
 import { ChatView, VIEW_TYPE_CHAT, VaultFilePickerModal, electronDialog } from "../../src/views/chat-view";
 import { ok, err } from "neverthrow";
@@ -76,6 +76,7 @@ vi.mock("../../src/views/setup-wizard", () => ({
 }));
 import type { SSEEvent, Source } from "../../src/types";
 import { TaskQueue } from "../../src/task-queue";
+import { displayLabelForRef } from "../../src/utils/model-ref";
 
 function makeLeaf(): WorkspaceLeaf {
     return new WorkspaceLeaf();
@@ -105,6 +106,32 @@ function makeStream(events: SSEEvent[]): {
 /** Flush one macrotask tick so async chains settle. */
 function tick(): Promise<void> {
     return new Promise((r) => setTimeout(r, 0));
+}
+
+beforeEach(() => {
+    Menu.clear();
+});
+
+/** Click a rail chip trigger and return the Menu it opened (null when no menu was shown). */
+function openRailMenu(container: MockElement, triggerCls: string): Menu | null {
+    const before = Menu.instances.length;
+    container.find(triggerCls)!.trigger("click", { clientX: 0, clientY: 0 } as MouseEvent);
+    return Menu.instances.length > before ? Menu.instances[Menu.instances.length - 1] : null;
+}
+
+/** Titles of a menu's clickable items, separators excluded. */
+function menuTitles(menu: Menu | null): string[] {
+    return menu?.menuItems.map((i) => i.title) ?? [];
+}
+
+/** Open a chip's menu and click the item with the given title. */
+function pickRailItem(container: MockElement, triggerCls: string, title: string): void {
+    openRailMenu(container, triggerCls)!.itemTitled(title)!.click();
+}
+
+/** Text shown on a chip trigger. */
+function triggerText(container: MockElement, triggerCls: string): string {
+    return container.find(triggerCls)!.find("lilbee-model-chip-select-text")!.textContent;
 }
 
 function makePlugin(): LilbeePlugin {
@@ -321,7 +348,7 @@ describe("ChatView.onOpen — DOM structure", () => {
         expect(addBtn!.attributes["data-icon"]).toBe("paperclip");
     });
 
-    it("creates toolbar groups for icon+select pairs", () => {
+    it("creates toolbar groups for the chat and embed chips", () => {
         const groups = container.findAll("lilbee-toolbar-group");
         expect(groups.length).toBe(2);
     });
@@ -1239,18 +1266,18 @@ describe("ChatView.clearChat — via toolbar button", () => {
 });
 
 describe("ChatView.onOpen — model selector", () => {
-    it("creates a select element with class lilbee-chat-model-select", async () => {
+    it("creates a trigger button with class lilbee-chat-model-select", async () => {
         Notice.clear();
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select");
-        expect(select).not.toBeNull();
-        expect(select!.tagName).toBe("SELECT");
+        const trigger = container.find("lilbee-chat-model-select");
+        expect(trigger).not.toBeNull();
+        expect(trigger!.tagName).toBe("BUTTON");
     });
 
-    it("populates options from listModels API with catalog+Other pattern", async () => {
+    it("populates menu items from listModels API with catalog+Other pattern", async () => {
         Notice.clear();
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
@@ -1258,14 +1285,11 @@ describe("ChatView.onOpen — model selector", () => {
         await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        const options = select.children.filter((c) => c.tagName === "OPTION");
-        // With empty featured catalog, the separator is suppressed
-        // (would otherwise become the dropdown's displayed value);
-        // only the Other-section options remain.
-        expect(options.length).toBe(2);
-        expect(options[0].textContent).toBe("llama3");
-        expect(options[1].textContent).toBe("phi3");
+        const menu = openRailMenu(container, "lilbee-chat-model-select")!;
+        // With an empty featured catalog only the Other-section items remain,
+        // and no separator is emitted.
+        expect(menuTitles(menu)).toEqual(["llama3", "phi3"]);
+        expect(menu.items.some((i) => i instanceof MockMenuSeparator)).toBe(false);
     });
 
     it("emits a separator between featured-installed and other-installed sections", async () => {
@@ -1307,12 +1331,11 @@ describe("ChatView.onOpen — model selector", () => {
         await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        const options = select.children.filter((c) => c.tagName === "OPTION");
-        expect(options.length).toBe(3);
-        expect(options[0].textContent).toContain("Llama 3");
-        expect(options[1].disabled).toBe(true);
-        expect(options[2].textContent).toBe("phi3");
+        const menu = openRailMenu(container, "lilbee-chat-model-select")!;
+        expect(menu.items.length).toBe(3);
+        expect((menu.items[0] as MockMenuItem).title).toContain("Llama 3");
+        expect(menu.items[1]).toBeInstanceOf(MockMenuSeparator);
+        expect((menu.items[2] as MockMenuItem).title).toBe("phi3");
     });
 
     it("appends provider suffix for non-native installed models", async () => {
@@ -1329,9 +1352,7 @@ describe("ChatView.onOpen — model selector", () => {
         await tick();
 
         const c = view.containerEl.children[1] as unknown as MockElement;
-        const select = c.find("lilbee-chat-model-select")!;
-        const options = select.children.filter((ch) => ch.tagName === "OPTION");
-        const labels = options.map((o) => o.textContent);
+        const labels = menuTitles(openRailMenu(c, "lilbee-chat-model-select"));
         expect(labels).toContain("llama3");
         expect(labels).toContain("phi3 [ollama]");
         await view.onClose();
@@ -1378,9 +1399,7 @@ describe("ChatView.onOpen — model selector", () => {
         await tick();
 
         const c = view.containerEl.children[1] as unknown as MockElement;
-        const select = c.find("lilbee-chat-model-select")!;
-        const options = select.children.filter((ch) => ch.tagName === "OPTION");
-        const labels = options.map((o) => o.textContent);
+        const labels = menuTitles(openRailMenu(c, "lilbee-chat-model-select"));
         expect(labels).toContain("qwen3:8b [ollama]");
         await view.onClose();
     });
@@ -1442,8 +1461,7 @@ describe("ChatView.onOpen — model selector", () => {
         await tick();
 
         const c = view.containerEl.children[1] as unknown as MockElement;
-        const select = c.find("lilbee-chat-model-select")!;
-        const labels = select.children.filter((ch) => ch.tagName === "OPTION").map((o) => o.textContent);
+        const labels = menuTitles(openRailMenu(c, "lilbee-chat-model-select"));
         const idxOllama = labels.indexOf("Llama 3 [Ollama]");
         const idxFrontier = labels.indexOf("Gemini Flash [Gemini]");
         expect(idxOllama).toBeGreaterThanOrEqual(0);
@@ -1451,7 +1469,7 @@ describe("ChatView.onOpen — model selector", () => {
         await view.onClose();
     });
 
-    it("lists a ready hosted (frontier) model and marks it selected when active", async () => {
+    it("lists a ready hosted (frontier) model and marks it checked when active", async () => {
         Notice.clear();
         const plugin = makePlugin();
         // Active chat model is the hosted ref; it is NOT in the installed registry.
@@ -1495,15 +1513,15 @@ describe("ChatView.onOpen — model selector", () => {
         await tick();
 
         const c = view.containerEl.children[1] as unknown as MockElement;
-        const select = c.find("lilbee-chat-model-select")!;
-        const options = select.children.filter((ch) => ch.tagName === "OPTION");
-        const hosted = options.find((o) => o.textContent === "gemini-2.0-flash [Gemini]")!;
-        expect(hosted).toBeDefined();
-        expect((hosted as any).selected).toBe(true);
+        const hosted = openRailMenu(c, "lilbee-chat-model-select")!.itemTitled("gemini-2.0-flash [Gemini]");
+        expect(hosted).not.toBeNull();
+        expect(hosted!.checked).toBe(true);
+        // The chip shows the active hosted model.
+        expect(triggerText(c, "lilbee-chat-model-select")).toBe("gemini-2.0-flash [Gemini]");
         await view.onClose();
     });
 
-    it("shows (connecting...) option on both selects when listModels fails", async () => {
+    it("shows (connecting...) on both triggers when listModels fails", async () => {
         vi.useFakeTimers();
         Notice.clear();
         const plugin = makePlugin();
@@ -1515,15 +1533,16 @@ describe("ChatView.onOpen — model selector", () => {
         await vi.advanceTimersByTimeAsync(0);
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const chatSelect = container.find("lilbee-chat-model-select")!;
-        const chatOptions = chatSelect.children.filter((c) => c.tagName === "OPTION");
-        expect(chatOptions.some((o) => o.textContent === "(connecting...)")).toBe(true);
+        expect(triggerText(container, "lilbee-chat-model-select")).toBe("(connecting...)");
+        expect(triggerText(container, "lilbee-embed-model-select")).toBe("(connecting...)");
+        // No options while unreachable — clicking the chip opens nothing.
+        expect(openRailMenu(container, "lilbee-chat-model-select")).toBeNull();
 
         await view.onClose();
         vi.useRealTimers();
     });
 
-    it("change event calls setChatModel and updates activeModel", async () => {
+    it("picking a menu item calls setChatModel and updates activeModel", async () => {
         Notice.clear();
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
@@ -1531,15 +1550,16 @@ describe("ChatView.onOpen — model selector", () => {
         await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        (select as any).value = "phi3";
-        select.trigger("change");
+        pickRailItem(container, "lilbee-chat-model-select", "phi3");
         await tick();
 
         expect(plugin.api.setChatModel).toHaveBeenCalledWith("phi3");
+        expect(plugin.activeModel).toBe("phi3");
+        // The chip label updates to the picked model.
+        expect(triggerText(container, "lilbee-chat-model-select")).toBe("phi3");
     });
 
-    it("change event shows Notice on setChatModel failure", async () => {
+    it("handleChatSelection shows Notice on setChatModel failure", async () => {
         Notice.clear();
         const plugin = makePlugin();
         plugin.api.setChatModel = vi.fn().mockResolvedValue(err(new Error("fail")));
@@ -1547,10 +1567,7 @@ describe("ChatView.onOpen — model selector", () => {
         await view.onOpen();
         await tick();
 
-        const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        (select as any).value = "bad-model";
-        select.trigger("change");
+        (view as any).handleChatSelection("bad-model");
         await tick();
 
         expect(Notice.instances.some((n) => n.message.includes("failed to switch"))).toBe(true);
@@ -1563,10 +1580,7 @@ describe("ChatView.onOpen — model selector", () => {
         await view.onOpen();
         await tick();
 
-        const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        (select as any).value = "phi3";
-        select.trigger("change");
+        (view as any).handleChatSelection("phi3");
         await tick();
 
         expect(plugin.refreshSettingsTab).toHaveBeenCalled();
@@ -1580,16 +1594,13 @@ describe("ChatView.onOpen — model selector", () => {
         await view.onOpen();
         await tick();
 
-        const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        (select as any).value = "bad-model";
-        select.trigger("change");
+        (view as any).handleChatSelection("bad-model");
         await tick();
 
         expect(plugin.refreshSettingsTab).not.toHaveBeenCalled();
     });
 
-    it("change event does nothing when value is empty", async () => {
+    it("keyboard activation (detail 0) anchors the menu to the chip instead of the mouse", async () => {
         Notice.clear();
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
@@ -1597,31 +1608,18 @@ describe("ChatView.onOpen — model selector", () => {
         await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        (select as any).value = "";
-        select.trigger("change");
-        await tick();
+        const keyboardClick = {
+            detail: 0,
+            currentTarget: { getBoundingClientRect: () => ({ left: 12, bottom: 34 }) },
+        } as unknown as MouseEvent;
+        container.find("lilbee-chat-model-select")!.trigger("click", keyboardClick);
 
-        expect(plugin.api.setChatModel).not.toHaveBeenCalled();
+        const menu = Menu.instances[Menu.instances.length - 1];
+        expect(menu.visible).toBe(true);
+        expect(menu.position).toEqual({ x: 12, y: 34 });
     });
 
-    it("change event does nothing when value is separator key", async () => {
-        Notice.clear();
-        const plugin = makePlugin();
-        const view = new ChatView(makeLeaf(), plugin);
-        await view.onOpen();
-        await tick();
-
-        const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        (select as any).value = "__separator__";
-        select.trigger("change");
-        await tick();
-
-        expect(plugin.api.setChatModel).not.toHaveBeenCalled();
-    });
-
-    it("excludes uninstalled catalog models from dropdown options", async () => {
+    it("excludes uninstalled catalog models from menu items", async () => {
         Notice.clear();
         const plugin = makePlugin();
         mockChatPicker(plugin, {
@@ -1638,9 +1636,7 @@ describe("ChatView.onOpen — model selector", () => {
         await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        const options = select.children.filter((c: MockElement) => c.tagName === "OPTION");
-        const labels = options.map((o: MockElement) => o.textContent);
+        const labels = menuTitles(openRailMenu(container, "lilbee-chat-model-select"));
         expect(labels).toContain("llama3");
         expect(labels).not.toContain("phi3 (not installed)");
         expect(labels).not.toContain("phi3");
@@ -1668,10 +1664,7 @@ describe("ChatView.onOpen — model selector", () => {
         await view.onOpen();
         await tick();
 
-        const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        (select as any).value = "phi3";
-        select.trigger("change");
+        (view as any).handleChatSelection("phi3");
         await tick();
         // Allow async IIFE to complete
         await new Promise((r) => setTimeout(r, 50));
@@ -1703,10 +1696,7 @@ describe("ChatView.onOpen — model selector", () => {
         await view.onOpen();
         await tick();
 
-        const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        (select as any).value = "phi3";
-        select.trigger("change");
+        (view as any).handleChatSelection("phi3");
         await tick();
         await new Promise((r) => setTimeout(r, 50));
 
@@ -1735,10 +1725,7 @@ describe("ChatView.onOpen — model selector", () => {
         await view.onOpen();
         await tick();
 
-        const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        (select as any).value = "phi3";
-        select.trigger("change");
+        (view as any).handleChatSelection("phi3");
         await tick();
         await new Promise((r) => setTimeout(r, 50));
 
@@ -1766,10 +1753,7 @@ describe("ChatView.onOpen — model selector", () => {
         await view.onOpen();
         await tick();
 
-        const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        (select as any).value = "phi3";
-        select.trigger("change");
+        (view as any).handleChatSelection("phi3");
         await tick();
         await new Promise((r) => setTimeout(r, 50));
 
@@ -1797,10 +1781,7 @@ describe("ChatView.onOpen — model selector", () => {
         await view.onOpen();
         await tick();
 
-        const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        (select as any).value = "phi3";
-        select.trigger("change");
+        (view as any).handleChatSelection("phi3");
         await tick();
         await new Promise((r) => setTimeout(r, 50));
 
@@ -1829,10 +1810,7 @@ describe("ChatView.onOpen — model selector", () => {
         await view.onOpen();
         await tick();
 
-        const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        (select as any).value = "phi3";
-        select.trigger("change");
+        (view as any).handleChatSelection("phi3");
         await tick();
         await new Promise((r) => setTimeout(r, 50));
 
@@ -1861,10 +1839,7 @@ describe("ChatView.onOpen — model selector", () => {
         await view.onOpen();
         await tick();
 
-        const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        (select as any).value = "phi3";
-        select.trigger("change");
+        (view as any).handleChatSelection("phi3");
         await tick();
         await new Promise((r) => setTimeout(r, 50));
 
@@ -1895,10 +1870,7 @@ describe("ChatView.onOpen — model selector", () => {
         await view.onOpen();
         await tick();
 
-        const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        (select as any).value = "phi3";
-        select.trigger("change");
+        (view as any).handleChatSelection("phi3");
         await tick();
         await new Promise((r) => setTimeout(r, 50));
 
@@ -1926,10 +1898,7 @@ describe("ChatView.onOpen — model selector", () => {
         await view.onOpen();
         await tick();
 
-        const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        (select as any).value = "phi3";
-        select.trigger("change");
+        (view as any).handleChatSelection("phi3");
         await tick();
         await new Promise((r) => setTimeout(r, 50));
 
@@ -1960,10 +1929,7 @@ describe("ChatView.onOpen — model selector", () => {
         await view.onOpen();
         await tick();
 
-        const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        (select as any).value = "phi3";
-        select.trigger("change");
+        (view as any).handleChatSelection("phi3");
         await tick();
         await new Promise((r) => setTimeout(r, 50));
 
@@ -2107,7 +2073,7 @@ describe("VaultFilePickerModal", () => {
 });
 
 describe("ChatView — toolbar groups and tooltips", () => {
-    it("groups chat dot+label+select in the first model chip", async () => {
+    it("groups chat dot+label+trigger in the first model chip", async () => {
         Notice.clear();
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
@@ -2178,6 +2144,9 @@ describe("ChatView.onOpen — add file button opens menu", () => {
         const container = view.containerEl.children[1] as unknown as MockElement;
         const addBtn = container.find("lilbee-chat-add-file")!;
         addBtn.trigger("click", { clientX: 0, clientY: 0 } as MouseEvent);
+        const menu = Menu.instances[Menu.instances.length - 1];
+        menu.itemTitled(MESSAGES.WIZARD_FILE_PICKER_DISK)!.click();
+        menu.itemTitled(MESSAGES.WIZARD_FOLDER_PICKER_DISK)!.click();
         await tick();
         await tick();
 
@@ -2195,6 +2164,7 @@ describe("ChatView.onOpen — add file button opens menu", () => {
         const container = view.containerEl.children[1] as unknown as MockElement;
         const addBtn = container.find("lilbee-chat-add-file")!;
         addBtn.trigger("click", { clientX: 0, clientY: 0 } as MouseEvent);
+        Menu.instances[Menu.instances.length - 1].itemTitled(MESSAGES.WIZARD_FILE_PICKER_DISK)!.click();
         await tick();
 
         expect((plugin as any).addExternalFiles).not.toHaveBeenCalled();
@@ -2211,9 +2181,27 @@ describe("ChatView.onOpen — add file button opens menu", () => {
         const container = view.containerEl.children[1] as unknown as MockElement;
         const addBtn = container.find("lilbee-chat-add-file")!;
         addBtn.trigger("click", { clientX: 0, clientY: 0 } as MouseEvent);
+        Menu.instances[Menu.instances.length - 1].itemTitled(MESSAGES.WIZARD_FILE_PICKER_DISK)!.click();
         await tick();
 
         expect(Notice.instances.some((n) => n.message.includes("could not open file picker"))).toBe(true);
+    });
+
+    it("crawl web menu item opens the CrawlModal", async () => {
+        Notice.clear();
+        const { CrawlModal } = await import("../../src/views/crawl-modal");
+        (CrawlModal as unknown as ReturnType<typeof vi.fn>).mockClear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        container.find("lilbee-chat-add-file")!.trigger("click", { clientX: 0, clientY: 0 } as MouseEvent);
+        const crawlItem = Menu.instances[Menu.instances.length - 1].itemTitled(MESSAGES.WIZARD_CRAWL_WEB)!;
+        expect(crawlItem.icon).toBe("globe");
+        crawlItem.click();
+
+        expect(CrawlModal).toHaveBeenCalled();
     });
 
     it("uog: ESC keydown dismisses the paperclip menu", async () => {
@@ -2253,6 +2241,7 @@ describe("ChatView.onOpen — add file button opens menu", () => {
 
             const escRemoval = removeEvents.find(([type]) => type === "keydown");
             expect(escRemoval).toBeDefined();
+            expect(Menu.instances[Menu.instances.length - 1].visible).toBe(false);
         } finally {
             document.addEventListener = origAdd as typeof document.addEventListener;
             document.removeEventListener = origRemove as typeof document.removeEventListener;
@@ -2670,10 +2659,7 @@ describe("ChatView.onClose — aborts both controllers", () => {
         await view.onOpen();
         await tick();
 
-        const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        (select as any).value = "phi3";
-        select.trigger("change");
+        (view as any).handleChatSelection("phi3");
         await tick();
 
         // pullController should be set
@@ -2900,17 +2886,13 @@ describe("ChatView — offline retry", () => {
         await vi.advanceTimersByTimeAsync(0);
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const chatSelect = container.find("lilbee-chat-model-select")!;
-        const chatOptions = chatSelect.children.filter((c) => c.tagName === "OPTION");
-        expect(chatOptions.some((o) => o.textContent === "(connecting...)")).toBe(true);
+        expect(triggerText(container, "lilbee-chat-model-select")).toBe("(connecting...)");
 
         // Server comes back online; the 5s retry hits the new mocks.
         online = true;
         await vi.advanceTimersByTimeAsync(5000);
 
-        const updatedOptions = chatSelect.children.filter((c) => c.tagName === "OPTION");
-        expect(updatedOptions.some((o) => o.textContent === "llama3")).toBe(true);
-        expect(updatedOptions.some((o) => o.textContent === "(connecting...)")).toBe(false);
+        expect(triggerText(container, "lilbee-chat-model-select")).toBe("llama3");
 
         await view.onClose();
     });
@@ -3000,7 +2982,7 @@ describe("ChatView — offline retry", () => {
         expect((view as any).retryCount).toBe(0);
     });
 
-    it("clears existing options before retry", async () => {
+    it("keeps a single connecting label across retries", async () => {
         const plugin = makePlugin();
         plugin.api.catalog = vi.fn().mockRejectedValue(new Error("offline"));
         plugin.api.installedModels = vi.fn().mockRejectedValue(new Error("offline"));
@@ -3011,22 +2993,11 @@ describe("ChatView — offline retry", () => {
         await vi.advanceTimersByTimeAsync(0);
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const chatSelect = container.find("lilbee-chat-model-select")!;
+        expect(triggerText(container, "lilbee-chat-model-select")).toBe("(connecting...)");
 
-        // After first failure: exactly one (connecting...) option
-        let connectingOptions = chatSelect.children.filter(
-            (c) => c.tagName === "OPTION" && c.textContent === "(connecting...)",
-        );
-        expect(connectingOptions.length).toBe(1);
-
-        // Advance past retry — second failure
+        // Advance past retry — second failure; label unchanged, not duplicated.
         await vi.advanceTimersByTimeAsync(5000);
-
-        // Still exactly one (connecting...) option (not duplicated)
-        connectingOptions = chatSelect.children.filter(
-            (c) => c.tagName === "OPTION" && c.textContent === "(connecting...)",
-        );
-        expect(connectingOptions.length).toBe(1);
+        expect(triggerText(container, "lilbee-chat-model-select")).toBe("(connecting...)");
 
         await view.onClose();
     });
@@ -3041,20 +3012,18 @@ describe("ChatView — offline retry", () => {
         await view.onOpen();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const chatSelect = container.find("lilbee-chat-model-select")!;
 
         // Failure 1 — connecting
         await vi.advanceTimersByTimeAsync(0);
-        expect(chatSelect.children.some((c) => c.textContent === "(connecting...)")).toBe(true);
+        expect(triggerText(container, "lilbee-chat-model-select")).toBe("(connecting...)");
 
         // Failure 2 — still connecting
         await vi.advanceTimersByTimeAsync(5000);
-        expect(chatSelect.children.some((c) => c.textContent === "(connecting...)")).toBe(true);
+        expect(triggerText(container, "lilbee-chat-model-select")).toBe("(connecting...)");
 
         // Failure 3 — switches to offline
         await vi.advanceTimersByTimeAsync(5000);
-        expect(chatSelect.children.some((c) => c.textContent === "(offline)")).toBe(true);
-        expect(chatSelect.children.some((c) => c.textContent === "(connecting...)")).toBe(false);
+        expect(triggerText(container, "lilbee-chat-model-select")).toBe("(offline)");
 
         await view.onClose();
     });
@@ -3096,9 +3065,7 @@ describe("ChatView — offline retry", () => {
         expect((view as any).retryTimer).toBeNull();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const chatSelect = container.find("lilbee-chat-model-select")!;
-        const options = chatSelect.children.filter((c) => c.tagName === "OPTION");
-        expect(options.some((o) => o.textContent === "llama3")).toBe(true);
+        expect(menuTitles(openRailMenu(container, "lilbee-chat-model-select"))).toContain("llama3");
 
         await view.onClose();
     });
@@ -3194,40 +3161,36 @@ describe("ChatView — embedding model selector", () => {
         confirmModalResult = true;
     });
 
-    it("creates an embedding select element with class lilbee-embed-model-select", async () => {
+    it("creates an embedding trigger button with class lilbee-embed-model-select", async () => {
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-embed-model-select");
-        expect(select).not.toBeNull();
-        expect(select!.tagName).toBe("SELECT");
+        const trigger = container.find("lilbee-embed-model-select");
+        expect(trigger).not.toBeNull();
+        expect(trigger!.tagName).toBe("BUTTON");
     });
 
-    it("populates embedding options from catalog API", async () => {
+    it("populates embedding menu items from catalog API", async () => {
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
         await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-embed-model-select")!;
-        const options = select.children.filter((c) => c.tagName === "OPTION");
-        expect(options.length).toBe(1);
-        expect(options[0].textContent).toBe("nomic-embed-text");
-        expect(options[0].value).toBe("nomic-embed-text");
+        expect(menuTitles(openRailMenu(container, "lilbee-embed-model-select"))).toEqual(["nomic-embed-text"]);
     });
 
-    it("marks the active embedding model as selected", async () => {
+    it("marks the active embedding model as checked and shows it on the chip", async () => {
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
         await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-embed-model-select")!;
-        const options = select.children.filter((c) => c.tagName === "OPTION");
-        expect(options[0].selected).toBe(true);
+        const menu = openRailMenu(container, "lilbee-embed-model-select")!;
+        expect(menu.itemTitled("nomic-embed-text")!.checked).toBe(true);
+        expect(triggerText(container, "lilbee-embed-model-select")).toBe("nomic-embed-text");
     });
 
     it("shows fallback option from config when catalog is empty", async () => {
@@ -3241,11 +3204,10 @@ describe("ChatView — embedding model selector", () => {
         await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-embed-model-select")!;
-        const options = select.children.filter((c) => c.tagName === "OPTION");
-        expect(options.length).toBe(1);
-        expect(options[0].textContent).toBe("custom-embed");
-        expect(options[0].selected).toBe(true);
+        const menu = openRailMenu(container, "lilbee-embed-model-select")!;
+        expect(menuTitles(menu)).toEqual(["custom-embed"]);
+        expect(menu.itemTitled("custom-embed")!.checked).toBe(true);
+        expect(triggerText(container, "lilbee-embed-model-select")).toBe("custom-embed");
     });
 
     it("shows fallback option when catalog returns error", async () => {
@@ -3257,13 +3219,10 @@ describe("ChatView — embedding model selector", () => {
         await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-embed-model-select")!;
-        const options = select.children.filter((c) => c.tagName === "OPTION");
-        expect(options.length).toBe(1);
-        expect(options[0].textContent).toBe("fallback-embed");
+        expect(menuTitles(openRailMenu(container, "lilbee-embed-model-select"))).toEqual(["fallback-embed"]);
     });
 
-    it("shows no options when catalog is empty and config has no embedding_model", async () => {
+    it("shows no menu when catalog is empty and config has no embedding_model", async () => {
         const plugin = makePlugin();
         plugin.api.catalog = vi
             .fn()
@@ -3274,22 +3233,21 @@ describe("ChatView — embedding model selector", () => {
         await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-embed-model-select")!;
-        const options = select.children.filter((c) => c.tagName === "OPTION");
-        expect(options.length).toBe(0);
+        expect(openRailMenu(container, "lilbee-embed-model-select")).toBeNull();
+        expect(triggerText(container, "lilbee-embed-model-select")).toBe("");
     });
 
     it("shows confirmation modal when embedding model is changed", async () => {
         const { ConfirmModal } = await import("../../src/views/confirm-modal");
         const plugin = makePlugin();
+        // Active embedding differs from the picked item so the pick is a real change.
+        plugin.api.config = vi.fn().mockResolvedValue({ chat_model: "llama3", embedding_model: "previous-embed" });
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
         await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-embed-model-select")!;
-        (select as any).value = "nomic-embed-text";
-        select.trigger("change");
+        pickRailItem(container, "lilbee-embed-model-select", "nomic-embed-text");
         await tick();
 
         expect(ConfirmModal).toHaveBeenCalled();
@@ -3297,14 +3255,13 @@ describe("ChatView — embedding model selector", () => {
 
     it("calls setEmbeddingModel and shows notices on confirm", async () => {
         const plugin = makePlugin();
+        plugin.api.config = vi.fn().mockResolvedValue({ chat_model: "llama3", embedding_model: "previous-embed" });
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
         await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-embed-model-select")!;
-        (select as any).value = "nomic-embed-text";
-        select.trigger("change");
+        pickRailItem(container, "lilbee-embed-model-select", "nomic-embed-text");
         await tick();
 
         expect(plugin.api.setEmbeddingModel).toHaveBeenCalledWith("nomic-embed-text");
@@ -3319,21 +3276,43 @@ describe("ChatView — embedding model selector", () => {
     it("4u1: embedding setEmbeddingModel failure does NOT refresh the Settings tab", async () => {
         Notice.clear();
         const plugin = makePlugin();
+        plugin.api.config = vi.fn().mockResolvedValue({ chat_model: "llama3", embedding_model: "previous-embed" });
         plugin.api.setEmbeddingModel = vi.fn().mockResolvedValue(err(new Error("nope")));
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
         await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-embed-model-select")!;
-        (select as any).value = "nomic-embed-text";
-        select.trigger("change");
+        pickRailItem(container, "lilbee-embed-model-select", "nomic-embed-text");
         await tick();
 
         expect(plugin.refreshSettingsTab).not.toHaveBeenCalled();
     });
 
-    it("reverts dropdown on cancel", async () => {
+    /** Simulate picking a value absent from the menu: optimistic label, then the handler. */
+    function pickEmbeddingValue(view: ChatView, value: string): void {
+        (view as any).embeddingTriggerTextEl.setText(value);
+        (view as any).handleEmbeddingSelection(value);
+    }
+
+    it("re-picking the active embedding model is a no-op (no confirm, no API call)", async () => {
+        const { ConfirmModal } = await import("../../src/views/confirm-modal");
+        (ConfirmModal as unknown as ReturnType<typeof vi.fn>).mockClear();
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        // "nomic-embed-text" is the active (checked) item.
+        pickRailItem(container, "lilbee-embed-model-select", "nomic-embed-text");
+        await tick();
+
+        expect(ConfirmModal).not.toHaveBeenCalled();
+        expect(plugin.api.setEmbeddingModel).not.toHaveBeenCalled();
+    });
+
+    it("reverts the chip label on cancel", async () => {
         confirmModalResult = false;
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
@@ -3341,16 +3320,14 @@ describe("ChatView — embedding model selector", () => {
         await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-embed-model-select")!;
-        (select as any).value = "other-model";
-        select.trigger("change");
+        pickEmbeddingValue(view, "other-model");
         await tick();
 
         expect(plugin.api.setEmbeddingModel).not.toHaveBeenCalled();
-        expect(select.value).toBe("nomic-embed-text");
+        expect(triggerText(container, "lilbee-embed-model-select")).toBe("nomic-embed-text");
     });
 
-    it("reverts dropdown and shows notice on setEmbeddingModel failure", async () => {
+    it("reverts the chip label and shows notice on setEmbeddingModel failure", async () => {
         const plugin = makePlugin();
         plugin.api.setEmbeddingModel = vi.fn().mockResolvedValue(err(new Error("fail")));
         const view = new ChatView(makeLeaf(), plugin);
@@ -3358,16 +3335,14 @@ describe("ChatView — embedding model selector", () => {
         await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-embed-model-select")!;
-        (select as any).value = "other-model";
-        select.trigger("change");
+        pickEmbeddingValue(view, "other-model");
         await tick();
 
         expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_FAILED_EMBEDDING)).toBe(true);
-        expect(select.value).toBe("nomic-embed-text");
+        expect(triggerText(container, "lilbee-embed-model-select")).toBe("nomic-embed-text");
     });
 
-    it("reverts dropdown and shows notice on setEmbeddingModel network error", async () => {
+    it("reverts the chip label and shows notice on setEmbeddingModel network error", async () => {
         const plugin = makePlugin();
         plugin.api.setEmbeddingModel = vi.fn().mockResolvedValue(err(new Error("network")));
         const view = new ChatView(makeLeaf(), plugin);
@@ -3375,28 +3350,11 @@ describe("ChatView — embedding model selector", () => {
         await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-embed-model-select")!;
-        (select as any).value = "other-model";
-        select.trigger("change");
+        pickEmbeddingValue(view, "other-model");
         await tick();
 
         expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_FAILED_EMBEDDING)).toBe(true);
-        expect(select.value).toBe("nomic-embed-text");
-    });
-
-    it("does nothing when change value is empty", async () => {
-        const plugin = makePlugin();
-        const view = new ChatView(makeLeaf(), plugin);
-        await view.onOpen();
-        await tick();
-
-        const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-embed-model-select")!;
-        (select as any).value = "";
-        select.trigger("change");
-        await tick();
-
-        expect(plugin.api.setEmbeddingModel).not.toHaveBeenCalled();
+        expect(triggerText(container, "lilbee-embed-model-select")).toBe("nomic-embed-text");
     });
 
     it("rail-level Browse more button opens the full catalog", async () => {
@@ -3431,15 +3389,13 @@ describe("ChatView — embedding model selector", () => {
         await vi.advanceTimersByTimeAsync(0);
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const embedSelect = container.find("lilbee-embed-model-select")!;
-        const options = embedSelect.children.filter((c) => c.tagName === "OPTION");
-        expect(options.some((o) => o.textContent === "(connecting...)")).toBe(true);
+        expect(triggerText(container, "lilbee-embed-model-select")).toBe("(connecting...)");
 
         await view.onClose();
         vi.useRealTimers();
     });
 
-    it("shows offline label on embedding select after threshold", async () => {
+    it("shows offline label on embedding trigger after threshold", async () => {
         vi.useFakeTimers();
         const plugin = makePlugin();
         plugin.api.catalog = vi.fn().mockRejectedValue(new Error("offline"));
@@ -3456,9 +3412,7 @@ describe("ChatView — embedding model selector", () => {
         await vi.advanceTimersByTimeAsync(5000);
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const embedSelect = container.find("lilbee-embed-model-select")!;
-        const options = embedSelect.children.filter((c) => c.tagName === "OPTION");
-        expect(options.some((o) => o.textContent === "(offline)")).toBe(true);
+        expect(triggerText(container, "lilbee-embed-model-select")).toBe("(offline)");
 
         await view.onClose();
         vi.useRealTimers();
@@ -3521,10 +3475,7 @@ describe("ChatView — embedding model selector", () => {
         await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-embed-model-select")!;
-        const options = select.children.filter((c) => c.tagName === "OPTION");
-        expect(options.length).toBe(1);
-        expect(options[0].textContent).toBe("nomic-embed-text");
+        expect(menuTitles(openRailMenu(container, "lilbee-embed-model-select"))).toEqual(["nomic-embed-text"]);
     });
 
     it("handles null config gracefully", async () => {
@@ -3535,23 +3486,22 @@ describe("ChatView — embedding model selector", () => {
         await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-embed-model-select")!;
-        const options = select.children.filter((c) => c.tagName === "OPTION");
         // Should still show models from catalog, just none marked active
-        expect(options.length).toBe(1);
-        expect(options[0].textContent).toBe("nomic-embed-text");
+        const menu = openRailMenu(container, "lilbee-embed-model-select")!;
+        expect(menuTitles(menu)).toEqual(["nomic-embed-text"]);
+        expect(menu.itemTitled("nomic-embed-text")!.checked).toBe(false);
     });
 
-    it("revertEmbeddingSelect no-ops when embeddingSelectEl is null", async () => {
+    it("revertEmbeddingTrigger no-ops when embeddingTriggerTextEl is null", async () => {
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
-        (view as any).embeddingSelectEl = null;
+        (view as any).embeddingTriggerTextEl = null;
         // Should not throw
-        (view as any).revertEmbeddingSelect("test");
+        (view as any).revertEmbeddingTrigger("test");
     });
 
-    it("revertEmbeddingSelect falls back to a server refresh when the previous value is not in options", async () => {
+    it("revertEmbeddingTrigger falls back to a server refresh when the previous value is not in options", async () => {
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
@@ -3561,7 +3511,7 @@ describe("ChatView — embedding model selector", () => {
             .spyOn(view as unknown as { fetchAndFillSelectors: () => Promise<void> }, "fetchAndFillSelectors")
             .mockResolvedValue();
 
-        (view as any).revertEmbeddingSelect("totally-unknown-model");
+        (view as any).revertEmbeddingTrigger("totally-unknown-model");
 
         expect(fetchSpy).toHaveBeenCalled();
     });
@@ -3582,17 +3532,15 @@ describe("ChatView — embedding model selector", () => {
         await tick();
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-embed-model-select")!;
-        const options = select.children.filter((c) => c.tagName === "OPTION");
-        expect(options.length).toBe(1);
-        expect(options[0].textContent).toBe("fallback");
+        expect(menuTitles(openRailMenu(container, "lilbee-embed-model-select"))).toEqual(["fallback"]);
+        expect(triggerText(container, "lilbee-embed-model-select")).toBe("fallback");
     });
 
-    it("fillEmbeddingSelector with null embeddingSelectEl is a no-op", async () => {
+    it("fillEmbeddingSelector with null embeddingTriggerTextEl does not throw", async () => {
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
-        (view as any).embeddingSelectEl = null;
+        (view as any).embeddingTriggerTextEl = null;
         // Should not throw
         (view as any).fillEmbeddingSelector(null, null);
     });
@@ -3745,29 +3693,20 @@ describe("ChatView — role separation on main-screen selectors", () => {
         expect(plugin.api.catalog).toHaveBeenCalledWith({ task: "embedding" });
 
         const container = view.containerEl.children[1] as unknown as MockElement;
-        const chatSelect = container.find("lilbee-chat-model-select")!;
-        const embedSelect = container.find("lilbee-embed-model-select")!;
+        const chatItems = menuTitles(openRailMenu(container, "lilbee-chat-model-select"));
+        const embedItems = menuTitles(openRailMenu(container, "lilbee-embed-model-select"));
 
-        const chatOptionValues = chatSelect.children
-            .map((c) => (c as any).value ?? c.textContent)
-            .filter((v: string) => v !== "__separator__");
-        const embedOptionValues = embedSelect.children.map((c) => (c as any).value ?? c.textContent);
-
-        // Chat selector echoes models.chat.installed — including the contaminated names.
-        // This proves the plugin delegates role filtering to the server (no client-side
-        // re-filter that could drift out of sync with the server contract). Using sorted
-        // equality pins BOTH directions: no entries dropped, no entries added. If the
-        // plugin later adds a client-side filter, this fails. Order is normalized because
-        // the dropdown renders entries sorted — the invariant is the set, not the order.
-        expect([...chatOptionValues].sort()).toEqual(
-            ["llama3", "Qwen/Qwen2-VL-7B-Instruct", "BAAI/bge-reranker-v2-m3"].sort(),
+        // Set equality (sorted, order-independent): the chat menu echoes
+        // models.chat.installed verbatim — role filtering belongs to the server.
+        expect([...chatItems].sort()).toEqual(
+            ["llama3", "Qwen/Qwen2-VL-7B-Instruct", "BAAI/bge-reranker-v2-m3"].map(displayLabelForRef).sort(),
         );
-        expect(chatOptionValues).toHaveLength(3);
+        expect(chatItems).toHaveLength(3);
 
-        // Embedding selector is populated from catalog({task: EMBEDDING}), which the
+        // Embedding menu is populated from catalog({task: EMBEDDING}), which the
         // server scopes to embedding models. If the plugin were reading from listModels
         // or a broader catalog call, vision/reranker names could leak here.
-        expect(embedOptionValues).toEqual(["nomic-embed-text"]);
+        expect(embedItems).toEqual(["nomic-embed-text"]);
     });
 });
 
@@ -3972,7 +3911,7 @@ describe("ChatView — optional model rail (Vision, Rerank)", () => {
         expect(labels).toContain("Rerank");
     });
 
-    it("Vision chip with no installed model still shows a select with Disabled + Browse", async () => {
+    it("Vision chip with no installed model still shows a menu with Disabled + Browse", async () => {
         const { CatalogModal } = await import("../../src/views/catalog-modal");
         (CatalogModal as unknown as ReturnType<typeof vi.fn>).mockClear();
         const plugin = makePlugin();
@@ -3982,15 +3921,13 @@ describe("ChatView — optional model rail (Vision, Rerank)", () => {
         await tick();
         const container = view.containerEl.children[1] as unknown as MockElement;
 
-        const select = container.find("lilbee-vision-model-select")!;
-        const optionTexts = select.options.map((o) => o.textContent);
-        expect(optionTexts).toEqual(["(disabled)", "Browse catalog…"]);
-        select.value = "__lilbee_browse__";
-        select.trigger("change");
+        const menu = openRailMenu(container, "lilbee-vision-model-select")!;
+        expect(menuTitles(menu)).toEqual(["(disabled)", "Browse catalog…"]);
+        menu.itemTitled("Browse catalog…")!.click();
         expect(CatalogModal).toHaveBeenCalledWith(expect.anything(), plugin, "vision");
     });
 
-    it("renders a Vision dropdown with Disabled + models + Browse when installed", async () => {
+    it("renders a Vision menu with Disabled + models + Browse when installed", async () => {
         const plugin = makePlugin();
         configureRoles(plugin, { vision: ["llava-7b", "qwen-vl"], visionActive: "llava-7b" });
         const view = new ChatView(makeLeaf(), plugin);
@@ -3998,9 +3935,10 @@ describe("ChatView — optional model rail (Vision, Rerank)", () => {
         await tick();
         const container = view.containerEl.children[1] as unknown as MockElement;
 
-        const select = container.find("lilbee-vision-model-select")!;
-        const optionTexts = select.options.map((o) => o.textContent);
-        expect(optionTexts).toEqual(["(disabled)", "llava-7b", "qwen-vl", "Browse catalog…"]);
+        const menu = openRailMenu(container, "lilbee-vision-model-select")!;
+        expect(menuTitles(menu)).toEqual(["(disabled)", "llava-7b", "qwen-vl", "Browse catalog…"]);
+        expect(menu.itemTitled("llava-7b")!.checked).toBe(true);
+        expect(triggerText(container, "lilbee-vision-model-select")).toBe("llava-7b");
     });
 
     it("includes hosted (LiteLLM) vision models with a Hosted suffix", async () => {
@@ -4026,9 +3964,9 @@ describe("ChatView — optional model rail (Vision, Rerank)", () => {
         await tick();
         const container = view.containerEl.children[1] as unknown as MockElement;
 
-        const optionTexts = container.find("lilbee-vision-model-select")!.options.map((o) => o.textContent);
-        expect(optionTexts).toContain("llava-7b");
-        expect(optionTexts.some((t) => t.includes("gpt-4o") && t.includes("Hosted"))).toBe(true);
+        const titles = menuTitles(openRailMenu(container, "lilbee-vision-model-select"));
+        expect(titles).toContain("llava-7b");
+        expect(titles.some((t) => t.includes("gpt-4o") && t.includes("Hosted"))).toBe(true);
     });
 
     it("fills the dot with is-active when a Vision model is active", async () => {
@@ -4053,11 +3991,12 @@ describe("ChatView — optional model rail (Vision, Rerank)", () => {
 
         const visionDot = container.findAll("is-vision")[0];
         expect(visionDot.classList.contains("is-active")).toBe(false);
-        const visionSelect = container.find("lilbee-vision-model-select")!;
-        expect(visionSelect.value).toBe("");
+        // The chip shows the disabled label, and the menu checks Disabled.
+        expect(triggerText(container, "lilbee-vision-model-select")).toBe("(disabled)");
+        expect(openRailMenu(container, "lilbee-vision-model-select")!.itemTitled("(disabled)")!.checked).toBe(true);
     });
 
-    it("selecting a Vision model calls setVisionModel and refreshes", async () => {
+    it("picking a Vision model calls setVisionModel and refreshes", async () => {
         const plugin = makePlugin();
         configureRoles(plugin, { vision: ["llava-7b", "qwen-vl"], visionActive: "llava-7b" });
         const view = new ChatView(makeLeaf(), plugin);
@@ -4065,16 +4004,14 @@ describe("ChatView — optional model rail (Vision, Rerank)", () => {
         await tick();
         const container = view.containerEl.children[1] as unknown as MockElement;
 
-        const select = container.find("lilbee-vision-model-select")!;
-        select.value = "qwen-vl";
-        select.trigger("change");
+        pickRailItem(container, "lilbee-vision-model-select", "qwen-vl");
         await tick();
 
         expect(plugin.api.setVisionModel).toHaveBeenCalledWith("qwen-vl");
         expect(plugin.fetchActiveModel).toHaveBeenCalled();
     });
 
-    it("selecting Disabled turns Vision off via setVisionModel('')", async () => {
+    it("picking Disabled turns Vision off via setVisionModel('')", async () => {
         const plugin = makePlugin();
         configureRoles(plugin, { vision: ["llava-7b"], visionActive: "llava-7b" });
         const view = new ChatView(makeLeaf(), plugin);
@@ -4082,15 +4019,13 @@ describe("ChatView — optional model rail (Vision, Rerank)", () => {
         await tick();
         const container = view.containerEl.children[1] as unknown as MockElement;
 
-        const select = container.find("lilbee-vision-model-select")!;
-        select.value = "";
-        select.trigger("change");
+        pickRailItem(container, "lilbee-vision-model-select", "(disabled)");
         await tick();
 
         expect(plugin.api.setVisionModel).toHaveBeenCalledWith("");
     });
 
-    it("selecting Browse catalog… from the Vision dropdown opens the catalog and resets the value", async () => {
+    it("picking Browse catalog… from the Vision menu opens the catalog and keeps the chip label", async () => {
         const { CatalogModal } = await import("../../src/views/catalog-modal");
         (CatalogModal as unknown as ReturnType<typeof vi.fn>).mockClear();
         const plugin = makePlugin();
@@ -4100,13 +4035,11 @@ describe("ChatView — optional model rail (Vision, Rerank)", () => {
         await tick();
         const container = view.containerEl.children[1] as unknown as MockElement;
 
-        const select = container.find("lilbee-vision-model-select")!;
-        select.value = "__lilbee_browse__";
-        select.trigger("change");
+        pickRailItem(container, "lilbee-vision-model-select", "Browse catalog…");
 
         expect(CatalogModal).toHaveBeenCalledWith(expect.anything(), plugin, "vision");
         expect(plugin.api.setVisionModel).not.toHaveBeenCalled();
-        expect(select.value).toBe("llava-7b");
+        expect(triggerText(container, "lilbee-vision-model-select")).toBe("llava-7b");
     });
 
     it("surfaces a Notice when setVisionModel fails", async () => {
@@ -4118,15 +4051,13 @@ describe("ChatView — optional model rail (Vision, Rerank)", () => {
         await tick();
         const container = view.containerEl.children[1] as unknown as MockElement;
 
-        const select = container.find("lilbee-vision-model-select")!;
-        select.value = "qwen-vl";
-        select.trigger("change");
+        pickRailItem(container, "lilbee-vision-model-select", "qwen-vl");
         await tick();
 
         expect(Notice.instances.some((n) => n.message.includes("Vision"))).toBe(true);
     });
 
-    it("selecting a Rerank model calls setRerankerModel", async () => {
+    it("picking a Rerank model calls setRerankerModel", async () => {
         const plugin = makePlugin();
         configureRoles(plugin, { rerank: ["bge-reranker", "jina-reranker"], rerankActive: "bge-reranker" });
         const view = new ChatView(makeLeaf(), plugin);
@@ -4134,9 +4065,7 @@ describe("ChatView — optional model rail (Vision, Rerank)", () => {
         await tick();
         const container = view.containerEl.children[1] as unknown as MockElement;
 
-        const select = container.find("lilbee-rerank-model-select")!;
-        select.value = "jina-reranker";
-        select.trigger("change");
+        pickRailItem(container, "lilbee-rerank-model-select", "jina-reranker");
         await tick();
 
         expect(plugin.api.setRerankerModel).toHaveBeenCalledWith("jina-reranker");
@@ -4152,69 +4081,54 @@ describe("ChatView — optional model rail (Vision, Rerank)", () => {
         await tick();
         const container = view.containerEl.children[1] as unknown as MockElement;
 
-        const select = container.find("lilbee-rerank-model-select")!;
-        select.value = "__lilbee_browse__";
-        select.trigger("change");
+        pickRailItem(container, "lilbee-rerank-model-select", "Browse catalog…");
         expect(CatalogModal).toHaveBeenCalledWith(expect.anything(), plugin, "rerank");
     });
 });
 
 describe("ChatView — null-element guard branches", () => {
-    it("fetchAndFillSelectors skips selector fills when chatSelectEl is null", async () => {
+    it("fetchAndFillSelectors skips trigger updates when both trigger text els are null", async () => {
         Notice.clear();
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
         await tick();
-        // Null both selects so the success-path guards (347/351) take the false branch.
-        (view as any).chatSelectEl = null;
-        (view as any).embeddingSelectEl = null;
+        // Null both triggers so the success-path optional chains take the false branch.
+        (view as any).chatTriggerTextEl = null;
+        (view as any).embeddingTriggerTextEl = null;
         (view as any).fetchAndFillSelectors();
         await tick();
         // No throw, and a successful fetch leaves retryCount at 0.
         expect((view as any).retryCount).toBe(0);
     });
 
-    it("fetchAndFillSelectors catch path skips selectors when both are null", async () => {
+    it("fetchAndFillSelectors catch path skips triggers when both are null", async () => {
         Notice.clear();
         const plugin = makePlugin();
-        // Force the Promise.all chain to reject so the catch (372/376) runs.
+        // Force the Promise.all chain to reject so the catch runs.
         (plugin.api as any).catalog = vi.fn().mockRejectedValue(new Error("boom"));
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
         await tick();
-        (view as any).chatSelectEl = null;
-        (view as any).embeddingSelectEl = null;
+        (view as any).chatTriggerTextEl = null;
+        (view as any).embeddingTriggerTextEl = null;
         const before = (view as any).retryCount;
         (view as any).fetchAndFillSelectors();
         await tick();
-        // Catch ran (retryCount incremented) without touching the null selects.
+        // Catch ran (retryCount incremented) without touching the null triggers.
         expect((view as any).retryCount).toBeGreaterThan(before);
         // Stop the retry timer the catch scheduled.
         const t = (view as any).retryTimer;
         if (t) clearTimeout(t);
     });
 
-    it("refreshModelSelector no-ops the empties when both selects are null", async () => {
+    it("refreshRail re-syncs the rail via fetchAndFillSelectors", async () => {
         Notice.clear();
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
         await tick();
-        (view as any).chatSelectEl = null;
-        (view as any).embeddingSelectEl = null;
         const spy = vi.spyOn(view as any, "fetchAndFillSelectors").mockImplementation(() => {});
-        (view as any).refreshModelSelector();
-        expect(spy).toHaveBeenCalled();
-    });
-
-    it("refreshRail re-syncs the rail via refreshModelSelector", async () => {
-        Notice.clear();
-        const plugin = makePlugin();
-        const view = new ChatView(makeLeaf(), plugin);
-        await view.onOpen();
-        await tick();
-        const spy = vi.spyOn(view as any, "refreshModelSelector").mockImplementation(() => {});
         view.refreshRail();
         expect(spy).toHaveBeenCalled();
     });
@@ -4328,13 +4242,10 @@ describe("ChatView — confirm-pull declined", () => {
         const autoPullSpy = vi.spyOn(view as any, "autoPullAndSet").mockResolvedValue(undefined);
         await view.onOpen();
         await tick();
-        const container = view.containerEl.children[1] as unknown as MockElement;
-        const select = container.find("lilbee-chat-model-select")!;
-        select.value = "acme/uninstalled";
-        select.trigger("change");
+        (view as any).handleChatSelection("acme/uninstalled");
         await tick();
         await tick();
-        // confirmed === false → autoPullAndSet must not run (539 false branch).
+        // confirmed === false → autoPullAndSet must not run.
         expect(autoPullSpy).not.toHaveBeenCalled();
     });
 });
@@ -4342,13 +4253,8 @@ describe("ChatView — confirm-pull declined", () => {
 describe("ChatView — vault file picker enqueues the chosen file", () => {
     it("choosing a vault file calls plugin.addToLilbee", async () => {
         Notice.clear();
-        // The menu mock fires every item's onClick, including the native picker.
-        const dialogSpy = vi
-            .spyOn(electronDialog, "showOpenDialog")
-            .mockResolvedValue({ canceled: true, filePaths: [] });
         const plugin = makePlugin();
         (plugin as any).addToLilbee = vi.fn().mockResolvedValue(undefined);
-        (plugin as any).addExternalFiles = vi.fn().mockResolvedValue(undefined);
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
 
@@ -4363,6 +4269,7 @@ describe("ChatView — vault file picker enqueues the chosen file", () => {
 
         const container = view.containerEl.children[1] as unknown as MockElement;
         container.find("lilbee-chat-add-file")!.trigger("click", { clientX: 0, clientY: 0 } as MouseEvent);
+        Menu.instances[Menu.instances.length - 1].itemTitled(MESSAGES.WIZARD_FILE_PICKER_VAULT)!.click();
 
         expect(captured).toHaveLength(1);
         const file = { path: "notes/a.md", name: "a.md" } as any;
@@ -4370,7 +4277,6 @@ describe("ChatView — vault file picker enqueues the chosen file", () => {
         // The arrow (file) => this.enqueueAddFile(file) runs enqueueAddFile → addToLilbee.
         expect((plugin as any).addToLilbee).toHaveBeenCalledWith(file);
         spy.mockRestore();
-        dialogSpy.mockRestore();
     });
 });
 


### PR DESCRIPTION
## Problem
The model rail chips use native `<select>` dropdowns. On macOS the option list is drawn by the OS outside the app window, so it can't be themed and never shows up in window-scoped screen recordings — the rerank reel can't show a model being picked.

## Solution
Clicking a chip now opens a menu with the same options as before and the active model checked; selecting an item does exactly what the dropdown did. The menus follow Obsidian's "Native menus" appearance setting: native by default on macOS (native scrolling and ergonomics), rendered in-window when the setting is off — which is what the demo vault uses so the recorder can capture the picker. Full suite passes at 100% coverage; the rerank demo tape moves to the menu in a separate change.

## Also: managed-server lifecycle fixes
Testing this build surfaced a vault stuck on "lilbee: error" with two orphaned servers running. Three fixes ride along: the port file from a previous run is deleted before spawning (so a stale port is never adopted), an in-flight server start bails after plugin unload instead of leaking a spawn, and a child whose startup discovery fails is killed so retries start clean.

## Also: chat auto-scroll
The chat view now follows a streaming answer to the bottom — including the final growth from sources and reasoning — but only while the view is already pinned there; scrolling up to read mid-stream is respected.