### PR TITLE
Open the post-wizard workspace as a main-area chat with the Task Center at the side

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1807,34 +1807,32 @@ export default class LilbeePlugin extends Plugin {
     }
 
     /**
-     * Open the chat view and the task center as adjacent leaves in the right
-     * sidebar so a fresh-install user lands on a usable workspace without
-     * having to discover the ribbon icon and the slash command. Idempotent —
-     * if either view is already open, just reveal it; no duplicates.
+     * Open the chat view in the main editor area and the task center in the
+     * right sidebar so a fresh-install user lands on a usable workspace
+     * without having to discover the ribbon icon and the slash command.
+     * Idempotent — if either view is already open, just reveal it; no
+     * duplicates.
      */
     async openCockpit(): Promise<void> {
         const workspace = this.app.workspace;
         const existingChat = workspace.getLeavesOfType(VIEW_TYPE_CHAT);
         const existingTasks = workspace.getLeavesOfType(VIEW_TYPE_TASKS);
 
+        // Chat gets a main-area tab: the post-wizard workspace is empty, and
+        // a sidebar leaf compresses the conversation into a narrow column.
         let chatLeaf = existingChat[0] ?? null;
         if (!chatLeaf) {
-            const leaf = workspace.getRightLeaf(false);
+            const leaf = workspace.getLeaf(true);
             if (!leaf) return;
             chatLeaf = leaf;
             await chatLeaf.setViewState({ type: VIEW_TYPE_CHAT, active: true });
         }
 
-        // Task center lives as a bottom panel under the editor — not a right
-        // sidebar tab, because the right sidebar collapses sibling leaves into
-        // tabs and only one would be visible at a time. getLeaf("split",
-        // "horizontal") splits the active root leaf in the main editor area
-        // along the horizontal axis (editor on top, task center beneath).
         let tasksLeaf = existingTasks[0] ?? null;
         if (!tasksLeaf) {
-            const split = workspace.getLeaf("split", "horizontal");
-            if (split) {
-                tasksLeaf = split;
+            const leaf = workspace.getRightLeaf(false);
+            if (leaf) {
+                tasksLeaf = leaf;
                 await tasksLeaf.setViewState({ type: VIEW_TYPE_TASKS, active: true });
             }
         }

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -3475,18 +3475,18 @@ describe("LilbeePlugin", () => {
     });
 
     describe("openCockpit()", () => {
-        it("opens chat in the right sidebar and splits the task center under the editor", async () => {
+        it("opens chat in the main area and the task center in the right sidebar", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
             const chatLeaf = { setViewState: vi.fn().mockResolvedValue(undefined) };
             const tasksLeaf = { setViewState: vi.fn().mockResolvedValue(undefined) };
             plugin.app.workspace.getLeavesOfType = vi.fn().mockReturnValue([]);
-            plugin.app.workspace.getRightLeaf = vi.fn().mockReturnValue(chatLeaf);
-            plugin.app.workspace.getLeaf = vi.fn().mockReturnValue(tasksLeaf);
+            plugin.app.workspace.getLeaf = vi.fn().mockReturnValue(chatLeaf);
+            plugin.app.workspace.getRightLeaf = vi.fn().mockReturnValue(tasksLeaf);
             plugin.app.workspace.revealLeaf = vi.fn();
             await plugin.openCockpit();
+            expect(plugin.app.workspace.getLeaf).toHaveBeenCalledWith(true);
             expect(chatLeaf.setViewState).toHaveBeenCalledWith({ type: "lilbee-chat", active: true });
-            expect(plugin.app.workspace.getLeaf).toHaveBeenCalledWith("split", "horizontal");
             expect(tasksLeaf.setViewState).toHaveBeenCalledWith({ type: "lilbee-tasks", active: true });
             expect(plugin.app.workspace.revealLeaf).toHaveBeenCalledWith(chatLeaf);
             expect(plugin.app.workspace.revealLeaf).toHaveBeenCalledWith(tasksLeaf);
@@ -3502,9 +3502,11 @@ describe("LilbeePlugin", () => {
                 if (type === "lilbee-tasks") return [existingTasks];
                 return [];
             });
+            plugin.app.workspace.getLeaf = vi.fn();
             plugin.app.workspace.getRightLeaf = vi.fn();
             plugin.app.workspace.revealLeaf = vi.fn();
             await plugin.openCockpit();
+            expect(plugin.app.workspace.getLeaf).not.toHaveBeenCalled();
             expect(plugin.app.workspace.getRightLeaf).not.toHaveBeenCalled();
             expect(existingChat.setViewState).not.toHaveBeenCalled();
             expect(existingTasks.setViewState).not.toHaveBeenCalled();
@@ -3512,23 +3514,23 @@ describe("LilbeePlugin", () => {
             expect(plugin.app.workspace.revealLeaf).toHaveBeenCalledWith(existingTasks);
         });
 
-        it("bails when getRightLeaf returns null and no chat leaf exists", async () => {
+        it("bails when getLeaf returns null and no chat leaf exists", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
             plugin.app.workspace.getLeavesOfType = vi.fn().mockReturnValue([]);
-            plugin.app.workspace.getRightLeaf = vi.fn().mockReturnValue(null);
+            plugin.app.workspace.getLeaf = vi.fn().mockReturnValue(null);
             plugin.app.workspace.revealLeaf = vi.fn();
             await plugin.openCockpit();
             expect(plugin.app.workspace.revealLeaf).not.toHaveBeenCalled();
         });
 
-        it("opens chat alone when the editor-split call returns null", async () => {
+        it("opens chat alone when getRightLeaf returns null", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
             const chatLeaf = { setViewState: vi.fn().mockResolvedValue(undefined) };
             plugin.app.workspace.getLeavesOfType = vi.fn().mockReturnValue([]);
-            plugin.app.workspace.getRightLeaf = vi.fn().mockReturnValue(chatLeaf);
-            plugin.app.workspace.getLeaf = vi.fn().mockReturnValue(null);
+            plugin.app.workspace.getLeaf = vi.fn().mockReturnValue(chatLeaf);
+            plugin.app.workspace.getRightLeaf = vi.fn().mockReturnValue(null);
             plugin.app.workspace.revealLeaf = vi.fn();
             await plugin.openCockpit();
             expect(plugin.app.workspace.revealLeaf).toHaveBeenCalledWith(chatLeaf);


### PR DESCRIPTION
The setup wizard's closing openCockpit() put the chat in the right sidebar and the Task Center in a bottom split, so a brand-new user's first chat landed in a narrow column. Now the chat opens as a main-area tab — the post-wizard workspace is empty, so it gets the full width — and the Task Center is revealed in the right sidebar. Idempotent behavior and the null guards are unchanged, with tests updated to match.

This is also what the re-recorded first-start reel captures, so the demo shows the real out-of-box layout instead of a scripted one.