### PR TITLE
Add the server version to the diagnostics export summary

### DIFF
--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -73,6 +73,7 @@ export function renderSummary(ctx: DiagnosticsContext, files: CollectedFile[]): 
         "",
         "## Environment",
         `- Plugin version: ${ctx.pluginVersion}`,
+        `- Server version: ${ctx.serverVersion || "(unknown)"}`,
         `- Platform: ${process.platform} ${process.arch}`,
         `- Server state: ${ctx.serverState}`,
         `- Server URL: ${ctx.serverUrl || "(none)"}`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -756,6 +756,7 @@ export default class LilbeePlugin extends Plugin {
             settings: this.settings,
             journalEntries: this.journal.entries,
             pluginVersion: this.manifest.version,
+            serverVersion: this.getSharedLilbeeVersion(),
             serverState: this.serverManager?.state ?? SERVER_STATE.STOPPED,
             serverUrl: this.serverManager?.serverUrl ?? this.settings.serverUrl,
             lastOutput: this.serverManager?.lastOutput ?? "",

--- a/src/types.ts
+++ b/src/types.ts
@@ -529,6 +529,7 @@ export interface DiagnosticsContext {
     settings: LilbeeSettings;
     journalEntries: readonly JournalEntry[];
     pluginVersion: string;
+    serverVersion: string;
     serverState: ServerState;
     serverUrl: string;
     lastOutput: string;

--- a/tests/diagnostics-export.test.ts
+++ b/tests/diagnostics-export.test.ts
@@ -29,6 +29,7 @@ function makeContext(): DiagnosticsContext {
         settings: { ...DEFAULT_SETTINGS },
         journalEntries: [],
         pluginVersion: "1.2.3",
+        serverVersion: "v0.4.0",
         serverState: SERVER_STATE.ERROR,
         serverUrl: "",
         lastOutput: "",

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -28,6 +28,7 @@ function makeContext(overrides: Partial<DiagnosticsContext> = {}): DiagnosticsCo
         settings: { ...DEFAULT_SETTINGS },
         journalEntries: [],
         pluginVersion: "1.2.3",
+        serverVersion: "v0.4.0",
         serverState: SERVER_STATE.ERROR,
         serverUrl: "http://127.0.0.1:1234",
         lastOutput: "Traceback: boom",
@@ -148,14 +149,18 @@ describe("collectDiagnostics", () => {
         const bundle = collectDiagnostics(makeContext());
         expect(bundle.summaryMarkdown.startsWith(MESSAGES.DIAG_REVIEW_WARNING)).toBe(true);
         expect(bundle.summaryMarkdown).toContain("1.2.3");
+        expect(bundle.summaryMarkdown).toContain("- Server version: v0.4.0");
         expect(bundle.summaryMarkdown).toContain(process.platform);
         expect(bundle.summaryMarkdown).toContain("Traceback: boom");
     });
 
-    it("renders placeholders for empty stderr, journal, url, and shared root", () => {
-        const bundle = collectDiagnostics(makeContext({ lastOutput: "", serverUrl: "", sharedRoot: null }));
+    it("renders placeholders for empty stderr, journal, url, shared root, and server version", () => {
+        const bundle = collectDiagnostics(
+            makeContext({ lastOutput: "", serverUrl: "", sharedRoot: null, serverVersion: "" }),
+        );
         expect(bundle.summaryMarkdown).toContain("(empty)");
         expect(bundle.summaryMarkdown).toContain("(none)");
+        expect(bundle.summaryMarkdown).toContain("- Server version: (unknown)");
     });
 
     it("marks a noteless miss as missing in the summary", () => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -4434,6 +4434,7 @@ describe("LilbeePlugin", () => {
                         serverUrl: plugin.settings.serverUrl,
                         lastOutput: "",
                         pluginVersion: "0.1.0",
+                        serverVersion: "",
                     }),
                 );
             });
@@ -4442,11 +4443,13 @@ describe("LilbeePlugin", () => {
                 const plugin = await createPlugin({ serverMode: "managed" });
                 await plugin.onload();
                 await flush();
+                vi.spyOn(plugin as any, "getSharedLilbeeVersion").mockReturnValue("v0.4.0");
                 const ctx = plugin.diagnosticsContext();
                 expect(ctx.dataDir).toBe(mockServerOpts.dataDir);
                 expect(ctx.sharedRoot).toBe((plugin as any).vaultRegistry.sharedRoot);
                 expect(ctx.serverState).toBe("ready");
                 expect(ctx.serverUrl).toBe("http://127.0.0.1:54321");
+                expect(ctx.serverVersion).toBe("v0.4.0");
                 expect(ctx.journalEntries).toBe(plugin.journal.entries);
             });
 


### PR DESCRIPTION
The diagnostics export's `summary.md` listed the plugin version, platform, and server state, but never the server version, even though TROUBLESHOOTING.md already told users to expect "OS, plugin and server versions" in there. So a crash report came back without the one number that pins down which server build was running.

## Server version in the summary

The Environment section now carries a `Server version` line, taken from the installed managed server release the plugin already tracks. It reads `(unknown)` when there's nothing recorded yet (for example an external server the plugin hasn't learned a version for), matching the existing `(none)` and `(empty)` placeholders in the same block.