### PR TITLE
Install from the Obsidian community plugin store

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This plugin runs **[lilbee](https://lilbee.sh/)** against your vault and gives y
   <a href="https://www.typescriptlang.org/"><img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-5.6-blue?logo=typescript&logoColor=white"></a>
   <a href="https://opensource.org/licenses/MIT"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
   <img alt="Platforms" src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey.svg">
-  <a href="https://obsidian.md"><img alt="Obsidian" src="https://img.shields.io/badge/Obsidian-Plugin-7c3aed?logo=obsidian&logoColor=white"></a>
+  <a href="https://community.obsidian.md/plugins/lilbee"><img alt="Obsidian community plugin" src="https://img.shields.io/badge/Obsidian-Community%20plugin-7c3aed?logo=obsidian&logoColor=white"></a>
   <a href="https://github.com/tobocop2/obsidian-lilbee/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/tobocop2/obsidian-lilbee/total"></a>
 </p>
 
@@ -29,9 +29,9 @@ Ask a question in plain English and lilbee answers from your vault, with citatio
 
 > **Tutorial reel:** every recording on this page (and a few extras) as videos with longer notes at [**obsidian.lilbee.sh/tutorial**](https://obsidian.lilbee.sh/tutorial).
 
-> ## ⚠️ Beta software
+> ## Now in the Obsidian community plugin store
 >
-> The plugin is in **active beta**. Installation goes through [BRAT](https://github.com/TfTHacker/obsidian42-brat) so you always get the latest pre-release. Interfaces, settings layout, and on-disk formats may shift between betas. Feedback, bug reports, and issues are very welcome; that's the whole point of the beta.
+> lilbee is an official [community plugin](https://community.obsidian.md/plugins/lilbee): install it from **Settings → Community plugins** inside Obsidian, nothing else needed. Feedback, bug reports, and issues are very welcome.
 
 > **Heads up: this downloads to your computer.** lilbee is a local search engine with its own models, so the plugin fetches the lilbee server (a few hundred MB) on first launch and the models you pick from the catalog (a few hundred MB up to several GB each) when you choose them. It's all stored locally and runs on your machine.
 
@@ -64,7 +64,7 @@ Ask a question in plain English and lilbee answers from your vault, with citatio
 
 ## Why a local search engine for Obsidian
 
-A vault is already a curated set of documents: notes you've taken, PDFs you've collected, scans you've filed away. That's exactly what a local search engine wants. This plugin points lilbee at your vault so a local model can reason over your library and answer with citations you click straight back to the source.
+A vault is already a curated set of documents: notes you've taken, PDFs you've collected, scans you've filed away. That's exactly what a local search engine wants. This plugin points lilbee at your vault so a local model can reason over your library with retrieval-augmented generation (RAG) and answer with citations you click straight back to the source.
 
 An [Encarta 99](https://en.wikipedia.org/wiki/Encarta) you build for yourself, from your own vault, shaped to your needs.
 
@@ -157,14 +157,12 @@ The plugin reads everything you've indexed and writes a wiki about it. Pages com
 
 ## Quick start
 
-1. Install **[BRAT](https://github.com/TfTHacker/obsidian42-brat)** in Obsidian (Settings → Community plugins → Browse → search "BRAT" → Install → Enable).
-2. Open the command palette (`Cmd/Ctrl + P`) → **BRAT: Plugins: Add a beta plugin for testing** → paste `tobocop2/obsidian-lilbee` → **Add Plugin**.
-3. Enable **lilbee** in Settings → Community plugins.
-4. The Setup Wizard auto-launches. Pick a chat model and an embedding model from the featured grid, then run the initial sync.
+1. In Obsidian, open **Settings → Community plugins → Browse**, search for **"lilbee"**, then **Install** and **Enable**. (Or start from the [store listing](https://community.obsidian.md/plugins/lilbee).)
+2. The Setup Wizard auto-launches. Pick a chat model and an embedding model from the featured grid, then run the initial sync.
 
 The plugin downloads and manages the [lilbee](https://lilbee.sh/) server automatically; nothing to install separately. The first launch fetches the right version for your platform and verifies it before starting. Wait for the status bar to show `lilbee: ready`, then open the chat.
 
-<p align="center"><img alt="first run on a fresh vault: install lilbee through BRAT, walk the setup wizard, and ask a question that gets a cited answer from your notes" src="https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/first_start.gif" width="640"></p>
+<p align="center"><img alt="first run on a fresh vault: install lilbee from the community plugin store, walk the setup wizard, and ask a question that gets a cited answer from your notes" src="https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/first_start.gif" width="640"></p>
 
 > **Hardware note:** the server runs on your CPU or GPU. A Mac with Apple Silicon (M1+) or a PC with an NVIDIA / AMD / Intel Arc GPU gives the best performance. 8 GB of RAM is the minimum; 16 to 32 GB is recommended. See [lilbee's hardware requirements](https://github.com/tobocop2/lilbee#hardware-requirements) for the full table.
 
@@ -191,7 +189,7 @@ Vaults on the same computer share one lilbee install and one model cache, so dow
 
 ## Updating the plugin
 
-Settings → BRAT → Beta Plugin List → click the edit (pencil) icon next to lilbee → change the version to the latest release tag. BRAT downloads the new version. **Restart Obsidian** after the update for the new version to take effect.
+Obsidian handles plugin updates: **Settings → Community plugins → Check for updates**, then update lilbee like any other plugin.
 
 ## Updating the server
 

--- a/site/index.html
+++ b/site/index.html
@@ -3,18 +3,25 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>lilbee for Obsidian: run local AI models and search your vault</title>
-<meta name="description" content="Obsidian's interface to lilbee. Browse a model catalog, pull a model that runs on your own machine, and ask questions about anything in your vault (notes, PDFs, ebooks, code, scans, 150+ file types) with the source one click away. Everything runs on your computer; cloud models are optional.">
+<title>lilbee: an Obsidian plugin for local AI chat and vault search</title>
+<meta name="description" content="lilbee is an Obsidian community plugin that runs local AI models for chat and semantic search over your vault: notes, PDFs, ebooks, code, scans, 150+ file types, with the source one click away. Crawl websites into your vault, pull models from a built-in catalog, or use your Ollama or LM Studio setup. Everything runs on your computer; cloud models are optional.">
 <link rel="canonical" href="https://obsidian.lilbee.sh/">
 
 <!-- Open Graph: rich link previews. -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="lilbee for Obsidian">
-<meta property="og:title" content="lilbee for Obsidian: run local AI models and search your vault">
-<meta property="og:description" content="Browse a model catalog, pull a model that runs on your own machine, and ask your Obsidian vault questions in plain English (notes, PDFs, ebooks, code, scans, 150+ file types) with the source one click away. Runs on your computer; cloud models optional.">
+<meta property="og:title" content="lilbee: an Obsidian plugin for local AI chat and vault search">
+<meta property="og:description" content="An Obsidian community plugin that runs local AI models for chat and semantic search over your vault (notes, PDFs, ebooks, code, scans, 150+ file types) with the source one click away. Runs on your computer; cloud models optional.">
 <meta property="og:url" content="https://obsidian.lilbee.sh/">
 <meta property="og:image" content="https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/what_is_lilbee.contact.png">
 <meta property="og:image:alt" content="lilbee for Obsidian: a cited answer from a vault note, shown inside Obsidian">
+
+<!-- Twitter Card: rich previews on X and clients that read the Twitter tags. -->
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="lilbee: an Obsidian plugin for local AI chat and vault search">
+<meta name="twitter:description" content="An Obsidian community plugin that runs local AI models for chat and semantic search over your vault, with the source one click away. Runs on your computer; cloud models optional.">
+<meta name="twitter:image" content="https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/what_is_lilbee.contact.png">
+<meta name="twitter:image:alt" content="lilbee for Obsidian: a cited answer from a vault note, shown inside Obsidian">
 
 <!-- SoftwareApplication JSON-LD: tells search engines what this is. -->
 <script type="application/ld+json">
@@ -22,10 +29,12 @@
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
   "name": "lilbee for Obsidian",
-  "description": "An Obsidian plugin and the vault interface to lilbee: ask your vault questions in plain English and get answers with the source one click away. Local-first; cloud models optional.",
+  "description": "An Obsidian community plugin that runs local AI models and turns your vault (notes, PDFs, ebooks, code, scans) into a searchable library you can chat with, with answers that cite the source. Includes a web crawler that saves sites into your vault as markdown, a model catalog from Hugging Face Hub, and works with your existing Ollama or LM Studio setup. Available in the Obsidian community plugin store.",
   "applicationCategory": "ProductivityApplication",
   "operatingSystem": "Obsidian (macOS, Windows, Linux)",
+  "keywords": "Obsidian plugin, Obsidian AI plugin, Obsidian community plugin, chat with your notes, second brain, local AI, local LLM, RAG, retrieval-augmented generation, semantic search, vector search, embeddings, cited answers, web crawler, OCR, PDF search, knowledge base, self-hosted, privacy, offline, Ollama, LM Studio",
   "url": "https://obsidian.lilbee.sh/",
+  "installUrl": "https://community.obsidian.md/plugins/lilbee",
   "license": "https://github.com/tobocop2/obsidian-lilbee/blob/main/LICENSE",
   "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
   "author": { "@type": "Person", "name": "Tobias Perelstein", "url": "https://github.com/tobocop2" },
@@ -44,6 +53,7 @@
     <div class="topstrip">
       <div><span class="badge">lilbee for Obsidian</span> <span>v0.6.66b</span></div>
       <div>
+        <span class="pill">In the community plugin store</span>
         <span class="pill">Runs offline</span>
         <span class="pill">100% coverage</span>
         <span class="pill">MIT</span>
@@ -188,7 +198,7 @@
           <div class="tutorial-clip">
             <video src="https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/first_start.webm" controls loop muted autoplay playsinline preload="metadata"></video>
           </div>
-          <p class="tutorial-caption">Brand-new on a fresh vault: install lilbee through BRAT, walk the setup wizard (pick a chat model and an embedder), then ask your first question and get a cited answer from your own notes, with a click-through to the source.</p>
+          <p class="tutorial-caption">Brand-new on a fresh vault: install lilbee from the community plugin store, walk the setup wizard (pick a chat model and an embedder), then ask your first question and get a cited answer from your own notes, with a click-through to the source.</p>
         </div>
 
         <div class="tutorialpane" role="tabpanel" id="tutorial-pane-tour" aria-labelledby="tutorial-tab-tour" hidden>
@@ -211,16 +221,14 @@
     <section>
       <div class="label">install</div>
       <div class="install">
-        <span class="prompt">slug:</span>
-        <span class="cmd">tobocop2/obsidian-lilbee</span>
-        <button type="button" class="copy" aria-label="Copy install slug">[ COPY ]</button>
+        <span class="prompt">store:</span>
+        <a class="cmd" href="obsidian://show-plugin?id=lilbee">obsidian://show-plugin?id=lilbee</a>
       </div>
       <div class="steps">
-        <div class="step"><span class="n">1</span><span>In Obsidian, install <a href="https://github.com/TfTHacker/obsidian42-brat">BRAT</a> from <em>Settings → Community plugins → Browse</em>. It's the standard helper for plugins still in beta.</span></div>
-        <div class="step"><span class="n">2</span><span>Run <em>BRAT: Add a beta plugin</em> and paste the slug above. Then enable <em>lilbee</em> in Community plugins.</span></div>
-        <div class="step"><span class="n">3</span><span>A setup wizard opens: pick a chat model and run the first sync. That's it; lilbee brings its own engine, nothing else to install.</span></div>
+        <div class="step"><span class="n">1</span><span>lilbee is in the official <a href="https://community.obsidian.md/plugins/lilbee">Obsidian community plugin store</a>. In Obsidian, go to <em>Settings → Community plugins → Browse</em>, search for <em>lilbee</em>, then <em>Install</em> and <em>Enable</em>. The link above jumps straight to the plugin page in Obsidian.</span></div>
+        <div class="step"><span class="n">2</span><span>A setup wizard opens: pick a chat model and run the first sync. That's it; lilbee brings its own engine, nothing else to install.</span></div>
       </div>
-      <p class="extras">lilbee is in active development, with frequent releases; BRAT updates you automatically. <a href="https://github.com/tobocop2/obsidian-lilbee/releases">latest release on GitHub &rarr;</a></p>
+      <p class="extras">lilbee is in active development, with frequent releases; updates arrive through Obsidian's plugin updater. <a href="https://community.obsidian.md/plugins/lilbee">view the store listing &rarr;</a></p>
       <p class="extras">It's early days. If it's useful to you, a <a href="https://github.com/tobocop2/obsidian-lilbee">&#9733; on GitHub</a> helps other Obsidian users find it, and bug reports are very welcome.</p>
     </section>
 
@@ -285,7 +293,7 @@
       <div class="links">
         <a href="https://github.com/tobocop2/obsidian-lilbee"><span class="num">[1]</span><span>GitHub</span><span class="dots">·······································</span><span class="desc">source &amp; readme</span></a>
         <a href="https://obsidian.lilbee.sh/tutorial"><span class="num">[2]</span><span>Tutorial reel</span><span class="dots">·······································</span><span class="desc">videos</span></a>
-        <a href="https://github.com/tobocop2/obsidian-lilbee#quick-start"><span class="num">[3]</span><span>Quick start</span><span class="dots">·······································</span><span class="desc">BRAT setup</span></a>
+        <a href="https://community.obsidian.md/plugins/lilbee"><span class="num">[3]</span><span>Plugin store</span><span class="dots">·······································</span><span class="desc">install</span></a>
         <a href="https://github.com/tobocop2/obsidian-lilbee/blob/main/docs/usage.md"><span class="num">[4]</span><span>Usage guide</span><span class="dots">·······································</span><span class="desc">commands &amp; settings</span></a>
         <a href="https://lilbee.sh/"><span class="num">[5]</span><span>lilbee</span><span class="dots">·······································</span><span class="desc">the engine</span></a>
         <a href="https://github.com/tobocop2/obsidian-lilbee/releases"><span class="num">[6]</span><span>Releases</span><span class="dots">·······································</span><span class="desc">changelog</span></a>

--- a/site/main.js
+++ b/site/main.js
@@ -1,5 +1,4 @@
-// Interactivity for the lilbee for Obsidian landing page: the tutorial reel tabs
-// and the copy-to-clipboard button on the install slug.
+// Interactivity for the lilbee for Obsidian landing page: the tutorial reel tabs.
 
 (function () {
   'use strict';
@@ -42,38 +41,5 @@
     });
   }
 
-  /** Copy the install slug to the clipboard when its [ COPY ] button is clicked. */
-  function initCopyButton() {
-    document.addEventListener('click', function (event) {
-      var button = event.target.closest('.copy');
-      if (!button) return;
-      var row = button.closest('.install');
-      var slug = row ? row.querySelector('.cmd') : null;
-      copyText(slug ? slug.textContent : '', function () { flashCopied(button); });
-    });
-  }
-
-  function copyText(text, done) {
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(text).then(done, done);
-      return;
-    }
-    var area = document.createElement('textarea');
-    area.value = text;
-    document.body.appendChild(area);
-    area.select();
-    try { document.execCommand('copy'); } catch (error) { /* clipboard unavailable */ }
-    document.body.removeChild(area);
-    done();
-  }
-
-  function flashCopied(button) {
-    if (button.textContent.indexOf('COPIED') !== -1) return;
-    var original = button.textContent;
-    button.textContent = '[ COPIED ]';
-    setTimeout(function () { button.textContent = original; }, 1200);
-  }
-
   initTablists();
-  initCopyButton();
 })();

--- a/site/style.css
+++ b/site/style.css
@@ -419,19 +419,8 @@ h1.sr {
   font-weight: 500;
   word-break: break-word;
 }
-.install .copy {
-  font-family: var(--mono);
-  font-size: 12px;
-  letter-spacing: 0.16em;
-  background: transparent;
-  border: none;
-  border-left: 1px solid var(--rule-2);
-  color: var(--ink-2);
-  padding: 0 1.1rem;
-  cursor: pointer;
-  white-space: nowrap;
-}
-.install .copy:hover { color: var(--accent-hot); background: rgba(124, 58, 237, 0.09); }
+.install a.cmd { color: var(--accent); }
+.install a.cmd:hover { color: var(--accent-hot); }
 
 .steps { margin-top: 1rem; display: grid; gap: 0.55rem; }
 .step { display: flex; gap: 0.8rem; font-size: 14px; color: var(--ink-2); line-height: 1.6; }

--- a/site/tutorial/tutorial.js
+++ b/site/tutorial/tutorial.js
@@ -46,7 +46,7 @@ const groups = [
     id: "set-up-and-tune",
     heading: "Set up &amp; tune",
     reels: [
-      { id: "first-start", name: "first_start", title: "First run: install to first cited answer", desc: "Brand-new to lilbee, on a fresh vault. Install it through BRAT, walk the setup wizard (pick a chat model and an embedder, run the first sync), then ask a question and get a cited answer from your own notes, with a click-through to the source. The whole onboarding in one take." },
+      { id: "first-start", name: "first_start", title: "First run: install to first cited answer", desc: "Brand-new to lilbee, on a fresh vault. Install it from the community plugin store, walk the setup wizard (pick a chat model and an embedder, run the first sync), then ask a question and get a cited answer from your own notes, with a click-through to the source. The whole onboarding in one take." },
       { id: "settings", name: "settings", title: "Settings", desc: "50+ settings: search depth, reranking, sampling, parsers, the wiki. Sane defaults; tune the moment you want to." },
       { id: "tour", name: "tour", title: "Tour: the palette as an async control surface", desc: "Fire a crawl, a file add, and a model download back to back without waiting, watch all three run at once in the Task Center, then ask the just-crawled page a cited question." },
     ],


### PR DESCRIPTION
lilbee was accepted into the official Obsidian community plugin store, so every BRAT instruction is now obsolete.

The README drops the beta-software warning for a short callout that lilbee is an official community plugin, and the quick start and update sections now just use Obsidian's own plugin browser and updater. The site swaps the BRAT slug box for an obsidian://show-plugin?id=lilbee deep link plus the store listing at community.obsidian.md/plugins/lilbee, and its metadata gets an SEO pass modeled on the lilbee server site.

The first-start reel still shows the BRAT install; it's being re-recorded separately on gh-pages.