### PR TITLE
SEO: FAQ section, FAQ/WebSite schema, and a regression guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,18 @@ Running a local server is unusual for an Obsidian plugin, so the automated store
 
 See **[Usage Guide](docs/usage.md)** for the full reference: every command, every setting, the chat toolbar, supported formats, troubleshooting, and advanced configuration. For the underlying engine (what it indexes, how retrieval works, model formats, hardware requirements), see [lilbee](https://lilbee.sh/).
 
+## FAQ
+
+**Do I need Ollama or LM Studio?** No. lilbee downloads and runs the AI models for you; it is a complete model manager, so there is no separate runner to set up. If you already use Ollama or LM Studio, point lilbee at them instead.
+
+**Does my vault leave my computer?** No. Indexing and search run on your own machine, and your notes stay on disk. A cloud model is used only if you pick one.
+
+**What can it search?** Your notes and markdown, plus PDFs, code, ebooks, and scanned images through OCR, and whole websites you crawl into the vault. Over 150 file types, with answers that cite the source.
+
+**Does it work offline?** Yes, with local models in place.
+
+**How do I install it?** From the Obsidian community plugin store: Settings → Community plugins, search for lilbee, install. It sets up the models for you on first run.
+
 ## Support
 
 Something broken? See [TROUBLESHOOTING.md](TROUBLESHOOTING.md), and use **Settings → lilbee → Export diagnostics** to attach logs to a bug report.

--- a/site/index.html
+++ b/site/index.html
@@ -45,6 +45,32 @@
 }
 </script>
 
+<!-- WebSite JSON-LD: names the site for search engines. -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "lilbee for Obsidian",
+  "url": "https://obsidian.lilbee.sh/",
+  "description": "A local AI plugin that turns your Obsidian vault into a search engine you can talk to, with cited answers and the models run for you."
+}
+</script>
+
+<!-- FAQPage JSON-LD: the questions people ask before they install. -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    { "@type": "Question", "name": "Do I need Ollama or LM Studio to use lilbee in Obsidian?", "acceptedAnswer": { "@type": "Answer", "text": "No. lilbee downloads and runs the AI models for you; it is a complete model manager, so there is no separate runner to set up. If you already use Ollama or LM Studio, you can point lilbee at them instead." } },
+    { "@type": "Question", "name": "Does my vault leave my computer?", "acceptedAnswer": { "@type": "Answer", "text": "No. Indexing and search run on your own machine, and your notes stay on disk. lilbee uses a cloud model only if you pick one." } },
+    { "@type": "Question", "name": "What can it search in my vault?", "acceptedAnswer": { "@type": "Answer", "text": "Your notes and markdown, plus PDFs, code, ebooks, and scanned images through OCR, and whole websites you crawl into the vault. Over 150 file types, with answers that cite the exact source." } },
+    { "@type": "Question", "name": "Does it work offline?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. With local models in place, lilbee searches, asks, and chats with your vault with no internet connection." } },
+    { "@type": "Question", "name": "How do I install it?", "acceptedAnswer": { "@type": "Answer", "text": "From the Obsidian community plugin store: open Settings, then Community plugins, search for lilbee, and install. lilbee sets up the models for you on first run." } }
+  ]
+}
+</script>
+
 <link rel="stylesheet" href="style.css">
 <script src="main.js" defer></script>
 </head>
@@ -315,6 +341,17 @@
         <a href="https://github.com/tobocop2/obsidian-lilbee/releases"><span class="num">[6]</span><span>Releases</span><span class="dots">·······································</span><span class="desc">changelog</span></a>
         <a href="coverage/"><span class="num">[7]</span><span>Coverage</span><span class="dots">·······································</span><span class="desc">100%</span></a>
         <a href="https://obsidian.md"><span class="num">[8]</span><span>Obsidian</span><span class="dots">·······································</span><span class="desc">obsidian.md</span></a>
+      </div>
+    </section>
+
+    <section>
+      <div class="label">questions</div>
+      <div class="faq">
+        <details><summary>Do I need Ollama or LM Studio to use lilbee in Obsidian?</summary><p>No. lilbee downloads and runs the AI models for you; it is a complete model manager, so there is no separate runner to set up. If you already use Ollama or LM Studio, you can point lilbee at them instead.</p></details>
+        <details><summary>Does my vault leave my computer?</summary><p>No. Indexing and search run on your own machine, and your notes stay on disk. lilbee uses a cloud model only if you pick one.</p></details>
+        <details><summary>What can it search in my vault?</summary><p>Your notes and markdown, plus PDFs, code, ebooks, and scanned images through OCR, and whole websites you crawl into the vault. Over 150 file types, with answers that cite the exact source.</p></details>
+        <details><summary>Does it work offline?</summary><p>Yes. With local models in place, lilbee searches, asks, and chats with your vault with no internet connection.</p></details>
+        <details><summary>How do I install it?</summary><p>From the Obsidian community plugin store: open Settings, then Community plugins, search for lilbee, and install. lilbee sets up the models for you on first run.</p></details>
       </div>
     </section>
 

--- a/site/style.css
+++ b/site/style.css
@@ -586,3 +586,25 @@ footer .meta { text-align: right; font-size: 12px; }
   .tagline { font-size: 18px; }
   .tutorialtabs .tutorialtab { padding: 0.45rem 0.6rem; font-size: 12px; }
 }
