### PR TITLE
Sharpen on-page SEO for the 'local AI for Obsidian' query

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   </a>
 </p>
 
-<p align="center"><strong>Local AI search and chat for your vault, inside Obsidian.</strong></p>
+<p align="center"><strong>Local AI search, chat, and web crawling for your vault, inside Obsidian.</strong></p>
 
 <p align="center"><a href="https://obsidian.lilbee.sh/">Project site</a> &nbsp;·&nbsp; <a href="https://obsidian.lilbee.sh/tutorial">Tutorial reel</a> &nbsp;·&nbsp; <a href="https://github.com/tobocop2/obsidian-lilbee/releases">Releases</a> &nbsp;·&nbsp; <a href="https://lilbee.sh/">lilbee engine</a></p>
 

--- a/site/index.html
+++ b/site/index.html
@@ -3,15 +3,15 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Local AI search &amp; chat for your Obsidian vault — lilbee</title>
+<title>Local AI search, chat &amp; web crawling for your Obsidian vault | lilbee</title>
 <meta name="description" content="lilbee turns your Obsidian vault into a local AI search engine: search, ask, and chat with your notes, PDFs, ebooks, code, and scans (150+ file types) and get answers that cite the exact source line (local RAG, done for you). lilbee downloads and runs the AI models for you, with nothing to set up and no Ollama required, or use your own Ollama, LM Studio, or cloud models. Crawl websites into your vault. Everything runs on your computer.">
 <link rel="canonical" href="https://obsidian.lilbee.sh/">
 
 <!-- Open Graph: rich link previews. -->
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="lilbee for Obsidian">
-<meta property="og:title" content="Local AI search &amp; chat for your Obsidian vault — lilbee">
-<meta property="og:description" content="Turn your Obsidian vault into a local AI search engine: search, ask, and chat with your notes, PDFs, code, and scans, with answers that cite the source line (local RAG, done for you). lilbee downloads and runs the models for you (no setup, no Ollama required), or use your own Ollama, LM Studio, or cloud models. Runs on your computer.">
+<meta property="og:title" content="Local AI search, chat &amp; web crawling for your Obsidian vault | lilbee">
+<meta property="og:description" content="Turn your Obsidian vault into a local AI search engine: search, ask, and chat with your notes, PDFs, code, and scans, with answers that cite the source line (local RAG, done for you). Crawl whole websites into your vault as markdown and search them too. lilbee downloads and runs the models for you (no setup, no Ollama required), or use your own Ollama, LM Studio, or cloud models. Runs on your computer.">
 <meta property="og:url" content="https://obsidian.lilbee.sh/">
 <meta property="og:image" content="https://obsidian.lilbee.sh/social-card.png">
 <meta property="og:image:width" content="1280">
@@ -20,8 +20,8 @@
 
 <!-- Twitter Card: rich previews on X and clients that read the Twitter tags. -->
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Local AI search &amp; chat for your Obsidian vault — lilbee">
-<meta name="twitter:description" content="Turn your Obsidian vault into a local AI search engine: search, ask, and chat with your notes, with cited answers (local RAG, done for you). lilbee downloads and runs the models for you, no setup, no Ollama required. Runs on your computer; cloud models optional.">
+<meta name="twitter:title" content="Local AI search, chat &amp; web crawling for your Obsidian vault | lilbee">
+<meta name="twitter:description" content="Turn your Obsidian vault into a local AI search engine: search, ask, and chat with your notes, with cited answers (local RAG, done for you). Crawl whole websites into your vault and search them too. lilbee downloads and runs the models for you, no setup, no Ollama required. Runs on your computer; cloud models optional.">
 <meta name="twitter:image" content="https://obsidian.lilbee.sh/social-card.png">
 <meta name="twitter:image:alt" content="lilbee for Obsidian: local AI search and chat for your vault, with a cited answer shown inside Obsidian">
 
