### PR TITLE
Count pending-sync files without enumerating the whole vault

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,8 @@ import {
     Notice,
     Plugin,
     type TAbstractFile,
+    TFile,
+    TFolder,
     type WorkspaceLeaf,
 } from "obsidian";
 import { LilbeeClient, SessionTokenError } from "./api";
@@ -103,7 +105,14 @@ const SUPPORTED_SYNC_EXTENSIONS = new Set(["md", "pdf", "txt", "html"]);
 
 // Vault-relative folder where managed mode stores lilbee's documents
 // (see configureManagedStorage). It is the only scope `Sync vault` reconciles.
-const MANAGED_DOCS_PREFIX = "lilbee/";
+const MANAGED_DOCS_FOLDER = "lilbee";
+
+// All files in a folder subtree, recursing into subfolders.
+function descendantFiles(folder: TFolder): TFile[] {
+    const files = folder.children.filter((c): c is TFile => c instanceof TFile);
+    const subfolders = folder.children.filter((c): c is TFolder => c instanceof TFolder);
+    return [...files, ...subfolders.flatMap(descendantFiles)];
+}
 
 const basename = (p: string): string => p.slice(p.lastIndexOf("/") + 1);
 
@@ -1966,25 +1975,26 @@ export default class LilbeePlugin extends Plugin {
         }, PENDING_SYNC_HINT_DEBOUNCE_MS);
     }
 
