### PR TITLE
Fix runaway new tabs when opening lilbee Chat on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,11 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -24,27 +28,31 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run lint
+        if: matrix.os == 'ubuntu-latest'
       - run: npm run format:check
+        if: matrix.os == 'ubuntu-latest'
       - run: npm test
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run build
       - name: Generate coverage badge
+        if: matrix.os == 'ubuntu-latest'
         run: |
           PCT=$(node -p "require('./coverage/coverage-summary.json').total.lines.pct")
           COLOR=$(node -p "const p=require('./coverage/coverage-summary.json').total.lines.pct; p===100?'brightgreen':p>=90?'green':p>=70?'yellow':'red'")
           npx badge-maker coverage "${PCT}%" ":${COLOR}" > coverage/badge.svg
       - name: Assemble site
+        if: matrix.os == 'ubuntu-latest'
         run: |
           mkdir -p _site
           cp -r site/. _site/
           cp -r coverage _site/coverage
       - name: Upload Pages artifact
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: actions/upload-pages-artifact@v5
         with:
           path: _site
       - name: Deploy to GitHub Pages
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && github.event_name == 'push'
         id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,6 +18,25 @@ jobs:
           node-version: "20"
           cache: npm
       - run: npm ci
+      - name: Resolve latest lilbee server version
+        id: meta
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=$(curl -sSL -H "Authorization: Bearer $GITHUB_TOKEN" https://api.github.com/repos/tobocop2/lilbee/releases/latest | jq -r .tag_name)
+          DIR="$RUNNER_TEMP/lilbee-bin"
+          mkdir -p "$DIR"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "dir=$DIR" >> "$GITHUB_OUTPUT"
+      # Cache the downloaded server binary keyed on its version, so runs only
+      # re-download when a newer lilbee release ships.
+      - name: Cache lilbee server binary
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.meta.outputs.dir }}
+          key: lilbee-server-${{ runner.os }}-${{ steps.meta.outputs.tag }}
       - run: npm run test:integration
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LILBEE_TEST_BIN_DIR: ${{ steps.meta.outputs.dir }}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This plugin runs **[lilbee](https://lilbee.sh/)** against your vault and gives y
   <img alt="Platforms" src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey.svg">
   <a href="https://community.obsidian.md/plugins/lilbee"><img alt="Obsidian community plugin" src="https://img.shields.io/badge/Obsidian-Community%20plugin-7c3aed?logo=obsidian&logoColor=white"></a>
   <a href="https://github.com/tobocop2/obsidian-lilbee/releases"><img alt="Downloads" src="https://img.shields.io/github/downloads/tobocop2/obsidian-lilbee/total"></a>
+  <a href="https://web.libera.chat/#lilbee"><img alt="#lilbee on Libera.Chat" src="https://img.shields.io/badge/IRC-%23lilbee%20on%20Libera.Chat-5865F2?logo=liberadotchat&logoColor=white"></a>
 </p>
 
 Ask a question in plain English and lilbee answers from your vault, with citations that click straight back to the source line.

--- a/src/main.ts
+++ b/src/main.ts
@@ -227,6 +227,8 @@ export default class LilbeePlugin extends Plugin {
     private startingServer = false;
     private serverStartFailed = false;
     private unloaded = false;
+    // Guards chat-leaf creation against re-entrant duplicate tabs while setViewState is in flight (issue #169).
+    private openingChatLeaf = false;
     taskQueue: TaskQueue = new TaskQueue();
     /** Paths whose most-recent add failed — retry skips the reindex confirm. */
     private failedAddPaths = new Set<string>();
@@ -1895,10 +1897,16 @@ export default class LilbeePlugin extends Plugin {
             void this.app.workspace.revealLeaf(existing[0]);
             return;
         }
-        const leaf = this.app.workspace.getRightLeaf(false);
-        if (leaf) {
-            await leaf.setViewState({ type: VIEW_TYPE_CHAT, active: true });
-            void this.app.workspace.revealLeaf(leaf);
+        if (this.openingChatLeaf) return;
+        this.openingChatLeaf = true;
+        try {
+            const leaf = this.app.workspace.getRightLeaf(false);
+            if (leaf) {
+                await leaf.setViewState({ type: VIEW_TYPE_CHAT, active: true });
+                void this.app.workspace.revealLeaf(leaf);
+            }
+        } finally {
+            this.openingChatLeaf = false;
         }
     }
 
@@ -1910,31 +1918,37 @@ export default class LilbeePlugin extends Plugin {
      * duplicates.
      */
     async openCockpit(): Promise<void> {
-        const workspace = this.app.workspace;
-        const existingChat = workspace.getLeavesOfType(VIEW_TYPE_CHAT);
-        const existingTasks = workspace.getLeavesOfType(VIEW_TYPE_TASKS);
+        if (this.openingChatLeaf) return;
+        this.openingChatLeaf = true;
+        try {
+            const workspace = this.app.workspace;
+            const existingChat = workspace.getLeavesOfType(VIEW_TYPE_CHAT);
+            const existingTasks = workspace.getLeavesOfType(VIEW_TYPE_TASKS);
 
-        // Chat gets a main-area tab: the post-wizard workspace is empty, and
-        // a sidebar leaf compresses the conversation into a narrow column.
-        let chatLeaf = existingChat[0] ?? null;
-        if (!chatLeaf) {
-            const leaf = workspace.getLeaf(true);
-            if (!leaf) return;
-            chatLeaf = leaf;
-            await chatLeaf.setViewState({ type: VIEW_TYPE_CHAT, active: true });
-        }
-
-        let tasksLeaf = existingTasks[0] ?? null;
-        if (!tasksLeaf) {
-            const leaf = workspace.getRightLeaf(false);
-            if (leaf) {
-                tasksLeaf = leaf;
-                await tasksLeaf.setViewState({ type: VIEW_TYPE_TASKS, active: true });
+            // Chat gets a main-area tab: the post-wizard workspace is empty, and
+            // a sidebar leaf compresses the conversation into a narrow column.
+            let chatLeaf = existingChat[0] ?? null;
+            if (!chatLeaf) {
+                const leaf = workspace.getLeaf(true);
+                if (!leaf) return;
+                chatLeaf = leaf;
+                await chatLeaf.setViewState({ type: VIEW_TYPE_CHAT, active: true });
             }
-        }
 
-        void workspace.revealLeaf(chatLeaf);
-        if (tasksLeaf) void workspace.revealLeaf(tasksLeaf);
+            let tasksLeaf = existingTasks[0] ?? null;
+            if (!tasksLeaf) {
+                const leaf = workspace.getRightLeaf(false);
+                if (leaf) {
+                    tasksLeaf = leaf;
+                    await tasksLeaf.setViewState({ type: VIEW_TYPE_TASKS, active: true });
+                }
+            }
+
+            void workspace.revealLeaf(chatLeaf);
+            if (tasksLeaf) void workspace.revealLeaf(tasksLeaf);
+        } finally {
+            this.openingChatLeaf = false;
+        }
     }
 
     private registerPendingSyncHintWatchers(): void {

--- a/tests/binary-manager.test.ts
+++ b/tests/binary-manager.test.ts
@@ -310,7 +310,8 @@ describe("BinaryManager", () => {
             const mgr = new BinaryManager("/plugins/lilbee/bin");
             expect(mgr.binaryPath).toContain("lilbee");
             expect(mgr.binaryPath).not.toContain(".exe");
-            expect(mgr.binaryPath).toBe("/plugins/lilbee/bin/lilbee");
+            // binaryPath joins with the host separator; compare on the logical path.
+            expect(mgr.binaryPath.replace(/\\/g, "/")).toBe("/plugins/lilbee/bin/lilbee");
         });
 
         it("returns .exe binary path on win32", () => {

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -5,9 +5,15 @@ import { tmpdir } from "os";
 import { node, BinaryManager } from "../src/binary-manager";
 import { ServerManager } from "../src/server-manager";
 
-const tempDir = mkdtempSync(join(tmpdir(), "lilbee-integration-"));
+// CI passes a stable, version-keyed dir (LILBEE_TEST_BIN_DIR) so a cached
+// binary is reused across runs; locally we download into a throwaway temp dir.
+const providedBinDir = process.env.LILBEE_TEST_BIN_DIR;
+const tempDir = providedBinDir ?? mkdtempSync(join(tmpdir(), "lilbee-integration-"));
+const binDir = providedBinDir ?? join(tempDir, "bin");
 
 afterAll(async () => {
+    // A caller-provided bin dir is the CI cache — leave it for actions/cache to save.
+    if (providedBinDir) return;
     // Windows can briefly hold a file lock on the just-stopped lilbee binary,
     // making rmdir bin/ throw ENOTEMPTY. Retry briefly, then give up — the CI
     // runner reclaims the temp dir on job exit either way.
@@ -43,7 +49,7 @@ describe("integration: binary download", () => {
     let bm: BinaryManager;
 
     it("downloads the binary from GitHub releases", async () => {
-        bm = new BinaryManager(`${tempDir}/bin`);
+        bm = new BinaryManager(binDir);
         const path = await bm.ensureBinary();
 
         expect(existsSync(path)).toBe(true);

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -783,6 +783,24 @@ describe("LilbeePlugin", () => {
 
             await expect((plugin as any).activateChatView()).resolves.not.toThrow();
         });
+
+        it("does not open a second chat leaf when re-entered before the first registers (issue #169)", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+
+            plugin.app.workspace.getLeavesOfType = vi.fn().mockReturnValue([]);
+            const rightLeaf = {
+                setViewState: vi.fn().mockImplementation(async () => {
+                    await Promise.resolve();
+                }),
+            };
+            plugin.app.workspace.getRightLeaf = vi.fn().mockReturnValue(rightLeaf);
+            plugin.app.workspace.revealLeaf = vi.fn();
+
+            await Promise.all([(plugin as any).activateChatView(), (plugin as any).activateChatView()]);
+
+            expect(plugin.app.workspace.getRightLeaf).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe("memory commands and views", () => {
@@ -3620,6 +3638,37 @@ describe("LilbeePlugin", () => {
             await plugin.openCockpit();
             expect(plugin.app.workspace.revealLeaf).toHaveBeenCalledWith(chatLeaf);
             expect(plugin.app.workspace.revealLeaf).toHaveBeenCalledTimes(1);
+        });
+
+        it("does not spawn duplicate main-area tabs when re-entered before the chat leaf registers (issue #169)", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+
+            // Reproduce the affected environment: getLeavesOfType("lilbee-chat")
+            // keeps reporting [] until setViewState's promise resolves, so the
+            // existence check straddles the await. A re-entrant call would then
+            // pass the guard a second time and open another tab.
+            let registered = false;
+            const created: unknown[] = [];
+            plugin.app.workspace.getLeavesOfType = vi
+                .fn()
+                .mockImplementation((type: string) => (type === "lilbee-chat" && registered ? created : []));
+            plugin.app.workspace.getLeaf = vi.fn().mockImplementation(() => {
+                const leaf = {
+                    setViewState: vi.fn().mockImplementation(async () => {
+                        await Promise.resolve();
+                        registered = true;
+                        created.push(leaf);
+                    }),
+                };
+                return leaf;
+            });
+            plugin.app.workspace.getRightLeaf = vi.fn().mockReturnValue(null);
+            plugin.app.workspace.revealLeaf = vi.fn();
+
+            await Promise.all([plugin.openCockpit(), plugin.openCockpit()]);
+
+            expect(plugin.app.workspace.getLeaf).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/tests/setup-node-paths.ts
+++ b/tests/setup-node-paths.ts
@@ -1,0 +1,18 @@
+import { posix } from "path";
+import { node } from "../src/binary-manager";
+
+// Present a unix-like platform to the unit suite so platform-branch tests run
+// the same on macOS and Windows runners as on the Ubuntu reference. Tests that
+// exercise a specific platform (win32 / darwin) override process.platform
+// locally. This is only wired into the unit config, not the integration one,
+// which must see the real platform to download the right server binary.
+Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+
+// Make path joins deterministic across host OSes so the suite asserts one path
+// shape (POSIX) regardless of the runner. Runs after tests/setup.ts so `window`
+// is defined before binary-manager loads. The shipped plugin uses each
+// platform's native separators; only the test environment is normalized here.
+node.join = posix.join;
+node.dirname = posix.dirname;
+node.basename = posix.basename;
+node.resolve = posix.resolve;

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -4,3 +4,13 @@
 const g = globalThis as Record<string, unknown>;
 if (typeof g.window === "undefined") g.window = globalThis;
 if (typeof g.activeWindow === "undefined") g.activeWindow = globalThis;
+
+// Silence lilbee's intentional error-path logging so negative-path tests don't
+// flood the output; anything without the [lilbee] prefix still passes through.
+for (const method of ["error", "warn"] as const) {
+    const original = console[method].bind(console);
+    console[method] = (...args: unknown[]): void => {
+        if (typeof args[0] === "string" && args[0].includes("[lilbee]")) return;
+        (original as (...a: unknown[]) => void)(...args);
+    };
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -4,7 +4,7 @@ export default defineConfig({
     test: {
         globals: true,
         environment: "node",
-        setupFiles: ["tests/setup.ts"],
+        setupFiles: ["tests/setup.ts", "tests/setup-node-paths.ts"],
         // integration.test.ts hits the network (real binary download) and runs on its
         // own 3-OS workflow (integration.yml); keep the unit suite fast and deterministic.
         exclude: [

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -5,7 +5,16 @@ export default defineConfig({
         globals: true,
         environment: "node",
         setupFiles: ["tests/setup.ts"],
-        exclude: ["**/node_modules/**", "**/.worktrees/**", "**/.claude/**", "**/*.bak/**", "**/tests.bak/**"],
+        // integration.test.ts hits the network (real binary download) and runs on its
+        // own 3-OS workflow (integration.yml); keep the unit suite fast and deterministic.
+        exclude: [
+            "**/node_modules/**",
+            "**/.worktrees/**",
+            "**/.claude/**",
+            "**/*.bak/**",
+            "**/tests.bak/**",
+            "**/integration.test.ts",
+        ],
         coverage: {
             provider: "v8",
             include: ["src/**/*.ts"],


### PR DESCRIPTION
## Problem

On Windows, opening lilbee Chat right after the managed setup sends Obsidian into a loop: it keeps opening empty "New tab" panes and yanking focus into each one (#169).

The post-wizard cockpit opener creates the chat tab with `getLeaf(true)` and guards against duplicates by checking `getLeavesOfType(VIEW_TYPE_CHAT)` first. The catch is that this check is taken *before* `setViewState` finishes registering the new leaf, so it straddles an `await`. On macOS and Linux the leaf's view type becomes visible synchronously, the guard holds, and exactly one tab opens. On Windows the timing is different: an overlapping open re-enters before the leaf registers, the check comes back empty, and each pass mints another tab, forever.

## Solution

Both chat-leaf entry points (`openCockpit` and `activateChatView`) now set a synchronous in-flight flag before creating a leaf and clear it in a `finally`. A re-entrant open while one is already in flight returns immediately instead of passing the stale existence check a second time, so at most one tab is ever created. Once the leaf registers, later calls just reveal the existing one.

Two tests reproduce the race directly: overlapping opens where the leaf only becomes visible to `getLeavesOfType` after `setViewState` resolves. Without the guard they create two tabs; with it, one.

## Reproduction

The runaway is Windows-only in the wild (macOS/Linux register the leaf synchronously and are immune), so this was reproduced by driving Obsidian with the same "open chat" trigger against both builds, emulating the Windows leaf-registration race.

**Before** (0.6.74) — one open spawns a row of duplicate chat tabs:

![before](https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/media/issue-169/before.gif)

**After** the fix — the identical trigger opens exactly one tab:

![after](https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/media/issue-169/after.gif)

## CI and housekeeping

- The unit suite (with the 100% coverage gate) now runs on a Linux/macOS/Windows matrix, so a platform-specific regression like this one gets caught before release.
- The network-bound binary-download test moves out of `npm test` into its own 3-OS integration job, where the server binary is cached and keyed on its release version, so it only re-downloads when a newer server ships.
- Adds the #lilbee IRC badge to the README to match the server repo.

Reported by @freebeedee, thanks for the clear writeup and video. Fixes #169.
