### PR TITLE
Stream thinking above the answer, move it up in settings, and show it by default

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -94,6 +94,7 @@ export const MESSAGES = {
     LABEL_SWITCH_MANAGED: "Switch to managed server",
     LABEL_MODELS: "Models",
     LABEL_REFRESH_MODELS: "Refresh models",
+    LABEL_CHAT_SECTION: "Chat",
     LABEL_SEARCH_RETRIEVAL: "Search & Retrieval",
     LABEL_RESULTS_COUNT: "Results count",
     LABEL_MAX_DISTANCE: "Search strictness",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1528,9 +1528,13 @@ export default class LilbeePlugin extends Plugin {
     /** Turn reasoning display on once, the first time we reach a ready server. */
     private async applyReasoningDefaultOnce(): Promise<void> {
         if (this.settings.reasoningDefaulted) return;
-        await this.api.updateConfig({ [CONFIG_KEY.SHOW_REASONING]: true });
+        // Patch only when the server reports it explicitly off; older servers omit the key.
+        const cfg = await this.api.config();
+        if (cfg.show_reasoning === false) {
+            await this.api.updateConfig({ [CONFIG_KEY.SHOW_REASONING]: true });
+        }
         this.settings.reasoningDefaulted = true;
-        await this.saveSettings();
+        await this.persistAll();
     }
 
     initWikiSync(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import { readSessionToken, resolveExternalDataRoot } from "./session-token";
 import { LilbeeSettingTab } from "./settings";
 import { VaultRegistry, computeVaultId, resolveSharedRoot, sharedBinDir, sharedModelsDir } from "./vault-registry";
 import {
+    CONFIG_KEY,
     DEFAULT_SETTINGS,
     DOT_STATE,
     ERROR_NAME,
@@ -1501,6 +1502,7 @@ export default class LilbeePlugin extends Plugin {
             const models = await this.api.listModels();
             this.activeModel = models.chat.active;
             this.setStatusReady();
+            await this.applyReasoningDefaultOnce();
         } catch {
             // Silently fail - will retry on next action
         }
@@ -1521,6 +1523,14 @@ export default class LilbeePlugin extends Plugin {
             this.initWikiSync();
             void this.reconcileWiki();
         }
+    }
+
+    /** Turn reasoning display on once, the first time we reach a ready server. */
+    private async applyReasoningDefaultOnce(): Promise<void> {
+        if (this.settings.reasoningDefaulted) return;
+        await this.api.updateConfig({ [CONFIG_KEY.SHOW_REASONING]: true });
+        this.settings.reasoningDefaulted = true;
+        await this.saveSettings();
     }
 
     initWikiSync(): void {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -112,6 +112,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
 
         this.renderConnectionSettings(containerEl);
         this.renderModelsSection(containerEl);
+        this.renderChatSettings(containerEl);
         this.renderSearchRetrievalSettings(containerEl);
         this.renderGenerationSettings(containerEl);
         this.renderMemorySection(containerEl);
@@ -474,6 +475,28 @@ export class LilbeeSettingTab extends PluginSettingTab {
         void this.loadModels(modelsContainer);
     }
 
+    private renderChatSettings(containerEl: HTMLElement): void {
+        new Setting(containerEl).setName(MESSAGES.LABEL_CHAT_SECTION).setHeading();
+
+        const showReasoningSetting = new Setting(containerEl)
+            .setName(MESSAGES.LABEL_SHOW_REASONING)
+            .setDesc(MESSAGES.DESC_SHOW_REASONING)
+            .addToggle((toggle) => {
+                toggle.onChange(async (value) => {
+                    if (this.suppressToggleChanges) return;
+                    try {
+                        await this.plugin.api.updateConfig({ [CONFIG_KEY.SHOW_REASONING]: value });
+                        new Notice(MESSAGES.NOTICE_FIELD_UPDATED(MESSAGES.LABEL_SHOW_REASONING));
+                    } catch {
+                        new Notice(MESSAGES.NOTICE_FAILED_UPDATE(MESSAGES.LABEL_SHOW_REASONING));
+                    }
+                });
+                this.serverConfigToggles.set(CONFIG_KEY.SHOW_REASONING, toggle);
+            });
+        showReasoningSetting.settingEl.hide();
+        this.serverConfigHideableEls.set(CONFIG_KEY.SHOW_REASONING, showReasoningSetting.settingEl);
+    }
+
     private renderSearchRetrievalSettings(containerEl: HTMLElement): void {
         new Setting(containerEl).setName(MESSAGES.LABEL_SEARCH_RETRIEVAL).setHeading();
 
@@ -743,24 +766,6 @@ export class LilbeeSettingTab extends PluginSettingTab {
             });
         this.chatModeSettingEl = chatModeSetting.settingEl;
         this.chatModeSettingEl.hide();
-
-        const showReasoningSetting = new Setting(details)
-            .setName(MESSAGES.LABEL_SHOW_REASONING)
-            .setDesc(MESSAGES.DESC_SHOW_REASONING)
-            .addToggle((toggle) => {
-                toggle.onChange(async (value) => {
-                    if (this.suppressToggleChanges) return;
-                    try {
-                        await this.plugin.api.updateConfig({ [CONFIG_KEY.SHOW_REASONING]: value });
-                        new Notice(MESSAGES.NOTICE_FIELD_UPDATED(MESSAGES.LABEL_SHOW_REASONING));
-                    } catch {
-                        new Notice(MESSAGES.NOTICE_FAILED_UPDATE(MESSAGES.LABEL_SHOW_REASONING));
-                    }
-                });
-                this.serverConfigToggles.set(CONFIG_KEY.SHOW_REASONING, toggle);
-            });
-        showReasoningSetting.settingEl.hide();
-        this.serverConfigHideableEls.set(CONFIG_KEY.SHOW_REASONING, showReasoningSetting.settingEl);
 
         const fields: { key: string; name: string; desc: string; integer: boolean; hideable?: boolean }[] = [
             {

--- a/src/types.ts
+++ b/src/types.ts
@@ -400,6 +400,13 @@ export interface LilbeeSettings {
      * plugin at a different location (e.g. an external SSD).
      */
     sharedRoot: string;
+    /**
+     * Whether the plugin has applied its on-by-default for reasoning display.
+     * The first time it reaches a ready server it turns `show_reasoning` on so
+     * the chat surfaces a reasoning model's thinking out of the box; after that
+     * the server config owns the value and the user's choice is respected.
+     */
+    reasoningDefaulted: boolean;
 }
 
 export const DEFAULT_SETTINGS: LilbeeSettings = {
@@ -424,6 +431,7 @@ export const DEFAULT_SETTINGS: LilbeeSettings = {
     lastCatalogTab: "discover",
     autoOpenCockpit: true,
     sharedRoot: "",
+    reasoningDefaulted: false,
 };
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -400,12 +400,7 @@ export interface LilbeeSettings {
      * plugin at a different location (e.g. an external SSD).
      */
     sharedRoot: string;
-    /**
-     * Whether the plugin has applied its on-by-default for reasoning display.
-     * The first time it reaches a ready server it turns `show_reasoning` on so
-     * the chat surfaces a reasoning model's thinking out of the box; after that
-     * the server config owns the value and the user's choice is respected.
-     */
+    /** Set once the plugin has applied its one-time `show_reasoning` on-by-default. */
     reasoningDefaulted: boolean;
 }
 

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -93,6 +93,18 @@ interface OptionalRoleSpec {
     failNotice: string;
 }
 
+/** Per-message streaming state: accumulated text and the live reasoning DOM. */
+interface StreamState {
+    fullContent: string;
+    reasoningContent: string;
+    sources: Source[];
+    renderPending: boolean;
+    reasoningRenderPending: boolean;
+    reasoningContentEl: HTMLElement | null;
+    reasoningDetailsEl: HTMLElement | null;
+    answerStarted: boolean;
+}
+
 const OPTIONAL_ROLE_SPECS: OptionalRoleSpec[] = [
     {
         key: "vision",
@@ -822,7 +834,16 @@ export class ChatView extends ItemView {
         textEl.hide();
         this.messagesEl.scrollTop = this.messagesEl.scrollHeight;
 
-        const state = { fullContent: "", reasoningContent: "", sources: [] as Source[], renderPending: false };
+        const state: StreamState = {
+            fullContent: "",
+            reasoningContent: "",
+            sources: [],
+            renderPending: false,
+            reasoningRenderPending: false,
+            reasoningContentEl: null,
+            reasoningDetailsEl: null,
+            answerStarted: false,
+        };
 
         const spinnerCreatedAt = Date.now();
         const revealContent = (): void => {
@@ -893,19 +914,30 @@ export class ChatView extends ItemView {
         event: SSEEvent,
         textEl: HTMLElement,
         assistantBubble: HTMLElement,
-        state: { fullContent: string; reasoningContent: string; sources: Source[] },
+        state: StreamState,
         revealContent: () => void,
         scheduleRender: () => void,
     ): void {
         switch (event.event) {
             case SSE_EVENT.TOKEN: {
                 revealContent();
+                // The model has moved from thinking to answering: collapse the
+                // reasoning so the answer is what's prominent.
+                if (!state.answerStarted) {
+                    state.answerStarted = true;
+                    state.reasoningDetailsEl?.removeAttribute("open");
+                }
                 state.fullContent += extractString(event.data, "token");
                 scheduleRender();
                 break;
             }
             case SSE_EVENT.REASONING: {
+                // Reasoning leads the answer, so show it first and stream it live
+                // for immediate feedback, in an expanded block above the answer.
+                revealContent();
+                const el = this.ensureReasoningBlock(assistantBubble, textEl, state);
                 state.reasoningContent += extractString(event.data, "token");
+                this.scheduleReasoningRender(state, el);
                 break;
             }
             case SSE_EVENT.SOURCES:
@@ -914,16 +946,13 @@ export class ChatView extends ItemView {
             case SSE_EVENT.DONE: {
                 revealContent();
                 const rendered = state.fullContent;
-                // Reasoning, banner, and sources all grow the bubble after the
-                // last token; render them inside one follow so the view ends
-                // pinned to the bottom.
+                // Banner and sources grow the bubble after the last token; render
+                // them inside one follow so the view ends pinned to the bottom.
                 void this.renderFollowing(async () => {
                     if (state.reasoningContent) {
-                        const details = assistantBubble.createEl("details", { cls: "lilbee-reasoning" });
-                        details.createEl("summary", { text: MESSAGES.LABEL_REASONING });
-                        const content = details.createDiv({ cls: "lilbee-reasoning-content" });
-                        void MarkdownRenderer.render(this.app, state.reasoningContent, content, "", this);
-                        details.removeAttribute("open");
+                        const el = this.ensureReasoningBlock(assistantBubble, textEl, state);
+                        await this.renderMarkdown(el, state.reasoningContent);
+                        state.reasoningDetailsEl?.removeAttribute("open");
                     }
                     this.renderBannerIfPresent(event.data, assistantBubble);
                     await this.renderMarkdown(textEl, rendered);
@@ -961,6 +990,30 @@ export class ChatView extends ItemView {
                 break;
             }
         }
+    }
+
+    /** Create the reasoning block above the answer on first use; return its content div. */
+    private ensureReasoningBlock(assistantBubble: HTMLElement, textEl: HTMLElement, state: StreamState): HTMLElement {
+        if (state.reasoningContentEl) return state.reasoningContentEl;
+        const details = assistantBubble.createEl("details", { cls: "lilbee-reasoning" });
+        details.setAttribute("open", "");
+        details.createEl("summary", { text: MESSAGES.LABEL_REASONING });
+        const content = details.createDiv({ cls: "lilbee-reasoning-content" });
+        // The answer div was created first; move the thinking above it so it reads first.
+        assistantBubble.insertBefore(details, textEl);
+        state.reasoningDetailsEl = details;
+        state.reasoningContentEl = content;
+        return content;
+    }
+
+    /** Coalesce live reasoning re-renders to one per frame. */
+    private scheduleReasoningRender(state: StreamState, el: HTMLElement): void {
+        if (state.reasoningRenderPending) return;
+        state.reasoningRenderPending = true;
+        window.requestAnimationFrame(() => {
+            state.reasoningRenderPending = false;
+            void this.renderFollowing(() => this.renderMarkdown(el, state.reasoningContent));
+        });
     }
 
     /** True when the message list is scrolled to (or near) the bottom. */

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -881,6 +881,7 @@ export class ChatView extends ItemView {
         } catch (err) {
             if (err instanceof Error && err.name === ERROR_NAME.ABORT_ERROR) {
                 revealContent();
+                state.reasoningDetailsEl?.removeAttribute("open");
                 if (state.fullContent) {
                     void this.renderMarkdown(textEl, `${state.fullContent}\n\n${MESSAGES.LABEL_STOPPED_MD}`);
                     this.history.push({ role: "assistant", content: state.fullContent });
@@ -921,8 +922,7 @@ export class ChatView extends ItemView {
         switch (event.event) {
             case SSE_EVENT.TOKEN: {
                 revealContent();
-                // The model has moved from thinking to answering: collapse the
-                // reasoning so the answer is what's prominent.
+                // First answer token: collapse the reasoning block.
                 if (!state.answerStarted) {
                     state.answerStarted = true;
                     state.reasoningDetailsEl?.removeAttribute("open");
@@ -932,8 +932,7 @@ export class ChatView extends ItemView {
                 break;
             }
             case SSE_EVENT.REASONING: {
-                // Reasoning leads the answer, so show it first and stream it live
-                // for immediate feedback, in an expanded block above the answer.
+                // Stream reasoning live into an expanded block above the answer.
                 revealContent();
                 const el = this.ensureReasoningBlock(assistantBubble, textEl, state);
                 state.reasoningContent += extractString(event.data, "token");
@@ -996,10 +995,11 @@ export class ChatView extends ItemView {
     private ensureReasoningBlock(assistantBubble: HTMLElement, textEl: HTMLElement, state: StreamState): HTMLElement {
         if (state.reasoningContentEl) return state.reasoningContentEl;
         const details = assistantBubble.createEl("details", { cls: "lilbee-reasoning" });
-        details.setAttribute("open", "");
+        // Expanded while thinking; collapsed if the answer already started.
+        if (!state.answerStarted) details.setAttribute("open", "");
         details.createEl("summary", { text: MESSAGES.LABEL_REASONING });
         const content = details.createDiv({ cls: "lilbee-reasoning-content" });
-        // The answer div was created first; move the thinking above it so it reads first.
+        // Move the reasoning block above the answer div.
         assistantBubble.insertBefore(details, textEl);
         state.reasoningDetailsEl = details;
         state.reasoningContentEl = content;

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -3665,6 +3665,29 @@ describe("LilbeePlugin", () => {
             expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready [external]");
         });
 
+        it("turns show_reasoning on the first time the server is ready, then never again", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const updateConfig = vi.fn().mockResolvedValue({ updated: ["show_reasoning"] });
+            plugin.api.updateConfig = updateConfig;
+            plugin.api.listModels = vi.fn().mockResolvedValue({
+                chat: { active: "qwen3:8b", installed: ["qwen3:8b"], catalog: [] },
+            });
+            const saveSpy = vi.spyOn(plugin, "saveSettings");
+            // Reset so the manual call exercises the first-ready apply branch.
+            plugin.settings.reasoningDefaulted = false;
+
+            await plugin.fetchActiveModel();
+            expect(updateConfig).toHaveBeenCalledWith({ show_reasoning: true });
+            expect(plugin.settings.reasoningDefaulted).toBe(true);
+            expect(saveSpy).toHaveBeenCalled();
+
+            // Already applied: a second ready pass leaves the server config alone.
+            updateConfig.mockClear();
+            await plugin.fetchActiveModel();
+            expect(updateConfig).not.toHaveBeenCalled();
+        });
+
         it("status bar shows task name during sync and flashes done after", async () => {
             const plugin = await createPlugin();
             await plugin.onload();

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -3665,27 +3665,60 @@ describe("LilbeePlugin", () => {
             expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready [external]");
         });
 
-        it("turns show_reasoning on the first time the server is ready, then never again", async () => {
+        it("turns show_reasoning on the first time the server reports it off, then never again", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
             const updateConfig = vi.fn().mockResolvedValue({ updated: ["show_reasoning"] });
             plugin.api.updateConfig = updateConfig;
+            plugin.api.config = vi.fn().mockResolvedValue({ show_reasoning: false });
             plugin.api.listModels = vi.fn().mockResolvedValue({
                 chat: { active: "qwen3:8b", installed: ["qwen3:8b"], catalog: [] },
             });
-            const saveSpy = vi.spyOn(plugin, "saveSettings");
+            const persistSpy = vi.spyOn(plugin as any, "persistAll");
             // Reset so the manual call exercises the first-ready apply branch.
             plugin.settings.reasoningDefaulted = false;
 
             await plugin.fetchActiveModel();
             expect(updateConfig).toHaveBeenCalledWith({ show_reasoning: true });
             expect(plugin.settings.reasoningDefaulted).toBe(true);
-            expect(saveSpy).toHaveBeenCalled();
+            expect(persistSpy).toHaveBeenCalled();
 
-            // Already applied: a second ready pass leaves the server config alone.
+            // Already applied: a second ready pass doesn't even re-read the config.
             updateConfig.mockClear();
             await plugin.fetchActiveModel();
             expect(updateConfig).not.toHaveBeenCalled();
+        });
+
+        it("leaves an already-on server alone but records the default as applied", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const updateConfig = vi.fn();
+            plugin.api.updateConfig = updateConfig;
+            plugin.api.config = vi.fn().mockResolvedValue({ show_reasoning: true });
+            plugin.api.listModels = vi.fn().mockResolvedValue({
+                chat: { active: "x", installed: [], catalog: [] },
+            });
+            plugin.settings.reasoningDefaulted = false;
+
+            await plugin.fetchActiveModel();
+            expect(updateConfig).not.toHaveBeenCalled();
+            expect(plugin.settings.reasoningDefaulted).toBe(true);
+        });
+
+        it("records the default as applied against an older server that omits show_reasoning", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const updateConfig = vi.fn();
+            plugin.api.updateConfig = updateConfig;
+            plugin.api.config = vi.fn().mockResolvedValue({});
+            plugin.api.listModels = vi.fn().mockResolvedValue({
+                chat: { active: "x", installed: [], catalog: [] },
+            });
+            plugin.settings.reasoningDefaulted = false;
+
+            await plugin.fetchActiveModel();
+            expect(updateConfig).not.toHaveBeenCalled();
+            expect(plugin.settings.reasoningDefaulted).toBe(true);
         });
 
         it("status bar shows task name during sync and flashes done after", async () => {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -3093,8 +3093,8 @@ describe("managed mode settings", () => {
             const tab = makeTab(plugin);
             const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
 
-            // Toggle order: [0] adaptiveThreshold (search/retrieval),
-            // [1] show_reasoning (generation), [2] worker_pool_eager_start (worker-pool),
+            // Toggle order: [0] show_reasoning (Chat), [1] adaptiveThreshold (search/retrieval),
+            // [2] worker_pool_eager_start (worker-pool),
             // [3] crawl_retry_on_rate_limit (crawling), [4+] wiki toggles.
             await toggleOnChanges[3](false);
             expect(plugin.api.updateConfig).toHaveBeenCalledWith({ crawl_retry_on_rate_limit: false });
@@ -3225,8 +3225,8 @@ describe("managed mode settings", () => {
             // load-bearing (if the flag failed to set, updateConfig WOULD be called).
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockClear();
             (tab as any).suppressToggleChanges = false;
-            // toggleOnChanges[3] is crawl_retry_on_rate_limit; [0]=adaptiveThreshold,
-            // [1]=show_reasoning, [2]=worker_pool_eager_start.
+            // toggleOnChanges[3] is crawl_retry_on_rate_limit; [0]=show_reasoning,
+            // [1]=adaptiveThreshold, [2]=worker_pool_eager_start.
             await toggleOnChanges[3](true);
             expect(plugin.api.updateConfig).toHaveBeenCalledWith({ crawl_retry_on_rate_limit: true });
         });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -560,7 +560,8 @@ describe("LilbeeSettingTab", () => {
             const tab = makeTab(plugin);
             const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
 
-            await toggleOnChanges[0](true);
+            // [0] is show_reasoning (Chat section, rendered first); [1] is adaptiveThreshold.
+            await toggleOnChanges[1](true);
             expect(plugin.settings.adaptiveThreshold).toBe(true);
             expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
         });
@@ -6401,8 +6402,8 @@ describe("managed mode settings", () => {
     });
 
     describe("show reasoning toggle", () => {
-        // toggleOnChanges[1] is show_reasoning; [0]=adaptiveThreshold.
-        const SHOW_REASONING_TOGGLE_IDX = 1;
+        // toggleOnChanges[0] is show_reasoning (Chat section, top); [1]=adaptiveThreshold.
+        const SHOW_REASONING_TOGGLE_IDX = 0;
 
         it("PATCHes show_reasoning when the toggle flips", async () => {
             const plugin = makePlugin();

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -77,6 +77,7 @@ describe("DEFAULT_SETTINGS", () => {
         const expected = [
             "adaptiveThreshold",
             "autoOpenCockpit",
+            "reasoningDefaulted",
             "manualToken",
             "maxDistance",
             "searchChunkType",

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -601,6 +601,94 @@ describe("ChatView.sendMessage — reasoning tokens", () => {
         expect(details!.children[0].textContent).toBe("Reasoning");
         const textEl = assistantBubble.find("lilbee-chat-content");
         expect(textEl!.textContent).toBe("The answer is 42.");
+        // Reasoning reads first: it sits above the answer in the bubble.
+        const idxReasoning = assistantBubble.children.indexOf(details!);
+        const idxAnswer = assistantBubble.children.indexOf(textEl!);
+        expect(idxReasoning).toBeGreaterThanOrEqual(0);
+        expect(idxReasoning).toBeLessThan(idxAnswer);
+        // Collapsed once the answer arrived.
+        expect(details!.getAttribute("open")).toBeNull();
+    });
+
+    it("streams reasoning live and expanded, above the answer, before the answer arrives", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        let release!: () => void;
+        const gate = new Promise<void>((r) => {
+            release = r;
+        });
+        const mockFn = vi.fn().mockReturnValue(
+            (async function* () {
+                yield { event: SSE_EVENT.REASONING, data: { token: "First, " } };
+                yield { event: SSE_EVENT.REASONING, data: { token: "I weigh the options." } };
+                await gate; // pause before any answer token
+                yield { event: SSE_EVENT.TOKEN, data: { token: "Answer." } };
+                yield { event: SSE_EVENT.DONE, data: {} };
+            })(),
+        );
+        plugin.api.chatStream = mockFn;
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const messagesEl = container.find("lilbee-chat-messages")!;
+        container.find("lilbee-chat-textarea")!.value = "think first";
+        container.find("lilbee-chat-send")!.trigger("click");
+
+        // Let the reasoning events stream and the rAF render flush, still before the answer.
+        await tick();
+        await tick();
+
+        const assistantBubble = messagesEl.children[1];
+        const details = assistantBubble.find("lilbee-reasoning");
+        expect(details).toBeTruthy();
+        // Expanded while thinking, for immediate feedback.
+        expect(details!.getAttribute("open")).toBe("");
+        // Reasoning content already rendered before the answer/DONE arrived.
+        const reasoningContent = assistantBubble.find("lilbee-reasoning-content");
+        expect(reasoningContent!.textContent).toContain("First, I weigh the options.");
+        // No answer text yet.
+        expect(assistantBubble.find("lilbee-chat-content")!.textContent).toBe("");
+        // Reasoning is above the (empty) answer in the bubble.
+        const textEl = assistantBubble.find("lilbee-chat-content");
+        expect(assistantBubble.children.indexOf(details!)).toBeLessThan(assistantBubble.children.indexOf(textEl!));
+
+        release();
+        await tick();
+        await tick();
+        // Once the answer streams in, the reasoning collapses.
+        expect(details!.getAttribute("open")).toBeNull();
+        expect(textEl!.textContent).toBe("Answer.");
+    });
+
+    it("coalesces live reasoning re-renders to one per frame", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const origRAF = globalThis.requestAnimationFrame;
+        const frames: FrameRequestCallback[] = [];
+        globalThis.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+            frames.push(cb);
+            return frames.length;
+        };
+        try {
+            const { mockFn, done } = makeStream([
+                { event: SSE_EVENT.REASONING, data: { token: "a" } },
+                { event: SSE_EVENT.REASONING, data: { token: "b" } },
+                { event: SSE_EVENT.REASONING, data: { token: "c" } },
+            ]);
+            plugin.api.chatStream = mockFn;
+            const view = new ChatView(makeLeaf(), plugin);
+            await view.onOpen();
+            const container = view.containerEl.children[1] as unknown as MockElement;
+            container.find("lilbee-chat-textarea")!.value = "x";
+            container.find("lilbee-chat-send")!.trigger("click");
+            await done;
+            await tick();
+            // Three reasoning tokens, but the pending guard collapses them to a single frame.
+            const reasoningFrames = frames.length;
+            expect(reasoningFrames).toBe(1);
+        } finally {
+            globalThis.requestAnimationFrame = origRAF;
+        }
     });
 
     it("does not render details block when no reasoning tokens", async () => {

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -691,6 +691,59 @@ describe("ChatView.sendMessage — reasoning tokens", () => {
         }
     });
 
+    it("collapses the reasoning block when the stream is stopped mid-thinking", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const mockFn = vi.fn().mockReturnValue(
+            (async function* () {
+                yield { event: SSE_EVENT.REASONING, data: { token: "Considering the options" } };
+                const abort = new Error("stopped");
+                abort.name = "AbortError";
+                throw abort;
+            })(),
+        );
+        plugin.api.chatStream = mockFn;
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const messagesEl = container.find("lilbee-chat-messages")!;
+        container.find("lilbee-chat-textarea")!.value = "stop me";
+        container.find("lilbee-chat-send")!.trigger("click");
+        await tick();
+        await tick();
+
+        const assistantBubble = messagesEl.children[1];
+        const details = assistantBubble.find("lilbee-reasoning");
+        expect(details).toBeTruthy();
+        // Stopping mid-thinking collapses the block instead of leaving it expanded above "(stopped)".
+        expect(details!.getAttribute("open")).toBeNull();
+    });
+
+    it("renders a late reasoning block collapsed when the answer already started", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const { mockFn, done } = makeStream([
+            { event: SSE_EVENT.TOKEN, data: { token: "Answer." } },
+            { event: SSE_EVENT.REASONING, data: { token: "afterthought" } },
+            { event: SSE_EVENT.DONE, data: {} },
+        ]);
+        plugin.api.chatStream = mockFn;
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const messagesEl = container.find("lilbee-chat-messages")!;
+        container.find("lilbee-chat-textarea")!.value = "x";
+        container.find("lilbee-chat-send")!.trigger("click");
+        await done;
+        await tick();
+
+        const assistantBubble = messagesEl.children[1];
+        const details = assistantBubble.find("lilbee-reasoning");
+        expect(details).toBeTruthy();
+        // The first answer token already arrived, so the block is created collapsed, not expanded.
+        expect(details!.getAttribute("open")).toBeNull();
+    });
+
     it("does not render details block when no reasoning tokens", async () => {
         Notice.clear();
         const plugin = makePlugin();


### PR DESCRIPTION
## Reasoning streams first, as it happens

When a reasoning model thinks before it answers, the thinking now appears first, above the answer, and streams in as the model produces it, so you get immediate feedback instead of waiting. Before this, the thinking only showed up after the whole answer had finished, in a collapsed block below it, which is backwards from how a reasoning model actually works.

The block stays expanded while the model is thinking and collapses on its own once the answer starts, so the final reply stays front and center. Click it open any time to see how the model got there.

## Show thinking moves up, and is on by default

The toggle was buried in the advanced generation settings. It now sits in its own Chat group near the top of Settings, next to where chat lives. The first time the plugin reaches a ready server it turns thinking on for you, so the feature is visible out of the box; after that the choice is yours and the plugin leaves it alone.