### PR TITLE
Leave nothing behind when the plugin is uninstalled

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -224,6 +224,15 @@ export const MESSAGES = {
     LABEL_STORAGE_MODELS: "Models cache",
     LABEL_STORAGE_VAULT: "This vault",
     LABEL_STORAGE_TOTAL: "Total",
+    LABEL_UNINSTALL: "Uninstall lilbee",
+    DESC_UNINSTALL: (path: string): string =>
+        `Deletes the server binary, downloaded models, and every vault's index from ${path}. Do this before removing the plugin and nothing is left behind. Your notes are not touched.`,
+    BUTTON_UNINSTALL: "Delete server and data",
+    CONFIRM_UNINSTALL: (size: string, vaultCount: number): string =>
+        `Delete the lilbee server and everything it downloaded (${size})? This removes the index data of ${vaultCount === 1 ? "1 vault" : `${vaultCount} vaults`}. Your notes stay where they are, but models will need to be downloaded again if you reinstall.`,
+    NOTICE_UNINSTALL_BLOCKED: (vaultName: string): string =>
+        `lilbee is still serving "${vaultName}". Close that vault or take over before deleting.`,
+    NOTICE_UNINSTALL_DONE: "lilbee server and data deleted. You can now remove the plugin.",
     LABEL_EMBEDDING_MODEL: "Embedding model",
     LABEL_RERANKER_TITLE: "Reranker model",
     LABEL_RERANKER_DISABLED: "(disabled)",
@@ -853,7 +862,7 @@ export const MESSAGES = {
     MANAGED_CONSENT_PILL_RECOMMENDED: "Recommended",
     MANAGED_CONSENT_CARD_MANAGED_TITLE: "Managed",
     MANAGED_CONSENT_CARD_MANAGED_DESC:
-        "This plugin downloads the server and handles start, stop, and updates. Nothing else to install.",
+        "This plugin downloads the server and handles start, stop, and updates. Nothing else to install. Everything lives in one folder you can delete from settings at any time.",
     MANAGED_CONSENT_CARD_EXTERNAL_TITLE: "External",
     MANAGED_CONSENT_CARD_EXTERNAL_DESC: "You run lilbee serve yourself. The plugin connects to it.",
     MANAGED_CONSENT_CARD_EXTERNAL_HINT: "For advanced / custom setups",

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,9 +15,17 @@ import { exportDiagnostics } from "./diagnostics-export";
 import { ErrorJournal } from "./error-journal";
 import type { ReleaseInfo } from "./binary-manager";
 import { ServerManager } from "./server-manager";
-import { readSessionToken, resolveExternalDataRoot } from "./session-token";
+import { getDefaultLilbeeDataRoot, readSessionToken, resolveExternalDataRoot } from "./session-token";
 import { LilbeeSettingTab } from "./settings";
-import { VaultRegistry, computeVaultId, resolveSharedRoot, sharedBinDir, sharedModelsDir } from "./vault-registry";
+import {
+    VaultRegistry,
+    computeVaultId,
+    deleteManagedInstall,
+    migrateLegacySharedRoot,
+    resolveSharedRoot,
+    sharedBinDir,
+    sharedModelsDir,
+} from "./vault-registry";
 import {
     DEFAULT_SETTINGS,
     DOT_STATE,
@@ -26,6 +34,7 @@ import {
     LOGS_DIR,
     MANAGED_CONSENT_RESULT,
     MANAGED_PHASE,
+    MIGRATION_RESULT,
     SERVER_MODE,
     SERVER_STATE,
     SETUP_OUTCOME,
@@ -1208,7 +1217,37 @@ export default class LilbeePlugin extends Plugin {
         this.previousServerMode = this.settings.serverMode;
         this.taskQueue.loadFromJSON(raw?.taskHistory as { history?: import("./types").TaskEntry[] } | undefined);
         this.vaultId = computeVaultId(this.getVaultBasePath());
-        this.vaultRegistry = new VaultRegistry(resolveSharedRoot(this.settings.sharedRoot));
+        this.vaultRegistry = new VaultRegistry(this.resolveMigratedSharedRoot());
+    }
+
+    /** Plugin-owned root by default; migrates a legacy CLI-shared install once, deferring while it's live. */
+    private resolveMigratedSharedRoot(): string {
+        const root = resolveSharedRoot(this.settings.sharedRoot);
+        if (this.settings.sharedRoot) return root;
+        const legacy = getDefaultLilbeeDataRoot();
+        if (legacy !== null && migrateLegacySharedRoot(legacy, root) === MIGRATION_RESULT.DEFERRED) return legacy;
+        return root;
+    }
+
+    /** Stop the managed server and delete the binary, model cache, and every vault's index data. */
+    async uninstallManagedInstall(): Promise<boolean> {
+        const registry = this.vaultRegistry;
+        if (!registry) return false;
+        if (registry.lockState(this.vaultId) === LOCK_STATE.LIVE_OTHER) {
+            const owner = registry.readLock();
+            const ownerName = owner ? this.lookupVaultName(owner.vaultId) : "another vault";
+            new Notice(MESSAGES.NOTICE_UNINSTALL_BLOCKED(ownerName));
+            return false;
+        }
+        if (this.serverManager) {
+            await this.serverManager.stop();
+            this.serverManager = null;
+        }
+        deleteManagedInstall(registry.sharedRoot);
+        this.binaryManager = null;
+        this.updateStatusBar(MESSAGES.STATUS_STOPPED, DOT_STATE.MUTED);
+        new Notice(MESSAGES.NOTICE_UNINSTALL_DONE);
+        return true;
     }
 
     getSharedLilbeeVersion(): string {

--- a/src/session-token.ts
+++ b/src/session-token.ts
@@ -19,19 +19,28 @@ import { PLATFORM } from "./types";
 
 const MAX_WALK_UP_DEPTH = 32;
 
-export function getDefaultLilbeeDataRoot(): string | null {
+function platformDataDir(): string | null {
     const home = process.env.HOME ?? process.env.USERPROFILE;
     if (!home) return null;
 
     if (process.platform === PLATFORM.DARWIN) {
-        return `${home}/Library/Application Support/lilbee`;
+        return `${home}/Library/Application Support`;
     }
     if (process.platform === PLATFORM.WIN32) {
-        const local = process.env.LOCALAPPDATA;
-        return local ? `${local}/lilbee` : `${home}/AppData/Local/lilbee`;
+        return process.env.LOCALAPPDATA ?? `${home}/AppData/Local`;
     }
-    const xdg = process.env.XDG_DATA_HOME;
-    return xdg ? `${xdg}/lilbee` : `${home}/.local/share/lilbee`;
+    return process.env.XDG_DATA_HOME ?? `${home}/.local/share`;
+}
+
+export function getDefaultLilbeeDataRoot(): string | null {
+    const base = platformDataDir();
+    return base ? `${base}/lilbee` : null;
+}
+
+/** Managed-mode root owned solely by this plugin — safe to delete wholesale on uninstall. */
+export function getDefaultPluginDataRoot(): string | null {
+    const base = platformDataDir();
+    return base ? `${base}/obsidian-lilbee` : null;
 }
 
 export function findLocalLilbeeRoot(startDir: string): string | null {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -17,7 +17,7 @@ import {
 } from "./types";
 import type { CatalogEntry, ConfigResponse, InstalledModel, LilbeeSettings, ServerMode } from "./types";
 import { exportDiagnostics } from "./diagnostics-export";
-import { formatBytes, reportForVault } from "./storage-stats";
+import { dirSizeBytes, formatBytes, reportForVault } from "./storage-stats";
 import { MESSAGES } from "./locales/en";
 import { displayLabelForRef, extractHfRepo } from "./utils/model-ref";
 import { CatalogModal } from "./views/catalog-modal";
@@ -293,6 +293,31 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 }
             }),
         );
+
+        this.renderUninstall(containerEl);
+    }
+
+    /** Danger-zone removal of the whole managed install, gated behind a sized confirm dialog. */
+    private renderUninstall(containerEl: HTMLElement): void {
+        const registry = this.plugin.vaultRegistry;
+        if (!registry) return;
+        new Setting(containerEl)
+            .setName(MESSAGES.LABEL_UNINSTALL)
+            .setDesc(MESSAGES.DESC_UNINSTALL(registry.sharedRoot))
+            .addButton((btn) =>
+                btn
+                    .setButtonText(MESSAGES.BUTTON_UNINSTALL)
+                    // setWarning is deprecated and setDestructive needs Obsidian 1.13+; the class is what both apply.
+                    .setClass("mod-warning")
+                    .onClick(async () => {
+                        const size = formatBytes(dirSizeBytes(registry.sharedRoot));
+                        const vaultCount = Math.max(registry.list().length, 1);
+                        const confirm = new ConfirmModal(this.app, MESSAGES.CONFIRM_UNINSTALL(size, vaultCount));
+                        confirm.open();
+                        if (!(await confirm.result)) return;
+                        if (await this.plugin.uninstallManagedInstall()) this.render();
+                    }),
+            );
     }
 
     /** Indeterminate progress panel for the managed-server update; hidden until an update runs. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -394,7 +394,7 @@ export interface LilbeeSettings {
     /**
      * Filesystem root that holds the shared lilbee binary, models cache, and
      * per-vault data directories. Empty string means "use platform default"
-     * (resolved via getDefaultLilbeeDataRoot). Set explicitly to point the
+     * (resolved via getDefaultPluginDataRoot). Set explicitly to point the
      * plugin at a different location (e.g. an external SSD).
      */
     sharedRoot: string;
@@ -471,6 +471,15 @@ export const LOCK_STATE = {
     STALE: "stale",
     LIVE_OTHER: "live_other",
 } as const satisfies Record<string, LockState>;
+
+/** Outcome of moving a legacy CLI-shared root into the plugin-owned root. */
+export type MigrationResult = "none" | "migrated" | "deferred";
+
+export const MIGRATION_RESULT = {
+    NONE: "none",
+    MIGRATED: "migrated",
+    DEFERRED: "deferred",
+} as const satisfies Record<string, MigrationResult>;
 
 /** Names of files/dirs the plugin writes inside the shared root. */
 export const SHARED_PATH = {

--- a/src/vault-registry.ts
+++ b/src/vault-registry.ts
@@ -3,23 +3,25 @@
  * One lilbee binary, one HF cache, many vault data-dirs, one active vault at a time.
  */
 import { node } from "./binary-manager";
-import { getDefaultLilbeeDataRoot } from "./session-token";
+import { getDefaultPluginDataRoot } from "./session-token";
 import {
     DEFAULT_SHARED_CONFIG,
     LOCK_STATE,
+    MIGRATION_RESULT,
     SHARED_PATH,
     type ActiveLock,
     type LockState,
+    type MigrationResult,
     type SharedConfig,
     type VaultRegistryEntry,
 } from "./types";
 
 const VAULT_ID_BYTES = 6;
-const FALLBACK_SHARED_ROOT = "/tmp/lilbee";
+const FALLBACK_SHARED_ROOT = "/tmp/obsidian-lilbee";
 
 export function resolveSharedRoot(setting: string): string {
     if (setting && setting.length > 0) return setting;
-    return getDefaultLilbeeDataRoot() ?? FALLBACK_SHARED_ROOT;
+    return getDefaultPluginDataRoot() ?? FALLBACK_SHARED_ROOT;
 }
 
 export function computeVaultId(vaultPath: string): string {
@@ -85,6 +87,92 @@ function isProcessAlive(pid: number): boolean {
         return true;
     } catch {
         return false;
+    }
+}
+
+/** Everything moved off the legacy root; the lock is stale by definition and is deleted instead. */
+const MIGRATABLE_ENTRIES = [
+    SHARED_PATH.BIN,
+    SHARED_PATH.MODELS,
+    SHARED_PATH.VAULTS,
+    SHARED_PATH.CONFIG,
+    SHARED_PATH.REGISTRY,
+] as const;
+
+/** Entries only the plugin writes; the CLI may create models/ or config files of its own. */
+const PLUGIN_MARKERS = [SHARED_PATH.BIN, SHARED_PATH.REGISTRY] as const;
+
+function hasPluginEntries(root: string): boolean {
+    return Object.values(SHARED_PATH).some((entry) => node.existsSync(node.join(root, entry)));
+}
+
+function moveEntry(from: string, to: string): void {
+    try {
+        node.renameSync(from, to);
+    } catch {
+        // cross-device rename; copy then remove
+        node.cpSync(from, to, { recursive: true });
+        node.rmSync(from, { recursive: true, force: true });
+    }
+}
+
+/** Registry entries carry absolute data-dir paths; repoint the ones under the legacy root. */
+function rewriteDataDirPrefixes(newRoot: string, legacyRoot: string): void {
+    const path = node.join(newRoot, SHARED_PATH.REGISTRY);
+    const entries = readJson<VaultRegistryEntry[]>(path);
+    if (entries === null) return;
+    const prefix = `${legacyRoot}/`;
+    const rewritten = entries.map((e) =>
+        e.dataDir.startsWith(prefix) ? { ...e, dataDir: node.join(newRoot, e.dataDir.slice(prefix.length)) } : e,
+    );
+    writeJsonAtomic(path, rewritten);
+}
+
+/**
+ * One-time move of plugin-created entries from the legacy CLI-shared data root
+ * into the plugin-owned root. Anything else in the legacy root (e.g. an
+ * external `lilbee serve` install) stays untouched. Returns DEFERRED while a
+ * live process still serves from the legacy root; the next plugin load retries.
+ */
+export function migrateLegacySharedRoot(legacyRoot: string | null, newRoot: string): MigrationResult {
+    if (!legacyRoot || hasPluginEntries(newRoot)) return MIGRATION_RESULT.NONE;
+    if (!PLUGIN_MARKERS.some((e) => node.existsSync(node.join(legacyRoot, e)))) return MIGRATION_RESULT.NONE;
+
+    const lock = readJson<ActiveLock>(node.join(legacyRoot, SHARED_PATH.LOCK));
+    if (lock !== null && isProcessAlive(lock.pid)) return MIGRATION_RESULT.DEFERRED;
+
+    ensureDir(newRoot);
+    for (const entry of MIGRATABLE_ENTRIES) {
+        const from = node.join(legacyRoot, entry);
+        if (!node.existsSync(from)) continue;
+        try {
+            moveEntry(from, node.join(newRoot, entry));
+        } catch (err) {
+            console.warn(`[lilbee] could not migrate ${from}; it will be recreated`, err);
+        }
+    }
+    try {
+        node.unlinkSync(node.join(legacyRoot, SHARED_PATH.LOCK));
+    } catch {
+        // no stale lock to clean up
+    }
+    rewriteDataDirPrefixes(newRoot, legacyRoot);
+    return MIGRATION_RESULT.MIGRATED;
+}
+
+/**
+ * Delete the managed install. The plugin-owned default root is removed
+ * wholesale; a user-overridden root may hold files the plugin never wrote,
+ * so only the entries the plugin creates are removed there.
+ */
+export function deleteManagedInstall(sharedRoot: string): void {
+    const defaultRoot = getDefaultPluginDataRoot() ?? FALLBACK_SHARED_ROOT;
+    if (node.resolve(sharedRoot) === node.resolve(defaultRoot)) {
+        node.rmSync(sharedRoot, { recursive: true, force: true });
+        return;
+    }
+    for (const entry of Object.values(SHARED_PATH)) {
+        node.rmSync(node.join(sharedRoot, entry), { recursive: true, force: true });
     }
 }
 

--- a/tests/locales/en.test.ts
+++ b/tests/locales/en.test.ts
@@ -450,3 +450,19 @@ describe("types", () => {
         expect(sorts).toContain(FILTERS.SORT.SIZE_DESC);
     });
 });
+
+describe("uninstall strings", () => {
+    it("DESC_UNINSTALL names the shared root", () => {
+        expect(MESSAGES.DESC_UNINSTALL("/data/obsidian-lilbee")).toContain("/data/obsidian-lilbee");
+    });
+
+    it("CONFIRM_UNINSTALL pluralizes the vault count", () => {
+        expect(MESSAGES.CONFIRM_UNINSTALL("1.2 GB", 1)).toContain("1 vault");
+        expect(MESSAGES.CONFIRM_UNINSTALL("1.2 GB", 3)).toContain("3 vaults");
+        expect(MESSAGES.CONFIRM_UNINSTALL("1.2 GB", 3)).toContain("1.2 GB");
+    });
+
+    it("NOTICE_UNINSTALL_BLOCKED names the owning vault", () => {
+        expect(MESSAGES.NOTICE_UNINSTALL_BLOCKED("Work")).toContain('"Work"');
+    });
+});

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -2,7 +2,7 @@ import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { windowStub } from "./window-stub";
 import { Notice } from "obsidian";
 import { App, MockElement, WorkspaceLeaf } from "./__mocks__/obsidian";
-import { SETUP_OUTCOME, SSE_EVENT } from "../src/types";
+import { LOCK_STATE, SETUP_OUTCOME, SSE_EVENT } from "../src/types";
 import { VaultRegistry } from "../src/vault-registry";
 import { FileProgressTracker } from "../src/main";
 import { MESSAGES } from "../src/locales/en";
@@ -670,6 +670,127 @@ describe("LilbeePlugin", () => {
             await plugin.loadSettings();
             expect(plugin.settings.topK).toBe(12);
             expect(plugin.settings.serverMode).toBe("managed");
+        });
+
+        it("uses the configured shared root verbatim without migrating", async () => {
+            const { node } = await import("../src/binary-manager");
+            const plugin = await createPlugin({ sharedRoot: "/custom/root" });
+            await plugin.loadSettings();
+            expect(plugin.vaultRegistry?.sharedRoot).toBe("/custom/root");
+            expect(node.renameSync).not.toHaveBeenCalled();
+        });
+
+        it("defaults to the plugin-owned root when there is no legacy install", async () => {
+            const plugin = await createPlugin();
+            await plugin.loadSettings();
+            expect(plugin.vaultRegistry?.sharedRoot).toMatch(/obsidian-lilbee/);
+        });
+
+        it("migrates a legacy install into the plugin-owned root", async () => {
+            const { node } = await import("../src/binary-manager");
+            const { getDefaultLilbeeDataRoot, getDefaultPluginDataRoot } = await import("../src/session-token");
+            const legacy = getDefaultLilbeeDataRoot() as string;
+            const newRoot = getDefaultPluginDataRoot() as string;
+            vi.mocked(node.existsSync).mockImplementation((p) => p === `${legacy}/bin`);
+
+            const plugin = await createPlugin();
+            await plugin.loadSettings();
+
+            expect(plugin.vaultRegistry?.sharedRoot).toBe(newRoot);
+            expect(node.renameSync).toHaveBeenCalledWith(`${legacy}/bin`, `${newRoot}/bin`);
+        });
+
+        it("keeps the legacy root for the session while a live process serves from it", async () => {
+            const { node } = await import("../src/binary-manager");
+            const { getDefaultLilbeeDataRoot } = await import("../src/session-token");
+            const legacy = getDefaultLilbeeDataRoot() as string;
+            vi.mocked(node.existsSync).mockImplementation(
+                (p) => p === `${legacy}/bin` || p === `${legacy}/active.lock`,
+            );
+            vi.mocked(node.readFileSync).mockImplementation((p) => {
+                if (p === `${legacy}/active.lock`) {
+                    return JSON.stringify({ vaultId: "other", pid: 1234, port: 1, startedAt: 1 });
+                }
+                throw new Error("ENOENT");
+            });
+            vi.mocked(node.processKill).mockImplementation(() => true);
+
+            const plugin = await createPlugin();
+            await plugin.loadSettings();
+
+            expect(plugin.vaultRegistry?.sharedRoot).toBe(legacy);
+            expect(node.renameSync).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("uninstallManagedInstall()", () => {
+        const fakeRegistry = (overrides: Record<string, unknown> = {}) => ({
+            sharedRoot: "/custom/root",
+            lockState: () => LOCK_STATE.OURS,
+            readLock: () => null,
+            get: () => null,
+            ...overrides,
+        });
+
+        it("returns false when there is no vault registry", async () => {
+            const plugin = await createPlugin();
+            await plugin.loadSettings();
+            (plugin as any).vaultRegistry = null;
+            expect(await plugin.uninstallManagedInstall()).toBe(false);
+        });
+
+        it("refuses while another vault's live process holds the lock", async () => {
+            const { node } = await import("../src/binary-manager");
+            const plugin = await createPlugin();
+            await plugin.loadSettings();
+            (plugin as any).vaultRegistry = fakeRegistry({
+                lockState: () => LOCK_STATE.LIVE_OTHER,
+                readLock: () => ({ vaultId: "other", pid: 1, port: 1, startedAt: 1 }),
+                get: () => ({ displayName: "Work Vault" }),
+            });
+
+            expect(await plugin.uninstallManagedInstall()).toBe(false);
+            expect(Notice.instances.map((n) => n.message).join()).toContain('still serving "Work Vault"');
+            expect(node.rmSync).not.toHaveBeenCalled();
+        });
+
+        it("names the owner generically when the lock vanished between checks", async () => {
+            const plugin = await createPlugin();
+            await plugin.loadSettings();
+            (plugin as any).vaultRegistry = fakeRegistry({
+                lockState: () => LOCK_STATE.LIVE_OTHER,
+                readLock: () => null,
+            });
+
+            expect(await plugin.uninstallManagedInstall()).toBe(false);
+            expect(Notice.instances.map((n) => n.message).join()).toContain('still serving "another vault"');
+        });
+
+        it("stops the server, deletes the install, and reports success", async () => {
+            const { node } = await import("../src/binary-manager");
+            const plugin = await createPlugin();
+            await plugin.loadSettings();
+            (plugin as any).vaultRegistry = fakeRegistry();
+            (plugin as any).serverManager = { stop: mockServerStop };
+            (plugin as any).binaryManager = {};
+
+            expect(await plugin.uninstallManagedInstall()).toBe(true);
+
+            expect(mockServerStop).toHaveBeenCalled();
+            expect((plugin as any).serverManager).toBeNull();
+            expect((plugin as any).binaryManager).toBeNull();
+            expect(node.rmSync).toHaveBeenCalled();
+            expect(Notice.instances.map((n) => n.message)).toContain(MESSAGES.NOTICE_UNINSTALL_DONE);
+        });
+
+        it("deletes the install when no server is running", async () => {
+            const { node } = await import("../src/binary-manager");
+            const plugin = await createPlugin();
+            await plugin.loadSettings();
+            (plugin as any).vaultRegistry = fakeRegistry();
+
+            expect(await plugin.uninstallManagedInstall()).toBe(true);
+            expect(node.rmSync).toHaveBeenCalled();
         });
     });
 

--- a/tests/session-token.test.ts
+++ b/tests/session-token.test.ts
@@ -3,6 +3,7 @@ import { node } from "../src/binary-manager";
 import {
     findLocalLilbeeRoot,
     getDefaultLilbeeDataRoot,
+    getDefaultPluginDataRoot,
     readSessionToken,
     resolveExternalDataRoot,
 } from "../src/session-token";
@@ -65,6 +66,50 @@ describe("session-token", () => {
             process.env.HOME = "/home/alice";
             delete process.env.XDG_DATA_HOME;
             expect(getDefaultLilbeeDataRoot()).toBe("/home/alice/.local/share/lilbee");
+        });
+    });
+
+    describe("getDefaultPluginDataRoot()", () => {
+        it("returns the plugin-owned macOS path when platform is darwin", () => {
+            setPlatform("darwin");
+            process.env.HOME = "/Users/alice";
+            expect(getDefaultPluginDataRoot()).toBe("/Users/alice/Library/Application Support/obsidian-lilbee");
+        });
+
+        it("returns null when no HOME or USERPROFILE is set", () => {
+            setPlatform("darwin");
+            delete process.env.HOME;
+            delete process.env.USERPROFILE;
+            expect(getDefaultPluginDataRoot()).toBeNull();
+        });
+
+        it("uses LOCALAPPDATA on windows when set", () => {
+            setPlatform("win32");
+            process.env.HOME = "C:\\Users\\alice";
+            process.env.LOCALAPPDATA = "C:\\Users\\alice\\AppData\\Local";
+            expect(getDefaultPluginDataRoot()).toBe("C:\\Users\\alice\\AppData\\Local/obsidian-lilbee");
+        });
+
+        it("falls back to ~/AppData/Local on windows when LOCALAPPDATA is unset", () => {
+            setPlatform("win32");
+            delete process.env.HOME;
+            process.env.USERPROFILE = "C:\\Users\\alice";
+            delete process.env.LOCALAPPDATA;
+            expect(getDefaultPluginDataRoot()).toBe("C:\\Users\\alice/AppData/Local/obsidian-lilbee");
+        });
+
+        it("uses XDG_DATA_HOME on linux when set", () => {
+            setPlatform("linux");
+            process.env.HOME = "/home/alice";
+            process.env.XDG_DATA_HOME = "/home/alice/xdg";
+            expect(getDefaultPluginDataRoot()).toBe("/home/alice/xdg/obsidian-lilbee");
+        });
+
+        it("falls back to ~/.local/share on linux when XDG is unset", () => {
+            setPlatform("linux");
+            process.env.HOME = "/home/alice";
+            delete process.env.XDG_DATA_HOME;
+            expect(getDefaultPluginDataRoot()).toBe("/home/alice/.local/share/obsidian-lilbee");
         });
     });
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -6810,3 +6810,67 @@ describe("Export diagnostics button", () => {
         expect(exportDiagnostics).toHaveBeenCalledWith(ctx);
     });
 });
