### PR TITLE
Use the non-deprecated getLeaf('tab') in the cockpit opener

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1929,7 +1929,8 @@ export default class LilbeePlugin extends Plugin {
             // a sidebar leaf compresses the conversation into a narrow column.
             let chatLeaf = existingChat[0] ?? null;
             if (!chatLeaf) {
-                const leaf = workspace.getLeaf(true);
+                // "tab" is the explicit form; the boolean getLeaf(true) is deprecated.
+                const leaf = workspace.getLeaf("tab");
                 if (!leaf) return;
                 chatLeaf = leaf;
                 await chatLeaf.setViewState({ type: VIEW_TYPE_CHAT, active: true });

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -3588,7 +3588,7 @@ describe("LilbeePlugin", () => {
             plugin.app.workspace.getRightLeaf = vi.fn().mockReturnValue(tasksLeaf);
             plugin.app.workspace.revealLeaf = vi.fn();
             await plugin.openCockpit();
-            expect(plugin.app.workspace.getLeaf).toHaveBeenCalledWith(true);
+            expect(plugin.app.workspace.getLeaf).toHaveBeenCalledWith("tab");
             expect(chatLeaf.setViewState).toHaveBeenCalledWith({ type: "lilbee-chat", active: true });
             expect(tasksLeaf.setViewState).toHaveBeenCalledWith({ type: "lilbee-tasks", active: true });
             expect(plugin.app.workspace.revealLeaf).toHaveBeenCalledWith(chatLeaf);


### PR DESCRIPTION
## What

`openCockpit` creates the chat tab with the boolean form `getLeaf(true)`. This switches it to the explicit `getLeaf("tab")`.

## Why

Both forms are valid in Obsidian's current API (`getLeaf(newLeaf?: PaneType | boolean)`), so this is a readability/explicitness modernization, not a bug fix. The explicit `PaneType` form has existed since Obsidian **0.16.0**, and the plugin's `minAppVersion` is **1.8.7**, so it's supported across the entire range the plugin targets — fully backward-compatible.

Verified against a live **Obsidian 1.13.1** runtime over the dev console: `getLeaf(true)` and `getLeaf("tab")` both create exactly one chat tab, so behavior is unchanged.

Context: a full live audit of the plugin's UI surface on 1.13.1 (all views, the settings tab in the new settings window, and 18 modals/commands) rendered cleanly with zero errors — the plugin is fully compatible with 1.13.1. This is just tidying the one boolean-form call.
