### PR TITLE
Add a crawl render mode (lightweight HTTP or browser)

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -7,6 +7,7 @@ import type {
     CatalogResponse,
     ConfigResponse,
     ConfigUpdateResponse,
+    CrawlRenderMode,
     DatasetFormat,
     DocumentResult,
     DocumentsResponse,
@@ -563,10 +564,12 @@ export class LilbeeClient {
         depth?: number | null,
         maxPages?: number | null,
         signal?: AbortSignal,
+        renderMode?: CrawlRenderMode,
     ): AsyncGenerator<SSEEvent, void> {
         const body: Record<string, unknown> = { url };
         if (depth !== undefined) body.depth = depth;
         if (maxPages !== undefined) body.max_pages = maxPages;
+        if (renderMode !== undefined) body.render_mode = renderMode;
         const res = await this.fetchWithRetry(
             `${this.baseUrl}/api/crawl`,
             {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -80,6 +80,7 @@ export const MESSAGES = {
     LABEL_CRAWL_RECURSIVE_INFO: "About whole-site crawl",
     NOTICE_CRAWL_RECURSIVE:
         "Whole-site crawl follows every internal link it finds on the same origin. Large sites can fetch hundreds of pages and take a while. Use Advanced to cap depth or page count. Request delay, concurrency and retry behavior live in Settings → Crawling.",
+    LABEL_CRAWL_USE_BROWSER: "Use browser (enables JavaScript, uses more memory)",
     HINT_CRAWL_BLANK_NO_LIMIT: "blank = no limit",
     ERROR_CRAWL_MAX_PAGES_POSITIVE: "Max pages must be a positive integer or blank",
     ERROR_CRAWL_DEPTH_INVALID: "Depth cap must be a non-negative integer or blank",
@@ -181,6 +182,11 @@ export const MESSAGES = {
     LABEL_CRAWL_RETRY_BASE_DELAY_MAX: "Retry base delay max (seconds)",
     LABEL_CRAWL_RETRY_MAX_BACKOFF: "Retry max backoff (seconds)",
     LABEL_CRAWL_RETRY_MAX_ATTEMPTS: "Retry attempts",
+    LABEL_CRAWL_RENDER_MODE: "Render mode",
+    DESC_CRAWL_RENDER_MODE:
+        "How pages are fetched. Lightweight is a fast HTTP fetch with no JavaScript. Browser runs Chromium so JavaScript-rendered pages work, at the cost of more memory and slower crawls.",
+    LABEL_CRAWL_RENDER_MODE_HTTP: "Lightweight (HTTP, no JavaScript)",
+    LABEL_CRAWL_RENDER_MODE_BROWSER: "Browser (Chromium, JavaScript)",
     LABEL_CRAWL_EXCLUDE_PATTERNS: "URL exclude patterns",
     DESC_CRAWL_EXCLUDE_PATTERNS:
         "Regex patterns that skip URLs at link-discovery during recursive crawls. One per line. Blank = no filtering.",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -81,6 +81,12 @@ export const MESSAGES = {
     NOTICE_CRAWL_RECURSIVE:
         "Whole-site crawl follows every internal link it finds on the same origin. Large sites can fetch hundreds of pages and take a while. Use Advanced to cap depth or page count. Request delay, concurrency and retry behavior live in Settings → Crawling.",
     LABEL_CRAWL_USE_BROWSER: "Use browser (enables JavaScript, uses more memory)",
+    TOOLTIP_CRAWL_URL: "Web page to crawl. A scheme is added for you if you leave it off.",
+    TOOLTIP_CRAWL_RECURSIVE: "Follow internal links on the same site instead of crawling just this page.",
+    TOOLTIP_CRAWL_USE_BROWSER:
+        "Render pages in Chromium so content built with JavaScript is captured. Use it for sites that render client-side.",
+    TOOLTIP_CRAWL_DEPTH: "How many links deep to follow from the starting page. Blank means no limit.",
+    TOOLTIP_CRAWL_MAX_PAGES: "Stop after fetching this many pages. Blank means no limit.",
     HINT_CRAWL_BLANK_NO_LIMIT: "blank = no limit",
     ERROR_CRAWL_MAX_PAGES_POSITIVE: "Max pages must be a positive integer or blank",
     ERROR_CRAWL_DEPTH_INVALID: "Depth cap must be a non-negative integer or blank",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1967,10 +1967,8 @@ export default class LilbeePlugin extends Plugin {
     }
 
     private async countPendingSync(): Promise<number> {
-        // Sync reconciles the server's own documents_dir; only managed storage
-        // (configureManagedStorage) points that at <vault>/lilbee. Elsewhere —
-        // external mode, or vault storage off — Sync vault can never ingest these
-        // files, so counting them shows a hint that clicking Sync never clears.
+        // Only managed mode with vault storage points the server's documents_dir at
+        // <vault>/lilbee; elsewhere Sync can't reconcile these files, so don't count them.
         if (this.settings.serverMode !== SERVER_MODE.MANAGED || !this.settings.storeContentInVault) {
             return 0;
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ import {
     TASK_TYPE,
     type ActiveLock,
     type BatchProgressPayload,
+    type CrawlRenderMode,
     type DiagnosticsContext,
     type DotState,
     type LilbeeSettings,
@@ -2103,7 +2104,12 @@ export default class LilbeePlugin extends Plugin {
         }
     }
 
-    async runCrawl(url: string, depth: number | null, maxPages: number | null): Promise<void> {
+    async runCrawl(
+        url: string,
+        depth: number | null,
+        maxPages: number | null,
+        renderMode?: CrawlRenderMode,
+    ): Promise<void> {
         const taskId = this.taskQueue.enqueue(`Crawl ${url}`, TASK_TYPE.CRAWL);
         if (taskId === null) {
             new Notice(MESSAGES.NOTICE_QUEUE_FULL);
@@ -2115,7 +2121,7 @@ export default class LilbeePlugin extends Plugin {
         let setupResolved = false;
         try {
             let pageCount = 0;
-            const rawStream = this.api.crawl(url, depth, maxPages, controller.signal);
+            const rawStream = this.api.crawl(url, depth, maxPages, controller.signal, renderMode);
             for await (const event of withIdleTimeout(rawStream, STREAM_IDLE_TIMEOUT_MS, () => controller.abort())) {
                 switch (event.event) {
                     case SSE_EVENT.SETUP_START: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1967,6 +1967,13 @@ export default class LilbeePlugin extends Plugin {
     }
 
     private async countPendingSync(): Promise<number> {
+        // Sync reconciles the server's own documents_dir; only managed storage
+        // (configureManagedStorage) points that at <vault>/lilbee. Elsewhere —
+        // external mode, or vault storage off — Sync vault can never ingest these
+        // files, so counting them shows a hint that clicking Sync never clears.
+        if (this.settings.serverMode !== SERVER_MODE.MANAGED || !this.settings.storeContentInVault) {
+            return 0;
+        }
         // The vault adapter can be gone if the timer fires after the host
         // environment teared down (vitest end-of-file cleanup while a real
         // setTimeout was still pending). Bail cleanly instead of crashing.

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,9 +4,8 @@ import type { ReleaseInfo } from "./binary-manager";
 import {
     CAPABILITY,
     CHAT_MODE,
-    CRAWL_RENDER_MODE,
-    CRAWL_RENDER_MODE_CONFIG_KEY,
     CONFIG_KEY,
+    CRAWL_RENDER_MODE,
     MEMORY_CONFIG_KEY,
     DEFAULT_SETTINGS,
     HOSTED_SOURCES,
@@ -1706,17 +1705,17 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 dropdown.setValue(CRAWL_RENDER_MODE.HTTP);
                 dropdown.onChange(async (value) => {
                     try {
-                        await this.plugin.api.updateConfig({ [CRAWL_RENDER_MODE_CONFIG_KEY]: value });
+                        await this.plugin.api.updateConfig({ [CONFIG_KEY.CRAWL_RENDER_MODE]: value });
                         new Notice(MESSAGES.NOTICE_FIELD_UPDATED(MESSAGES.LABEL_CRAWL_RENDER_MODE));
                     } catch {
                         new Notice(MESSAGES.NOTICE_FAILED_UPDATE(MESSAGES.LABEL_CRAWL_RENDER_MODE));
                     }
                 });
-                this.serverConfigDropdowns.set(CRAWL_RENDER_MODE_CONFIG_KEY, dropdown);
+                this.serverConfigDropdowns.set(CONFIG_KEY.CRAWL_RENDER_MODE, dropdown);
             });
-        this.appendResetAffordance(renderModeSetting, CRAWL_RENDER_MODE_CONFIG_KEY, MESSAGES.LABEL_CRAWL_RENDER_MODE);
+        this.appendResetAffordance(renderModeSetting, CONFIG_KEY.CRAWL_RENDER_MODE, MESSAGES.LABEL_CRAWL_RENDER_MODE);
         renderModeContainer.hide();
-        this.serverConfigHideableEls.set(CRAWL_RENDER_MODE_CONFIG_KEY, renderModeContainer);
+        this.serverConfigHideableEls.set(CONFIG_KEY.CRAWL_RENDER_MODE, renderModeContainer);
 
         const patternsSetting = new Setting(containerEl)
             .setName(MESSAGES.LABEL_CRAWL_EXCLUDE_PATTERNS)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,6 +4,8 @@ import type { ReleaseInfo } from "./binary-manager";
 import {
     CAPABILITY,
     CHAT_MODE,
+    CRAWL_RENDER_MODE,
+    CRAWL_RENDER_MODE_CONFIG_KEY,
     CONFIG_KEY,
     MEMORY_CONFIG_KEY,
     DEFAULT_SETTINGS,
@@ -72,6 +74,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
     private serverConfigToggles: Map<string, { setValue: (v: boolean) => unknown }> = new Map();
     private memoryToggles: Map<string, { setValue: (v: boolean) => unknown }> = new Map();
     private serverConfigTextAreas: Map<string, HTMLTextAreaElement> = new Map();
+    private serverConfigDropdowns: Map<string, { setValue: (v: string) => unknown }> = new Map();
     // Rows hidden until loadServerDefaults sees a defined value for the matching cfg key.
     private serverConfigHideableEls: Map<string, HTMLElement> = new Map();
     private configDefaults: Record<string, unknown> = {};
@@ -99,6 +102,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         this.serverConfigInputs.clear();
         this.serverConfigToggles.clear();
         this.serverConfigTextAreas.clear();
+        this.serverConfigDropdowns.clear();
         this.serverConfigHideableEls.clear();
 
         const filterInput = containerEl.createEl("input", {
@@ -574,6 +578,12 @@ export class LilbeeSettingTab extends PluginSettingTab {
                     const v = cfg[key];
                     if (Array.isArray(v)) {
                         textArea.value = v.join("\n");
+                    }
+                }
+                for (const [key, dropdown] of this.serverConfigDropdowns) {
+                    const v = cfg[key];
+                    if (typeof v === "string") {
+                        dropdown.setValue(v);
                     }
                 }
                 if (typeof cfg.rag_system_prompt === "string") {
@@ -1683,6 +1693,30 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 });
             this.appendResetAffordance(numSetting, numField.key, numField.name);
         }
+
+        // Wrap the render-mode row in its own child div so the hide-until-supported
+        // toggle targets just this row, not the capability-gated crawling container.
+        const renderModeContainer = containerEl.createDiv();
+        const renderModeSetting = new Setting(renderModeContainer)
+            .setName(MESSAGES.LABEL_CRAWL_RENDER_MODE)
+            .setDesc(MESSAGES.DESC_CRAWL_RENDER_MODE)
+            .addDropdown((dropdown) => {
+                dropdown.addOption(CRAWL_RENDER_MODE.HTTP, MESSAGES.LABEL_CRAWL_RENDER_MODE_HTTP);
+                dropdown.addOption(CRAWL_RENDER_MODE.BROWSER, MESSAGES.LABEL_CRAWL_RENDER_MODE_BROWSER);
+                dropdown.setValue(CRAWL_RENDER_MODE.HTTP);
+                dropdown.onChange(async (value) => {
+                    try {
+                        await this.plugin.api.updateConfig({ [CRAWL_RENDER_MODE_CONFIG_KEY]: value });
+                        new Notice(MESSAGES.NOTICE_FIELD_UPDATED(MESSAGES.LABEL_CRAWL_RENDER_MODE));
+                    } catch {
+                        new Notice(MESSAGES.NOTICE_FAILED_UPDATE(MESSAGES.LABEL_CRAWL_RENDER_MODE));
+                    }
+                });
+                this.serverConfigDropdowns.set(CRAWL_RENDER_MODE_CONFIG_KEY, dropdown);
+            });
+        this.appendResetAffordance(renderModeSetting, CRAWL_RENDER_MODE_CONFIG_KEY, MESSAGES.LABEL_CRAWL_RENDER_MODE);
+        renderModeContainer.hide();
+        this.serverConfigHideableEls.set(CRAWL_RENDER_MODE_CONFIG_KEY, renderModeContainer);
 
         const patternsSetting = new Setting(containerEl)
             .setName(MESSAGES.LABEL_CRAWL_EXCLUDE_PATTERNS)

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,13 +110,12 @@ export const CRAWL_RENDER_MODE = {
     BROWSER: "browser",
 } as const satisfies Record<string, CrawlRenderMode>;
 
-export const CRAWL_RENDER_MODE_CONFIG_KEY = "crawl_render_mode";
-
 export const CONFIG_KEY = {
     RAG_SYSTEM_PROMPT: "rag_system_prompt",
     GENERAL_SYSTEM_PROMPT: "general_system_prompt",
     CHAT_MODE: "chat_mode",
     SHOW_REASONING: "show_reasoning",
+    CRAWL_RENDER_MODE: "crawl_render_mode",
 } as const;
 
 export type ChatMode = "search" | "chat";

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,8 +99,18 @@ export interface ConfigResponse {
     max_context_sources?: number;
     diversity_max_per_source?: number;
     mmr_lambda?: number;
+    crawl_render_mode?: CrawlRenderMode;
     [key: string]: unknown;
 }
+
+export type CrawlRenderMode = "http" | "browser";
+
+export const CRAWL_RENDER_MODE = {
+    HTTP: "http",
+    BROWSER: "browser",
+} as const satisfies Record<string, CrawlRenderMode>;
+
+export const CRAWL_RENDER_MODE_CONFIG_KEY = "crawl_render_mode";
 
 export const CONFIG_KEY = {
     RAG_SYSTEM_PROMPT: "rag_system_prompt",

--- a/src/views/crawl-modal.ts
+++ b/src/views/crawl-modal.ts
@@ -2,6 +2,7 @@ import { App, Modal, Notice, setIcon } from "obsidian";
 import type LilbeePlugin from "../main";
 import { MESSAGES } from "../locales/en";
 import { bindEscapeToClose, ensureUrlScheme } from "../utils";
+import { CRAWL_RENDER_MODE, CRAWL_RENDER_MODE_CONFIG_KEY, type CrawlRenderMode } from "../types";
 
 type ParseResult = { value: number | null; error: string | null };
 
@@ -79,6 +80,25 @@ export class CrawlModal extends Modal {
         };
         infoBtn.addEventListener("click", () => setNoticeOpen(!noticeOpen));
 
+        const browserRow = contentEl.createDiv({ cls: "lilbee-crawl-browser-row" });
+        const browserLabel = browserRow.createEl("label", { cls: "lilbee-crawl-browser" });
+        const browserInput = browserLabel.createEl("input", {
+            cls: "lilbee-crawl-browser-input",
+            attr: { type: "checkbox" },
+        });
+        asInput(browserInput).checked = false;
+        browserLabel.createSpan({ text: MESSAGES.LABEL_CRAWL_USE_BROWSER });
+
+        // Pre-set the toggle from the server's current crawl_render_mode (sticky default).
+        void this.plugin.api
+            .config()
+            .then((cfg) => {
+                asInput(browserInput).checked = cfg.crawl_render_mode === CRAWL_RENDER_MODE.BROWSER;
+            })
+            .catch(() => {
+                /* Leave the toggle at its lightweight default if config is unreachable. */
+            });
+
         const advanced = contentEl.createEl("details", { cls: "lilbee-crawl-advanced" });
         advanced.createEl("summary", { text: MESSAGES.LABEL_CRAWL_ADVANCED });
 
@@ -150,7 +170,16 @@ export class CrawlModal extends Modal {
                 maxPages = maxRes.value;
             }
 
-            void this.plugin.runCrawl(url, depth, maxPages);
+            const renderMode: CrawlRenderMode = asInput(browserInput).checked
+                ? CRAWL_RENDER_MODE.BROWSER
+                : CRAWL_RENDER_MODE.HTTP;
+            // Persist the choice so the toggle is sticky next time; the explicit render_mode below
+            // drives this crawl regardless, so a failed write must not block it.
+            void this.plugin.api.updateConfig({ [CRAWL_RENDER_MODE_CONFIG_KEY]: renderMode }).catch(() => {
+                /* Non-fatal: the crawl still runs with the explicit render_mode below. */
+            });
+
+            void this.plugin.runCrawl(url, depth, maxPages, renderMode);
             this.close();
         });
 

--- a/src/views/crawl-modal.ts
+++ b/src/views/crawl-modal.ts
@@ -41,11 +41,14 @@ export class CrawlModal extends Modal {
         const urlInput = contentEl.createEl("input", {
             cls: "lilbee-crawl-url",
             placeholder: MESSAGES.PLACEHOLDER_URL,
-            attr: { type: "text" },
+            attr: { type: "text", title: MESSAGES.TOOLTIP_CRAWL_URL },
         });
 
         const recursiveRow = contentEl.createDiv({ cls: "lilbee-crawl-recursive-row" });
-        const recursiveLabel = recursiveRow.createEl("label", { cls: "lilbee-crawl-recursive" });
+        const recursiveLabel = recursiveRow.createEl("label", {
+            cls: "lilbee-crawl-recursive",
+            attr: { title: MESSAGES.TOOLTIP_CRAWL_RECURSIVE },
+        });
         const recursiveInput = recursiveLabel.createEl("input", {
             cls: "lilbee-crawl-recursive-input",
             attr: { type: "checkbox" },
@@ -81,7 +84,10 @@ export class CrawlModal extends Modal {
         infoBtn.addEventListener("click", () => setNoticeOpen(!noticeOpen));
 
         const browserRow = contentEl.createDiv({ cls: "lilbee-crawl-browser-row" });
-        const browserLabel = browserRow.createEl("label", { cls: "lilbee-crawl-browser" });
+        const browserLabel = browserRow.createEl("label", {
+            cls: "lilbee-crawl-browser",
+            attr: { title: MESSAGES.TOOLTIP_CRAWL_USE_BROWSER },
+        });
         const browserInput = browserLabel.createEl("input", {
             cls: "lilbee-crawl-browser-input",
             attr: { type: "checkbox" },
@@ -108,7 +114,7 @@ export class CrawlModal extends Modal {
         const depthInput = depthLabel.createEl("input", {
             cls: "lilbee-crawl-depth",
             placeholder: MESSAGES.HINT_CRAWL_BLANK_NO_LIMIT,
-            attr: { type: "number", min: "0" },
+            attr: { type: "number", min: "0", title: MESSAGES.TOOLTIP_CRAWL_DEPTH },
         });
         asInput(depthInput).value = "";
 
@@ -116,7 +122,7 @@ export class CrawlModal extends Modal {
         const maxInput = maxLabel.createEl("input", {
             cls: "lilbee-crawl-max-pages",
             placeholder: MESSAGES.HINT_CRAWL_BLANK_NO_LIMIT,
-            attr: { type: "number", min: "1" },
+            attr: { type: "number", min: "1", title: MESSAGES.TOOLTIP_CRAWL_MAX_PAGES },
         });
         asInput(maxInput).value = "";
 

--- a/src/views/crawl-modal.ts
+++ b/src/views/crawl-modal.ts
@@ -2,7 +2,7 @@ import { App, Modal, Notice, setIcon } from "obsidian";
 import type LilbeePlugin from "../main";
 import { MESSAGES } from "../locales/en";
 import { bindEscapeToClose, ensureUrlScheme } from "../utils";
-import { CRAWL_RENDER_MODE, CRAWL_RENDER_MODE_CONFIG_KEY, type CrawlRenderMode } from "../types";
+import { CONFIG_KEY, CRAWL_RENDER_MODE, type CrawlRenderMode } from "../types";
 
 type ParseResult = { value: number | null; error: string | null };
 
@@ -173,11 +173,8 @@ export class CrawlModal extends Modal {
             const renderMode: CrawlRenderMode = asInput(browserInput).checked
                 ? CRAWL_RENDER_MODE.BROWSER
                 : CRAWL_RENDER_MODE.HTTP;
-            // Persist the choice so the toggle is sticky next time; the explicit render_mode below
-            // drives this crawl regardless, so a failed write must not block it.
-            void this.plugin.api.updateConfig({ [CRAWL_RENDER_MODE_CONFIG_KEY]: renderMode }).catch(() => {
-                /* Non-fatal: the crawl still runs with the explicit render_mode below. */
-            });
+            // Persist the sticky default; non-fatal since runCrawl below drives this crawl explicitly.
+            void this.plugin.api.updateConfig({ [CONFIG_KEY.CRAWL_RENDER_MODE]: renderMode }).catch(() => {});
 
             void this.plugin.runCrawl(url, depth, maxPages, renderMode);
             this.close();

--- a/styles.css
+++ b/styles.css
@@ -1452,6 +1452,21 @@
     cursor: pointer;
 }
 
+.lilbee-crawl-browser-row {
+    display: flex;
+    align-items: center;
+    gap: var(--size-4-1, 4px);
+    margin: var(--size-4-2, 8px) 0;
+}
+
+.lilbee-crawl-browser {
+    display: flex;
+    align-items: center;
+    gap: var(--size-4-2, 8px);
+    font-size: var(--font-small, 13px);
+    cursor: pointer;
+}
+
 .lilbee-crawl-info-btn {
     width: 18px;
     height: 18px;

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -784,6 +784,20 @@ describe("pullModel()", () => {
             });
         });
 
+        it("includes render_mode in the body when a render mode is passed", async () => {
+            fetchMock.mockResolvedValue(
+                sseResponse(['event: crawl_done\ndata: {"pages_crawled":1,"files_written":1}\n\n']),
+            );
+
+            await collect(client.crawl("https://example.com", 0, null, undefined, "browser"));
+
+            expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/api/crawl`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ url: "https://example.com", depth: 0, max_pages: null, render_mode: "browser" }),
+            });
+        });
+
         it("omits depth and max_pages from the body when they are not passed", async () => {
             fetchMock.mockResolvedValue(
                 sseResponse(['event: crawl_done\ndata: {"pages_crawled":1,"files_written":1}\n\n']),

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -2698,7 +2698,13 @@ describe("LilbeePlugin", () => {
 
             await plugin.runCrawl("https://example.com", 0, 50);
 
-            expect(plugin.api.crawl).toHaveBeenCalledWith("https://example.com", 0, 50, expect.any(AbortSignal));
+            expect(plugin.api.crawl).toHaveBeenCalledWith(
+                "https://example.com",
+                0,
+                50,
+                expect.any(AbortSignal),
+                undefined,
+            );
             expect(Notice.instances.some((n) => n.message.includes("crawl done"))).toBe(true);
             expect(syncSpy).toHaveBeenCalled();
             expect(plugin.taskQueue.completed.length).toBeGreaterThan(0);
@@ -2717,7 +2723,35 @@ describe("LilbeePlugin", () => {
 
             await plugin.runCrawl("https://example.com", null, null);
 
-            expect(plugin.api.crawl).toHaveBeenCalledWith("https://example.com", null, null, expect.any(AbortSignal));
+            expect(plugin.api.crawl).toHaveBeenCalledWith(
+                "https://example.com",
+                null,
+                null,
+                expect.any(AbortSignal),
+                undefined,
+            );
+        });
+
+        it("forwards an explicit render mode to api.crawl", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+
+            plugin.api.crawl = vi.fn().mockReturnValue(
+                (async function* () {
+                    yield { event: SSE_EVENT.CRAWL_DONE, data: { pages_crawled: 1 } };
+                })(),
+            );
+            vi.spyOn(plugin, "triggerSync").mockResolvedValue(undefined);
+
+            await plugin.runCrawl("https://example.com", 0, null, "browser");
+
+            expect(plugin.api.crawl).toHaveBeenCalledWith(
+                "https://example.com",
+                0,
+                null,
+                expect.any(AbortSignal),
+                "browser",
+            );
         });
 
         it("CRAWL_DONE without pages_crawled uses local pageCount", async () => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1513,9 +1513,47 @@ describe("LilbeePlugin", () => {
     });
 
     describe("updatePendingSyncHint()", () => {
+        it("hides the sync pill in external mode even when lilbee/ files are unsynced", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue([
+                { path: "lilbee/a.md", name: "a.md", extension: "md" },
+                { path: "lilbee/b.pdf", name: "b.pdf", extension: "pdf" },
+            ]);
+            const listSpy = plugin.api.listDocuments as ReturnType<typeof vi.fn>;
+            listSpy.mockClear();
+            plugin.syncPillEl!.style.display = "";
+
+            await plugin.updatePendingSyncHint();
+
+            // External servers reconcile their own documents_dir, never the vault,
+            // so Sync vault can't ingest these — the pill must stay hidden.
+            expect(plugin.syncPillEl?.style.display).toBe("none");
+            expect(listSpy).not.toHaveBeenCalled();
+        });
+
+        it("hides the sync pill when managed but vault storage is off", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            plugin.settings.serverMode = "managed";
+            plugin.settings.storeContentInVault = false;
+            (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue([
+                { path: "lilbee/a.md", name: "a.md", extension: "md" },
+            ]);
+            const listSpy = plugin.api.listDocuments as ReturnType<typeof vi.fn>;
+            listSpy.mockClear();
+            plugin.syncPillEl!.style.display = "";
+
+            await plugin.updatePendingSyncHint();
+
+            expect(plugin.syncPillEl?.style.display).toBe("none");
+            expect(listSpy).not.toHaveBeenCalled();
+        });
+
         it("shows the sync pill with the count when the vault has unknown files", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
+            plugin.settings.serverMode = "managed";
             (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue([
                 { path: "lilbee/a.md", name: "a.md", extension: "md" },
                 { path: "lilbee/b.pdf", name: "b.pdf", extension: "pdf" },
@@ -1540,6 +1578,7 @@ describe("LilbeePlugin", () => {
         it("hides the sync pill when nothing is pending", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
+            plugin.settings.serverMode = "managed";
             (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue([
                 { path: "lilbee/a.md", name: "a.md", extension: "md" },
             ]);
@@ -1560,6 +1599,7 @@ describe("LilbeePlugin", () => {
         it("counts only lilbee/ docs, skipping loose notes, unsupported files, and wiki pages", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
+            plugin.settings.serverMode = "managed";
             plugin.wikiSync = {
                 isWikiPath: (p: string) => p.startsWith("lilbee/wiki/"),
                 reconcile: vi.fn(),
@@ -1586,6 +1626,7 @@ describe("LilbeePlugin", () => {
         it("pages through listDocuments when has_more is true", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
+            plugin.settings.serverMode = "managed";
             (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue([
                 { path: "lilbee/a.md", name: "a.md", extension: "md" },
                 { path: "lilbee/b.md", name: "b.md", extension: "md" },
@@ -1615,6 +1656,7 @@ describe("LilbeePlugin", () => {
         it("hides the sync pill when listDocuments rejects (server offline)", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
+            plugin.settings.serverMode = "managed";
             (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue([
                 { path: "lilbee/a.md", name: "a.md", extension: "md" },
             ]);
@@ -1628,6 +1670,7 @@ describe("LilbeePlugin", () => {
         it("renders the sync pill independently of the main status pill", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
+            plugin.settings.serverMode = "managed";
             (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue([
                 { path: "lilbee/a.md", name: "a.md", extension: "md" },
                 { path: "lilbee/b.md", name: "b.md", extension: "md" },
@@ -1657,6 +1700,7 @@ describe("LilbeePlugin", () => {
         it("bails after the await if the pill was torn down mid-flight", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
+            plugin.settings.serverMode = "managed";
             (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue([
                 { path: "lilbee/a.md", name: "a.md", extension: "md" },
             ]);
@@ -1670,6 +1714,7 @@ describe("LilbeePlugin", () => {
         it("hides the sync pill when the vault adapter is gone (timer fired post-teardown)", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
+            plugin.settings.serverMode = "managed";
             (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
             await expect(plugin.updatePendingSyncHint()).resolves.toBeUndefined();
             expect(plugin.syncPillEl?.style.display).toBe("none");

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1527,7 +1527,7 @@ describe("LilbeePlugin", () => {
             await plugin.updatePendingSyncHint();
 
             // External servers reconcile their own documents_dir, never the vault,
-            // so Sync vault can't ingest these — the pill must stay hidden.
+            // so Sync vault can't ingest these, so the pill must stay hidden.
             expect(plugin.syncPillEl?.style.display).toBe("none");
             expect(listSpy).not.toHaveBeenCalled();
         });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -235,6 +235,8 @@ interface Captured {
     blurHandlers: BlurCapture[];
     sliderOnChanges: SliderOnChange[];
     dropdownOnChanges: DropdownOnChange[];
+    dropdownOptions: Array<Record<string, string>>;
+    dropdownSetValues: string[][];
     toggleOnChanges: ToggleOnChange[];
     buttonOnClicks: ButtonOnClick[];
     extraButtonOnClicks: ButtonOnClick[];
@@ -246,6 +248,8 @@ function captureSettingCallbacks(fn: () => void): Captured {
     const blurHandlers: BlurCapture[] = [];
     const sliderOnChanges: SliderOnChange[] = [];
     const dropdownOnChanges: DropdownOnChange[] = [];
+    const dropdownOptions: Array<Record<string, string>> = [];
+    const dropdownSetValues: string[][] = [];
     const toggleOnChanges: ToggleOnChange[] = [];
     const buttonOnClicks: ButtonOnClick[] = [];
     const extraButtonOnClicks: ButtonOnClick[] = [];
@@ -323,16 +327,29 @@ function captureSettingCallbacks(fn: () => void): Captured {
     };
 
     Setting.prototype.addDropdown = function (cb: (dropdown: any) => void) {
+        const options: Record<string, string> = {};
+        const setValues: string[] = [];
         const fakeDropdown = {
-            addOption: (_v: string, _l: string) => fakeDropdown,
-            addOptions: (_opts: Record<string, string>) => fakeDropdown,
-            setValue: () => fakeDropdown,
+            addOption: (v: string, l: string) => {
+                options[v] = l;
+                return fakeDropdown;
+            },
+            addOptions: (opts: Record<string, string>) => {
+                Object.assign(options, opts);
+                return fakeDropdown;
+            },
+            setValue: (v: string) => {
+                setValues.push(v);
+                return fakeDropdown;
+            },
             onChange: (handler: DropdownOnChange) => {
                 dropdownOnChanges.push(handler);
                 return fakeDropdown;
             },
         };
         cb(fakeDropdown);
+        dropdownOptions.push(options);
+        dropdownSetValues.push(setValues);
         return this;
     };
 
@@ -403,6 +420,8 @@ function captureSettingCallbacks(fn: () => void): Captured {
         blurHandlers,
         sliderOnChanges,
         dropdownOnChanges,
+        dropdownOptions,
+        dropdownSetValues,
         toggleOnChanges,
         buttonOnClicks,
         extraButtonOnClicks,
@@ -3131,6 +3150,45 @@ describe("managed mode settings", () => {
 
             await textOnChanges[CRAWL_DEPTH]("3");
             expect(Notice.instances.some((n: any) => n.message.includes("failed to update"))).toBe(true);
+        });
+
+        // Locate the render-mode dropdown by its option set rather than a brittle absolute index.
+        const renderModeIndex = (dropdownOptions: Array<Record<string, string>>): number =>
+            dropdownOptions.findIndex((o) => "http" in o && "browser" in o);
+
+        it("PATCHes crawl_render_mode when the render-mode dropdown changes", async () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const { dropdownOnChanges, dropdownOptions } = captureSettingCallbacks(() => tab.display());
+
+            const idx = renderModeIndex(dropdownOptions);
+            expect(idx).toBeGreaterThanOrEqual(0);
+            await dropdownOnChanges[idx]("browser");
+            expect(plugin.api.updateConfig).toHaveBeenCalledWith({ crawl_render_mode: "browser" });
+        });
+
+        it("shows an error notice when the render-mode PATCH fails", async () => {
+            const plugin = makePlugin();
+            (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("boom"));
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const { dropdownOnChanges, dropdownOptions } = captureSettingCallbacks(() => tab.display());
+
+            await dropdownOnChanges[renderModeIndex(dropdownOptions)]("browser");
+            expect(Notice.instances.some((n: any) => n.message.includes("failed to update"))).toBe(true);
+        });
+
+        it("hydrates the render-mode dropdown from the server's crawl_render_mode", async () => {
+            const plugin = makePlugin();
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({ crawl_render_mode: "browser" });
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const { dropdownOptions, dropdownSetValues } = captureSettingCallbacks(() => tab.display());
+
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(dropdownSetValues[renderModeIndex(dropdownOptions)]).toContain("browser");
         });
     });
 

--- a/tests/views/crawl-modal.test.ts
+++ b/tests/views/crawl-modal.test.ts
@@ -3,9 +3,13 @@ import { App, Notice } from "obsidian";
 import { MockElement } from "../__mocks__/obsidian";
 import { CrawlModal } from "../../src/views/crawl-modal";
 
-function makePlugin() {
+function makePlugin(renderMode: string = "http") {
     return {
         runCrawl: vi.fn(),
+        api: {
+            config: vi.fn().mockResolvedValue({ crawl_render_mode: renderMode }),
+            updateConfig: vi.fn().mockResolvedValue({}),
+        },
     };
 }
 
@@ -178,7 +182,7 @@ describe("CrawlModal", () => {
         const closeSpy = vi.spyOn(modal, "close");
         setUrl(el, "https://example.com");
         clickCrawl(el);
-        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", null, null);
+        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", null, null, "http");
         expect(closeSpy).toHaveBeenCalled();
     });
 
@@ -186,7 +190,7 @@ describe("CrawlModal", () => {
         const { plugin, el } = openModal();
         setUrl(el, "https://example.com");
         clickCrawl(el);
-        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", 0, null);
+        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", 0, null, "http");
     });
 
     it("Recursive on + Advanced filled → sends the parsed numbers", () => {
@@ -196,7 +200,7 @@ describe("CrawlModal", () => {
         (el.find("lilbee-crawl-depth") as any).value = "2";
         (el.find("lilbee-crawl-max-pages") as any).value = "20";
         clickCrawl(el);
-        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", 2, 20);
+        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", 2, 20, "http");
     });
 
     it("Recursive on + depth only → sends (n, null)", () => {
@@ -205,7 +209,7 @@ describe("CrawlModal", () => {
         setUrl(el, "https://example.com");
         (el.find("lilbee-crawl-depth") as any).value = "3";
         clickCrawl(el);
-        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", 3, null);
+        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", 3, null, "http");
     });
 
     it("Recursive on + max only → sends (null, n)", () => {
@@ -214,7 +218,7 @@ describe("CrawlModal", () => {
         setUrl(el, "https://example.com");
         (el.find("lilbee-crawl-max-pages") as any).value = "100";
         clickCrawl(el);
-        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", null, 100);
+        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", null, 100, "http");
     });
 
     it("max_pages=0 blocks submit with inline error", () => {
@@ -320,7 +324,7 @@ describe("CrawlModal", () => {
         expect(plugin.runCrawl).not.toHaveBeenCalled();
         (el.find("lilbee-crawl-max-pages") as any).value = "5";
         clickCrawl(el);
-        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", null, 5);
+        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", null, 5, "http");
         expect(err.textContent).toBe("");
     });
 
@@ -328,14 +332,14 @@ describe("CrawlModal", () => {
         const { plugin, el } = openModal();
         setUrl(el, "example.com");
         clickCrawl(el);
-        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", 0, null);
+        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", 0, null, "http");
     });
 
     it("preserves http:// when already present", () => {
         const { plugin, el } = openModal();
         setUrl(el, "http://example.com");
         clickCrawl(el);
-        expect(plugin.runCrawl).toHaveBeenCalledWith("http://example.com", 0, null);
+        expect(plugin.runCrawl).toHaveBeenCalledWith("http://example.com", 0, null, "http");
     });
 
     it("Recursive on + depth=0 → sends (0, null) (seed-only with recursive on is still valid)", () => {
@@ -344,6 +348,72 @@ describe("CrawlModal", () => {
         setUrl(el, "https://example.com");
         (el.find("lilbee-crawl-depth") as any).value = "0";
         clickCrawl(el);
-        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", 0, null);
+        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", 0, null, "http");
+    });
+
+    it("renders the Use-browser toggle, unchecked by default", () => {
+        const { el } = openModal();
+        const browser = el.find("lilbee-crawl-browser-input") as any;
+        expect(browser).not.toBeNull();
+        expect(browser.checked).toBe(false);
+        const texts = collectTexts(el);
+        expect(texts.some((t) => t.includes("Use browser"))).toBe(true);
+    });
+
+    it("pre-sets the browser toggle from the server's crawl_render_mode", async () => {
+        const app = new App();
+        const plugin = makePlugin("browser");
+        const modal = new CrawlModal(app as any, plugin as any);
+        modal.onOpen();
+        const el = modal.contentEl as unknown as MockElement;
+        await Promise.resolve();
+        await Promise.resolve();
+        expect((el.find("lilbee-crawl-browser-input") as any).checked).toBe(true);
+        expect(plugin.api.config).toHaveBeenCalled();
+    });
+
+    it("on submit sends browser render mode and persists it via config", () => {
+        const { plugin, el } = openModal();
+        setUrl(el, "https://example.com");
+        (el.find("lilbee-crawl-browser-input") as any).checked = true;
+        clickCrawl(el);
+        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", 0, null, "browser");
+        expect(plugin.api.updateConfig).toHaveBeenCalledWith({ crawl_render_mode: "browser" });
+    });
+
+    it("on submit persists http when the browser toggle is off", () => {
+        const { plugin, el } = openModal();
+        setUrl(el, "https://example.com");
+        clickCrawl(el);
+        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", 0, null, "http");
+        expect(plugin.api.updateConfig).toHaveBeenCalledWith({ crawl_render_mode: "http" });
+    });
+
+    it("leaves the browser toggle at its lightweight default when config() is unreachable", async () => {
+        const app = new App();
+        const plugin = {
+            runCrawl: vi.fn(),
+            api: {
+                config: vi.fn().mockRejectedValue(new Error("unreachable")),
+                updateConfig: vi.fn().mockResolvedValue({}),
+            },
+        };
+        const modal = new CrawlModal(app as any, plugin as any);
+        modal.onOpen();
+        const el = modal.contentEl as unknown as MockElement;
+        await Promise.resolve();
+        await Promise.resolve();
+        expect((el.find("lilbee-crawl-browser-input") as any).checked).toBe(false);
+    });
+
+    it("still runs the crawl when persisting the render mode fails", async () => {
+        const { plugin, el } = openModal();
+        (plugin.api.updateConfig as any).mockRejectedValue(new Error("write failed"));
+        setUrl(el, "https://example.com");
+        (el.find("lilbee-crawl-browser-input") as any).checked = true;
+        clickCrawl(el);
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", 0, null, "browser");
     });
 });

--- a/tests/views/crawl-modal.test.ts
+++ b/tests/views/crawl-modal.test.ts
@@ -2,6 +2,7 @@ import { vi, describe, it, expect, beforeEach } from "vitest";
 import { App, Notice } from "obsidian";
 import { MockElement } from "../__mocks__/obsidian";
 import { CrawlModal } from "../../src/views/crawl-modal";
+import { MESSAGES } from "../../src/locales/en";
 
 function makePlugin(renderMode: string = "http") {
     return {
@@ -358,6 +359,16 @@ describe("CrawlModal", () => {
         expect(browser.checked).toBe(false);
         const texts = collectTexts(el);
         expect(texts.some((t) => t.includes("Use browser"))).toBe(true);
+    });
+
+    it("sets hover tooltips on the modal controls", () => {
+        const { el } = openModal();
+        const title = (cls: string): string | null => (el.find(cls) as unknown as MockElement)?.getAttribute("title");
+        expect(title("lilbee-crawl-url")).toBe(MESSAGES.TOOLTIP_CRAWL_URL);
+        expect(title("lilbee-crawl-recursive")).toBe(MESSAGES.TOOLTIP_CRAWL_RECURSIVE);
+        expect(title("lilbee-crawl-browser")).toBe(MESSAGES.TOOLTIP_CRAWL_USE_BROWSER);
+        expect(title("lilbee-crawl-depth")).toBe(MESSAGES.TOOLTIP_CRAWL_DEPTH);
+        expect(title("lilbee-crawl-max-pages")).toBe(MESSAGES.TOOLTIP_CRAWL_MAX_PAGES);
     });
 
     it("pre-sets the browser toggle from the server's crawl_render_mode", async () => {


### PR DESCRIPTION
Crawling has always fetched every page the same way. That works for static and server-rendered sites, but pages that build their content with JavaScript came back empty. This adds a choice between a fast, browserless fetch and a full browser.

## Lightweight by default, browser when a page needs it

Crawls now default to a quick HTTP fetch with no browser. When a site only renders its content with JavaScript, turn on "Use browser" in the Crawl dialog and the server loads it in Chromium instead, at the cost of more memory and a slower crawl. The toggle remembers your last choice, and Settings has a matching Render mode control if you would rather set the default once and forget it. On older servers that do not support this yet, the controls stay hidden and crawling behaves exactly as before.

This needs lilbee server 0.6.66b499 or newer. Managed installs update themselves the next time you open Obsidian after this update. If you run your own server in external mode, update it before reaching for the browser option.

## Sync Bug

While in here, this also fixes a long-standing annoyance: the status-bar sync badge could sit there showing a count that clicking it never cleared. That only happened with an external server, where the documents the badge counts live in your vault but the server keeps its own copy elsewhere, so a sync had nothing it could reconcile. The badge now appears only when the plugin is actually managing your vault's documents, so the number it shows is always something a sync can resolve.