### PR TITLE
Explain a chat stream that dies mid-read instead of saying 'network error'

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -554,6 +554,10 @@ export const MESSAGES = {
     ERROR_SERVER_UNREACHABLE: "Could not connect to lilbee server. Is it running?",
     ERROR_STREAM: (msg: string) => `lilbee: ${msg}`,
     ERROR_CHAT_FAILED: (reason: string) => `Chat failed: ${reason}`,
+    ERROR_STREAM_INTERRUPTED_MANAGED:
+        "Chat failed: the server closed the stream unexpectedly. Check the server logs in the logs folder of lilbee's data directory (inside Obsidian's app data folder), then try again.",
+    ERROR_STREAM_INTERRUPTED_EXTERNAL:
+        "Chat failed: the server closed the stream unexpectedly. Check the output of your lilbee serve process, then try again.",
     NOTICE_MODEL_UNAVAILABLE_SETUP: "Your model isn't available. Opening setup so you can pick a working one.",
     ERROR_RATE_LIMITED: (retryAfterSeconds: number | null) =>
         retryAfterSeconds !== null

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -161,6 +161,19 @@ export function sessionTokenInvalidMessage(serverMode: ServerMode): string {
         : MESSAGES.NOTICE_SESSION_TOKEN_INVALID;
 }
 
+/** Chromium rejects a response stream that dies mid-read with this TypeError message. */
+const STREAM_INTERRUPTED_MESSAGE = "network error";
+
+export function isStreamInterruptedError(err: unknown): boolean {
+    return err instanceof TypeError && err.message === STREAM_INTERRUPTED_MESSAGE;
+}
+
+export function streamInterruptedMessage(serverMode: ServerMode): string {
+    return serverMode === SERVER_MODE.MANAGED
+        ? MESSAGES.ERROR_STREAM_INTERRUPTED_MANAGED
+        : MESSAGES.ERROR_STREAM_INTERRUPTED_EXTERNAL;
+}
+
 /**
  * Pull a human-readable message out of an unknown thrown value.
  * Centralizes the `err instanceof Error ? err.message : <fallback>` pattern.

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -50,6 +50,8 @@ import {
     noticeForResultError,
     getRelevantSystemMemoryGB,
     configString,
+    isStreamInterruptedError,
+    streamInterruptedMessage,
 } from "../utils";
 import { SetupWizard } from "./setup-wizard";
 import { hostedOptions, isUsableHostedRow } from "./catalog-helpers";
@@ -866,6 +868,8 @@ export class ChatView extends ItemView {
                 }
             } else if (err instanceof RateLimitedError) {
                 this.renderInlineError(assistantBubble, MESSAGES.ERROR_RATE_LIMITED(err.retryAfterSeconds));
+            } else if (isStreamInterruptedError(err)) {
+                this.renderInlineError(assistantBubble, streamInterruptedMessage(this.plugin.settings.serverMode));
             } else {
                 this.renderInlineError(
                     assistantBubble,

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -13,6 +13,8 @@ import {
     formatElapsed,
     getRelevantSystemMemoryGB,
     isRoleMismatchDetail,
+    isStreamInterruptedError,
+    streamInterruptedMessage,
     noticeForResultError,
     noticeServerUnreachableIfApplicable,
     percentFromSse,
@@ -229,6 +231,28 @@ describe("extractSseErrorMessage", () => {
 
     it("falls back for a payload with no message field", () => {
         expect(extractSseErrorMessage({ other: "x" }, "fallback")).toBe("fallback");
+    });
+});
+
+describe("isStreamInterruptedError", () => {
+    it("matches Chromium's mid-read stream TypeError", () => {
+        expect(isStreamInterruptedError(new TypeError("network error"))).toBe(true);
+    });
+
+    it("ignores other TypeErrors and non-TypeErrors", () => {
+        expect(isStreamInterruptedError(new TypeError("Failed to fetch"))).toBe(false);
+        expect(isStreamInterruptedError(new Error("network error"))).toBe(false);
+        expect(isStreamInterruptedError("network error")).toBe(false);
+    });
+});
+
+describe("streamInterruptedMessage", () => {
+    it("points managed mode at the data-directory logs", () => {
+        expect(streamInterruptedMessage(SERVER_MODE.MANAGED)).toBe(MESSAGES.ERROR_STREAM_INTERRUPTED_MANAGED);
+    });
+
+    it("points external mode at the lilbee serve output", () => {
+        expect(streamInterruptedMessage(SERVER_MODE.EXTERNAL)).toBe(MESSAGES.ERROR_STREAM_INTERRUPTED_EXTERNAL);
     });
 });
 

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -1172,6 +1172,39 @@ describe("ChatView.sendMessage — API throws", () => {
         expect((view as any).history.length).toBe(0);
     });
 
+    it.each([
+        ["managed", MESSAGES.ERROR_STREAM_INTERRUPTED_MANAGED],
+        ["external", MESSAGES.ERROR_STREAM_INTERRUPTED_EXTERNAL],
+    ])("maps a dead stream (TypeError: network error) to the %s-mode log pointer", async (mode, expected) => {
+        Notice.clear();
+        const plugin = makePlugin();
+        (plugin.settings as { serverMode?: string }).serverMode = mode;
+        let resolveThrown!: () => void;
+        const thrown = new Promise<void>((r) => {
+            resolveThrown = r;
+        });
+        plugin.api.chatStream = vi.fn().mockReturnValue(
+            (async function* () {
+                resolveThrown();
+                throw new TypeError("network error");
+            })(),
+        );
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const messagesEl = container.find("lilbee-chat-messages")!;
+        const textarea = container.find("lilbee-chat-textarea")!;
+        textarea.value = "dead stream question";
+
+        container.find("lilbee-chat-send")!.trigger("click");
+        await thrown;
+        await tick();
+
+        const errBubble = messagesEl.children[1];
+        expect(errBubble.find("lilbee-chat-error-text")!.textContent).toBe(expected);
+        expect(Notice.instances.some((n) => n.message === expected)).toBe(true);
+    });
+
     it("surfaces 'Chat failed' Notice when handleSend itself throws synchronously", async () => {
         Notice.clear();
         const plugin = makePlugin();


### PR DESCRIPTION
## Problem
When the server's chat pipeline crashes after the SSE response has started, the connection drops with no body and Chromium rejects the read with `TypeError: network error`. The chat view relayed that verbatim as "Chat failed: network error", which says nothing about what happened or where to look. This is exactly what a vault with an embedder/index dimension mismatch produced.

## Solution
The chat view now recognizes that specific failure and shows a clear message: the server closed the stream unexpectedly, with a pointer to the server logs. Managed mode points at the logs folder in lilbee's data directory; external mode points at the `lilbee serve` output. Other errors keep the existing reason passthrough.

Pairs with the server change that emits a proper SSE error event for pre-stream failures; this message covers older servers and hard crashes that still drop the connection.