### PR TITLE
Fix the integration suite crashing on import since the store review

### DIFF
--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
     test: {
         globals: true,
         environment: "node",
+        setupFiles: ["tests/setup.ts"],
         include: ["tests/integration.test.ts"],
         testTimeout: 180_000,
         alias: {


### PR DESCRIPTION
The store review commit (0455d6a) swapped node.fetch in binary-manager from globalThis.fetch to window.fetch to satisfy the obsidianmd/no-global-this store rule. That binding is evaluated at module scope, and the integration suite runs vitest with environment: node, where window does not exist. Importing binary-manager now throws ReferenceError before any test runs, which is why Integration Test has been red on every push to main since.

The unit suite already solves exactly this with tests/setup.ts, which mirrors window and activeWindow onto globalThis. The integration config just never loaded it. This adds the same setupFiles line there, so window.fetch resolves to Node's fetch during integration runs and to the renderer's fetch inside Obsidian.

Verified locally on macOS: the integration suite passes (download and server start, 2/2), unit tests stay at 100% coverage, and lint, format, and the store eslint config are all clean.