### PR TITLE
Stop gitleaks flagging the synthetic redaction test fixtures

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,14 @@
+# Gitleaks config. Extends the default ruleset (so every real secret pattern
+# still fires) and allowlists the redaction unit test, whose fixtures are
+# synthetic secret-shaped strings that exist only to prove redactSecrets()
+# rewrites them to [redacted].
+title = "lilbee gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Synthetic secret-shaped fixtures for the redaction unit tests"
+paths = [
+    '''tests/redact\.test\.ts''',
+]


### PR DESCRIPTION
The Security Scan on main started failing after the diagnostics export merge: gitleaks flags `tests/redact.test.ts` because the redaction unit tests deliberately contain secret-shaped fixtures (a fake `hf_token=...`, `api_key=...`, etc.) to prove redactSecrets() rewrites them to [redacted]. None are real credentials.

This adds a `.gitleaks.toml` that extends the default ruleset (so every real secret pattern still fires everywhere else) and allowlists only that one test file. Verified locally with gitleaks: the full-repo scan reports no leaks with the config, and the default rules remain active.