### PR TITLE
Move the first-run reel up to second in the reel order

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Ask a question in plain English and lilbee answers from your vault, with citatio
 >
 > lilbee is an official [community plugin](https://community.obsidian.md/plugins/lilbee): install it from **Settings → Community plugins** inside Obsidian, nothing else needed. Feedback, bug reports, and issues are very welcome.
 
+<p align="center"><img alt="first run on a fresh vault: install lilbee from the community plugin store, walk the setup wizard, and ask a question that gets a cited answer from your notes" src="https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/first_start.gif" width="640"></p>
+
 > **Heads up: this downloads to your computer.** lilbee is a local search engine with its own models, so the plugin fetches the lilbee server (a few hundred MB) on first launch and the models you pick from the catalog (a few hundred MB up to several GB each) when you choose them. It's all stored locally and runs on your machine.
 
 ---
@@ -160,9 +162,7 @@ The plugin reads everything you've indexed and writes a wiki about it. Pages com
 1. In Obsidian, open **Settings → Community plugins → Browse**, search for **"lilbee"**, then **Install** and **Enable**. (Or start from the [store listing](https://community.obsidian.md/plugins/lilbee).)
 2. The Setup Wizard auto-launches. Pick a chat model and an embedding model from the featured grid, then run the initial sync.
 
-The plugin downloads and manages the [lilbee](https://lilbee.sh/) server automatically; nothing to install separately. The first launch fetches the right version for your platform and verifies it before starting. Wait for the status bar to show `lilbee: ready`, then open the chat.
-
-<p align="center"><img alt="first run on a fresh vault: install lilbee from the community plugin store, walk the setup wizard, and ask a question that gets a cited answer from your notes" src="https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/first_start.gif" width="640"></p>
+The plugin downloads and manages the [lilbee](https://lilbee.sh/) server automatically; nothing to install separately. The first launch fetches the right version for your platform and verifies it before starting. Wait for the status bar to show `lilbee: ready`, then open the chat. (The first-run reel near the top walks the whole flow; longer cut on the [tutorial page](https://obsidian.lilbee.sh/tutorial).)
 
 > **Hardware note:** the server runs on your CPU or GPU. A Mac with Apple Silicon (M1+) or a PC with an NVIDIA / AMD / Intel Arc GPU gives the best performance. 8 GB of RAM is the minimum; 16 to 32 GB is recommended. See [lilbee's hardware requirements](https://github.com/tobocop2/lilbee#hardware-requirements) for the full table.
 

--- a/site/index.html
+++ b/site/index.html
@@ -94,6 +94,7 @@
         <div class="tutorial-watch"><a class="tutorial-cta" href="tutorial/">▶&nbsp; watch the full tutorial reel</a></div>
         <div class="tutorialtabs" role="tablist" aria-label="Tutorial reel">
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-onlilbee"  aria-controls="tutorial-pane-onlilbee"  aria-selected="true"  tabindex="0">what is lilbee</button>
+          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-firststart" aria-controls="tutorial-pane-firststart" aria-selected="false" tabindex="-1">first run</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-ask"       aria-controls="tutorial-pane-ask"       aria-selected="false" tabindex="-1">ask &amp; cite</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-vision"    aria-controls="tutorial-pane-vision"    aria-selected="false" tabindex="-1">scanned PDF</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-crawl"     aria-controls="tutorial-pane-crawl"     aria-selected="false" tabindex="-1">crawl</button>
@@ -105,7 +106,6 @@
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-gemini"    aria-controls="tutorial-pane-gemini"    aria-selected="false" tabindex="-1">cloud</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-multipart" aria-controls="tutorial-pane-multipart" aria-selected="false" tabindex="-1">multi-part</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-rerank"    aria-controls="tutorial-pane-rerank"    aria-selected="false" tabindex="-1">reranking</button>
-          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-firststart" aria-controls="tutorial-pane-firststart" aria-selected="false" tabindex="-1">first run</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-settings"  aria-controls="tutorial-pane-settings"  aria-selected="false" tabindex="-1">settings</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-tour"      aria-controls="tutorial-pane-tour"      aria-selected="false" tabindex="-1">tour</button>
         </div>

--- a/site/tutorial/tutorial.js
+++ b/site/tutorial/tutorial.js
@@ -5,6 +5,7 @@ const groups = [
     heading: "What it is",
     reels: [
       { id: "what-is-lilbee", name: "what_is_lilbee", title: "What is lilbee", desc: "Add lilbee's own README to your library and watch it ingest, then ask “what is lilbee in one sentence?” and get a cited answer straight from the README. The citation opens it at the source." },
+      { id: "first-start", name: "first_start", title: "First run: install to first cited answer", desc: "Brand-new to lilbee, on a fresh vault. Install it from the community plugin store, walk the setup wizard (pick a chat model and an embedder, run the first sync), then ask a question and get a cited answer from your own notes, with a click-through to the source. The whole onboarding in one take." },
       { id: "ask", name: "add", title: "Ask &amp; cite your documents", desc: "Add a PDF from the command palette, watch the Task Center index it, then ask a question and get a cited answer. Click the citation and the source preview opens at the exact page." },
     ],
   },
@@ -46,7 +47,6 @@ const groups = [
     id: "set-up-and-tune",
     heading: "Set up &amp; tune",
     reels: [
-      { id: "first-start", name: "first_start", title: "First run: install to first cited answer", desc: "Brand-new to lilbee, on a fresh vault. Install it from the community plugin store, walk the setup wizard (pick a chat model and an embedder, run the first sync), then ask a question and get a cited answer from your own notes, with a click-through to the source. The whole onboarding in one take." },
       { id: "settings", name: "settings", title: "Settings", desc: "50+ settings: search depth, reranking, sampling, parsers, the wiki. Sane defaults; tune the moment you want to." },
       { id: "tour", name: "tour", title: "Tour: the palette as an async control surface", desc: "Fire a crawl, a file add, and a model download back to back without waiting, watch all three run at once in the Task Center, then ask the just-crawled page a cited question." },
     ],


### PR DESCRIPTION
Now that lilbee installs straight from the community plugin store, the first-run reel (install to first cited answer) is a friction-free onboarding story worth leading with. This promotes it from the end of the reel to second, right after "what is lilbee", on every surface: the homepage tab strip, the grouped tutorial page (moved into the opening "What it is" group), and the README (the reel now sits under the community-store callout near the top, with Quick start pointing to it instead of repeating the gif).