+    // Files under lilbee's managed document folder (<vault>/lilbee/), walked
+    // from that folder alone rather than enumerating the whole vault. Loose
+    // notes outside it are indexed only via the explicit Add action.
+    private collectManagedDocFiles(): TFile[] {
+        // The vault adapter (or the folder) can be gone if the timer fires
+        // after the host environment teared down. Bail cleanly.
+        const root = this.app?.vault?.getAbstractFileByPath?.(MANAGED_DOCS_FOLDER);
+        if (!(root instanceof TFolder)) return [];
+        return descendantFiles(root);
+    }
+
     private async countPendingSync(): Promise<number> {
         // Only managed mode with vault storage points the server's documents_dir at
         // <vault>/lilbee; elsewhere Sync can't reconcile these files, so don't count them.
         if (this.settings.serverMode !== SERVER_MODE.MANAGED || !this.settings.storeContentInVault) {
             return 0;
         }
-        // The vault adapter can be gone if the timer fires after the host
-        // environment teared down (vitest end-of-file cleanup while a real
-        // setTimeout was still pending). Bail cleanly instead of crashing.
-        const files = this.app?.vault?.getFiles?.();
-        if (!Array.isArray(files)) return 0;
-        // Only count files inside lilbee's managed document folder
-        // (<vault>/lilbee/). That's the scope `Sync vault` actually
-        // reconciles. Loose vault notes live outside it and are indexed
-        // only via the explicit Add action (which copies them in), so
-        // counting them here would show a count that sync can never clear.
-        const docFiles = files
+        const docFiles = this.collectManagedDocFiles()
             .filter((f) => SUPPORTED_SYNC_EXTENSIONS.has(f.extension.toLowerCase()))
-            .filter((f) => f.path.startsWith(MANAGED_DOCS_PREFIX) && !this.wikiSync?.isWikiPath(f.path));
+            .filter((f) => !this.wikiSync?.isWikiPath(f.path));
         const known = new Set<string>();
         try {
             // Page through the documents endpoint so we count every known

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -330,7 +330,14 @@ export class App {
 export class TFile {
     path = "";
     name = "";
+    extension = "";
     parent: { path: string; name: string } | null = null;
+}
+
+export class TFolder {
+    path = "";
+    name = "";
+    children: Array<TFile | TFolder> = [];
 }
 
 type ModalKeyHandler = (e: KeyboardEvent) => unknown;

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1,7 +1,7 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { windowStub } from "./window-stub";
 import { Notice } from "obsidian";
-import { App, MockElement, WorkspaceLeaf } from "./__mocks__/obsidian";
+import { App, MockElement, WorkspaceLeaf, TFile, TFolder } from "./__mocks__/obsidian";
 import { SETUP_OUTCOME, SSE_EVENT } from "../src/types";
 import { VaultRegistry } from "../src/vault-registry";
 import { FileProgressTracker } from "../src/main";
@@ -1513,10 +1513,41 @@ describe("LilbeePlugin", () => {
     });
 
     describe("updatePendingSyncHint()", () => {
+        // Build the lilbee/ folder getAbstractFileByPath returns, nesting each
+        // file under TFolder nodes for any path segments between lilbee/ and
+        // the filename (so lilbee/wiki/d.md lands in a real wiki subfolder).
+        const managedFolder = (files: Array<{ path: string; name: string; extension: string }>): TFolder => {
+            const root = new TFolder();
+            root.path = "lilbee";
+            for (const f of files) {
+                const segments = f.path.split("/").slice(1, -1);
+                let parent = root;
+                let prefix = "lilbee";
+                for (const seg of segments) {
+                    prefix = `${prefix}/${seg}`;
+                    let next = parent.children.find((c): c is TFolder => c instanceof TFolder && c.path === prefix);
+                    if (!next) {
+                        next = new TFolder();
+                        next.path = prefix;
+                        parent.children.push(next);
+                    }
+                    parent = next;
+                }
+                parent.children.push(Object.assign(new TFile(), f));
+            }
+            return root;
+        };
+        const stubManagedDocs = (
+            plugin: Awaited<ReturnType<typeof createPlugin>>,
+            files: Array<{ path: string; name: string; extension: string }>,
+        ): void => {
+            (plugin.app.vault.getAbstractFileByPath as ReturnType<typeof vi.fn>).mockReturnValue(managedFolder(files));
+        };
+
         it("hides the sync pill in external mode even when lilbee/ files are unsynced", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
-            (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue([
+            stubManagedDocs(plugin, [
                 { path: "lilbee/a.md", name: "a.md", extension: "md" },
                 { path: "lilbee/b.pdf", name: "b.pdf", extension: "pdf" },
             ]);
@@ -1537,9 +1568,7 @@ describe("LilbeePlugin", () => {
             await plugin.onload();
             plugin.settings.serverMode = "managed";
             plugin.settings.storeContentInVault = false;
-            (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue([
-                { path: "lilbee/a.md", name: "a.md", extension: "md" },
-            ]);
+            stubManagedDocs(plugin, [{ path: "lilbee/a.md", name: "a.md", extension: "md" }]);
             const listSpy = plugin.api.listDocuments as ReturnType<typeof vi.fn>;
             listSpy.mockClear();
             plugin.syncPillEl!.style.display = "";
@@ -1554,7 +1583,7 @@ describe("LilbeePlugin", () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
             plugin.settings.serverMode = "managed";
-            (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue([
+            stubManagedDocs(plugin, [
                 { path: "lilbee/a.md", name: "a.md", extension: "md" },
                 { path: "lilbee/b.pdf", name: "b.pdf", extension: "pdf" },
                 { path: "lilbee/c.txt", name: "c.txt", extension: "txt" },
@@ -1579,9 +1608,7 @@ describe("LilbeePlugin", () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
             plugin.settings.serverMode = "managed";
-            (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue([
-                { path: "lilbee/a.md", name: "a.md", extension: "md" },
-            ]);
+            stubManagedDocs(plugin, [{ path: "lilbee/a.md", name: "a.md", extension: "md" }]);
             (plugin.api.listDocuments as ReturnType<typeof vi.fn>).mockResolvedValue({
                 documents: [{ filename: "a.md", chunk_count: 1, ingested_at: "" }],
                 total: 1,
@@ -1604,10 +1631,11 @@ describe("LilbeePlugin", () => {
                 isWikiPath: (p: string) => p.startsWith("lilbee/wiki/"),
                 reconcile: vi.fn(),
             } as any;
-            (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue([
+            // Loose notes live outside lilbee/, so the folder walk never sees
+            // them — only the unsupported and wiki entries need filtering out.
+            stubManagedDocs(plugin, [
                 { path: "lilbee/a.md", name: "a.md", extension: "md" }, // counts
                 { path: "lilbee/b.png", name: "b.png", extension: "png" }, // unsupported
-                { path: "notes/c.md", name: "c.md", extension: "md" }, // loose note, indexed via Add
                 { path: "lilbee/wiki/d.md", name: "d.md", extension: "md" }, // wiki
             ]);
             (plugin.api.listDocuments as ReturnType<typeof vi.fn>).mockResolvedValue({
@@ -1627,7 +1655,7 @@ describe("LilbeePlugin", () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
             plugin.settings.serverMode = "managed";
-            (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue([
+            stubManagedDocs(plugin, [
                 { path: "lilbee/a.md", name: "a.md", extension: "md" },
                 { path: "lilbee/b.md", name: "b.md", extension: "md" },
             ]);
@@ -1657,9 +1685,7 @@ describe("LilbeePlugin", () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
             plugin.settings.serverMode = "managed";
-            (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue([
-                { path: "lilbee/a.md", name: "a.md", extension: "md" },
-            ]);
+            stubManagedDocs(plugin, [{ path: "lilbee/a.md", name: "a.md", extension: "md" }]);
             (plugin.api.listDocuments as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("offline"));
 
             await plugin.updatePendingSyncHint();
@@ -1671,7 +1697,7 @@ describe("LilbeePlugin", () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
             plugin.settings.serverMode = "managed";
-            (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue([
+            stubManagedDocs(plugin, [
                 { path: "lilbee/a.md", name: "a.md", extension: "md" },
                 { path: "lilbee/b.md", name: "b.md", extension: "md" },
             ]);
@@ -1701,9 +1727,7 @@ describe("LilbeePlugin", () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
             plugin.settings.serverMode = "managed";
-            (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue([
-                { path: "lilbee/a.md", name: "a.md", extension: "md" },
-            ]);
+            stubManagedDocs(plugin, [{ path: "lilbee/a.md", name: "a.md", extension: "md" }]);
             (plugin.api.listDocuments as ReturnType<typeof vi.fn>).mockImplementation(async () => {
                 plugin.syncPillEl = null; // simulate onunload during the await
                 return { documents: [], total: 0, limit: 100, offset: 0, has_more: false };
@@ -1711,11 +1735,11 @@ describe("LilbeePlugin", () => {
             await expect(plugin.updatePendingSyncHint()).resolves.toBeUndefined();
         });
 
-        it("hides the sync pill when the vault adapter is gone (timer fired post-teardown)", async () => {
+        it("hides the sync pill when the managed folder is gone (timer fired post-teardown)", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
             plugin.settings.serverMode = "managed";
-            (plugin.app.vault.getFiles as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+            (plugin.app.vault.getAbstractFileByPath as ReturnType<typeof vi.fn>).mockReturnValue(null);
             await expect(plugin.updatePendingSyncHint()).resolves.toBeUndefined();
             expect(plugin.syncPillEl?.style.display).toBe("none");
         });


### PR DESCRIPTION
The status bar's pending-sync pill counts how many files in the managed lilbee/ folder still need syncing. It was doing that by listing every file in the vault and then filtering down to the ones under lilbee/ — exactly the kind of whole-vault enumeration the Obsidian store review flags as a privacy concern.

This walks the lilbee/ folder directly instead, so the plugin only ever looks at the files it actually manages. The count comes out identical to before, and loose notes elsewhere in the vault are never touched.

Verified live in Obsidian: adding an unsynced file under lilbee/ shows the pill, a note outside lilbee/ is correctly ignored, and removing the files hides the pill again. The full suite passes at 100% coverage, and lint, format, and build are clean.