+
+/* FAQ disclosure ----------------------------------------------------- */
+.faq { display: flex; flex-direction: column; gap: 0.5rem; }
+.faq details {
+  border: 1px solid var(--rule-2);
+  border-radius: 6px;
+  background: var(--bg-elev);
+  padding: 0.1rem 0.9rem;
+}
+.faq summary {
+  cursor: pointer;
+  padding: 0.7rem 0;
+  color: var(--ink);
+  font-weight: 600;
+  list-style: none;
+}
+.faq summary::-webkit-details-marker { display: none; }
+.faq summary::before { content: '+'; color: var(--accent); margin-right: 0.6rem; }
+.faq details[open] summary::before { content: '−'; }
+.faq details[open] summary { border-bottom: 1px solid var(--rule); }
+.faq p { color: var(--ink-2); margin: 0.6rem 0 0.9rem; }
+.faq a { color: var(--accent); }

--- a/tests/seo.test.ts
+++ b/tests/seo.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// SEO invariants for the marketing site. Encodes the on-page rules so a stale
+// canonical, a missing Open Graph tag, or a page that drops out of the sitemap
+// fails CI instead of silently costing rankings.
+
+const SITE = resolve(dirname(fileURLToPath(import.meta.url)), "..", "site");
+const BASE = "https://obsidian.lilbee.sh/";
+
+function read(rel: string): string {
+    return readFileSync(resolve(SITE, rel), "utf-8");
+}
+
+function meta(html: string, key: string, attr = "property"): string | null {
+    const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const match = new RegExp(`<meta ${attr}="${escaped}" content="([^"]*)"`).exec(html);
+    return match ? match[1] : null;
+}
+
+function jsonLdBlocks(html: string): string[] {
+    const blocks = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)];
+    return blocks.map((block) => block[1]);
+}
+
+describe("home page SEO", () => {
+    const home = read("index.html");
+
+    it("has a present, length-bounded title", () => {
+        const match = /<title>([\s\S]*?)<\/title>/.exec(home);
+        expect(match).not.toBeNull();
+        const title = (match ? match[1] : "").trim();
+        expect(title.length).toBeGreaterThanOrEqual(20);
+        expect(title.length).toBeLessThanOrEqual(75);
+    });
+
+    it("has a present meta description", () => {
+        const description = meta(home, "description", "name");
+        expect(description).toBeTruthy();
+        expect((description ?? "").length).toBeGreaterThanOrEqual(50);
+    });
+
+    it("has a self-referential canonical", () => {
+        const match = /<link rel="canonical" href="([^"]+)"/.exec(home);
+        expect(match?.[1]).toBe(BASE);
+    });
+
+    it("has a complete Open Graph and Twitter card set", () => {
+        for (const property of ["og:type", "og:title", "og:description", "og:url", "og:image"]) {
+            expect(meta(home, property)).toBeTruthy();
+        }
+        expect(meta(home, "og:url")).toBe(BASE);
+        expect(meta(home, "twitter:card", "name")).toBeTruthy();
+    });
+
+    it("has exactly one h1", () => {
+        const count = (home.match(/<h1[\s>]/g) ?? []).length;
+        expect(count).toBe(1);
+    });
+
+    it("gives every image alt text", () => {
+        for (const tag of home.match(/<img\b[^>]*>/g) ?? []) {
+            const match = /alt="([^"]*)"/.exec(tag);
+            expect(match !== null && match[1].trim().length > 0).toBe(true);
+        }
+    });
+
+    it("has valid JSON-LD including WebSite and FAQPage", () => {
+        const blocks = jsonLdBlocks(home);
+        expect(blocks.length).toBeGreaterThan(0);
+        const types = new Set<string>();
+        for (const block of blocks) {
+            const data = JSON.parse(block) as Record<string, unknown>;
+            expect(data["@context"]).toBeTruthy();
+            expect(data["@type"]).toBeTruthy();
+            types.add(String(data["@type"]));
+        }
+        expect(types.has("WebSite")).toBe(true);
+        expect(types.has("FAQPage")).toBe(true);
+    });
+});
+
+describe("sitemap", () => {
+    it("lists URLs that all resolve to files, each with a trailing slash", () => {
+        const sitemap = read("sitemap.xml");
+        const locs = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) => match[1]);
+        expect(locs).toContain(BASE);
+        for (const loc of locs) {
+            expect(loc.endsWith("/")).toBe(true);
+            const rel = loc.slice(BASE.length);
+            const file = resolve(SITE, rel === "" ? "index.html" : `${rel}index.html`);
+            expect(() => readFileSync(file)).not.toThrow();
+        }
+    });
+});


### PR DESCRIPTION
## Problem

The Obsidian site has strong meta tags but no FAQ structured data and no `WebSite` schema, and there was no guard against on-page SEO regressions. lilbee.sh is getting the same treatment in its own repo; this keeps the two properties in step without duplicating the Obsidian search intent.

## Solution

Add an embedded FAQ to the home page with `FAQPage` JSON-LD and a `WebSite` block alongside the existing `SoftwareApplication`. The FAQ leads with lilbee being a complete model manager that runs the models for you, so you do not need a separate runner (it still notes you can point it at your own Ollama or LM Studio). README gains a matching FAQ.

A Vitest module encodes the on-page SEO invariants (present title and description, self-referential canonical, complete Open Graph, exactly one h1, valid JSON-LD including WebSite and FAQPage, and sitemap URLs that resolve to files with trailing slashes) so they fail CI if they regress.

The sitemap trailing-slash fix and IndexNow key already landed on main, so they are not repeated here.