@@ -34,7 +34,7 @@
   "description": "An Obsidian community plugin that turns your vault into a local AI search engine: it downloads and runs local AI models for you (no setup, no Ollama required) and lets you search, ask, and chat with your notes, PDFs, code, and scans, with answers that cite the source (local RAG, done for you). Includes a web crawler that saves sites into your vault as markdown, a built-in model catalog from Hugging Face Hub, and works with your existing Ollama or LM Studio. Available in the Obsidian community plugin store.",
   "applicationCategory": "ProductivityApplication",
   "operatingSystem": "Obsidian (macOS, Windows, Linux)",
-  "keywords": "Obsidian plugin, Obsidian AI plugin, Obsidian community plugin, chat with your notes, second brain, local AI, local LLM, model manager, managed models, no setup, run models locally, RAG, retrieval-augmented generation, semantic search, vector search, embeddings, cited answers, web crawler, OCR, PDF search, knowledge base, self-hosted, privacy, offline, Ollama, LM Studio",
+  "keywords": "Obsidian plugin, Obsidian AI plugin, Obsidian community plugin, chat with your notes, second brain, local AI, local LLM, model manager, managed models, no setup, run models locally, RAG, retrieval-augmented generation, semantic search, vector search, embeddings, cited answers, web crawler, crawl websites into your vault, save websites as markdown, OCR, PDF search, knowledge base, self-hosted, privacy, offline, Ollama, LM Studio",
   "url": "https://obsidian.lilbee.sh/",
   "installUrl": "https://community.obsidian.md/plugins/lilbee",
   "license": "https://github.com/tobocop2/obsidian-lilbee/blob/main/LICENSE",
@@ -48,7 +48,7 @@
 <script src="main.js" defer></script>
 </head>
 <body>
-<h1 class="sr">lilbee for Obsidian</h1>
+<h1 class="sr">Local AI search, chat, and web crawling for your Obsidian vault</h1>
 <div class="layout">
   <main class="main">
 
@@ -75,7 +75,7 @@
  / _|___ _ _   / _ \| |__ __(_)__| (_)__ _ _ _
 |  _/ _ \ '_| | (_) | '_ (_-&lt; / _` | / _` | ' \
 |_| \___/_|    \___/|_.__/__/_\__,_|_\__,_|_||_|</pre>
-      <h1 class="tagline">Obsidian's interface to <strong><a href="https://lilbee.sh/">lilbee</a></strong>: find, run, and manage local AI models, and search your vault and the sites you crawl with them.</h1>
+      <h2 class="tagline">Obsidian's interface to <strong><a href="https://lilbee.sh/">lilbee</a></strong>: find, run, and manage local AI models, and search your vault and the sites you crawl with them.</h2>
       <p class="sub">Browse a model catalog and pull a model that runs on your own machine, then ask questions about anything in your vault (notes, PDFs, ebooks, code, scans, <strong>150+ file types</strong> in all) and get answers with the source one click away.</p>
       <div class="surfaces">
         <span class="surfaces-label">one plugin, inside obsidian</span>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -2,13 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://obsidian.lilbee.sh/</loc>
-    <lastmod>2026-06-08</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://obsidian.lilbee.sh/tutorial</loc>
-    <lastmod>2026-06-08</lastmod>
+    <lastmod>2026-06-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## Problem

The plugin already has solid SEO metadata, but a few things were holding back the page for the query people actually type, "obsidian local ai" / "local ai obsidian":

- The page had two `h1`s (a screen-reader one reading just "lilbee for Obsidian", plus the visible tagline), so its primary heading didn't carry the target phrase.
- The web crawler, one of the real differentiators, was barely present in the title and social tags.
- The title tags used an em dash.

## Solution

- Make the screen-reader `h1` the single, keyword-first heading: "Local AI search, chat, and web crawling for your Obsidian vault", and demote the visible tagline to `h2` (styling is class-based and margins are globally reset, so nothing moves visually).
- Surface the crawler in the title, Open Graph/Twitter titles and descriptions, the JSON-LD keywords, and the README's one-line summary.
- Swap the em dash in the title tags for a pipe (the conventional title separator) and refresh the sitemap `lastmod`.

On-page only. The bigger remaining levers for this query are off-page (awesome-obsidian listing, forum/Reddit mentions, plugin install count) and aren't something a PR can do.