+
+describe("uninstall lilbee section", () => {
+    const makeRegistry = () => ({
+        sharedRoot: "/r",
+        resolveDataDir: () => "/r/vaults/a",
+        list: () => [{ id: "a" }, { id: "b" }],
+    });
+
+    afterEach(() => {
+        mockGenericConfirmResult = true;
+    });
+
+    it("is omitted when there is no vault registry", () => {
+        const plugin = makePlugin({ serverMode: "managed" });
+        const tab = makeTab(plugin);
+        const container = new MockElement() as unknown as HTMLElement;
+        const { buttonOnClicks } = captureSettingCallbacks(() => (tab as any).renderUninstall(container));
+        expect(buttonOnClicks).toHaveLength(0);
+    });
+
+    it("deletes after confirmation and re-renders", async () => {
+        const plugin = makePlugin({ serverMode: "managed" });
+        (plugin as any).vaultRegistry = makeRegistry();
+        (plugin as any).uninstallManagedInstall = vi.fn().mockResolvedValue(true);
+        const tab = makeTab(plugin);
+        const renderSpy = vi.spyOn(tab, "render").mockImplementation(() => {});
+        const container = new MockElement() as unknown as HTMLElement;
+
+        const { buttonOnClicks } = captureSettingCallbacks(() => (tab as any).renderUninstall(container));
+        await buttonOnClicks[0]();
+
+        expect((plugin as any).uninstallManagedInstall).toHaveBeenCalled();
+        expect(renderSpy).toHaveBeenCalled();
+    });
+
+    it("does nothing when the confirm dialog is canceled", async () => {
+        const plugin = makePlugin({ serverMode: "managed" });
+        (plugin as any).vaultRegistry = makeRegistry();
+        (plugin as any).uninstallManagedInstall = vi.fn().mockResolvedValue(true);
+        const tab = makeTab(plugin);
+        const container = new MockElement() as unknown as HTMLElement;
+
+        const { buttonOnClicks } = captureSettingCallbacks(() => (tab as any).renderUninstall(container));
+        mockGenericConfirmResult = false;
+        await buttonOnClicks[0]();
+
+        expect((plugin as any).uninstallManagedInstall).not.toHaveBeenCalled();
+    });
+
+    it("does not re-render when deletion was refused", async () => {
+        const plugin = makePlugin({ serverMode: "managed" });
+        (plugin as any).vaultRegistry = makeRegistry();
+        (plugin as any).uninstallManagedInstall = vi.fn().mockResolvedValue(false);
+        const tab = makeTab(plugin);
+        const renderSpy = vi.spyOn(tab, "render").mockImplementation(() => {});
+        const container = new MockElement() as unknown as HTMLElement;
+
+        const { buttonOnClicks } = captureSettingCallbacks(() => (tab as any).renderUninstall(container));
+        await buttonOnClicks[0]();
+
+        expect((plugin as any).uninstallManagedInstall).toHaveBeenCalled();
+        expect(renderSpy).not.toHaveBeenCalled();
+    });
+});

