### PR TITLE
Spawn the managed server with a UTF-8 locale

### DIFF
--- a/src/server-manager.ts
+++ b/src/server-manager.ts
@@ -121,6 +121,12 @@ export class ServerManager {
     private buildSpawnEnv(): Record<string, string | undefined> {
         const env: Record<string, string | undefined> = {
             ...process.env,
+            // Force UTF-8 locale/stdio: GUI-spawned children inherit no locale,
+            // so the server defaults to ASCII and crashes crawling non-ASCII output.
+            LANG: "en_US.UTF-8",
+            LC_ALL: "en_US.UTF-8",
+            PYTHONIOENCODING: "utf-8",
+            PYTHONUTF8: "1",
             LILBEE_CORS_ORIGINS: "app://obsidian.md",
             LILBEE_PARENT_PID: String(process.pid),
             LILBEE_MODELS_DIR: this.opts.modelsDir,

--- a/tests/server-manager.test.ts
+++ b/tests/server-manager.test.ts
@@ -127,6 +127,12 @@ describe("ServerManager", () => {
             expect(opts.env.LILBEE_CORS_ORIGINS).toBe("app://obsidian.md");
             expect(opts.env.LILBEE_PARENT_PID).toBe(String(process.pid));
             expect(opts.env.LILBEE_MODELS_DIR).toBe("/tmp/models");
+            // UTF-8 locale so the server's Python doesn't fall back to ASCII
+            // stdio and crash crawling pages with non-ASCII output (e.g. "→").
+            expect(opts.env.LANG).toBe("en_US.UTF-8");
+            expect(opts.env.LC_ALL).toBe("en_US.UTF-8");
+            expect(opts.env.PYTHONIOENCODING).toBe("utf-8");
+            expect(opts.env.PYTHONUTF8).toBe("1");
             expect(opts.env.LILBEE_RAG_SYSTEM_PROMPT).toBeUndefined();
             expect(opts.env.LILBEE_GENERAL_SYSTEM_PROMPT).toBeUndefined();
             expect(opts.stdio).toEqual(["ignore", "pipe", "pipe"]);


### PR DESCRIPTION
## Problem

Crawling a web page completed but indexed nothing. The managed lilbee server is spawned by Obsidian (a GUI app), which passes no locale to child processes, so the server's Python fell back to ASCII for stdio. Crawling a page whose output contains a non-ASCII character (e.g. a Wikipedia article with a literal "→") then died with a UnicodeEncodeError — the crawl task reported done, but the page was never saved.

## Solution

Set `LANG`/`LC_ALL=en_US.UTF-8`, `PYTHONIOENCODING=utf-8`, and `PYTHONUTF8=1` on the server's spawn environment so it runs UTF-8 end to end regardless of how the host launched the app. Verified against the shipped server binary: under a C locale the crawl indexes nothing; with the UTF-8 env it saves the page.