### PR TITLE
Export diagnostics so crash reports come with the logs attached

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ See **[Usage Guide](docs/usage.md)** for the full reference: every command, ever
 
 ## Support
 
+Something broken? See [TROUBLESHOOTING.md](TROUBLESHOOTING.md), and use **Settings → lilbee → Export diagnostics** to attach logs to a bug report.
+
 lilbee is built and maintained by one person. If it is useful to you, you can chip in via [PayPal](https://paypal.me/lilbeedotsh). Bug reports and pull requests help just as much.
 
 ## License

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,106 @@
+# Troubleshooting
+
+When something breaks, this page gets you from "it doesn't work" to a bug report with the right logs attached. Start with the diagnostics export; everything after that is for digging deeper yourself.
+
+This covers the plugin side. For the lilbee engine itself (indexing, retrieval, model errors), see the [server troubleshooting guide](https://github.com/tobocop2/lilbee/blob/main/TROUBLESHOOTING.md).
+
+## Start here: Export diagnostics
+
+**One click collects everything a bug report needs.** Three ways to run it:
+
+- **Settings → lilbee → Diagnostics → Export diagnostics**
+- Command palette: `Cmd/Ctrl + P` → **lilbee: Export diagnostics**
+- The **Export diagnostics** link on a server-crash notice
+
+The export writes a zip to your **Downloads** folder (falling back to the vault's lilbee data folder if Downloads doesn't exist), reveals it in Finder / Explorer, and copies a human-readable summary to your clipboard, ready to paste into a GitHub issue.
+
+Inside the zip:
+
+- `summary.md`, a human-readable overview of versions, settings, and recent errors
+- `logs/server.log`, `logs/server-fault.log`, `logs/worker-*.log`, `logs/spawn-crash.log`, `logs/plugin.log` (see [Where the logs live](#where-the-logs-live))
+- `config.toml` and your plugin settings, with secrets redacted
+- Environment info (OS, plugin and server versions)
+
+> **Review before sharing.** Tokens and API keys are redacted automatically, but file paths and note titles are not. Skim the zip before attaching it anywhere public.
+
+## Reading errors in the developer console
+
+Obsidian ships Chromium's developer tools, and the plugin logs everything there with a `[lilbee]` prefix.
+
+1. Open the console: `Cmd + Opt + I` (macOS) or `Ctrl + Shift + I` (Windows / Linux).
+2. Switch to the **Console** tab and type `[lilbee]` into the filter box.
+
+A few snippets worth pasting into the console:
+
+```js
+// Last stderr output from the managed server (in-memory buffer)
+app.plugins.plugins.lilbee.serverManager?.lastStderr
+
+// Current server state: "stopped", "starting", "ready", or "error"
+app.plugins.plugins.lilbee.serverManager?.state
+
+// Where this vault's server data lives
+app.plugins.plugins.lilbee.serverManager?.dataDir
+
+// Installed plugin version
+app.plugins.plugins.lilbee.manifest.version
+```
+
+## Where the logs live
+
+All vaults on a machine share one lilbee install. The shared root is:
+
+| OS | Shared root |
+|----|-------------|
+| **macOS** | `~/Library/Application Support/lilbee` |
+| **Windows** | `%LOCALAPPDATA%\lilbee` |
+| **Linux** | `~/.local/share/lilbee` (`XDG_DATA_HOME` respected) |
+
+Each vault keeps its own data under `<shared root>/vaults/<id>/`, and the server binary lives at `<shared root>/bin/lilbee`. The logs are in `vaults/<id>/logs/`:
+
+| File | What's in it |
+|------|--------------|
+| `server.log` | The lilbee server's main log |
+| `server-fault.log` | Native crash tracebacks |
+| `worker-*.log` | Model subprocess logs, one per worker |
+| `spawn-crash.log` | stderr the plugin captured when the managed server died |
+| `plugin.log` | The plugin's own error journal |
+
+You don't have to guess the `<id>`: **Settings → lilbee** shows the resolved shared root and this vault's data folder in the storage section.
+
+## Running the server by hand
+
+When the managed server won't start and the logs don't say why, run it in a terminal with debug logging and watch the output directly. **Close Obsidian first**, so the two don't fight over the same data dir.
+
+macOS / Linux:
+
+```bash
+LILBEE_LOG_LEVEL=DEBUG "<shared root>/bin/lilbee" serve --data-dir "<vault data dir>"
+```
+
+Windows (PowerShell):
+
+```powershell
+$env:LILBEE_LOG_LEVEL="DEBUG"; & "$env:LOCALAPPDATA\lilbee\bin\lilbee.exe" serve --data-dir "<vault data dir>"
+```
+
+Fill in both paths from the settings tab's storage section. If it crashes here too, the terminal output is exactly what a bug report needs.
+
+## Common causes
+
+- **macOS Gatekeeper.** The server binary is unsigned, and the plugin clears the quarantine flag automatically. If macOS still blocks it: System Settings → Privacy & Security → **Allow Anyway**.
+- **Antivirus / SmartScreen on Windows.** Some scanners quarantine the freshly downloaded exe. Add an exclusion for `%LOCALAPPDATA%\lilbee\bin` and re-run the download from settings.
+- **Outdated NVIDIA drivers.** The CUDA build needs current drivers; update them if the server crashes on startup with a GPU error.
+- **Intel Macs aren't supported in managed mode.** Managed mode covers Apple Silicon Macs, Linux x64, and Windows x64. On an Intel Mac, use external mode: `pip install lilbee`, run `lilbee serve` yourself, and point the plugin at it from Settings → Connection.
+- **Disk space.** Models run from hundreds of MB to several GB each. A download or index job failing partway through is often just a full disk.
+- **RAM / VRAM exhaustion.** Crashes during chat or indexing usually mean the model doesn't fit in memory. Try a smaller model from the catalog, or close other heavy apps.
+
+## Clean reset
+
+If the install seems wrecked and you'd rather start over than debug:
+
+1. Quit Obsidian.
+2. Rename the shared lilbee folder (paths in the table above), e.g. to `lilbee.bak`.
+3. Restart Obsidian. The plugin downloads a fresh server, models re-download, and the index rebuilds on the next sync.
+
+**Your notes are never touched.** Everything under the shared folder is derived data: the server binary, the model cache, and the index. Once you've confirmed the fresh install works, delete the renamed folder.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "obsidian-lilbee",
       "version": "0.6.67",
+      "dependencies": {
+        "fflate": "^0.8.3"
+      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^25.6.0",
@@ -3560,6 +3563,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
       "eslint --fix",
       "prettier --write"
     ]
+  },
+  "dependencies": {
+    "fflate": "^0.8.3"
   }
 }

--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -1,6 +1,7 @@
 import { requestUrl } from "obsidian";
 import { execFile, spawn } from "child_process";
 import {
+    appendFileSync,
     existsSync,
     mkdirSync,
     chmodSync,
@@ -27,6 +28,7 @@ const statfsAsync = promisify(statfs);
 export const node = {
     spawn,
     execFile: execFileAsync,
+    appendFileSync,
     existsSync,
     mkdirSync,
     chmodSync,

--- a/src/diagnostics-export.ts
+++ b/src/diagnostics-export.ts
@@ -1,0 +1,46 @@
+import { Notice } from "obsidian";
+import { shell } from "electron";
+import { node } from "./binary-manager";
+import { buildZip, collectDiagnostics, resolveOutputDir } from "./diagnostics";
+import { MESSAGES } from "./locales/en";
+import type { DiagnosticsContext } from "./types";
+
+const NOTICE_DURATION_MS = 15_000;
+
+function timestampSlug(): string {
+    return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+/** Collect, zip, write, reveal, copy summary. Never throws; reports via Notice. */
+export async function exportDiagnostics(ctx: DiagnosticsContext): Promise<void> {
+    const bundle = collectDiagnostics(ctx);
+    const outDir = resolveOutputDir(ctx.dataDir ?? ".");
+    const zipPath = node.join(outDir, `lilbee-diagnostics-${timestampSlug()}.zip`);
+
+    let writtenPath = zipPath;
+    try {
+        node.writeFileSync(zipPath, buildZip(bundle));
+        new Notice(MESSAGES.NOTICE_DIAGNOSTICS_EXPORTED(zipPath), NOTICE_DURATION_MS);
+    } catch {
+        const summaryPath = node.join(outDir, `lilbee-diagnostics-${timestampSlug()}.summary.md`);
+        try {
+            node.writeFileSync(summaryPath, bundle.summaryMarkdown);
+            writtenPath = summaryPath;
+            new Notice(MESSAGES.NOTICE_DIAGNOSTICS_SUMMARY_ONLY(summaryPath), NOTICE_DURATION_MS);
+        } catch (e) {
+            new Notice(MESSAGES.NOTICE_DIAGNOSTICS_FAILED(e instanceof Error ? e.message : String(e)));
+            return;
+        }
+    }
+
+    try {
+        shell.showItemInFolder(writtenPath);
+    } catch {
+        // notice already carries the path
+    }
+    try {
+        await navigator.clipboard.writeText(bundle.summaryMarkdown);
+    } catch {
+        // clipboard is best-effort
+    }
+}

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,14 +1,15 @@
 import { strToU8, zipSync } from "fflate";
 import { node } from "./binary-manager";
+import { formatJournalEntry } from "./error-journal";
 import { MESSAGES } from "./locales/en";
 import { redactSecrets, redactSettings } from "./redact";
+import { LOG_FILE, LOGS_DIR } from "./types";
 import type { CollectedFile, DiagnosticsBundle, DiagnosticsContext } from "./types";
 
 export const LOG_TAIL_MAX_BYTES = 1_048_576;
-const LOGS_SUBDIR = "logs";
 const NOTE_NOT_FOUND = "not found";
 const NOTE_TRUNCATED = "truncated to last 1 MiB";
-const EXPECTED_LOGS = ["server.log", "server-fault.log", "spawn-crash.log", "plugin.log"];
+const EXPECTED_LOGS = Object.values(LOG_FILE);
 
 /** Reads a file, keeping only the last LOG_TAIL_MAX_BYTES when oversized. */
 function readTailCapped(path: string): { text: string; note: string | null } {
@@ -32,7 +33,7 @@ function collectFile(zipName: string, path: string): CollectedFile {
 /** Lists .log file names under <dataDir>/logs, or [] when unreadable. */
 function listLogFiles(dataDir: string): string[] {
     try {
-        const dir = node.join(dataDir, LOGS_SUBDIR);
+        const dir = node.join(dataDir, LOGS_DIR);
         if (!node.existsSync(dir)) return [];
         return node
             .readdirSync(dir)
@@ -47,11 +48,11 @@ function listLogFiles(dataDir: string): string[] {
 function collectLogFiles(dataDir: string | null): CollectedFile[] {
     if (dataDir === null) return [];
     const found = listLogFiles(dataDir).map((name) =>
-        collectFile(`${LOGS_SUBDIR}/${name}`, node.join(dataDir, LOGS_SUBDIR, name)),
+        collectFile(`${LOGS_DIR}/${name}`, node.join(dataDir, LOGS_DIR, name)),
     );
     const haveNames = new Set(found.map((f) => f.name));
     for (const name of EXPECTED_LOGS) {
-        const zipName = `${LOGS_SUBDIR}/${name}`;
+        const zipName = `${LOGS_DIR}/${name}`;
         if (!haveNames.has(zipName)) found.push({ name: zipName, data: null, note: NOTE_NOT_FOUND });
     }
     return found;
@@ -59,9 +60,7 @@ function collectLogFiles(dataDir: string | null): CollectedFile[] {
 
 /** Renders the journal entries as plain log lines. */
 function journalText(ctx: DiagnosticsContext): string {
-    return ctx.journalEntries
-        .map((e) => `${e.timestamp} [${e.label}] ${e.message}${e.stack ? `\n${e.stack}` : ""}`)
-        .join("\n");
+    return ctx.journalEntries.map(formatJournalEntry).join("\n");
 }
 
 /** Renders the human-readable summary.md for the bundle. */

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,135 @@
+import { strToU8, zipSync } from "fflate";
+import { node } from "./binary-manager";
+import { MESSAGES } from "./locales/en";
+import { redactSecrets, redactSettings } from "./redact";
+import type { CollectedFile, DiagnosticsBundle, DiagnosticsContext } from "./types";
+
+export const LOG_TAIL_MAX_BYTES = 1_048_576;
+const LOGS_SUBDIR = "logs";
+const NOTE_NOT_FOUND = "not found";
+const NOTE_TRUNCATED = "truncated to last 1 MiB";
+const EXPECTED_LOGS = ["server.log", "server-fault.log", "spawn-crash.log", "plugin.log"];
+
+/** Reads a file, keeping only the last LOG_TAIL_MAX_BYTES when oversized. */
+function readTailCapped(path: string): { text: string; note: string | null } {
+    const size = node.statSync(path).size;
+    const text = node.readFileSync(path, "utf-8");
+    if (size <= LOG_TAIL_MAX_BYTES) return { text, note: null };
+    return { text: text.slice(-LOG_TAIL_MAX_BYTES), note: NOTE_TRUNCATED };
+}
+
+/** Collects one file as redacted bytes, or a miss with the reason noted. */
+function collectFile(zipName: string, path: string): CollectedFile {
+    try {
+        if (!node.existsSync(path)) return { name: zipName, data: null, note: NOTE_NOT_FOUND };
+        const { text, note } = readTailCapped(path);
+        return { name: zipName, data: strToU8(redactSecrets(text)), note };
+    } catch (e) {
+        return { name: zipName, data: null, note: e instanceof Error ? e.message : String(e) };
+    }
+}
+
+/** Lists .log file names under <dataDir>/logs, or [] when unreadable. */
+function listLogFiles(dataDir: string): string[] {
+    try {
+        const dir = node.join(dataDir, LOGS_SUBDIR);
+        if (!node.existsSync(dir)) return [];
+        return node
+            .readdirSync(dir)
+            .filter((f) => String(f).endsWith(".log"))
+            .map(String);
+    } catch {
+        return [];
+    }
+}
+
+/** Collects every log under the data dir, recording misses for expected names. */
+function collectLogFiles(dataDir: string | null): CollectedFile[] {
+    if (dataDir === null) return [];
+    const found = listLogFiles(dataDir).map((name) =>
+        collectFile(`${LOGS_SUBDIR}/${name}`, node.join(dataDir, LOGS_SUBDIR, name)),
+    );
+    const haveNames = new Set(found.map((f) => f.name));
+    for (const name of EXPECTED_LOGS) {
+        const zipName = `${LOGS_SUBDIR}/${name}`;
+        if (!haveNames.has(zipName)) found.push({ name: zipName, data: null, note: NOTE_NOT_FOUND });
+    }
+    return found;
+}
+
+/** Renders the journal entries as plain log lines. */
+function journalText(ctx: DiagnosticsContext): string {
+    return ctx.journalEntries
+        .map((e) => `${e.timestamp} [${e.label}] ${e.message}${e.stack ? `\n${e.stack}` : ""}`)
+        .join("\n");
+}
+
+/** Renders the human-readable summary.md for the bundle. */
+export function renderSummary(ctx: DiagnosticsContext, files: CollectedFile[]): string {
+    const lines: string[] = [
+        MESSAGES.DIAG_REVIEW_WARNING,
+        "",
+        "# lilbee diagnostics",
+        "",
+        "## Environment",
+        `- Plugin version: ${ctx.pluginVersion}`,
+        `- Platform: ${process.platform} ${process.arch}`,
+        `- Server state: ${ctx.serverState}`,
+        `- Server URL: ${ctx.serverUrl || "(none)"}`,
+        `- Data dir: ${ctx.dataDir ?? `(not local) ${MESSAGES.DIAG_REMOTE_SERVER_NOTE}`}`,
+        `- Shared root: ${ctx.sharedRoot ?? "(none)"}`,
+        "",
+        "## Last server stderr",
+        "```",
+        redactSecrets(ctx.lastStderr) || "(empty)",
+        "```",
+        "",
+        "## Collected files",
+        ...files.map((f) => `- ${f.name}: ${f.data === null ? (f.note ?? "missing") : (f.note ?? "ok")}`),
+        "",
+        "## Recent plugin errors",
+        "```",
+        redactSecrets(journalText(ctx)) || "(none)",
+        "```",
+    ];
+    return lines.join("\n");
+}
+
+/** Gathers logs, config, settings, and the journal into a redacted bundle. */
+export function collectDiagnostics(ctx: DiagnosticsContext): DiagnosticsBundle {
+    const files: CollectedFile[] = collectLogFiles(ctx.dataDir);
+    if (ctx.dataDir !== null) {
+        files.push(collectFile("config.toml", node.join(ctx.dataDir, "config.toml")));
+    }
+    files.push({
+        name: "settings.json",
+        data: strToU8(JSON.stringify(redactSettings(ctx.settings), null, 2)),
+        note: null,
+    });
+    files.push({ name: "journal.log", data: strToU8(redactSecrets(journalText(ctx))), note: null });
+    const summaryMarkdown = renderSummary(ctx, files);
+    return { files, summaryMarkdown };
+}
+
+/** Zips the summary plus every collected file, skipping misses. */
+export function buildZip(bundle: DiagnosticsBundle): Uint8Array {
+    const entries: Record<string, Uint8Array> = { "summary.md": strToU8(bundle.summaryMarkdown) };
+    for (const file of bundle.files) {
+        if (file.data !== null) entries[file.name] = file.data;
+    }
+    return zipSync(entries);
+}
+
+/** Returns ~/Downloads when present, otherwise the given fallback dir. */
+export function resolveOutputDir(fallbackDir: string): string {
+    const home = process.env.HOME ?? process.env.USERPROFILE;
+    if (home) {
+        const downloads = node.join(home, "Downloads");
+        try {
+            if (node.existsSync(downloads)) return downloads;
+        } catch {
+            // fall through to fallbackDir
+        }
+    }
+    return fallbackDir;
+}

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -1,0 +1,3 @@
+declare module "electron" {
+    export const shell: { showItemInFolder(fullPath: string): void };
+}

--- a/src/error-journal.ts
+++ b/src/error-journal.ts
@@ -1,0 +1,40 @@
+import { node } from "./binary-manager";
+import type { JournalEntry } from "./types";
+import { appendCapped } from "./utils/capped-log";
+
+export const JOURNAL_MAX_ENTRIES = 200;
+export const PLUGIN_LOG_MAX_BYTES = 262_144;
+const PLUGIN_LOG_FILE = "plugin.log";
+
+/** In-memory ring buffer of plugin errors, mirrored best-effort to logs/plugin.log. */
+export class ErrorJournal {
+    private _entries: JournalEntry[] = [];
+    private logPath: string | null = null;
+
+    get entries(): readonly JournalEntry[] {
+        return this._entries;
+    }
+
+    /** Point persistence at `<dataDir>/logs`. */
+    setLogDir(dir: string): void {
+        this.logPath = node.join(dir, PLUGIN_LOG_FILE);
+    }
+
+    record(label: string, message: string, stack?: string): void {
+        const entry: JournalEntry = {
+            timestamp: new Date().toISOString(),
+            label,
+            message,
+            stack: stack ?? null,
+        };
+        this._entries.push(entry);
+        if (this._entries.length > JOURNAL_MAX_ENTRIES) this._entries.shift();
+        this.append(entry);
+    }
+
+    private append(entry: JournalEntry): void {
+        if (!this.logPath) return;
+        const line = `${entry.timestamp} [${entry.label}] ${entry.message}${entry.stack ? `\n${entry.stack}` : ""}\n`;
+        appendCapped(this.logPath, line, PLUGIN_LOG_MAX_BYTES);
+    }
+}

--- a/src/error-journal.ts
+++ b/src/error-journal.ts
@@ -1,10 +1,14 @@
 import { node } from "./binary-manager";
-import type { JournalEntry } from "./types";
+import { LOG_FILE, type JournalEntry } from "./types";
 import { appendCapped } from "./utils/capped-log";
 
 export const JOURNAL_MAX_ENTRIES = 200;
 export const PLUGIN_LOG_MAX_BYTES = 262_144;
-const PLUGIN_LOG_FILE = "plugin.log";
+
+/** One journal entry as a log line (no trailing newline). */
+export function formatJournalEntry(entry: JournalEntry): string {
+    return `${entry.timestamp} [${entry.label}] ${entry.message}${entry.stack ? `\n${entry.stack}` : ""}`;
+}
 
 /** In-memory ring buffer of plugin errors, mirrored best-effort to logs/plugin.log. */
 export class ErrorJournal {
@@ -17,7 +21,7 @@ export class ErrorJournal {
 
     /** Point persistence at `<dataDir>/logs`. */
     setLogDir(dir: string): void {
-        this.logPath = node.join(dir, PLUGIN_LOG_FILE);
+        this.logPath = node.join(dir, LOG_FILE.PLUGIN);
     }
 
     record(label: string, message: string, stack?: string): void {
@@ -34,7 +38,6 @@ export class ErrorJournal {
 
     private append(entry: JournalEntry): void {
         if (!this.logPath) return;
-        const line = `${entry.timestamp} [${entry.label}] ${entry.message}${entry.stack ? `\n${entry.stack}` : ""}\n`;
-        appendCapped(this.logPath, line, PLUGIN_LOG_MAX_BYTES);
+        appendCapped(this.logPath, `${formatJournalEntry(entry)}\n`, PLUGIN_LOG_MAX_BYTES);
     }
 }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -921,6 +921,15 @@ export const MESSAGES = {
         "Review this bundle before sharing. Secrets are redacted, but log lines can include file paths and note titles.",
     DIAG_REMOTE_SERVER_NOTE:
         "External server data dir is not locally readable; server logs must be fetched from the machine running lilbee serve.",
+    BUTTON_EXPORT_DIAGNOSTICS: "Export diagnostics",
+    LABEL_EXPORT_DIAGNOSTICS: "Diagnostics",
+    DESC_EXPORT_DIAGNOSTICS:
+        "Bundle logs, settings (secrets removed), and recent errors into a zip you can attach to a bug report.",
+    NOTICE_DIAGNOSTICS_EXPORTED: (path: string): string =>
+        `Diagnostics saved to ${path}. The summary is on your clipboard. Review the contents before sharing.`,
+    NOTICE_DIAGNOSTICS_SUMMARY_ONLY: (path: string): string =>
+        `Zip creation failed; wrote summary.md to ${path} instead. Review the contents before sharing.`,
+    NOTICE_DIAGNOSTICS_FAILED: (detail: string): string => `Diagnostics export failed: ${detail}`,
 } as const;
 
 export const FILTERS = {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -915,6 +915,12 @@ export const MESSAGES = {
     LABEL_MEMORY_AUTO_EXTRACT: "Auto-extract memories from chat",
     DESC_MEMORY_AUTO_EXTRACT: "After each answer, lilbee proposes memories to save. Review them in the Memories view.",
     NOTICE_MEMORY_CONFIG_FAILED: "lilbee: could not update memory settings",
+
+    // Diagnostics export
+    DIAG_REVIEW_WARNING:
+        "Review this bundle before sharing. Secrets are redacted, but log lines can include file paths and note titles.",
+    DIAG_REMOTE_SERVER_NOTE:
+        "External server data dir is not locally readable; server logs must be fetched from the machine running lilbee serve.",
 } as const;
 
 export const FILTERS = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ import {
     DOT_STATE,
     ERROR_NAME,
     LOCK_STATE,
+    LOGS_DIR,
     MANAGED_CONSENT_RESULT,
     MANAGED_PHASE,
     SERVER_MODE,
@@ -399,7 +400,7 @@ export default class LilbeePlugin extends Plugin {
 
             try {
                 this.serverManager = this.buildServerManager(binaryPath, registry, sharedRoot);
-                this.journal.setLogDir(node.join(this.serverManager.dataDir, "logs"));
+                this.journal.setLogDir(node.join(this.serverManager.dataDir, LOGS_DIR));
                 this.updateStatusBar(MESSAGES.STATUS_STARTING, DOT_STATE.PRIMARY);
                 this.setStatusClass("lilbee-status-starting");
                 onProgress?.({ phase: MANAGED_PHASE.STARTING, message: MESSAGES.STATUS_STARTING_SERVER });

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,8 @@ import { LilbeeClient, SessionTokenError } from "./api";
 import type { RequestOutcome } from "./api";
 import { BinaryManager, getLatestRelease, checkForUpdate, node } from "./binary-manager";
 import { exportDatasetToDisk, importDatasetFromDisk } from "./dataset-io";
+import { exportDiagnostics } from "./diagnostics-export";
+import { ErrorJournal } from "./error-journal";
 import type { ReleaseInfo } from "./binary-manager";
 import { ServerManager } from "./server-manager";
 import { readSessionToken, resolveExternalDataRoot } from "./session-token";
@@ -31,6 +33,7 @@ import {
     TASK_TYPE,
     type ActiveLock,
     type BatchProgressPayload,
+    type DiagnosticsContext,
     type DotState,
     type LilbeeSettings,
     type ManagedServerProgressHandler,
@@ -211,6 +214,7 @@ export default class LilbeePlugin extends Plugin {
     chatRibbonIconEl: HTMLElement | null = null;
     binaryManager: BinaryManager | null = null;
     serverManager: ServerManager | null = null;
+    journal = new ErrorJournal();
     vaultRegistry: VaultRegistry | null = null;
     vaultId = "";
     syncController: AbortController | null = null;
@@ -242,6 +246,7 @@ export default class LilbeePlugin extends Plugin {
     private serverEverReady = false;
 
     async onload(): Promise<void> {
+        this.registerErrorCapture();
         await this.loadSettings();
         this.wikiEnabled = this.settings.wikiEnabled;
 
@@ -394,6 +399,7 @@ export default class LilbeePlugin extends Plugin {
 
             try {
                 this.serverManager = this.buildServerManager(binaryPath, registry, sharedRoot);
+                this.journal.setLogDir(node.join(this.serverManager.dataDir, "logs"));
                 this.updateStatusBar(MESSAGES.STATUS_STARTING, DOT_STATE.PRIMARY);
                 this.setStatusClass("lilbee-status-starting");
                 onProgress?.({ phase: MANAGED_PHASE.STARTING, message: MESSAGES.STATUS_STARTING_SERVER });
@@ -464,8 +470,11 @@ export default class LilbeePlugin extends Plugin {
             onStateChange: (state) => this.handleServerStateChange(state),
             onRestartsExhausted: (stderr: string) => {
                 if (this.serverStartFailed) return;
+                console.error(`[lilbee] server crashed; stderr:\n${stderr}`);
+                this.journal.record("server-crash", MESSAGES.ERROR_SERVER_CRASHED, stderr || undefined);
                 const detail = stderr ? `\n${stderr.split("\n").slice(-5).join("\n")}` : "";
-                new Notice(`${MESSAGES.ERROR_SERVER_CRASHED}${detail}`, NOTICE_PERMANENT);
+                const notice = new Notice(`${MESSAGES.ERROR_SERVER_CRASHED}${detail}`, NOTICE_PERMANENT);
+                this.attachExportLink(notice);
             },
             onShutdownFailure: (err: Error) => {
                 new Notice(`${MESSAGES.ERROR_SERVER_SHUTDOWN_FAILED}: ${err.message}`);
@@ -690,13 +699,48 @@ export default class LilbeePlugin extends Plugin {
         onProgress?.("Update complete.");
     }
 
+    /** Journal lilbee-originated window errors and unhandled rejections. */
+    private registerErrorCapture(): void {
+        this.registerDomEvent(window, "error", (e: ErrorEvent) => {
+            const stack: string = e.error instanceof Error ? (e.error.stack ?? "") : "";
+            if (stack.includes("lilbee")) this.journal.record("window", e.message, stack);
+        });
+        this.registerDomEvent(window, "unhandledrejection", (e: PromiseRejectionEvent) => {
+            const reason: unknown = e.reason;
+            if (!(reason instanceof Error)) return;
+            const stack = reason.stack ?? "";
+            if (stack.includes("lilbee")) this.journal.record("unhandledrejection", reason.message, stack);
+        });
+    }
+
+    private attachExportLink(notice: Notice): void {
+        const link = notice.noticeEl.createEl("a", { text: MESSAGES.BUTTON_EXPORT_DIAGNOSTICS });
+        link.addEventListener("click", () => void exportDiagnostics(this.diagnosticsContext()));
+    }
+
+    /** Snapshot of plugin + server state for the diagnostics collector. */
+    diagnosticsContext(): DiagnosticsContext {
+        return {
+            dataDir: this.serverManager?.dataDir ?? null,
+            sharedRoot: this.vaultRegistry?.sharedRoot ?? null,
+            settings: this.settings,
+            journalEntries: this.journal.entries,
+            pluginVersion: this.manifest.version,
+            serverState: this.serverManager?.state ?? SERVER_STATE.STOPPED,
+            serverUrl: this.serverManager?.serverUrl ?? this.settings.serverUrl,
+            lastStderr: this.serverManager?.lastStderr ?? "",
+        };
+    }
+
     private showError(label: string, err: unknown): void {
+        const detail = errorMessage(err, String(err));
+        this.journal.record(label, detail, err instanceof Error ? err.stack : undefined);
         console.error(`[lilbee] ${label}:`, err);
         const stderr = this.serverManager?.lastStderr;
         if (stderr) console.error(`[lilbee] server stderr:\n${stderr}`);
-        const detail = errorMessage(err, String(err));
         const stderrTail = stderr ? `\n${stderr.split("\n").slice(-5).join("\n")}` : "";
-        new Notice(`lilbee: ${label} — ${detail}${stderrTail}`, NOTICE_ERROR_DURATION_MS);
+        const notice = new Notice(`lilbee: ${label} — ${detail}${stderrTail}`, NOTICE_ERROR_DURATION_MS);
+        if (this.serverManager !== null) this.attachExportLink(notice);
         this.updateStatusBar(MESSAGES.STATUS_ERROR, DOT_STATE.ERROR);
         this.setStatusClass(null);
         this.serverStartFailed = true;
@@ -1062,6 +1106,13 @@ export default class LilbeePlugin extends Plugin {
             id: "status",
             name: "Show status",
             callback: () => new StatusModal(this.app, this).open(),
+        });
+
+        // Plain callback: exporting diagnostics must work while the server is down.
+        this.addCommand({
+            id: "export-diagnostics",
+            name: MESSAGES.BUTTON_EXPORT_DIAGNOSTICS,
+            callback: () => void exportDiagnostics(this.diagnosticsContext()),
         });
 
         this.addCommand({

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -4,8 +4,8 @@ export const REDACTED = "[redacted]";
 
 /** Key-value pairs whose key smells like a credential, in TOML/JSON/header shapes. */
 const SECRET_LINE_PATTERNS: RegExp[] = [
-    /((?:\w*[_-])?(?:token|api[_-]?key|apikey|secret)\s*[:=]\s*["']?)(?:bearer\s+)?[^"'\s]+/gi,
-    /(authorization\s*[:=]\s*["']?)(?:bearer\s+)?[^"'\s]+/gi,
+    /\b((?:\w+[_-])?(?:token|api[_-]?key|apikey|secret)\s*[:=]\s*["']?)(?:bearer\s+)?[^"'\s]+/gi,
+    /\b(authorization\s*[:=]\s*["']?)(?:bearer\s+)?[^"'\s]+/gi,
 ];
 
 /** Blanks credential values in log/config text while keeping line shape. */

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -1,0 +1,31 @@
+import type { LilbeeSettings, SharedConfig } from "./types";
+
+export const REDACTED = "[redacted]";
+
+/** Key-value pairs whose key smells like a credential, in TOML/JSON/header shapes. */
+const SECRET_LINE_PATTERNS: RegExp[] = [
+    /((?:\w*[_-])?(?:token|api[_-]?key|apikey|secret)\s*[:=]\s*["']?)(?:bearer\s+)?[^"'\s]+/gi,
+    /(authorization\s*[:=]\s*["']?)(?:bearer\s+)?[^"'\s]+/gi,
+];
+
+/** Blanks credential values in log/config text while keeping line shape. */
+export function redactSecrets(text: string): string {
+    let out = text;
+    for (const pattern of SECRET_LINE_PATTERNS) {
+        out = out.replace(pattern, `$1${REDACTED}`);
+    }
+    return out;
+}
+
+const SECRET_SETTING_KEYS = ["manualToken", "hfToken"] as const;
+
+/** Returns a copy of the settings with credential fields blanked. */
+export function redactSettings(settings: LilbeeSettings & Partial<SharedConfig>): Record<string, unknown> {
+    const copy: Record<string, unknown> = { ...settings };
+    for (const key of SECRET_SETTING_KEYS) {
+        if (typeof copy[key] === "string" && (copy[key] as string).length > 0) {
+            copy[key] = REDACTED;
+        }
+    }
+    return copy;
+}

--- a/src/server-manager.ts
+++ b/src/server-manager.ts
@@ -2,6 +2,7 @@ import type { ChildProcess } from "child_process";
 import type { ServerState } from "./types";
 import { PLATFORM, SERVER_STATE } from "./types";
 import { node } from "./binary-manager";
+import { appendCapped } from "./utils/capped-log";
 
 const SERVER_MANAGER_CONFIG = {
     HEALTH_POLL_INTERVAL_MS: 1000,
@@ -11,6 +12,7 @@ const SERVER_MANAGER_CONFIG = {
     MAX_CRASH_RESTARTS: 3,
     PORT_FILE_POLL_INTERVAL_MS: 500,
     PORT_FILE_MAX_ATTEMPTS: 240,
+    SPAWN_CRASH_LOG_MAX_BYTES: 262_144,
 } as const;
 
 export interface ServerManagerOptions {
@@ -63,6 +65,20 @@ export class ServerManager {
 
     private get portFilePath(): string {
         return `${this.opts.dataDir}/data/server.port`;
+    }
+
+    private get crashLogPath(): string {
+        return `${this.opts.dataDir}/logs/spawn-crash.log`;
+    }
+
+    /** Persist the stderr ring buffer so a crash survives an Obsidian restart. */
+    private snapshotCrashStderr(): void {
+        const header = `=== crash ${new Date().toISOString()} ===\n`;
+        appendCapped(
+            this.crashLogPath,
+            `${header}${this.lastStderr}\n`,
+            SERVER_MANAGER_CONFIG.SPAWN_CRASH_LOG_MAX_BYTES,
+        );
     }
 
     private setState(s: ServerState): void {
@@ -123,6 +139,7 @@ export class ServerManager {
         child.on("exit", () => {
             this.child = null;
             if (this.stopping) return;
+            this.snapshotCrashStderr();
             if (this.crashCount < SERVER_MANAGER_CONFIG.MAX_CRASH_RESTARTS) {
                 this.crashCount++;
                 this.setState(SERVER_STATE.ERROR);

--- a/src/server-manager.ts
+++ b/src/server-manager.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess } from "child_process";
 import type { ServerState } from "./types";
-import { PLATFORM, SERVER_STATE } from "./types";
+import { LOG_FILE, LOGS_DIR, PLATFORM, SERVER_STATE } from "./types";
 import { node } from "./binary-manager";
 import { appendCapped } from "./utils/capped-log";
 
@@ -68,7 +68,7 @@ export class ServerManager {
     }
 
     private get crashLogPath(): string {
-        return `${this.opts.dataDir}/logs/spawn-crash.log`;
+        return `${this.opts.dataDir}/${LOGS_DIR}/${LOG_FILE.SPAWN_CRASH}`;
     }
 
     /** Persist the stderr ring buffer so a crash survives an Obsidian restart. */

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,6 +16,7 @@ import {
     ERROR_NAME,
 } from "./types";
 import type { CatalogEntry, ConfigResponse, InstalledModel, LilbeeSettings, ServerMode } from "./types";
+import { exportDiagnostics } from "./diagnostics-export";
 import { formatBytes, reportForVault } from "./storage-stats";
 import { MESSAGES } from "./locales/en";
 import { displayLabelForRef, extractHfRepo } from "./utils/model-ref";
@@ -121,6 +122,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         this.renderCrawlingSettings(this.crawlingContainerEl);
         this.wikiContainerEl = containerEl.createDiv();
         this.renderWikiSettings(this.wikiContainerEl);
+        this.renderDiagnostics(containerEl);
         this.renderAdvancedSettings(containerEl);
         this.loadServerDefaults();
         this.loadConfigDefaults();
@@ -378,6 +380,17 @@ export class LilbeeSettingTab extends PluginSettingTab {
         appendStorageRow(list, MESSAGES.LABEL_STORAGE_MODELS, report.modelsBytes);
         appendStorageRow(list, MESSAGES.LABEL_STORAGE_VAULT, report.vaultBytes, report.vaultDataDir);
         appendStorageRow(list, MESSAGES.LABEL_STORAGE_TOTAL, report.totalBytes);
+    }
+
+    private renderDiagnostics(containerEl: HTMLElement): void {
+        new Setting(containerEl)
+            .setName(MESSAGES.LABEL_EXPORT_DIAGNOSTICS)
+            .setDesc(MESSAGES.DESC_EXPORT_DIAGNOSTICS)
+            .addButton((btn) =>
+                btn.setButtonText(MESSAGES.BUTTON_EXPORT_DIAGNOSTICS).onClick(() => {
+                    void exportDiagnostics(this.plugin.diagnosticsContext());
+                }),
+            );
     }
 
     private renderExternalSettings(containerEl: HTMLElement): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -479,6 +479,17 @@ export const SHARED_PATH = {
     LOCK: "active.lock",
 } as const;
 
+/** Subdirectory of a vault data dir where all log files land. */
+export const LOGS_DIR = "logs";
+
+/** Log file names the diagnostics bundle knows about. */
+export const LOG_FILE = {
+    SERVER: "server.log",
+    FAULT: "server-fault.log",
+    SPAWN_CRASH: "spawn-crash.log",
+    PLUGIN: "plugin.log",
+} as const;
+
 /** One captured plugin-side error. */
 export interface JournalEntry {
     timestamp: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -479,6 +479,42 @@ export const SHARED_PATH = {
     LOCK: "active.lock",
 } as const;
 
+/** One captured plugin-side error. */
+export interface JournalEntry {
+    timestamp: string;
+    label: string;
+    message: string;
+    stack: string | null;
+}
+
+/** One file gathered (or missed) by the diagnostics collector. */
+export interface CollectedFile {
+    /** Path inside the zip, e.g. "logs/worker-chat.log". */
+    name: string;
+    /** File bytes after tail-capping and redaction; null when the file was missed. */
+    data: Uint8Array | null;
+    /** Manifest note, e.g. "not found" or "truncated to last 1 MiB". Null when collected whole. */
+    note: string | null;
+}
+
+/** Everything the collector gathered, ready to zip. */
+export interface DiagnosticsBundle {
+    files: CollectedFile[];
+    summaryMarkdown: string;
+}
+
+/** Inputs the collector reads from the live plugin. */
+export interface DiagnosticsContext {
+    dataDir: string | null;
+    sharedRoot: string | null;
+    settings: LilbeeSettings;
+    journalEntries: readonly JournalEntry[];
+    pluginVersion: string;
+    serverState: ServerState;
+    serverUrl: string;
+    lastStderr: string;
+}
+
 /** SSE event type constants — shared across chat, sync, and model pull streams. */
 export const SSE_EVENT = {
     TOKEN: "token",

--- a/src/utils/capped-log.ts
+++ b/src/utils/capped-log.ts
@@ -1,0 +1,16 @@
+import { node } from "../binary-manager";
+
+/** Append to a log file, first trimming it to its newest `maxBytes` tail. Never throws. */
+export function appendCapped(path: string, chunk: string, maxBytes: number): void {
+    try {
+        const dir = node.dirname(path);
+        if (!node.existsSync(dir)) node.mkdirSync(dir, { recursive: true });
+        if (node.existsSync(path) && node.statSync(path).size > maxBytes) {
+            const content = node.readFileSync(path, "utf-8");
+            node.writeFileSync(path, content.slice(-maxBytes));
+        }
+        node.appendFileSync(path, chunk);
+    } catch {
+        // capture must never break the caller
+    }
+}

--- a/tests/__mocks__/electron.ts
+++ b/tests/__mocks__/electron.ts
@@ -1,0 +1,3 @@
+import { vi } from "vitest";
+
+export const shell = { showItemInFolder: vi.fn() };

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -591,6 +591,13 @@ export class Plugin {
     registerView = vi.fn();
     registerEvent = vi.fn();
     registerInterval = vi.fn((handle: number) => handle);
+
+    // Test helper: handlers registered via registerDomEvent, invoked directly
+    // by tests since the Node env has no DOM event machinery.
+    domEvents: Array<{ el: unknown; type: string; cb: (...args: never[]) => void }> = [];
+    registerDomEvent = vi.fn((el: unknown, type: string, cb: (...args: never[]) => void) => {
+        this.domEvents.push({ el, type, cb });
+    });
 }
 
 export class PluginSettingTab {
@@ -642,6 +649,7 @@ export class Notice {
     message: string;
     duration: number | undefined;
     hidden = false;
+    noticeEl = new MockElement("div");
     static instances: Notice[] = [];
     constructor(message: string, duration?: number) {
         this.message = message;

--- a/tests/capped-log.test.ts
+++ b/tests/capped-log.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { node } from "../src/binary-manager";
+import { appendCapped } from "../src/utils/capped-log";
+
+vi.mock("../src/binary-manager", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../src/binary-manager")>();
+    return {
+        ...actual,
+        node: {
+            ...actual.node,
+            existsSync: vi.fn().mockReturnValue(true),
+            mkdirSync: vi.fn(),
+            appendFileSync: vi.fn(),
+            readFileSync: vi.fn().mockReturnValue(""),
+            writeFileSync: vi.fn(),
+            statSync: vi.fn().mockReturnValue({ size: 0 }),
+            dirname: (p: string) => p.split("/").slice(0, -1).join("/"),
+        },
+    };
+});
+
+const mocked = node as unknown as {
+    existsSync: ReturnType<typeof vi.fn>;
+    mkdirSync: ReturnType<typeof vi.fn>;
+    appendFileSync: ReturnType<typeof vi.fn>;
+    readFileSync: ReturnType<typeof vi.fn>;
+    writeFileSync: ReturnType<typeof vi.fn>;
+    statSync: ReturnType<typeof vi.fn>;
+};
+
+describe("appendCapped", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocked.existsSync.mockReturnValue(true);
+        mocked.readFileSync.mockReturnValue("");
+        mocked.statSync.mockReturnValue({ size: 0 });
+    });
+
+    it("creates the parent dir when missing", () => {
+        mocked.existsSync.mockReturnValue(false);
+        appendCapped("/data/logs/plugin.log", "line\n", 100);
+        expect(mocked.mkdirSync).toHaveBeenCalledWith("/data/logs", { recursive: true });
+        expect(mocked.appendFileSync).toHaveBeenCalledWith("/data/logs/plugin.log", "line\n");
+    });
+
+    it("does not create the parent dir when it exists", () => {
+        appendCapped("/data/logs/plugin.log", "line\n", 100);
+        expect(mocked.mkdirSync).not.toHaveBeenCalled();
+    });
+
+    it("trims an oversized file to its newest tail before appending", () => {
+        const oversized = "a".repeat(50) + "b".repeat(60);
+        mocked.statSync.mockReturnValue({ size: oversized.length });
+        mocked.readFileSync.mockReturnValue(oversized);
+        appendCapped("/data/logs/plugin.log", "new\n", 100);
+        expect(mocked.writeFileSync).toHaveBeenCalledWith("/data/logs/plugin.log", oversized.slice(-100));
+        const writeOrder = mocked.writeFileSync.mock.invocationCallOrder[0];
+        const appendOrder = mocked.appendFileSync.mock.invocationCallOrder[0];
+        expect(writeOrder).toBeLessThan(appendOrder);
+    });
+
+    it("leaves a file at or under the cap untrimmed", () => {
+        mocked.statSync.mockReturnValue({ size: 100 });
+        appendCapped("/data/logs/plugin.log", "new\n", 100);
+        expect(mocked.writeFileSync).not.toHaveBeenCalled();
+        expect(mocked.appendFileSync).toHaveBeenCalledWith("/data/logs/plugin.log", "new\n");
+    });
+
+    it("swallows existsSync errors", () => {
+        mocked.existsSync.mockImplementation(() => {
+            throw new Error("EACCES");
+        });
+        expect(() => appendCapped("/data/logs/plugin.log", "line\n", 100)).not.toThrow();
+    });
+
+    it("swallows appendFileSync errors", () => {
+        mocked.appendFileSync.mockImplementation(() => {
+            throw new Error("ENOSPC");
+        });
+        expect(() => appendCapped("/data/logs/plugin.log", "line\n", 100)).not.toThrow();
+    });
+});

--- a/tests/diagnostics-export.test.ts
+++ b/tests/diagnostics-export.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Notice } from "obsidian";
+import { shell } from "electron";
+import { exportDiagnostics } from "../src/diagnostics-export";
+import { node } from "../src/binary-manager";
+import { DEFAULT_SETTINGS, SERVER_STATE } from "../src/types";
+import type { DiagnosticsContext } from "../src/types";
+
+vi.mock("../src/binary-manager", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../src/binary-manager")>();
+    return {
+        ...actual,
+        node: {
+            ...actual.node,
+            existsSync: vi.fn().mockReturnValue(true),
+            readdirSync: vi.fn().mockReturnValue([]),
+            readFileSync: vi.fn().mockReturnValue(""),
+            statSync: vi.fn().mockReturnValue({ size: 0 }),
+            writeFileSync: vi.fn(),
+            join: (...parts: string[]) => parts.join("/"),
+        },
+    };
+});
+
+function makeContext(): DiagnosticsContext {
+    return {
+        dataDir: "/data",
+        sharedRoot: "/shared",
+        settings: { ...DEFAULT_SETTINGS },
+        journalEntries: [],
+        pluginVersion: "1.2.3",
+        serverState: SERVER_STATE.ERROR,
+        serverUrl: "",
+        lastStderr: "",
+    };
+}
+
+describe("exportDiagnostics", () => {
+    let writeText: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        Notice.clear();
+        vi.stubEnv("HOME", "/Users/alice");
+        writeText = vi.fn().mockResolvedValue(undefined);
+        vi.stubGlobal("navigator", { clipboard: { writeText } });
+        vi.mocked(node.writeFileSync).mockImplementation(() => undefined);
+        vi.mocked(node.existsSync).mockReturnValue(true);
+    });
+
+    it("writes the zip to Downloads, reveals it, copies the summary, and notifies", async () => {
+        await exportDiagnostics(makeContext());
+
+        const write = vi.mocked(node.writeFileSync);
+        expect(write).toHaveBeenCalledTimes(1);
+        const [zipPath, body] = write.mock.calls[0] as [string, unknown];
+        expect(zipPath).toMatch(/\/Users\/alice\/Downloads\/lilbee-diagnostics-.*\.zip$/);
+        expect(body).toBeInstanceOf(Uint8Array);
+        expect(vi.mocked(shell.showItemInFolder)).toHaveBeenCalledWith(zipPath);
+        expect(writeText).toHaveBeenCalledTimes(1);
+        expect(writeText.mock.calls[0][0]).toContain("Review this bundle before sharing");
+        expect(Notice.instances.some((n) => n.message.includes("Review the contents before sharing"))).toBe(true);
+    });
+
+    it("falls back to summary.md when the zip write fails", async () => {
+        vi.mocked(node.writeFileSync).mockImplementationOnce(() => {
+            throw new Error("disk full");
+        });
+
+        await exportDiagnostics(makeContext());
+
+        const write = vi.mocked(node.writeFileSync);
+        expect(write).toHaveBeenCalledTimes(2);
+        const [summaryPath, body] = write.mock.calls[1] as [string, unknown];
+        expect(summaryPath).toMatch(/summary\.md$/);
+        expect(typeof body).toBe("string");
+        expect(Notice.instances.some((n) => n.message.includes("summary.md"))).toBe(true);
+        expect(vi.mocked(shell.showItemInFolder)).toHaveBeenCalledWith(summaryPath);
+    });
+
+    it("reports failure and skips reveal when every write throws an Error", async () => {
+        vi.mocked(node.writeFileSync).mockImplementation(() => {
+            throw new Error("disk full");
+        });
+
+        await exportDiagnostics({ ...makeContext(), dataDir: null });
+
+        expect(Notice.instances.some((n) => n.message.includes("Diagnostics export failed: disk full"))).toBe(true);
+        expect(vi.mocked(shell.showItemInFolder)).not.toHaveBeenCalled();
+    });
+
+    it("stringifies non-Error throwables in the failure notice", async () => {
+        vi.mocked(node.writeFileSync).mockImplementation(() => {
+            throw "disk exploded";
+        });
+
+        await exportDiagnostics(makeContext());
+
+        expect(Notice.instances.some((n) => n.message.includes("Diagnostics export failed: disk exploded"))).toBe(true);
+        expect(vi.mocked(shell.showItemInFolder)).not.toHaveBeenCalled();
+    });
+
+    it("treats clipboard and reveal failures as non-fatal", async () => {
+        writeText.mockRejectedValueOnce(new Error("no clipboard"));
+        vi.mocked(shell.showItemInFolder).mockImplementationOnce(() => {
+            throw new Error("no shell");
+        });
+
+        await exportDiagnostics(makeContext());
+
+        expect(Notice.instances.some((n) => n.message.includes("Diagnostics saved to"))).toBe(true);
+    });
+});

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { strFromU8, unzipSync } from "fflate";
+import { buildZip, collectDiagnostics, LOG_TAIL_MAX_BYTES, renderSummary, resolveOutputDir } from "../src/diagnostics";
+import { node } from "../src/binary-manager";
+import { MESSAGES } from "../src/locales/en";
+import { DEFAULT_SETTINGS, SERVER_STATE } from "../src/types";
+import type { DiagnosticsContext } from "../src/types";
+
+vi.mock("../src/binary-manager", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../src/binary-manager")>();
+    return {
+        ...actual,
+        node: {
+            ...actual.node,
+            existsSync: vi.fn().mockReturnValue(false),
+            readdirSync: vi.fn().mockReturnValue([]),
+            readFileSync: vi.fn(),
+            statSync: vi.fn().mockReturnValue({ size: 10 }),
+            join: (...parts: string[]) => parts.join("/"),
+        },
+    };
+});
+
+function makeContext(overrides: Partial<DiagnosticsContext> = {}): DiagnosticsContext {
+    return {
+        dataDir: "/data",
+        sharedRoot: "/shared",
+        settings: { ...DEFAULT_SETTINGS },
+        journalEntries: [],
+        pluginVersion: "1.2.3",
+        serverState: SERVER_STATE.ERROR,
+        serverUrl: "http://127.0.0.1:1234",
+        lastStderr: "Traceback: boom",
+        ...overrides,
+    };
+}
+
+function fileText(ctx: DiagnosticsContext, name: string): string {
+    const bundle = collectDiagnostics(ctx);
+    const file = bundle.files.find((f) => f.name === name);
+    expect(file).toBeDefined();
+    expect(file?.data).not.toBeNull();
+    return strFromU8(file?.data as Uint8Array);
+}
+
+describe("collectDiagnostics", () => {
+    beforeEach(() => {
+        vi.mocked(node.existsSync).mockReturnValue(false);
+        vi.mocked(node.readdirSync).mockReturnValue([]);
+        vi.mocked(node.statSync).mockReturnValue({ size: 10 } as ReturnType<typeof node.statSync>);
+        vi.mocked(node.readFileSync).mockReturnValue("");
+    });
+
+    it("records misses for absent log files instead of failing", () => {
+        const bundle = collectDiagnostics(makeContext());
+        const misses = bundle.files.filter((f) => f.data === null);
+        expect(misses.length).toBeGreaterThan(0);
+        for (const miss of misses) expect(miss.note).toBe("not found");
+        expect(bundle.summaryMarkdown).toContain("not found");
+    });
+
+    it("collects existing logs with secrets redacted", () => {
+        vi.mocked(node.existsSync).mockReturnValue(true);
+        vi.mocked(node.readdirSync).mockReturnValue(["worker-chat.log"] as unknown as ReturnType<
+            typeof node.readdirSync
+        >);
+        vi.mocked(node.readFileSync).mockReturnValue('api_key = "sk-123"\nINFO ready');
+        const bundle = collectDiagnostics(makeContext());
+        const file = bundle.files.find((f) => f.name === "logs/worker-chat.log");
+        expect(file?.data).not.toBeNull();
+        const text = strFromU8(file?.data as Uint8Array);
+        expect(text).toContain("[redacted]");
+        expect(text).not.toContain("sk-123");
+    });
+
+    it("tail-caps oversized logs and notes truncation", () => {
+        vi.mocked(node.existsSync).mockReturnValue(true);
+        vi.mocked(node.readdirSync).mockReturnValue(["worker-chat.log"] as unknown as ReturnType<
+            typeof node.readdirSync
+        >);
+        vi.mocked(node.statSync).mockReturnValue({ size: LOG_TAIL_MAX_BYTES * 2 } as ReturnType<typeof node.statSync>);
+        vi.mocked(node.readFileSync).mockReturnValue("y\n".repeat(LOG_TAIL_MAX_BYTES));
+        const bundle = collectDiagnostics(makeContext());
+        const file = bundle.files.find((f) => f.name === "logs/worker-chat.log");
+        expect(file?.data?.length).toBeLessThanOrEqual(LOG_TAIL_MAX_BYTES);
+        expect(file?.note).toContain("truncated");
+    });
+
+    it("turns unreadable files into misses with the error noted", () => {
+        vi.mocked(node.existsSync).mockReturnValue(true);
+        vi.mocked(node.readdirSync).mockReturnValue(["worker-chat.log"] as unknown as ReturnType<
+            typeof node.readdirSync
+        >);
+        vi.mocked(node.readFileSync).mockImplementation(() => {
+            throw new Error("EACCES");
+        });
+        const bundle = collectDiagnostics(makeContext());
+        const file = bundle.files.find((f) => f.name === "logs/worker-chat.log");
+        expect(file?.data).toBeNull();
+        expect(file?.note).toContain("EACCES");
+    });
+
+    it("stringifies non-Error throws in the miss note", () => {
+        vi.mocked(node.existsSync).mockReturnValue(true);
+        vi.mocked(node.readdirSync).mockReturnValue(["worker-chat.log"] as unknown as ReturnType<
+            typeof node.readdirSync
+        >);
+        vi.mocked(node.readFileSync).mockImplementation(() => {
+            throw "nope";
+        });
+        const bundle = collectDiagnostics(makeContext());
+        const file = bundle.files.find((f) => f.name === "logs/worker-chat.log");
+        expect(file?.data).toBeNull();
+        expect(file?.note).toContain("nope");
+    });
+
+    it("does not duplicate an expected log that was found", () => {
+        vi.mocked(node.existsSync).mockReturnValue(true);
+        vi.mocked(node.readdirSync).mockReturnValue(["server.log"] as unknown as ReturnType<typeof node.readdirSync>);
+        vi.mocked(node.readFileSync).mockReturnValue("INFO ready");
+        const bundle = collectDiagnostics(makeContext());
+        expect(bundle.files.filter((f) => f.name === "logs/server.log")).toHaveLength(1);
+    });
+
+    it("notes the remote server when dataDir is null and still includes settings.json", () => {
+        const bundle = collectDiagnostics(makeContext({ dataDir: null }));
+        expect(bundle.summaryMarkdown).toContain(MESSAGES.DIAG_REMOTE_SERVER_NOTE);
+        expect(bundle.files.some((f) => f.name === "settings.json")).toBe(true);
+    });
+
+    it("includes redacted settings and the journal", () => {
+        const ctx = makeContext({
+            settings: { ...DEFAULT_SETTINGS, manualToken: "tok" },
+            journalEntries: [{ timestamp: "2026-06-11T00:00:00Z", label: "chat", message: "boom", stack: null }],
+        });
+        expect(fileText(ctx, "settings.json")).toContain("[redacted]");
+        expect(fileText(ctx, "journal.log")).toContain("boom");
+    });
+
+    it("includes journal entry stacks", () => {
+        const ctx = makeContext({
+            journalEntries: [{ timestamp: "t", label: "l", message: "m", stack: "at deepFrame" }],
+        });
+        expect(fileText(ctx, "journal.log")).toContain("at deepFrame");
+    });
+
+    it("renders a summary with warning header, environment, and stderr", () => {
+        const bundle = collectDiagnostics(makeContext());
+        expect(bundle.summaryMarkdown.startsWith(MESSAGES.DIAG_REVIEW_WARNING)).toBe(true);
+        expect(bundle.summaryMarkdown).toContain("1.2.3");
+        expect(bundle.summaryMarkdown).toContain(process.platform);
+        expect(bundle.summaryMarkdown).toContain("Traceback: boom");
+    });
+
+    it("renders placeholders for empty stderr, journal, url, and shared root", () => {
+        const bundle = collectDiagnostics(makeContext({ lastStderr: "", serverUrl: "", sharedRoot: null }));
+        expect(bundle.summaryMarkdown).toContain("(empty)");
+        expect(bundle.summaryMarkdown).toContain("(none)");
+    });
+
+    it("marks a noteless miss as missing in the summary", () => {
+        const summary = renderSummary(makeContext(), [{ name: "logs/server.log", data: null, note: null }]);
+        expect(summary).toContain("- logs/server.log: missing");
+    });
+
+    it("ignores non-log files and readdir failures", () => {
+        vi.mocked(node.existsSync).mockReturnValue(true);
+        vi.mocked(node.readdirSync).mockReturnValue(["notes.txt"] as unknown as ReturnType<typeof node.readdirSync>);
+        const bundle = collectDiagnostics(makeContext());
+        expect(bundle.files.some((f) => f.name === "logs/notes.txt")).toBe(false);
+
+        vi.mocked(node.readdirSync).mockImplementation(() => {
+            throw new Error("EIO");
+        });
+        const fallback = collectDiagnostics(makeContext());
+        expect(fallback.files.some((f) => f.name === "logs/server.log")).toBe(true);
+    });
+});
+
+describe("buildZip", () => {
+    beforeEach(() => {
+        vi.mocked(node.existsSync).mockReturnValue(true);
+        vi.mocked(node.readdirSync).mockReturnValue(["worker-chat.log"] as unknown as ReturnType<
+            typeof node.readdirSync
+        >);
+        vi.mocked(node.statSync).mockReturnValue({ size: 10 } as ReturnType<typeof node.statSync>);
+        vi.mocked(node.readFileSync).mockReturnValue("INFO ready");
+    });
+
+    it("zips the summary and collected files, skipping misses", () => {
+        const bundle = collectDiagnostics(makeContext());
+        const entries = unzipSync(buildZip(bundle));
+        expect(Object.keys(entries)).toContain("summary.md");
+        expect(Object.keys(entries)).toContain("logs/worker-chat.log");
+        expect(Object.keys(entries)).not.toContain("logs/spawn-crash.log");
+    });
+});
+
+describe("resolveOutputDir", () => {
+    it("returns ~/Downloads when it exists", () => {
+        vi.stubEnv("HOME", "/Users/alice");
+        vi.mocked(node.existsSync).mockReturnValue(true);
+        expect(resolveOutputDir("/fallback")).toBe("/Users/alice/Downloads");
+    });
+
+    it("falls back when Downloads is missing", () => {
+        vi.stubEnv("HOME", "/Users/alice");
+        vi.mocked(node.existsSync).mockReturnValue(false);
+        expect(resolveOutputDir("/fallback")).toBe("/fallback");
+    });
+
+    it("falls back when existsSync throws", () => {
+        vi.stubEnv("HOME", "/Users/alice");
+        vi.mocked(node.existsSync).mockImplementation(() => {
+            throw new Error("EPERM");
+        });
+        expect(resolveOutputDir("/fallback")).toBe("/fallback");
+    });
+
+    it("falls back when no home dir is set", () => {
+        vi.stubEnv("HOME", "");
+        vi.stubEnv("USERPROFILE", "");
+        expect(resolveOutputDir("/fallback")).toBe("/fallback");
+    });
+
+    it("uses USERPROFILE when HOME is unset", () => {
+        vi.stubEnv("HOME", undefined);
+        vi.stubEnv("USERPROFILE", "C:/Users/alice");
+        vi.mocked(node.existsSync).mockReturnValue(true);
+        expect(resolveOutputDir("/fallback")).toBe("C:/Users/alice/Downloads");
+    });
+});

--- a/tests/error-journal.test.ts
+++ b/tests/error-journal.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { node } from "../src/binary-manager";
+import { ErrorJournal, JOURNAL_MAX_ENTRIES, PLUGIN_LOG_MAX_BYTES } from "../src/error-journal";
+
+vi.mock("../src/binary-manager", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../src/binary-manager")>();
+    return {
+        ...actual,
+        node: {
+            ...actual.node,
+            existsSync: vi.fn().mockReturnValue(true),
+            mkdirSync: vi.fn(),
+            appendFileSync: vi.fn(),
+            readFileSync: vi.fn().mockReturnValue(""),
+            writeFileSync: vi.fn(),
+            statSync: vi.fn().mockReturnValue({ size: 0 }),
+            dirname: (p: string) => p.split("/").slice(0, -1).join("/"),
+        },
+    };
+});
+
+const mocked = node as unknown as {
+    existsSync: ReturnType<typeof vi.fn>;
+    appendFileSync: ReturnType<typeof vi.fn>;
+    readFileSync: ReturnType<typeof vi.fn>;
+    writeFileSync: ReturnType<typeof vi.fn>;
+    statSync: ReturnType<typeof vi.fn>;
+};
+
+describe("ErrorJournal", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocked.existsSync.mockReturnValue(true);
+        mocked.readFileSync.mockReturnValue("");
+        mocked.statSync.mockReturnValue({ size: 0 });
+    });
+
+    it("records entries with ISO timestamp, label, message, and stack", () => {
+        const journal = new ErrorJournal();
+        journal.record("sync", "boom", "stacktrace");
+        expect(journal.entries).toHaveLength(1);
+        const entry = journal.entries[0];
+        expect(entry.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+        expect(entry.label).toBe("sync");
+        expect(entry.message).toBe("boom");
+        expect(entry.stack).toBe("stacktrace");
+    });
+
+    it("defaults stack to null", () => {
+        const journal = new ErrorJournal();
+        journal.record("sync", "boom");
+        expect(journal.entries[0].stack).toBeNull();
+    });
+
+    it("evicts the oldest entries beyond JOURNAL_MAX_ENTRIES", () => {
+        const journal = new ErrorJournal();
+        for (let i = 0; i < JOURNAL_MAX_ENTRIES + 5; i++) {
+            journal.record("label", `m${i}`);
+        }
+        expect(journal.entries).toHaveLength(JOURNAL_MAX_ENTRIES);
+        expect(journal.entries[0].message).toBe("m5");
+    });
+
+    it("does not write to disk before setLogDir", () => {
+        const journal = new ErrorJournal();
+        journal.record("sync", "boom");
+        expect(mocked.appendFileSync).not.toHaveBeenCalled();
+    });
+
+    it("appends to <dir>/plugin.log after setLogDir", () => {
+        const journal = new ErrorJournal();
+        journal.setLogDir("/data/logs");
+        journal.record("sync", "boom", "trace");
+        expect(mocked.appendFileSync).toHaveBeenCalledTimes(1);
+        const [path, line] = mocked.appendFileSync.mock.calls[0] as [string, string];
+        expect(path).toContain("plugin.log");
+        expect(line).toContain("boom");
+        expect(line).toContain("[sync]");
+        expect(line).toContain("\ntrace\n");
+    });
+
+    it("trims an oversized plugin.log before appending", () => {
+        const oversized = "x".repeat(PLUGIN_LOG_MAX_BYTES + 100);
+        mocked.statSync.mockReturnValue({ size: oversized.length });
+        mocked.readFileSync.mockReturnValue(oversized);
+        const journal = new ErrorJournal();
+        journal.setLogDir("/data/logs");
+        journal.record("sync", "boom");
+        expect(mocked.writeFileSync).toHaveBeenCalledTimes(1);
+        const written = mocked.writeFileSync.mock.calls[0][1] as string;
+        expect(written.length).toBeLessThanOrEqual(PLUGIN_LOG_MAX_BYTES);
+        expect(mocked.appendFileSync).toHaveBeenCalled();
+    });
+
+    it("survives disk failures silently and keeps the entry in memory", () => {
+        mocked.appendFileSync.mockImplementation(() => {
+            throw new Error("ENOSPC");
+        });
+        const journal = new ErrorJournal();
+        journal.setLogDir("/data/logs");
+        expect(() => journal.record("sync", "boom")).not.toThrow();
+        expect(journal.entries).toHaveLength(1);
+        expect(journal.entries[0].message).toBe("boom");
+    });
+});

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1,7 +1,7 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { windowStub } from "./window-stub";
 import { Notice } from "obsidian";
-import { App, WorkspaceLeaf } from "./__mocks__/obsidian";
+import { App, MockElement, WorkspaceLeaf } from "./__mocks__/obsidian";
 import { SSE_EVENT } from "../src/types";
 import { FileProgressTracker } from "../src/main";
 import { MESSAGES } from "../src/locales/en";
@@ -11,6 +11,10 @@ import { exportDatasetToDisk, importDatasetFromDisk } from "../src/dataset-io";
 vi.mock("../src/dataset-io", () => ({
     exportDatasetToDisk: vi.fn().mockResolvedValue(undefined),
     importDatasetFromDisk: vi.fn().mockResolvedValue(undefined),
+}));
+import { exportDiagnostics } from "../src/diagnostics-export";
+vi.mock("../src/diagnostics-export", () => ({
+    exportDiagnostics: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock("../src/api", () => ({
     SessionTokenError: class SessionTokenError extends Error {
@@ -381,17 +385,18 @@ describe("LilbeePlugin", () => {
             expect(startSpy).toHaveBeenCalled();
         });
 
-        it("adds all twenty-six commands", async () => {
+        it("adds all twenty-seven commands", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
 
-            expect(plugin.addCommand).toHaveBeenCalledTimes(26);
+            expect(plugin.addCommand).toHaveBeenCalledTimes(27);
             const allIds = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.map((c: any[]) => c[0].id);
             expect(allIds).toContain("model-picker-chat");
             expect(allIds).toContain("model-picker-embedding");
             expect(allIds).toContain("model-info-active-chat");
             expect(allIds).toContain("model-info-active-embedding");
             expect(allIds).toContain("take-over");
+            expect(allIds).toContain("export-diagnostics");
             const ids = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.map((c: any[]) => c[0].id);
             expect(ids).toContain("search");
             expect(ids).toContain("chat");
@@ -4341,6 +4346,196 @@ describe("LilbeePlugin", () => {
             expect(notice).toBeDefined();
             expect(notice!.message).toContain("database locked");
             mockLastStderr = "";
+        });
+
+        describe("diagnostics export wiring", () => {
+            const exportLink = (notice: Notice): MockElement | undefined =>
+                (notice.noticeEl as unknown as MockElement).children.find((c) => c.tagName === "A");
+
+            const domHandler = (plugin: unknown, type: string): ((e: unknown) => void) => {
+                const events = (plugin as { domEvents: Array<{ type: string; cb: (e: unknown) => void }> }).domEvents;
+                const entry = events.find((d) => d.type === type);
+                expect(entry).toBeDefined();
+                return entry!.cb;
+            };
+
+            it("export-diagnostics command invokes exportDiagnostics while the server is down", async () => {
+                const plugin = await createPlugin();
+                await plugin.onload();
+                expect((plugin as any).serverManager).toBeNull();
+                const cmd = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.find(
+                    (c: any[]) => c[0].id === "export-diagnostics",
+                )![0];
+                expect(cmd.checkCallback).toBeUndefined();
+                (plugin as any).vaultRegistry = null;
+                cmd.callback();
+                expect(exportDiagnostics).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        dataDir: null,
+                        sharedRoot: null,
+                        serverState: "stopped",
+                        serverUrl: plugin.settings.serverUrl,
+                        lastStderr: "",
+                        pluginVersion: "0.1.0",
+                    }),
+                );
+            });
+
+            it("diagnosticsContext reads the live managed server when present", async () => {
+                const plugin = await createPlugin({ serverMode: "managed" });
+                await plugin.onload();
+                await flush();
+                const ctx = plugin.diagnosticsContext();
+                expect(ctx.dataDir).toBe(mockServerOpts.dataDir);
+                expect(ctx.sharedRoot).toBe((plugin as any).vaultRegistry.sharedRoot);
+                expect(ctx.serverState).toBe("ready");
+                expect(ctx.serverUrl).toBe("http://127.0.0.1:54321");
+                expect(ctx.journalEntries).toBe(plugin.journal.entries);
+            });
+
+            it("showError records label, message, and stack to the journal", async () => {
+                const plugin = await createPlugin();
+                await plugin.onload();
+                (plugin as any).showError("indexing failed", new Error("boom"));
+                const entry = plugin.journal.entries.find((e) => e.label === "indexing failed");
+                expect(entry).toBeDefined();
+                expect(entry!.message).toBe("boom");
+                expect(entry!.stack).toContain("boom");
+            });
+
+            it("showError journals non-Error values with a null stack", async () => {
+                const plugin = await createPlugin();
+                await plugin.onload();
+                (plugin as any).showError("weird failure", 42);
+                const entry = plugin.journal.entries.find((e) => e.label === "weird failure");
+                expect(entry).toBeDefined();
+                expect(entry!.message).toBe("42");
+                expect(entry!.stack).toBeNull();
+            });
+
+            it("showError attaches an export link to its notice when a server manager exists", async () => {
+                const plugin = await createPlugin({ serverMode: "managed" });
+                await plugin.onload();
+                await flush();
+                (plugin as any).showError("sync failed", new Error("boom"));
+                const notice = Notice.instances.find((n) => n.message.includes("sync failed"))!;
+                const link = exportLink(notice);
+                expect(link).toBeDefined();
+                expect(link!.textContent).toBe(MESSAGES.BUTTON_EXPORT_DIAGNOSTICS);
+                link!.trigger("click");
+                expect(exportDiagnostics).toHaveBeenCalled();
+            });
+
+            it("showError attaches no export link without a server manager", async () => {
+                const plugin = await createPlugin();
+                await plugin.onload();
+                (plugin as any).showError("sync failed", new Error("boom"));
+                const notice = Notice.instances.find((n) => n.message.includes("sync failed"))!;
+                expect(exportLink(notice)).toBeUndefined();
+            });
+
+            it("journals window errors with lilbee in the stack", async () => {
+                const plugin = await createPlugin();
+                await plugin.onload();
+                const handler = domHandler(plugin, "error");
+                const err = new Error("boom");
+                err.stack = "Error: boom\n    at plugin:lilbee:main.js:1:1";
+                handler({ message: "boom", error: err });
+                const entry = plugin.journal.entries.find((e) => e.label === "window");
+                expect(entry).toBeDefined();
+                expect(entry!.message).toBe("boom");
+                expect(entry!.stack).toContain("lilbee");
+            });
+
+            it("ignores window errors from other plugins, non-Error errors, and missing stacks", async () => {
+                const plugin = await createPlugin();
+                await plugin.onload();
+                const handler = domHandler(plugin, "error");
+                const foreign = new Error("other");
+                foreign.stack = "Error: other\n    at plugin:other:main.js:1:1";
+                handler({ message: "other", error: foreign });
+                const stackless = new Error("bare");
+                stackless.stack = undefined;
+                handler({ message: "bare", error: stackless });
+                handler({ message: "string", error: "not an error" });
+                expect(plugin.journal.entries.some((e) => e.label === "window")).toBe(false);
+            });
+
+            it("journals unhandled rejections with lilbee in the stack", async () => {
+                const plugin = await createPlugin();
+                await plugin.onload();
+                const handler = domHandler(plugin, "unhandledrejection");
+                const err = new Error("rejected");
+                err.stack = "Error: rejected\n    at plugin:lilbee:main.js:2:2";
+                handler({ reason: err });
+                const entry = plugin.journal.entries.find((e) => e.label === "unhandledrejection");
+                expect(entry).toBeDefined();
+                expect(entry!.message).toBe("rejected");
+                expect(entry!.stack).toContain("lilbee");
+            });
+
+            it("ignores unhandled rejections from elsewhere, non-Error reasons, and missing stacks", async () => {
+                const plugin = await createPlugin();
+                await plugin.onload();
+                const handler = domHandler(plugin, "unhandledrejection");
+                const foreign = new Error("other");
+                foreign.stack = "Error: other\n    at plugin:other:main.js:1:1";
+                handler({ reason: foreign });
+                const stackless = new Error("bare");
+                stackless.stack = undefined;
+                handler({ reason: stackless });
+                handler({ reason: "not an error" });
+                expect(plugin.journal.entries.some((e) => e.label === "unhandledrejection")).toBe(false);
+            });
+
+            it("onRestartsExhausted logs stderr, journals the crash, and attaches an export link", async () => {
+                const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+                try {
+                    const plugin = await createPlugin({ serverMode: "managed" });
+                    await plugin.onload();
+                    await flush();
+
+                    mockServerOpts.onRestartsExhausted("bind: address already in use");
+
+                    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("bind: address already in use"));
+                    const entry = plugin.journal.entries.find((e) => e.label === "server-crash");
+                    expect(entry).toBeDefined();
+                    expect(entry!.message).toBe(MESSAGES.ERROR_SERVER_CRASHED);
+                    expect(entry!.stack).toBe("bind: address already in use");
+
+                    const notice = Notice.instances.find((n) => n.message.includes("crashed after multiple restarts"))!;
+                    const link = exportLink(notice);
+                    expect(link).toBeDefined();
+                    expect(link!.textContent).toBe(MESSAGES.BUTTON_EXPORT_DIAGNOSTICS);
+                    link!.trigger("click");
+                    expect(exportDiagnostics).toHaveBeenCalled();
+                } finally {
+                    consoleSpy.mockRestore();
+                }
+            });
+
+            it("onRestartsExhausted journals a null stack when stderr is empty", async () => {
+                const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+                try {
+                    const plugin = await createPlugin({ serverMode: "managed" });
+                    await plugin.onload();
+                    await flush();
+                    mockServerOpts.onRestartsExhausted("");
+                    const entry = plugin.journal.entries.find((e) => e.label === "server-crash");
+                    expect(entry).toBeDefined();
+                    expect(entry!.stack).toBeNull();
+                } finally {
+                    consoleSpy.mockRestore();
+                }
+            });
+
+            it("points the journal at <dataDir>/logs when the managed server starts", async () => {
+                const plugin = await createPlugin({ serverMode: "managed" });
+                const spy = vi.spyOn(plugin.journal, "setLogDir");
+                await plugin.onload();
+                await flush();
+                expect(spy).toHaveBeenCalledWith(`${mockServerOpts.dataDir}/logs`);
+            });
         });
 
         it("ensureBinary progress callback updates status bar", async () => {

--- a/tests/redact.test.ts
+++ b/tests/redact.test.ts
@@ -19,6 +19,13 @@ describe("redactSecrets", () => {
         expect(redactSecrets(line)).toBe(line);
     });
 
+    it("handles a huge unbroken token in linear time", () => {
+        const huge = "y".repeat(1_048_576);
+        const start = Date.now();
+        expect(redactSecrets(huge)).toBe(huge);
+        expect(Date.now() - start).toBeLessThan(2_000);
+    });
+
     it("redacts every occurrence in multi-line text", () => {
         const text = 'a_token = "one"\npath = "/x"\napi_key = "two"';
         const out = redactSecrets(text);

--- a/tests/redact.test.ts
+++ b/tests/redact.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { redactSecrets, redactSettings } from "../src/redact";
+import { DEFAULT_SETTINGS, DEFAULT_SHARED_CONFIG } from "../src/types";
+
+describe("redactSecrets", () => {
+    it.each([
+        ['token = "abc123"', 'token = "[redacted]"'],
+        ['api_key = "sk-foo.bar"', 'api_key = "[redacted]"'],
+        ["apiKey: deadbeef", "apiKey: [redacted]"],
+        ["Authorization: Bearer abc.def", "Authorization: [redacted]"],
+        ["hf_token=hf_abcDEF123", "hf_token=[redacted]"],
+        ["secret: 's3cr3t'", "secret: '[redacted]'"],
+    ])("redacts %s", (input, expected) => {
+        expect(redactSecrets(input)).toBe(expected);
+    });
+
+    it("keeps non-secret lines untouched", () => {
+        const line = 'data_dir = "/Users/alice/notes"';
+        expect(redactSecrets(line)).toBe(line);
+    });
+
+    it("redacts every occurrence in multi-line text", () => {
+        const text = 'a_token = "one"\npath = "/x"\napi_key = "two"';
+        const out = redactSecrets(text);
+        expect(out).not.toContain("one");
+        expect(out).not.toContain("two");
+        expect(out).toContain('path = "/x"');
+    });
+});
+
+describe("redactSettings", () => {
+    it("blanks secret fields and keeps the rest", () => {
+        const settings = {
+            ...DEFAULT_SETTINGS,
+            manualToken: "tok123",
+            hfToken: "hf_x",
+            serverUrl: "http://127.0.0.1:7433",
+        };
+        const out = redactSettings(settings);
+        expect(out.manualToken).toBe("[redacted]");
+        expect(out.hfToken).toBe("[redacted]");
+        expect(out.serverUrl).toBe("http://127.0.0.1:7433");
+    });
+
+    it("leaves empty secret fields empty", () => {
+        const out = redactSettings({ ...DEFAULT_SETTINGS, ...DEFAULT_SHARED_CONFIG });
+        expect(out.manualToken).toBe("");
+        expect(out.hfToken).toBe("");
+    });
+
+    it("ignores secret fields that are absent", () => {
+        const out = redactSettings({ ...DEFAULT_SETTINGS });
+        expect(out.hfToken).toBeUndefined();
+    });
+});

--- a/tests/server-manager.test.ts
+++ b/tests/server-manager.test.ts
@@ -67,6 +67,7 @@ describe("ServerManager", () => {
     let existsSyncSpy: ReturnType<typeof vi.spyOn>;
     let readFileSyncSpy: ReturnType<typeof vi.spyOn>;
     let unlinkSyncSpy: ReturnType<typeof vi.spyOn>;
+    let appendFileSyncSpy: ReturnType<typeof vi.spyOn>;
     let child: MockChild;
 
     beforeEach(() => {
@@ -78,6 +79,8 @@ describe("ServerManager", () => {
         existsSyncSpy = vi.spyOn(node, "existsSync").mockReturnValue(true);
         readFileSyncSpy = vi.spyOn(node, "readFileSync").mockReturnValue("9999");
         unlinkSyncSpy = vi.spyOn(node, "unlinkSync").mockImplementation(() => {});
+        appendFileSyncSpy = vi.spyOn(node, "appendFileSync").mockImplementation(() => {});
+        vi.spyOn(node, "statSync").mockReturnValue({ size: 0 } as any);
     });
 
     afterEach(() => {
@@ -632,6 +635,66 @@ describe("ServerManager", () => {
             await vi.advanceTimersByTimeAsync(5000);
             expect(spawnSpy).toHaveBeenCalledOnce();
             expect(mgr.state).toBe("stopped");
+        });
+    });
+
+    // ── crash stderr snapshot ───────────────────────────────────────
+
+    describe("crash stderr snapshot", () => {
+        function crashLogCalls() {
+            return appendFileSyncSpy.mock.calls.filter(([path]) => String(path).includes("logs/spawn-crash.log"));
+        }
+
+        it("appends stderr to logs/spawn-crash.log on crash exit", async () => {
+            const mgr = new ServerManager(defaultOpts());
+            const p = mgr.start();
+            await vi.advanceTimersByTimeAsync(1000);
+            await p;
+
+            child.stderr._emit("data", Buffer.from("fatal: bind failed\n"));
+            child._emit("exit", 1, null);
+
+            const calls = crashLogCalls();
+            expect(calls).toHaveLength(1);
+            const [path, chunk] = calls[0] as unknown as [string, string];
+            expect(path).toBe("/tmp/data/logs/spawn-crash.log");
+            expect(chunk).toMatch(/^=== crash \d{4}-\d{2}-\d{2}T/);
+            expect(chunk).toContain("fatal: bind failed");
+        });
+
+        it("does not snapshot on clean stop", async () => {
+            const mgr = new ServerManager(defaultOpts());
+            const p = mgr.start();
+            await vi.advanceTimersByTimeAsync(1000);
+            await p;
+
+            child.kill = vi.fn(() => {
+                setTimeout(() => child._emit("exit", 0, null), 10);
+            });
+            const stopPromise = mgr.stop();
+            await vi.advanceTimersByTimeAsync(50);
+            await stopPromise;
+
+            expect(crashLogCalls()).toHaveLength(0);
+        });
+
+        it("snapshot failures do not break crash handling", async () => {
+            appendFileSyncSpy.mockImplementation(() => {
+                throw new Error("ENOSPC");
+            });
+            const mgr = new ServerManager(defaultOpts());
+            const p = mgr.start();
+            await vi.advanceTimersByTimeAsync(1000);
+            await p;
+
+            const child2 = mockChild();
+            spawnSpy.mockReturnValue(child2 as any);
+            child._emit("exit", 1, null);
+
+            expect(mgr.state).toBe("error");
+            // Restart timer still fires and respawns the server.
+            await vi.advanceTimersByTimeAsync(3500);
+            expect(spawnSpy).toHaveBeenCalledTimes(2);
         });
     });
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -73,6 +73,11 @@ vi.mock("../src/views/setup-wizard", () => ({
     }),
 }));
 
+import { exportDiagnostics } from "../src/diagnostics-export";
+vi.mock("../src/diagnostics-export", () => ({
+    exportDiagnostics: vi.fn().mockResolvedValue(undefined),
+}));
+
 let mockGenericConfirmResult = true;
 vi.mock("../src/views/confirm-modal", () => ({
     ConfirmModal: vi.fn().mockImplementation(function () {
@@ -117,6 +122,7 @@ function makePlugin(overrides: Partial<LilbeeSettings> & { lilbeeVersion?: strin
     const initWikiSync = vi.fn();
     const reconcileWiki = vi.fn().mockResolvedValue(undefined);
     const configureManagedStorage = vi.fn().mockResolvedValue(undefined);
+    const diagnosticsContext = vi.fn().mockReturnValue({ pluginVersion: "0.0.0-test" });
     return {
         settings,
         api,
@@ -129,6 +135,7 @@ function makePlugin(overrides: Partial<LilbeeSettings> & { lilbeeVersion?: strin
         initWikiSync,
         reconcileWiki,
         configureManagedStorage,
+        diagnosticsContext,
         activeModel: "",
         wikiEnabled: overrides.wikiEnabled !== undefined ? settings.wikiEnabled : true,
         wikiSync: null,
@@ -907,8 +914,8 @@ describe("LilbeeSettingTab", () => {
             const tab = makeTab(plugin);
             const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
-            // Setup wizard + Start + Check for updates + Refresh + Browse Catalog + Wiki Lint + Wiki Prune + Reset all = 8
-            expect(buttonOnClicks.length).toBe(8);
+            // Setup wizard + Start + Check for updates + Refresh + Browse Catalog + Wiki Lint + Wiki Prune + Export diagnostics + Reset all = 9
+            expect(buttonOnClicks.length).toBe(9);
             // Refresh is the fourth button (index 3)
             await expect(buttonOnClicks[3]()).resolves.not.toThrow();
         });
@@ -4135,9 +4142,9 @@ describe("managed mode settings", () => {
             const tab = makeTab(plugin);
             const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
-            // Wiki section renders before the Advanced section's Reset-all button, so lint/prune sit
-            // 3rd/2nd from the end: … lint, prune, reset-all.
-            const lintIdx = buttonOnClicks.length - 3;
+            // Wiki section renders before the Diagnostics and Advanced sections, so lint/prune sit
+            // 4th/3rd from the end: … lint, prune, export-diagnostics, reset-all.
+            const lintIdx = buttonOnClicks.length - 4;
             await buttonOnClicks[lintIdx]();
             expect(plugin.runWikiLint).toHaveBeenCalled();
         });
@@ -4149,7 +4156,7 @@ describe("managed mode settings", () => {
             const tab = makeTab(plugin);
             const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
-            const pruneIdx = buttonOnClicks.length - 2;
+            const pruneIdx = buttonOnClicks.length - 3;
             await buttonOnClicks[pruneIdx]();
             expect(plugin.runWikiPrune).toHaveBeenCalled();
         });
@@ -6746,5 +6753,45 @@ describe("LilbeeSettingTab.renderMemorySection", () => {
         (tab as any).renderMemorySection(new MockElement() as unknown as HTMLElement);
         await flush();
         expect(Notice.instances.map((n) => n.message)).not.toContain(MESSAGES.NOTICE_MEMORY_CONFIG_FAILED);
+    });
+});
+
+describe("Export diagnostics button", () => {
+    it("calls exportDiagnostics with the plugin's diagnostics context", () => {
+        const plugin = makePlugin();
+        mockChatPicker(plugin);
+        const ctx = { pluginVersion: "0.0.0-test" };
+        (plugin.diagnosticsContext as unknown as ReturnType<typeof vi.fn>).mockReturnValue(ctx);
+        const tab = makeTab(plugin);
+
+        const origAddButton = Setting.prototype.addButton;
+        const namedButtons: Array<{ name: string; onClick: () => unknown }> = [];
+        Setting.prototype.addButton = function (cb: (btn: any) => void) {
+            const name = (this as any)._name as string;
+            const fakeBtn = {
+                setButtonText: () => fakeBtn,
+                setDisabled: () => fakeBtn,
+                setWarning: () => fakeBtn,
+                setClass: () => fakeBtn,
+                onClick: (handler: () => unknown) => {
+                    namedButtons.push({ name, onClick: handler });
+                    return fakeBtn;
+                },
+            };
+            cb(fakeBtn);
+            return this;
+        };
+        try {
+            tab.display();
+        } finally {
+            Setting.prototype.addButton = origAddButton;
+        }
+
+        const diagnostics = namedButtons.find((b) => b.name === MESSAGES.LABEL_EXPORT_DIAGNOSTICS);
+        expect(diagnostics).toBeDefined();
+        diagnostics!.onClick();
+
+        expect(plugin.diagnosticsContext).toHaveBeenCalledTimes(1);
+        expect(exportDiagnostics).toHaveBeenCalledWith(ctx);
     });
 });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -15,6 +15,7 @@ export default defineConfig({
         },
         alias: {
             obsidian: new URL("./tests/__mocks__/obsidian.ts", import.meta.url).pathname,
+            electron: new URL("./tests/__mocks__/electron.ts", import.meta.url).pathname,
         },
     },
 });


### PR DESCRIPTION
When the managed server crashes or never starts, users have had nothing to share: stdout was dropped, only the last 20 stderr lines lived in memory, and the dev console was the only trace of plugin-side errors. Support threads stalled on "it keeps crashing" with no evidence.

## Export diagnostics

One click bundles everything a bug report needs into a zip: the server's logs (including the new server.log and fault log the server now writes), worker logs, the stderr the plugin captured when the server died, the plugin's own error journal, redacted settings and config, environment info, and a human-readable summary.md. The zip lands in Downloads, gets revealed in Finder/Explorer, and the summary is copied to the clipboard. It's reachable from three places: a settings button, a command palette entry, and a link right on the crash notice. Session tokens and API keys are redacted, and the user is told to review the bundle before sharing since paths and note titles stay.

## Capture that survives a restart

The plugin now keeps evidence on disk instead of in memory. Server crashes append the captured stderr to spawn-crash.log, plugin errors land in a persistent journal at plugin.log (window errors and unhandled rejections from the plugin included), and the crash notice now logs the full stderr buffer to the console instead of only showing the last five lines. All capture is best-effort and size-capped, so it can never break the plugin itself.

## Troubleshooting guide

A new TROUBLESHOOTING.md walks users from "it doesn't work" to a useful bug report: the export feature first, then dev-console steps, log locations per OS, running the server by hand, common causes (Gatekeeper, antivirus, drivers, Intel Macs, memory), and a clean reset that never touches notes. Linked from the README's support section.

Pairs with tobocop2/lilbee#339, which gives the server its own persistent logs; either side ships independently.