--- a/tests/vault-registry.test.ts
+++ b/tests/vault-registry.test.ts
@@ -4,12 +4,15 @@ import {
     VaultRegistry,
     computeVaultId,
     defaultDataDirFor,
+    deleteManagedInstall,
+    migrateLegacySharedRoot,
     resolveSharedRoot,
     sharedBinDir,
     sharedModelsDir,
     vaultsRootDir,
 } from "../src/vault-registry";
-import { LOCK_STATE, type ActiveLock, type VaultRegistryEntry } from "../src/types";
+import { getDefaultPluginDataRoot } from "../src/session-token";
+import { LOCK_STATE, MIGRATION_RESULT, SHARED_PATH, type ActiveLock, type VaultRegistryEntry } from "../src/types";
 
 /* ------------------------------------------------------------------ */
 /*  In-memory fs                                                      */
@@ -43,6 +46,19 @@ function makeFs() {
         mkdir: (p: string) => {
             dirs.add(p);
         },
+        rm: (p: string) => {
+            files.delete(p);
+            dirs.delete(p);
+            for (const k of [...files.keys()]) if (k.startsWith(`${p}/`)) files.delete(k);
+            for (const d of [...dirs]) if (d.startsWith(`${p}/`)) dirs.delete(d);
+        },
+        cp: (from: string, to: string) => {
+            const v = files.get(from);
+            if (v !== undefined) files.set(to, v);
+            for (const k of [...files.keys()]) {
+                if (k.startsWith(`${from}/`)) files.set(to + k.slice(from.length), files.get(k) as string);
+            }
+        },
     };
 }
 
