### PR TITLE
Lead with local RAG and local LLM in the title, README, and store description

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   </a>
 </p>
 
-<p align="center"><strong>A local search engine for your vault, inside Obsidian.</strong></p>
+<p align="center"><strong>Local RAG for your vault: search and chat with your notes, inside Obsidian.</strong></p>
 
 <p align="center"><a href="https://obsidian.lilbee.sh/">Project site</a> &nbsp;·&nbsp; <a href="https://obsidian.lilbee.sh/tutorial">Tutorial reel</a> &nbsp;·&nbsp; <a href="https://github.com/tobocop2/obsidian-lilbee/releases">Releases</a> &nbsp;·&nbsp; <a href="https://lilbee.sh/">lilbee engine</a></p>
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 	"name": "lilbee",
 	"version": "0.6.67",
 	"minAppVersion": "1.7.2",
-	"description": "Search and chat with your notes, PDFs, and crawled web pages using local AI, with click-to-verify citations. Manages models for you, or bring your own from Ollama, LM Studio, OpenAI, Claude, Gemini.",
+	"description": "Local RAG for your vault: ask questions and chat with your notes, PDFs, and crawled web pages, with click-to-verify citations. Runs local LLMs for you, or bring your own from Ollama, LM Studio, OpenAI, Claude, Gemini.",
 	"author": "tobocop2",
 	"authorUrl": "https://obsidian.lilbee.sh/",
 	"isDesktopOnly": true

--- a/site/index.html
+++ b/site/index.html
@@ -3,23 +3,23 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>lilbee: an Obsidian plugin for local AI chat and vault search</title>
-<meta name="description" content="lilbee is an Obsidian community plugin that runs local AI models for chat and semantic search over your vault: notes, PDFs, ebooks, code, scans, 150+ file types, with the source one click away. Crawl websites into your vault, pull models from a built-in catalog, or use your Ollama or LM Studio setup. Everything runs on your computer; cloud models are optional.">
+<title>Local RAG &amp; AI chat for your Obsidian vault — lilbee</title>
+<meta name="description" content="lilbee is an Obsidian community plugin for local RAG: ask questions and chat with your vault — notes, PDFs, ebooks, code, scans, 150+ file types — with the source one click away. Crawl websites into your vault, pull models from a built-in catalog, or run local LLMs with your Ollama or LM Studio setup. Everything runs on your computer; cloud models are optional.">
 <link rel="canonical" href="https://obsidian.lilbee.sh/">
 
 <!-- Open Graph: rich link previews. -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="lilbee for Obsidian">
-<meta property="og:title" content="lilbee: an Obsidian plugin for local AI chat and vault search">
-<meta property="og:description" content="An Obsidian community plugin that runs local AI models for chat and semantic search over your vault (notes, PDFs, ebooks, code, scans, 150+ file types) with the source one click away. Runs on your computer; cloud models optional.">
+<meta property="og:title" content="Local RAG &amp; AI chat for your Obsidian vault — lilbee">
+<meta property="og:description" content="An Obsidian community plugin for local RAG: chat with and search your vault (notes, PDFs, ebooks, code, scans, 150+ file types) with the source one click away. Runs local LLMs for you, or use your Ollama or LM Studio setup. Runs on your computer; cloud models optional.">
 <meta property="og:url" content="https://obsidian.lilbee.sh/">
 <meta property="og:image" content="https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/what_is_lilbee.contact.png">
 <meta property="og:image:alt" content="lilbee for Obsidian: a cited answer from a vault note, shown inside Obsidian">
 
 <!-- Twitter Card: rich previews on X and clients that read the Twitter tags. -->
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="lilbee: an Obsidian plugin for local AI chat and vault search">
-<meta name="twitter:description" content="An Obsidian community plugin that runs local AI models for chat and semantic search over your vault, with the source one click away. Runs on your computer; cloud models optional.">
+<meta name="twitter:title" content="Local RAG &amp; AI chat for your Obsidian vault — lilbee">
+<meta name="twitter:description" content="An Obsidian community plugin for local RAG: chat with and search your vault, with the source one click away. Runs local LLMs for you, or use your Ollama or LM Studio setup. Runs on your computer; cloud models optional.">
 <meta name="twitter:image" content="https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/what_is_lilbee.contact.png">
 <meta name="twitter:image:alt" content="lilbee for Obsidian: a cited answer from a vault note, shown inside Obsidian">
 
@@ -29,7 +29,7 @@
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
   "name": "lilbee for Obsidian",
-  "description": "An Obsidian community plugin that runs local AI models and turns your vault (notes, PDFs, ebooks, code, scans) into a searchable library you can chat with, with answers that cite the source. Includes a web crawler that saves sites into your vault as markdown, a model catalog from Hugging Face Hub, and works with your existing Ollama or LM Studio setup. Available in the Obsidian community plugin store.",
+  "description": "An Obsidian community plugin for local RAG: it runs local LLMs and turns your vault (notes, PDFs, ebooks, code, scans) into a searchable library you can chat with, with answers that cite the source. Includes a web crawler that saves sites into your vault as markdown, a model catalog from Hugging Face Hub, and works with your existing Ollama or LM Studio setup. Available in the Obsidian community plugin store.",
   "applicationCategory": "ProductivityApplication",
   "operatingSystem": "Obsidian (macOS, Windows, Linux)",
   "keywords": "Obsidian plugin, Obsidian AI plugin, Obsidian community plugin, chat with your notes, second brain, local AI, local LLM, RAG, retrieval-augmented generation, semantic search, vector search, embeddings, cited answers, web crawler, OCR, PDF search, knowledge base, self-hosted, privacy, offline, Ollama, LM Studio",


### PR DESCRIPTION
People searching for what lilbee does type the category, not the brand: "local LLM", "RAG", "Ollama RAG", "chat with my notes". Those exact phrases were missing from the three places that actually get matched in search, even though the GitHub topics already cover them.

This puts "Local RAG" and "local LLM" into the page <title> and meta/OG/Twitter/JSON-LD descriptions (so the site ranks for those queries), the README's opening tagline, and the manifest description (kept in sync with the store listing). No version bump; the manifest change just rides along for the next release.

Merging deploys the site via the existing Pages step in ci.yml.