### PR TITLE
Fix blank model dropdowns and expose a show-thinking toggle

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -144,6 +144,7 @@ export const MESSAGES = {
     LABEL_GEN_NUM_CTX: "Context window",
     LABEL_GEN_SEED: "Seed",
     LABEL_GEN_MAX_TOKENS: "Max tokens",
+    LABEL_SHOW_REASONING: "Show thinking",
     LABEL_GEN_MAX_REASONING_CHARS: "Max reasoning characters",
     LABEL_GEN_MODEL_KEEP_ALIVE: "Model keep-alive (s)",
     LABEL_GEN_GPU_MEMORY_FRACTION: "GPU memory fraction",
@@ -381,6 +382,8 @@ export const MESSAGES = {
     DESC_GEN_NUM_CTX: "Maximum amount of text the AI can consider at once",
     DESC_GEN_SEED: "Set a number for reproducible responses. Leave blank for varied answers.",
     DESC_GEN_MAX_TOKENS: "Hard cap on generated tokens per response (blank = no cap)",
+    DESC_SHOW_REASONING:
+        "Show a reasoning model's thinking in the chat, in a collapsible block above each answer. Off strips it.",
     DESC_GEN_MAX_REASONING_CHARS:
         "Maximum reasoning characters before lilbee forces the model to answer (per-model overrides apply on top)",
     DESC_GEN_MODEL_KEEP_ALIVE: "Seconds the loaded model stays warm between calls (0 = unload immediately)",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -19,7 +19,7 @@ import type { CatalogEntry, ConfigResponse, InstalledModel, LilbeeSettings, Serv
 import { exportDiagnostics } from "./diagnostics-export";
 import { formatBytes, reportForVault } from "./storage-stats";
 import { MESSAGES } from "./locales/en";
-import { displayLabelForRef, extractHfRepo } from "./utils/model-ref";
+import { displayLabelForRef, extractHfRepo, matchModelOption } from "./utils/model-ref";
 import { CatalogModal } from "./views/catalog-modal";
 import { hostedOptions } from "./views/catalog-helpers";
 import { ConfirmModal } from "./views/confirm-modal";
@@ -744,6 +744,24 @@ export class LilbeeSettingTab extends PluginSettingTab {
         this.chatModeSettingEl = chatModeSetting.settingEl;
         this.chatModeSettingEl.hide();
 
+        const showReasoningSetting = new Setting(details)
+            .setName(MESSAGES.LABEL_SHOW_REASONING)
+            .setDesc(MESSAGES.DESC_SHOW_REASONING)
+            .addToggle((toggle) => {
+                toggle.onChange(async (value) => {
+                    if (this.suppressToggleChanges) return;
+                    try {
+                        await this.plugin.api.updateConfig({ [CONFIG_KEY.SHOW_REASONING]: value });
+                        new Notice(MESSAGES.NOTICE_FIELD_UPDATED(MESSAGES.LABEL_SHOW_REASONING));
+                    } catch {
+                        new Notice(MESSAGES.NOTICE_FAILED_UPDATE(MESSAGES.LABEL_SHOW_REASONING));
+                    }
+                });
+                this.serverConfigToggles.set(CONFIG_KEY.SHOW_REASONING, toggle);
+            });
+        showReasoningSetting.settingEl.hide();
+        this.serverConfigHideableEls.set(CONFIG_KEY.SHOW_REASONING, showReasoningSetting.settingEl);
+
         const fields: { key: string; name: string; desc: string; integer: boolean; hideable?: boolean }[] = [
             {
                 key: "temperature",
@@ -1193,7 +1211,12 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 for (const [value, label] of options) {
                     dropdown.addOption(value, label);
                 }
-                dropdown.setValue(active || RERANKER_DISABLED_KEY);
+                dropdown.setValue(
+                    matchModelOption(
+                        active || RERANKER_DISABLED_KEY,
+                        options.map(([value]) => value),
+                    ),
+                );
                 dropdown.onChange(async (value) => {
                     await this.handleRerankerChange(value, catalogEntries, installed);
                 });
@@ -1340,7 +1363,12 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 for (const [value, label] of options) {
                     dropdown.addOption(value, label);
                 }
-                dropdown.setValue(active || VISION_DISABLED_KEY);
+                dropdown.setValue(
+                    matchModelOption(
+                        active || VISION_DISABLED_KEY,
+                        options.map(([value]) => value),
+                    ),
+                );
                 dropdown.onChange(async (value) => {
                     await this.handleVisionChange(value, catalogEntries, installed);
                 });
@@ -2088,7 +2116,12 @@ export class LilbeeSettingTab extends PluginSettingTab {
             for (const [value, label] of options) {
                 dropdown.addOption(value, label);
             }
-            dropdown.setValue(active);
+            dropdown.setValue(
+                matchModelOption(
+                    active,
+                    options.map(([value]) => value),
+                ),
+            );
             dropdown.onChange(async (value) => {
                 if (value === SEPARATOR_KEY) return;
                 await this.handleChatChange(value, catalogEntries);

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,7 @@ export interface ConfigResponse {
     chunk_overlap?: number;
     tesseract_timeout?: number;
     max_tokens?: number;
+    show_reasoning?: boolean;
     max_reasoning_chars?: number;
     model_keep_alive?: string;
     gpu_memory_fraction?: number;
@@ -105,6 +106,7 @@ export const CONFIG_KEY = {
     RAG_SYSTEM_PROMPT: "rag_system_prompt",
     GENERAL_SYSTEM_PROMPT: "general_system_prompt",
     CHAT_MODE: "chat_mode",
+    SHOW_REASONING: "show_reasoning",
 } as const;
 
 export type ChatMode = "search" | "chat";

--- a/src/utils/model-ref.ts
+++ b/src/utils/model-ref.ts
@@ -30,6 +30,20 @@ export function extractHfRepo(ref: string): string {
     return ref.slice(0, slash);
 }
 
+/**
+ * The dropdown option value that represents `active`. Server config stores a full
+ * native ref (`<repo>/<file>.gguf`) but installed-featured options key on the bare
+ * `hf_repo`, so an exact lookup misses and the dropdown renders blank. Match exactly
+ * first (hosted refs, other-installed full refs), then by bare repo; fall back to the
+ * ref unchanged when nothing matches.
+ */
+export function matchModelOption(active: string, optionValues: string[]): string {
+    if (optionValues.includes(active)) return active;
+    const repo = extractHfRepo(active);
+    if (optionValues.includes(repo)) return repo;
+    return active;
+}
+
 /** Convert a `<repo>` segment (org-stripped) into a friendly label. Mirrors the server's `clean_display_name`. */
 export function cleanDisplayName(repo: string): string {
     let name = repo.includes("/") ? repo.slice(repo.indexOf("/") + 1) : repo;

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -3093,9 +3093,9 @@ describe("managed mode settings", () => {
             const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
 
             // Toggle order: [0] adaptiveThreshold (search/retrieval),
-            // [1] worker_pool_eager_start (worker-pool),
-            // [2] crawl_retry_on_rate_limit (crawling), [3+] wiki toggles.
-            await toggleOnChanges[2](false);
+            // [1] show_reasoning (generation), [2] worker_pool_eager_start (worker-pool),
+            // [3] crawl_retry_on_rate_limit (crawling), [4+] wiki toggles.
+            await toggleOnChanges[3](false);
             expect(plugin.api.updateConfig).toHaveBeenCalledWith({ crawl_retry_on_rate_limit: false });
         });
 
@@ -3106,7 +3106,7 @@ describe("managed mode settings", () => {
             const tab = makeTab(plugin);
             const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
 
-            await toggleOnChanges[2](false);
+            await toggleOnChanges[3](false);
             expect(Notice.instances.some((n: any) => n.message.includes("failed to update"))).toBe(true);
         });
 
@@ -3224,9 +3224,9 @@ describe("managed mode settings", () => {
             // load-bearing (if the flag failed to set, updateConfig WOULD be called).
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockClear();
             (tab as any).suppressToggleChanges = false;
-            // toggleOnChanges[2] is crawl_retry_on_rate_limit; [0]=adaptiveThreshold,
-            // [1]=worker_pool_eager_start.
-            await toggleOnChanges[2](true);
+            // toggleOnChanges[3] is crawl_retry_on_rate_limit; [0]=adaptiveThreshold,
+            // [1]=show_reasoning, [2]=worker_pool_eager_start.
+            await toggleOnChanges[3](true);
             expect(plugin.api.updateConfig).toHaveBeenCalledWith({ crawl_retry_on_rate_limit: true });
         });
 
@@ -3238,7 +3238,7 @@ describe("managed mode settings", () => {
             await new Promise((r) => setTimeout(r, 0));
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockClear();
             (tab as any).suppressToggleChanges = true;
-            await toggleOnChanges[2](true);
+            await toggleOnChanges[3](true);
             (tab as any).suppressToggleChanges = false;
             expect(plugin.api.updateConfig).not.toHaveBeenCalled();
         });
@@ -5265,7 +5265,9 @@ describe("managed mode settings", () => {
 
             expect(options[0]["gpustack/bge-reranker-v2-m3-GGUF"]).toBe("BGE Reranker v2 m3");
             expect(options[0]["gpustack/bge-reranker-v2-m3-GGUF"]).not.toContain(MESSAGES.LABEL_NOT_INSTALLED);
-            expect(values[0]).toBe(installedRef);
+            // The featured option keys on the bare hf_repo, so the active full ref selects
+            // that option (matchModelOption) instead of a missing full-ref value that renders blank.
+            expect(values[0]).toBe("gpustack/bge-reranker-v2-m3-GGUF");
         });
 
         it("parses reranker_model as empty when config lacks the field", async () => {
@@ -6311,7 +6313,7 @@ describe("managed mode settings", () => {
         // ([0]=adaptiveThreshold).
         const POOL_CALL_TIMEOUT_IDX = 19;
         const POOL_MAX_IDLE_IDX = 20;
-        const POOL_EAGER_TOGGLE_IDX = 1;
+        const POOL_EAGER_TOGGLE_IDX = 2;
 
         it("hides each worker-pool row when cfg keys are undefined", async () => {
             const plugin = makePlugin();
@@ -6393,6 +6395,45 @@ describe("managed mode settings", () => {
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockClear();
             (tab as any).suppressToggleChanges = true;
             await toggleOnChanges[POOL_EAGER_TOGGLE_IDX](true);
+            (tab as any).suppressToggleChanges = false;
+            expect(plugin.api.updateConfig).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("show reasoning toggle", () => {
+        // toggleOnChanges[1] is show_reasoning; [0]=adaptiveThreshold.
+        const SHOW_REASONING_TOGGLE_IDX = 1;
+
+        it("PATCHes show_reasoning when the toggle flips", async () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
+
+            await toggleOnChanges[SHOW_REASONING_TOGGLE_IDX](true);
+            expect(plugin.api.updateConfig).toHaveBeenCalledWith({ show_reasoning: true });
+        });
+
+        it("surfaces a notice when the show_reasoning PATCH fails", async () => {
+            Notice.clear();
+            const plugin = makePlugin();
+            (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("boom"));
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
+
+            await toggleOnChanges[SHOW_REASONING_TOGGLE_IDX](true);
+            expect(Notice.instances.some((n) => n.message.includes("failed to update"))).toBe(true);
+        });
+
+        it("suppresses show_reasoning echo-patches while the suppress flag is set", async () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
+            (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockClear();
+            (tab as any).suppressToggleChanges = true;
+            await toggleOnChanges[SHOW_REASONING_TOGGLE_IDX](true);
             (tab as any).suppressToggleChanges = false;
             expect(plugin.api.updateConfig).not.toHaveBeenCalled();
         });

--- a/tests/utils/model-ref.test.ts
+++ b/tests/utils/model-ref.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { cleanDisplayName, displayLabelForRef, extractHfRepo, nativeModelRef } from "../../src/utils/model-ref";
+import {
+    cleanDisplayName,
+    displayLabelForRef,
+    extractHfRepo,
+    matchModelOption,
+    nativeModelRef,
+} from "../../src/utils/model-ref";
 
 describe("nativeModelRef", () => {
     it("builds the full file ref when a concrete .gguf filename is present", () => {
@@ -96,6 +102,32 @@ describe("extractHfRepo", () => {
 
     it("returns a .gguf ref with no slash unchanged", () => {
         expect(extractHfRepo("loose.gguf")).toBe("loose.gguf");
+    });
+});
+
+describe("matchModelOption", () => {
+    it("matches a full native ref to its bare-repo option key", () => {
+        const options = ["Qwen/Qwen3-0.6B-GGUF", "gemini/gemini-2.5-flash"];
+        expect(matchModelOption("Qwen/Qwen3-0.6B-GGUF/Qwen3-0.6B-Q8_0.gguf", options)).toBe("Qwen/Qwen3-0.6B-GGUF");
+    });
+
+    it("prefers an exact option match over the bare repo (other-installed full refs)", () => {
+        const ref = "user/custom-GGUF/custom-Q4_K_M.gguf";
+        const options = ["user/custom-GGUF", ref];
+        expect(matchModelOption(ref, options)).toBe(ref);
+    });
+
+    it("returns hosted/provider refs unchanged when present", () => {
+        const options = ["gemini/gemini-2.5-flash", "Qwen/Qwen3-0.6B-GGUF"];
+        expect(matchModelOption("gemini/gemini-2.5-flash", options)).toBe("gemini/gemini-2.5-flash");
+    });
+
+    it("matches the empty disabled-sentinel option", () => {
+        expect(matchModelOption("", ["", "Qwen/Qwen3-0.6B-GGUF"])).toBe("");
+    });
+
+    it("falls back to the active ref when nothing matches", () => {
+        expect(matchModelOption("ollama/llama3", ["gemini/gemini-2.5-flash"])).toBe("ollama/llama3");
     });
 });
 


### PR DESCRIPTION
## Blank model dropdowns in settings

The active-model dropdowns for chat, vision, and reranker showed up empty whenever the selected model was a local one, even with a model set. The dropdown couldn't match the stored model against its own options and fell back to blank. Hosted models like Gemini were unaffected, which is why it looked inconsistent. The dropdowns now find and show the active model however it's stored.

## Show thinking

Reasoning models can stream their thinking, and the chat view already knew how to show it in a collapsible block above the answer, but there was no way to turn it on, so it never appeared. A "Show thinking" toggle now sits next to Chat mode in settings: on surfaces the thinking, off hides it.