@@ -56,6 +72,8 @@ function mountFs(fs: ReturnType<typeof makeFs>) {
         fs.mkdir(p as string);
         return undefined;
     });
+    vi.spyOn(node, "rmSync").mockImplementation((p) => fs.rm(p as string));
+    vi.spyOn(node, "cpSync").mockImplementation((f, t) => fs.cp(f as string, t as string));
 }
 
 /* ------------------------------------------------------------------ */
@@ -67,19 +85,19 @@ describe("resolveSharedRoot", () => {
         expect(resolveSharedRoot("/custom/path")).toBe("/custom/path");
     });
 
-    it("falls back to platform default when setting is empty", () => {
+    it("falls back to the plugin-owned platform default when setting is empty", () => {
         const result = resolveSharedRoot("");
         // On any normal test host HOME/USERPROFILE is set so we get a real path.
-        expect(result).toMatch(/lilbee/);
+        expect(result).toMatch(/obsidian-lilbee/);
     });
 
-    it("falls back to /tmp/lilbee when both HOME and USERPROFILE are missing", () => {
+    it("falls back to /tmp/obsidian-lilbee when both HOME and USERPROFILE are missing", () => {
         const origHome = process.env.HOME;
         const origUser = process.env.USERPROFILE;
         delete process.env.HOME;
         delete process.env.USERPROFILE;
         try {
-            expect(resolveSharedRoot("")).toBe("/tmp/lilbee");
+            expect(resolveSharedRoot("")).toBe("/tmp/obsidian-lilbee");
         } finally {
             if (origHome !== undefined) process.env.HOME = origHome;
             if (origUser !== undefined) process.env.USERPROFILE = origUser;
@@ -371,5 +389,171 @@ describe("VaultRegistry write/release lock", () => {
         expect(reg.readLock()).toBeNull();
         fs.write("/r/active.lock", JSON.stringify(lock({ pid: 99 })));
         expect(reg.readLock()?.pid).toBe(99);
+    });
+});
+
+/* ------------------------------------------------------------------ */
+/*  migrateLegacySharedRoot                                            */
+/* ------------------------------------------------------------------ */
+
+describe("migrateLegacySharedRoot", () => {
+    beforeEach(() => vi.restoreAllMocks());
+
+    const deadPid = () =>
+        vi.spyOn(node, "processKill").mockImplementation(() => {
+            throw new Error("ESRCH");
+        });
+
+    it("NONE when there is no legacy root", () => {
+        mountFs(makeFs());
+        expect(migrateLegacySharedRoot(null, "/new")).toBe(MIGRATION_RESULT.NONE);
+    });
+
+    it("NONE when the new root already has plugin entries", () => {
+        const fs = makeFs();
+        fs.write("/new/registry.json", "[]");
+        fs.write("/old/bin", "binary");
+        mountFs(fs);
+        expect(migrateLegacySharedRoot("/old", "/new")).toBe(MIGRATION_RESULT.NONE);
+        expect(fs.exists("/old/bin")).toBe(true);
+    });
+
+    it("NONE when the legacy root has no plugin markers", () => {
+        const fs = makeFs();
+        fs.write("/old/data/server.json", "{}");
+        fs.write("/old/models", "cli-models");
+        mountFs(fs);
+        expect(migrateLegacySharedRoot("/old", "/new")).toBe(MIGRATION_RESULT.NONE);
+        expect(fs.exists("/old/models")).toBe(true);
+    });
+
+    it("DEFERRED while a live process holds the legacy lock", () => {
+        const fs = makeFs();
+        fs.write("/old/bin", "binary");
+        fs.write("/old/active.lock", JSON.stringify(lock()));
+        mountFs(fs);
+        vi.spyOn(node, "processKill").mockImplementation(() => true);
+        expect(migrateLegacySharedRoot("/old", "/new")).toBe(MIGRATION_RESULT.DEFERRED);
+        expect(fs.exists("/old/bin")).toBe(true);
+    });
+
+    it("moves every plugin entry, drops the stale lock, and rewrites data-dir paths", () => {
+        const fs = makeFs();
+        fs.write("/old/bin", "binary");
+        fs.write("/old/models", "models");
+        fs.write("/old/vaults", "vaults");
+        fs.write("/old/config.json", JSON.stringify({ lilbeeVersion: "v1" }));
+        fs.write(
+            "/old/registry.json",
+            JSON.stringify([entry("a", { dataDir: "/old/vaults/a" }), entry("b", { dataDir: "/elsewhere/b" })]),
+        );
+        fs.write("/old/active.lock", JSON.stringify(lock()));
+        mountFs(fs);
+        deadPid();
+
+        expect(migrateLegacySharedRoot("/old", "/new")).toBe(MIGRATION_RESULT.MIGRATED);
+
+        expect(fs.read("/new/bin")).toBe("binary");
+        expect(fs.read("/new/models")).toBe("models");
+        expect(fs.read("/new/vaults")).toBe("vaults");
+        expect(JSON.parse(fs.read("/new/config.json"))).toMatchObject({ lilbeeVersion: "v1" });
+        expect(fs.exists("/old/bin")).toBe(false);
+        expect(fs.exists("/old/active.lock")).toBe(false);
+        const rewritten = JSON.parse(fs.read("/new/registry.json")) as VaultRegistryEntry[];
+        expect(rewritten.find((e) => e.id === "a")?.dataDir).toBe("/new/vaults/a");
+        expect(rewritten.find((e) => e.id === "b")?.dataDir).toBe("/elsewhere/b");
+    });
+
+    it("migrates a legacy root that never had a lock file", () => {
+        const fs = makeFs();
+        fs.write("/old/registry.json", "[]");
+        mountFs(fs);
+        expect(migrateLegacySharedRoot("/old", "/new")).toBe(MIGRATION_RESULT.MIGRATED);
+        expect(fs.read("/new/registry.json")).toBe("[]");
+    });
+
+    it("falls back to copy + remove when rename fails (cross-device)", () => {
+        const fs = makeFs();
+        fs.write("/old/bin", "binary");
+        mountFs(fs);
+        vi.spyOn(node, "renameSync").mockImplementation(() => {
+            throw new Error("EXDEV");
+        });
+        expect(migrateLegacySharedRoot("/old", "/new")).toBe(MIGRATION_RESULT.MIGRATED);
+        expect(fs.read("/new/bin")).toBe("binary");
+        expect(fs.exists("/old/bin")).toBe(false);
+    });
+
+    it("keeps going when one entry cannot be moved at all", () => {
+        const fs = makeFs();
+        fs.write("/old/bin", "binary");
+        fs.write("/old/registry.json", "[]");
+        mountFs(fs);
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+        vi.spyOn(node, "renameSync").mockImplementation((f, t) => {
+            if ((f as string) === "/old/bin") throw new Error("EXDEV");
+            fs.rename(f as string, t as string);
+        });
+        vi.spyOn(node, "cpSync").mockImplementation(() => {
+            throw new Error("EACCES");
+        });
+
+        expect(migrateLegacySharedRoot("/old", "/new")).toBe(MIGRATION_RESULT.MIGRATED);
+        expect(fs.read("/new/registry.json")).toBe("[]");
+        expect(fs.exists("/old/bin")).toBe(true);
+        expect(warn).toHaveBeenCalled();
+    });
+});
+
+/* ------------------------------------------------------------------ */
+/*  deleteManagedInstall                                               */
+/* ------------------------------------------------------------------ */
+
+describe("deleteManagedInstall", () => {
+    beforeEach(() => vi.restoreAllMocks());
+
+    it("removes the whole root when it is the plugin-owned default", () => {
+        const root = getDefaultPluginDataRoot() as string;
+        const fs = makeFs();
+        fs.write(`${root}/bin`, "binary");
+        fs.write(`${root}/anything-else`, "x");
+        mountFs(fs);
+        deleteManagedInstall(root);
+        expect(node.rmSync).toHaveBeenCalledTimes(1);
+        expect(fs.exists(`${root}/bin`)).toBe(false);
+        expect(fs.exists(`${root}/anything-else`)).toBe(false);
+    });
+
+    it("treats the /tmp fallback as the default root when no home is set", () => {
+        const origHome = process.env.HOME;
+        const origUser = process.env.USERPROFILE;
+        delete process.env.HOME;
+        delete process.env.USERPROFILE;
+        const fs = makeFs();
+        fs.write("/tmp/obsidian-lilbee/bin", "binary");
+        mountFs(fs);
+        try {
+            deleteManagedInstall("/tmp/obsidian-lilbee");
+            expect(node.rmSync).toHaveBeenCalledTimes(1);
+            expect(fs.exists("/tmp/obsidian-lilbee/bin")).toBe(false);
+        } finally {
+            if (origHome !== undefined) process.env.HOME = origHome;
+            if (origUser !== undefined) process.env.USERPROFILE = origUser;
+        }
+    });
+
+    it("removes only plugin-created entries from a custom root", () => {
+        const fs = makeFs();
+        fs.write("/custom/bin", "binary");
+        fs.write("/custom/registry.json", "[]");
+        fs.write("/custom/active.lock", "{}");
+        fs.write("/custom/data/server.json", "{}");
+        mountFs(fs);
+        deleteManagedInstall("/custom");
+        expect(fs.exists("/custom/bin")).toBe(false);
+        expect(fs.exists("/custom/registry.json")).toBe(false);
+        expect(fs.exists("/custom/active.lock")).toBe(false);
+        expect(fs.exists("/custom/data/server.json")).toBe(true);
+        expect(node.rmSync).toHaveBeenCalledTimes(Object.values(SHARED_PATH).length);
     });
 });


### PR DESCRIPTION
Until now a managed install kept the server binary, the model cache, and every vault's index in the same data folder the lilbee CLI uses. Removing the plugin from Obsidian deleted none of it, and there was no safe way to clean it up by hand without risking a standalone lilbee serve install that shares that folder.

## A folder the plugin actually owns

Managed installs now live in their own platform data directory (obsidian-lilbee instead of lilbee). Nothing else writes there, so the plugin can delete the whole thing with confidence, and an external lilbee serve install can never be collateral damage. External mode is untouched and still discovers the CLI's data root as before.

Existing installs migrate on the first load after updating: the binary, models, vault data, and registry move over in place (a rename, not a copy, so it's instant and nothing re-downloads). Anything the plugin didn't create stays in the old folder. If another vault's Obsidian is actively serving from the old location, the move waits for the next launch instead of pulling the rug out.

## Deleting everything from settings

The managed section in settings gains an uninstall row. It shows where the data lives, asks for confirmation with the real on-disk size and how many vaults' indexes are included, stops the server, and deletes the folder. It refuses while another vault is being served so one vault can't silently destroy a neighbor's index. Afterwards a notice confirms it's safe to remove the plugin itself.

Obsidian gives plugins no hook that runs on uninstall, so this is the closest possible flow to "uninstall and it's gone": delete the data with one click, then remove the plugin. The consent dialog shown before the first download now mentions that everything lives in one folder removable from settings, so users know the exit exists before they commit to the entrance.