### PR TITLE
Uninstall the managed server from Settings, and pick which release to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Ask a question in plain English and lilbee answers from your vault, with citatio
 - [How it works](#how-it-works)
 - [Privacy & network use](#privacy--network-use)
 - [Updating the plugin](#updating-the-plugin)
-- [Updating the server](#updating-the-server)
+- [Changing the server version](#changing-the-server-version)
+- [Uninstalling](#uninstalling)
 - [Documentation](#documentation)
 
 ---
@@ -215,6 +216,8 @@ The plugin tracks the installed lilbee server version and shows it under Setting
 - an older release: **Downgrade to 0.6.72**, for when a new build misbehaves
 
 Whichever you pick, one click stops the running server, downloads the build, verifies it, and starts it again.
+
+The plugin is built and tested against the latest server release. Older releases still install and run, but they are not supported, and features the plugin expects may be missing.
 
 This changes only the lilbee **server**, never the plugin itself. The plugin's own code is updated through Obsidian like any other community plugin. Each server download is checked against the SHA256 digest GitHub publishes for the release before it runs, so a corrupted or tampered download is discarded instead of executed.
 

--- a/README.md
+++ b/README.md
@@ -206,11 +206,35 @@ Vaults on the same computer share one lilbee install and one model cache, so dow
 
 Obsidian handles plugin updates: **Settings → Community plugins → Check for updates**, then update lilbee like any other plugin.
 
-## Updating the server
+## Changing the server version
 
-The plugin tracks the installed lilbee server version. Go to Settings → lilbee → **Check for updates**. If a newer release is available the button changes to **Update to vX.Y.Z**: one click stops the running server, downloads the new version, verifies it, and restarts.
+The plugin tracks the installed lilbee server version and shows it under Settings → lilbee → **Server version**, next to a dropdown of recent releases. Pick a release and the button says what it will do:
 
-This updates only the lilbee **server**, never the plugin itself. The plugin's own code is updated through Obsidian like any other community plugin; the **Check for updates** button only manages the separate server it downloads. Each server download is checked against the SHA256 digest GitHub publishes for the release before it runs, so a corrupted or tampered download is discarded instead of executed.
+- a newer release: **Update to 0.6.76**
+- the one you already have: **Reinstall**, which also repairs a corrupted download
+- an older release: **Downgrade to 0.6.72**, for when a new build misbehaves
+
+Whichever you pick, one click stops the running server, downloads the build, verifies it, and starts it again.
+
+This changes only the lilbee **server**, never the plugin itself. The plugin's own code is updated through Obsidian like any other community plugin. Each server download is checked against the SHA256 digest GitHub publishes for the release before it runs, so a corrupted or tampered download is discarded instead of executed.
+
+## Uninstalling
+
+In **managed mode** (the default) the plugin downloaded a server executable and a model cache that live outside your vault. Obsidian doesn't know about either, so removing the plugin won't remove them.
+
+Open Settings → lilbee → **Uninstall server** first. It deletes the executable, the downloaded models, and this vault's search index, and tells you how much space that frees before you confirm. Your notes are never touched. Then remove the plugin the usual way, from **Community plugins**.
+
+Uninstalling the server doesn't disable the plugin. Settings shows an **Install server** button, and lilbee stays quiet until you click it.
+
+If you already removed the plugin, delete the data directory yourself:
+
+```
+macOS     ~/Library/Application Support/obsidian-lilbee
+Linux     ~/.local/share/obsidian-lilbee
+Windows   %LOCALAPPDATA%\obsidian-lilbee
+```
+
+In **external mode** the plugin downloads nothing, so there's nothing to clean up beyond the server you installed yourself.
 
 ## Advanced
 

--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -55,6 +55,10 @@ export const node = {
 export const GITHUB_REPO = "tobocop2/lilbee";
 export const LILBEE_GITHUB_REPO_URL = `https://github.com/${GITHUB_REPO}`;
 const RELEASES_API = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
+const RELEASE_LIST_API = `https://api.github.com/repos/${GITHUB_REPO}/releases`;
+
+/** How many recent releases the version picker offers. */
+export const RELEASE_HISTORY_LIMIT = 10;
 
 /** Run `nvidia-smi` and return its stdout, or null if it is absent or fails. */
 async function runNvidiaSmi(): Promise<string | null> {
@@ -115,6 +119,8 @@ interface GitHubAsset {
 interface GitHubRelease {
     tag_name: string;
     assets: GitHubAsset[];
+    draft?: boolean;
+    prerelease?: boolean;
 }
 
 export interface ReleaseInfo {
@@ -127,18 +133,35 @@ export interface ReleaseInfo {
 }
 
 /** Choose the CUDA asset when detected and shipped; otherwise the default build. */
-function selectAsset(data: GitHubRelease, cudaTag: CudaTag | null): { variant: ServerVariant; asset: GitHubAsset } {
+function selectAsset(
+    data: GitHubRelease,
+    cudaTag: CudaTag | null,
+    warnOnFallback = true,
+): { variant: ServerVariant; asset: GitHubAsset } {
     if (cudaTag) {
         const cudaAsset = data.assets.find((a) => a.name === getPlatformAssetName(cudaTag));
         if (cudaAsset) return { variant: cudaTag, asset: cudaAsset };
-        console.warn(
-            `[lilbee] GPU detected (${cudaTag}) but ${data.tag_name} ships no matching build; using the default build instead.`,
-        );
+        if (warnOnFallback) {
+            console.warn(
+                `[lilbee] GPU detected (${cudaTag}) but ${data.tag_name} ships no matching build; using the default build instead.`,
+            );
+        }
     }
     const defaultName = getPlatformAssetName(null);
     const asset = data.assets.find((a) => a.name === defaultName);
     if (!asset) throw new Error(`No asset "${defaultName}" in release ${data.tag_name}`);
     return { variant: SERVER_VARIANT.DEFAULT, asset };
+}
+
+function toReleaseInfo(data: GitHubRelease, cudaTag: CudaTag | null, warnOnFallback = true): ReleaseInfo {
+    const { variant, asset } = selectAsset(data, cudaTag, warnOnFallback);
+    return {
+        tag: data.tag_name,
+        assetUrl: asset.browser_download_url,
+        variant,
+        sizeBytes: asset.size,
+        digest: asset.digest,
+    };
 }
 
 export async function getLatestRelease(): Promise<ReleaseInfo> {
@@ -147,15 +170,30 @@ export async function getLatestRelease(): Promise<ReleaseInfo> {
         headers: { Accept: "application/vnd.github.v3+json" },
     });
     if (res.status >= 400) throw new Error(`GitHub API responded ${res.status}`);
-    const data = res.json as GitHubRelease;
-    const { variant, asset } = selectAsset(data, await detectCudaTag());
-    return {
-        tag: data.tag_name,
-        assetUrl: asset.browser_download_url,
-        variant,
-        sizeBytes: asset.size,
-        digest: asset.digest,
-    };
+    return toReleaseInfo(res.json as GitHubRelease, await detectCudaTag());
+}
+
+/**
+ * Recent published releases, newest first, that ship a build for this machine.
+ * Drafts, prereleases, and releases without a matching asset are left out.
+ */
+export async function listReleases(limit = RELEASE_HISTORY_LIMIT): Promise<ReleaseInfo[]> {
+    const res = await node.requestUrl({
+        url: `${RELEASE_LIST_API}?per_page=${limit}`,
+        headers: { Accept: "application/vnd.github.v3+json" },
+    });
+    if (res.status >= 400) throw new Error(`GitHub API responded ${res.status}`);
+    const cudaTag = await detectCudaTag();
+    const releases: ReleaseInfo[] = [];
+    for (const data of res.json as GitHubRelease[]) {
+        if (data.draft || data.prerelease) continue;
+        try {
+            releases.push(toReleaseInfo(data, cudaTag, false));
+        } catch {
+            // Release ships no build for this platform; it isn't installable here.
+        }
+    }
+    return releases;
 }
 
 export function checkForUpdate(currentVersion: string, latestTag: string): boolean {

--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -58,7 +58,7 @@ const RELEASES_API = `https://api.github.com/repos/${GITHUB_REPO}/releases/lates
 const RELEASE_LIST_API = `https://api.github.com/repos/${GITHUB_REPO}/releases`;
 
 /** How many recent releases the version picker offers. */
-export const RELEASE_HISTORY_LIMIT = 10;
+const RELEASE_HISTORY_LIMIT = 10;
 
 /** Run `nvidia-smi` and return its stdout, or null if it is absent or fails. */
 async function runNvidiaSmi(): Promise<string | null> {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -43,7 +43,13 @@ export const MESSAGES = {
     BUTTON_TEST: "Test",
     BUTTON_RESET_MANAGED: "Reset to managed",
     BUTTON_RUN_SETUP_WIZARD: "Run setup wizard",
-    BUTTON_CHECK_UPDATES: "Check for updates",
+    BUTTON_INSTALL_SERVER: "Install server",
+    BUTTON_REINSTALL: "Reinstall",
+    BUTTON_UNINSTALL_SERVER: "Uninstall server",
+    BUTTON_UNINSTALL: "Uninstall",
+    BUTTON_INSTALL_TAG: (tag: string) => `Install ${tag}`,
+    BUTTON_UPDATE_TO: (tag: string) => `Update to ${tag}`,
+    BUTTON_DOWNGRADE_TO: (tag: string) => `Downgrade to ${tag}`,
     BUTTON_CLEAR_CHAT: "Clear chat",
     BUTTON_CLEAR_TASKS: "Clear",
     BUTTON_SEND: "Send",
@@ -53,7 +59,6 @@ export const MESSAGES = {
     LABEL_DISABLED: "Disabled",
     LABEL_NOT_SET: "Not set",
     LABEL_NO_MODEL_SELECTED: "no model selected",
-    LABEL_UPTODATE: "Up to date",
     LABEL_UNKNOWN: "unknown version",
     LABEL_ALL_TASKS: "All tasks",
     LABEL_ALL_SIZES: "All sizes",
@@ -94,6 +99,9 @@ export const MESSAGES = {
     LABEL_SERVER_STATUS: "Server status",
     LABEL_SERVER_CONTROLS: "Server controls",
     LABEL_SERVER_VERSION: "Server version",
+    LABEL_UNINSTALL: "Uninstall",
+    LABEL_UNINSTALL_SERVER: "Uninstall server",
+    LABEL_INSTALL_SERVER: "Install server",
     LABEL_SERVER_URL: "Server URL",
     LABEL_SESSION_TOKEN: "Session token",
     LABEL_SETUP_WIZARD: "Setup wizard",
@@ -371,6 +379,46 @@ export const MESSAGES = {
     DESC_SERVER_STATUS_CURRENT: "Current state of the managed lilbee server",
     DESC_SERVER_CONTROLS_START_STOP: "Start, stop, or restart the managed server",
     DESC_SERVER_VERSION_UNKNOWN: "Unknown",
+    DESC_SERVER_VERSION_INSTALLED: (tag: string) => `${tag} installed. This is the latest release.`,
+    DESC_SERVER_VERSION_OUTDATED: (tag: string) => `${tag} installed. Newer releases are available.`,
+    DESC_SERVER_VERSION_PLAIN: (tag: string) => `${tag} installed.`,
+    DESC_SERVER_VERSION_UPDATE: (installed: string, tag: string) => `${installed} installed. ${tag} is available.`,
+    DESC_SERVER_VERSION_DOWNGRADE: (installed: string) =>
+        `${installed} installed. Downgrading replaces it with an older build.`,
+    DESC_SERVER_VERSION_LOADING: "Reading the release list from GitHub...",
+    DESC_SERVER_VERSION_OFFLINE: (tag: string) => `${tag} installed. The release list could not be read from GitHub.`,
+
+    TOOLTIP_UNINSTALL_SECTION:
+        "Obsidian does not manage the lilbee server executable or its models, this plugin does. " +
+        "Removing the plugin from Obsidian's Community plugins pane leaves both on disk. Uninstall here first.",
+    CALLOUT_UNINSTALL_FIRST:
+        "Removing the plugin does not remove the server. The executable, the downloaded models, and this vault's " +
+        "index live outside your vault, so Obsidian never touches them. Uninstall here before you remove the plugin " +
+        "and nothing is left behind.",
+    DESC_UNINSTALL_SERVER: (size: string) =>
+        `Deletes the executable, the models, and this vault's index. Frees ${size}. Your notes are not touched.`,
+    DESC_INSTALL_SERVER: (size: string) =>
+        `Downloads the lilbee server, about ${size}. Models are pulled on demand afterwards.`,
+    DESC_SERVER_NOT_INSTALLED:
+        "The server is not installed. Chat, search, and sync are unavailable until you install it.",
+
+    CONFIRM_UNINSTALL_TITLE: "Uninstall the lilbee server?",
+    CONFIRM_UNINSTALL_BODY:
+        "This removes everything lilbee downloaded or built for this vault. It cannot be undone, but you can " +
+        "install the server again at any time.",
+    LABEL_UNINSTALL_BINARY: "Server executable",
+    LABEL_UNINSTALL_MODELS: "Downloaded models",
+    LABEL_UNINSTALL_INDEX: "Search index for this vault",
+    LABEL_UNINSTALL_KEEP: "Your notes and attachments",
+    LABEL_UNINSTALL_KEEP_VALUE: "untouched",
+    LABEL_UNINSTALL_DELETE_TAG: "Delete",
+    LABEL_UNINSTALL_KEEP_TAG: "Keep",
+
+    NOTICE_UNINSTALLED: (size: string) => `lilbee server uninstalled. ${size} freed.`,
+    NOTICE_INSTALLED: (tag: string) => `lilbee server ${tag} installed.`,
+    ERROR_UNINSTALL_FAILED: "Could not uninstall the lilbee server",
+    ERROR_INSTALL_FAILED: "Could not install the lilbee server",
+    ERROR_RELEASE_LIST: "Could not read the lilbee release list from GitHub",
     DESC_SERVER_URL_HELP: "Address of the lilbee HTTP server",
     DESC_SESSION_TOKEN_AUTO:
         "Read automatically from the lilbee data directory on every request. Works when the server runs on the same machine as Obsidian. Set LILBEE_DATA if you use a non-default data directory.",
@@ -485,6 +533,7 @@ export const MESSAGES = {
     STATUS_AUTH_ERROR: "lilbee: auth error",
     NOTICE_SERVER_UNREACHABLE: "lilbee: server unreachable",
     STATUS_STOPPED: "lilbee: stopped",
+    STATUS_NOT_INSTALLED: "lilbee: server not installed",
     STATUS_ADDING: "lilbee: adding {label}...",
     STATUS_NOTHING_NEW: "lilbee: nothing new to add",
     STATUS_ADD_CANCELLED: "lilbee: add cancelled",
@@ -542,11 +591,9 @@ export const MESSAGES = {
     ERROR_FAILED_START: "lilbee: failed to start server",
     ERROR_FAILED_UPDATE: "lilbee: update failed",
     ERROR_ALREADY_UPTODATE: "lilbee: already up to date",
-    NOTICE_SERVER_UPTODATE: (version: string) => `lilbee server is up to date (${version})`,
     NOTICE_SERVER_AUTO_UPDATING: (version: string) => `lilbee: updating server to ${version}...`,
     NOTICE_SERVER_AUTO_UPDATED: (version: string) => `lilbee server updated to ${version}`,
     NOTICE_SERVER_AUTO_UPDATE_FAILED: "lilbee: automatic server update failed. You can retry from settings.",
-    ERROR_COULD_NOT_CHECK: "lilbee: could not check for updates",
     ERROR_COULD_NOT_REACH: "Could not connect to lilbee server. Is it running?",
     ERROR_LOAD_CATALOG: "lilbee: failed to load catalog",
     ERROR_LOAD_DOCUMENTS: "lilbee: failed to load documents",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -47,6 +47,7 @@ export const MESSAGES = {
     BUTTON_REINSTALL: "Reinstall",
     BUTTON_UNINSTALL_SERVER: "Uninstall server",
     BUTTON_UNINSTALL: "Uninstall",
+    BUTTON_DOWNLOADING: "Downloading...",
     BUTTON_INSTALL_TAG: (tag: string) => `Install ${tag}`,
     BUTTON_UPDATE_TO: (tag: string) => `Update to ${tag}`,
     BUTTON_DOWNGRADE_TO: (tag: string) => `Downgrade to ${tag}`,

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -388,6 +388,9 @@ export const MESSAGES = {
     DESC_SERVER_VERSION_LOADING: "Reading the release list from GitHub...",
     DESC_SERVER_VERSION_OFFLINE: (tag: string) => `${tag} installed. The release list could not be read from GitHub.`,
 
+    TOOLTIP_SERVER_VERSION_SUPPORT:
+        "This plugin is built and tested against the latest server release. Older releases still install and run, " +
+        "but they are not supported, and features the plugin expects may be missing.",
     TOOLTIP_UNINSTALL_SECTION:
         "Obsidian does not manage the lilbee server executable or its models, this plugin does. " +
         "Removing the plugin from Obsidian's Community plugins pane leaves both on disk. Uninstall here first.",

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import { exportDiagnostics } from "./diagnostics-export";
 import { ErrorJournal } from "./error-journal";
 import type { ReleaseInfo } from "./binary-manager";
 import { ServerManager } from "./server-manager";
+import { executeUninstall, planUninstall } from "./server-uninstall";
 import { readSessionToken, resolveExternalDataRoot } from "./session-token";
 import { LilbeeSettingTab } from "./settings";
 import { VaultRegistry, computeVaultId, resolveSharedRoot, sharedBinDir, sharedModelsDir } from "./vault-registry";
@@ -50,6 +51,7 @@ import {
     type SyncDone,
     type SyncOptions,
     type TaskEntry,
+    type UninstallPlan,
     type VaultAdapter,
 } from "./types";
 import { MESSAGES } from "./locales/en";
@@ -334,7 +336,10 @@ export default class LilbeePlugin extends Plugin {
         // wizard arrives at the Model step against a server that isn't
         // actually ready yet (empty catalog, failed reads).
         if (this.settings.setupCompleted) {
-            if (this.settings.serverMode === SERVER_MODE.MANAGED) {
+            if (this.settings.serverMode === SERVER_MODE.MANAGED && this.serverUninstalled) {
+                // The user removed the server on purpose. Wait to be asked.
+                this.showNotInstalledStatus();
+            } else if (this.settings.serverMode === SERVER_MODE.MANAGED) {
                 void this.ensureManagedConsentThenStart().then((outcome) => {
                     // If the user opts into external mode from the consent modal,
                     // drop them on the plugin's external-server settings.
@@ -389,6 +394,10 @@ export default class LilbeePlugin extends Plugin {
         if (this.startingServer) return;
         const registry = this.vaultRegistry;
         if (!registry) return;
+        if (this.serverUninstalled) {
+            this.showNotInstalledStatus();
+            return;
+        }
         this.startingServer = true;
         this.serverStartFailed = false;
 
@@ -434,7 +443,7 @@ export default class LilbeePlugin extends Plugin {
         if (!registry) return { kind: SETUP_OUTCOME.CANCELED };
 
         const binaryPresent = new BinaryManager(sharedBinDir(registry.sharedRoot)).binaryExists();
-        if (binaryPresent) {
+        if (binaryPresent && !this.serverUninstalled) {
             await this.startManagedServer(onProgress);
             return { kind: SETUP_OUTCOME.STARTED, mode: SERVER_MODE.MANAGED };
         }
@@ -447,6 +456,7 @@ export default class LilbeePlugin extends Plugin {
             this.settings.serverMode = SERVER_MODE.MANAGED;
             this.previousServerMode = SERVER_MODE.MANAGED;
             await this.persistAll();
+            this.setServerUninstalled(false);
             await this.startManagedServer(onProgress);
             return { kind: SETUP_OUTCOME.STARTED, mode: SERVER_MODE.MANAGED };
         }
@@ -659,6 +669,60 @@ export default class LilbeePlugin extends Plugin {
         }
     }
 
+    /** True when the shared bin dir holds a server binary this vault can run. */
+    isServerInstalled(): boolean {
+        const registry = this.vaultRegistry;
+        if (!registry) return false;
+        return new BinaryManager(sharedBinDir(registry.sharedRoot)).binaryExists();
+    }
+
+    /** Size what an uninstall would delete, so the confirmation can list it. */
+    planServerUninstall(): UninstallPlan | null {
+        const registry = this.vaultRegistry;
+        if (!registry) return null;
+        return planUninstall(registry.sharedRoot, registry.resolveDataDir(this.vaultId));
+    }
+
+    /**
+     * Delete the server binary, the shared models, and this vault's index, then
+     * remember the choice so no later launch downloads the server again.
+     * Returns the bytes freed. Vault documents are never touched.
+     */
+    async uninstallServer(plan: UninstallPlan): Promise<number> {
+        const registry = this.vaultRegistry;
+        if (!registry) return 0;
+
+        await this.serverManager?.stop();
+        this.serverManager = null;
+        this.binaryManager = null;
+        registry.releaseLock(this.vaultId);
+
+        executeUninstall(plan);
+
+        registry.saveConfig({
+            ...registry.loadConfig(),
+            lilbeeVersion: "",
+            lilbeeVariant: "",
+            serverUninstalled: true,
+        });
+        this.serverUninstalled = true;
+        this.serverEverReady = false;
+        this.serverUnreachable = false;
+        this.showNotInstalledStatus();
+        return plan.totalBytes;
+    }
+
+    /** Download *release* and start it, clearing an earlier uninstall. */
+    async installServer(release: ReleaseInfo, onProgress?: (msg: string) => void): Promise<void> {
+        this.setServerUninstalled(false);
+        await this.updateServer(release, onProgress);
+    }
+
+    private showNotInstalledStatus(): void {
+        this.updateStatusBar(MESSAGES.STATUS_NOT_INSTALLED, DOT_STATE.MUTED, false);
+        this.setStatusClass(null);
+    }
+
     async checkForUpdate(): Promise<{ available: boolean; release?: ReleaseInfo }> {
         const release = await getLatestRelease();
         const versionChanged = checkForUpdate(this.getSharedLilbeeVersion(), release.tag);
@@ -676,6 +740,7 @@ export default class LilbeePlugin extends Plugin {
     private async autoUpdateServerBinary(): Promise<void> {
         const registry = this.vaultRegistry;
         if (!registry) return;
+        if (this.serverUninstalled) return;
         const config = registry.loadConfig();
         if (config.lastUpdateCheckPluginVersion === this.manifest.version) return;
         let result: { available: boolean; release?: ReleaseInfo };
@@ -1214,6 +1279,21 @@ export default class LilbeePlugin extends Plugin {
         this.taskQueue.loadFromJSON(raw?.taskHistory as { history?: import("./types").TaskEntry[] } | undefined);
         this.vaultId = computeVaultId(this.getVaultBasePath());
         this.vaultRegistry = new VaultRegistry(resolveSharedRoot(this.settings.sharedRoot));
+        this.serverUninstalled = this.vaultRegistry.loadConfig().serverUninstalled;
+    }
+
+    /** Mirrors `SharedConfig.serverUninstalled`; read on every status paint and health probe. */
+    private serverUninstalled = false;
+
+    isServerUninstalled(): boolean {
+        return this.serverUninstalled;
+    }
+
+    setServerUninstalled(uninstalled: boolean): void {
+        this.serverUninstalled = uninstalled;
+        const reg = this.vaultRegistry;
+        if (!reg) return;
+        reg.saveConfig({ ...reg.loadConfig(), serverUninstalled: uninstalled });
     }
 
     getSharedLilbeeVersion(): string {
@@ -1311,6 +1391,10 @@ export default class LilbeePlugin extends Plugin {
     }
 
     private setStatusReady(): void {
+        if (this.settings.serverMode === SERVER_MODE.MANAGED && this.serverUninstalled) {
+            this.showNotInstalledStatus();
+            return;
+        }
         // Managed mode without a running serverManager is the "released"
         // state (after switch-to-another-vault or onunload). Stay stuck
         // on STOPPED instead of cheerfully claiming "ready" against a
@@ -1339,6 +1423,8 @@ export default class LilbeePlugin extends Plugin {
         if (this.taskQueue.activeAll.length > 0) return;
         if (this.startingServer) return;
         if (this.chatInFlight > 0) return;
+        // Nothing to probe, and "error" would misread a deliberate uninstall.
+        if (this.serverUninstalled) return;
         // Re-read the token before probing — the server writes a fresh one on
         // every restart, and this is the cheapest way to stay in sync.
         this.api.setToken(this.readCurrentToken());

--- a/src/server-uninstall.ts
+++ b/src/server-uninstall.ts
@@ -1,0 +1,29 @@
+/**
+ * Removal of everything managed mode put on disk: the server binary, the
+ * shared model cache, and one vault's index. Never touches the Obsidian vault.
+ */
+import { node } from "./binary-manager";
+import { dirSizeBytes } from "./storage-stats";
+import { sharedBinDir, sharedModelsDir } from "./vault-registry";
+import { UNINSTALL_TARGET, type UninstallPlan, type UninstallTarget, type UninstallTargetKind } from "./types";
+
+function target(kind: UninstallTargetKind, path: string): UninstallTarget {
+    return { kind, path, bytes: dirSizeBytes(path) };
+}
+
+/** Size every removable path so the confirmation can name what it deletes. */
+export function planUninstall(sharedRoot: string, vaultDataDir: string): UninstallPlan {
+    const targets = [
+        target(UNINSTALL_TARGET.BINARY, sharedBinDir(sharedRoot)),
+        target(UNINSTALL_TARGET.MODELS, sharedModelsDir(sharedRoot)),
+        target(UNINSTALL_TARGET.INDEX, vaultDataDir),
+    ];
+    return { targets, totalBytes: targets.reduce((sum, t) => sum + t.bytes, 0) };
+}
+
+/** Delete every planned path. Missing paths are not an error. */
+export function executeUninstall(plan: UninstallPlan): void {
+    for (const t of plan.targets) {
+        node.rmSync(t.path, { recursive: true, force: true });
+    }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -134,7 +134,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         this.renderWikiSettings(this.wikiContainerEl);
         this.renderDiagnostics(containerEl);
         this.renderAdvancedSettings(containerEl);
-        if (this.plugin.settings.serverMode === SERVER_MODE.MANAGED && this.plugin.isServerInstalled()) {
+        if (this.plugin.settings.serverMode === SERVER_MODE.MANAGED && this.hasManagedServer()) {
             this.renderUninstallSection(containerEl, this.storageTotalBytes);
         }
         this.loadServerDefaults();
@@ -213,8 +213,17 @@ export class LilbeeSettingTab extends PluginSettingTab {
         }
     }
 
+    /**
+     * A binary on disk that the plugin is still allowed to run. An uninstalled
+     * server never starts, even if a binary was put back by hand, until an
+     * explicit install clears the flag.
+     */
+    private hasManagedServer(): boolean {
+        return this.plugin.isServerInstalled() && !this.plugin.isServerUninstalled();
+    }
+
     private renderManagedSettings(containerEl: HTMLElement): void {
-        if (!this.plugin.isServerInstalled()) {
+        if (!this.hasManagedServer()) {
             this.renderInstallServer(containerEl);
             this.renderSharedRootSetting(containerEl);
             return;
@@ -363,7 +372,8 @@ export class LilbeeSettingTab extends PluginSettingTab {
         heading.settingEl.setAttribute("title", MESSAGES.TOOLTIP_UNINSTALL_SECTION);
 
         const callout = containerEl.createDiv({ cls: "lilbee-uninstall-callout" });
-        callout.createSpan({ cls: "lilbee-uninstall-callout-mark", text: "!" });
+        const mark = callout.createSpan({ cls: "lilbee-uninstall-callout-mark", text: "!" });
+        mark.setAttribute("aria-hidden", "true");
         callout.createEl("p", { text: MESSAGES.CALLOUT_UNINSTALL_FIRST });
 
         new Setting(containerEl)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,6 @@
-import { App, ButtonComponent, Notice, PluginSettingTab, setIcon, Setting } from "obsidian";
+import { App, ButtonComponent, DropdownComponent, Notice, PluginSettingTab, setIcon, Setting } from "obsidian";
 import type LilbeePlugin from "./main";
+import { listReleases } from "./binary-manager";
 import type { ReleaseInfo } from "./binary-manager";
 import {
     CAPABILITY,
@@ -15,17 +16,20 @@ import {
     SSE_EVENT,
     TASK_TYPE,
     ERROR_NAME,
+    VERSION_ACTION,
 } from "./types";
-import type { CatalogEntry, ConfigResponse, InstalledModel, LilbeeSettings, ServerMode } from "./types";
+import type { CatalogEntry, ConfigResponse, InstalledModel, LilbeeSettings, ServerMode, UninstallPlan } from "./types";
 import { exportDiagnostics } from "./diagnostics-export";
 import { formatBytes, reportForVault } from "./storage-stats";
 import { MESSAGES } from "./locales/en";
 import { displayLabelForRef, extractHfRepo, matchModelOption } from "./utils/model-ref";
+import { versionActionFor, versionButtonLabel, versionDescription } from "./utils/server-version";
 import { CatalogModal } from "./views/catalog-modal";
 import { hostedOptions } from "./views/catalog-helpers";
 import { ConfirmModal } from "./views/confirm-modal";
 import { ConfirmPullModal } from "./views/confirm-pull-modal";
 import { SetupWizard } from "./views/setup-wizard";
+import { UninstallModal } from "./views/uninstall-modal";
 import {
     debounce,
     DEBOUNCE_MS,
@@ -128,6 +132,9 @@ export class LilbeeSettingTab extends PluginSettingTab {
         this.renderWikiSettings(this.wikiContainerEl);
         this.renderDiagnostics(containerEl);
         this.renderAdvancedSettings(containerEl);
+        if (this.plugin.settings.serverMode === SERVER_MODE.MANAGED && this.plugin.isServerInstalled()) {
+            this.renderUninstallSection(containerEl);
+        }
         this.loadServerDefaults();
         this.loadConfigDefaults();
         void this.applyCapabilityGating();
@@ -205,6 +212,12 @@ export class LilbeeSettingTab extends PluginSettingTab {
     }
 
     private renderManagedSettings(containerEl: HTMLElement): void {
+        if (!this.plugin.isServerInstalled()) {
+            this.renderInstallServer(containerEl);
+            this.renderSharedRootSetting(containerEl);
+            return;
+        }
+
         const statusSetting = new Setting(containerEl)
             .setName(MESSAGES.LABEL_SERVER_STATUS)
             .setDesc(MESSAGES.DESC_SERVER_STATUS_CURRENT);
@@ -253,50 +266,204 @@ export class LilbeeSettingTab extends PluginSettingTab {
         this.renderSharedRootSetting(containerEl);
         this.renderAdoptDataDir(containerEl);
         this.renderStorageReport(containerEl);
+        this.renderVersionSetting(containerEl);
+    }
 
-        const updateSetting = new Setting(containerEl)
+    /**
+     * One control for upgrade, downgrade, and reinstall. The dropdown lists
+     * recent releases newest-first; the button names what the selection does.
+     */
+    private renderVersionSetting(containerEl: HTMLElement): void {
+        const installed = this.plugin.getSharedLilbeeVersion();
+        const setting = new Setting(containerEl)
             .setName(MESSAGES.LABEL_SERVER_VERSION)
-            .setDesc(this.plugin.getSharedLilbeeVersion() || MESSAGES.DESC_SERVER_VERSION_UNKNOWN);
-
+            .setDesc(MESSAGES.DESC_SERVER_VERSION_LOADING);
         const progress = this.renderUpdateProgress(containerEl);
 
-        let pendingRelease: ReleaseInfo | null = null;
-        updateSetting.addButton((checkBtn) =>
-            checkBtn.setButtonText(MESSAGES.BUTTON_CHECK_UPDATES).onClick(async () => {
-                if (pendingRelease) {
-                    if (!(await this.runServerUpdate(pendingRelease, checkBtn, progress))) {
-                        pendingRelease = null;
-                    }
-                    return;
-                }
+        let releases: ReleaseInfo[] = [];
+        let selectedTag = installed;
+        // addDropdown / addButton run their callback synchronously, so both are set below.
+        let dropdown!: DropdownComponent;
+        let actionBtn!: ButtonComponent;
 
-                checkBtn.setDisabled(true);
-                checkBtn.setButtonText(MESSAGES.STATUS_CHECKING_CONNECTION);
-                try {
-                    const result = await this.plugin.checkForUpdate();
-                    if (result.available && result.release) {
-                        pendingRelease = result.release;
-                        checkBtn.setButtonText(`Update to ${result.release.tag}`);
-                        checkBtn.setDisabled(false);
-                    } else {
-                        // 51g: explicit feedback on the no-update path so the
-                        // click visibly registers. Surface the *current*
-                        // version so the user can see what was checked, and
-                        // pin the inline button label to "Up to date" until
-                        // the next click — both the toast and the button
-                        // change confirm the action.
-                        const current = this.plugin.getSharedLilbeeVersion() || MESSAGES.LABEL_UNKNOWN;
-                        new Notice(MESSAGES.NOTICE_SERVER_UPTODATE(current));
-                        checkBtn.setButtonText(MESSAGES.LABEL_UPTODATE);
-                        checkBtn.setDisabled(false);
-                    }
-                } catch {
-                    new Notice(MESSAGES.ERROR_COULD_NOT_CHECK);
-                    checkBtn.setButtonText(MESSAGES.BUTTON_CHECK_UPDATES);
-                    checkBtn.setDisabled(false);
-                }
-            }),
-        );
+        const refresh = (): void => {
+            const tags = releases.map((r) => r.tag);
+            const action = versionActionFor(tags, installed, selectedTag);
+            setting.setDesc(versionDescription(action, installed, selectedTag, tags[0] === installed));
+            actionBtn.setButtonText(versionButtonLabel(action, selectedTag));
+            actionBtn.buttonEl.toggleClass("mod-cta", action === VERSION_ACTION.UPDATE);
+            actionBtn.buttonEl.toggleClass("mod-warning", action === VERSION_ACTION.DOWNGRADE);
+        };
+
+        setting.addDropdown((dd) => {
+            dropdown = dd;
+            dd.setDisabled(true);
+            dd.onChange((value) => {
+                selectedTag = value;
+                refresh();
+            });
+        });
+
+        setting.addButton((btn) => {
+            actionBtn = btn;
+            btn.setDisabled(true);
+            btn.setButtonText(MESSAGES.BUTTON_REINSTALL).onClick(async () => {
+                const release = releases.find((r) => r.tag === selectedTag);
+                if (!release) return;
+                const label = versionButtonLabel(
+                    versionActionFor(
+                        releases.map((r) => r.tag),
+                        installed,
+                        selectedTag,
+                    ),
+                    selectedTag,
+                );
+                await this.runServerUpdate(release, btn, progress, label);
+            });
+        });
+
+        void this.loadReleases().then((loaded) => {
+            if (loaded === null) {
+                setting.setDesc(
+                    installed ? MESSAGES.DESC_SERVER_VERSION_OFFLINE(installed) : MESSAGES.DESC_SERVER_VERSION_UNKNOWN,
+                );
+                return;
+            }
+            releases = loaded;
+            if (releases.length === 0) return;
+            if (!releases.some((r) => r.tag === selectedTag)) selectedTag = releases[0].tag;
+            for (const release of releases) dropdown.addOption(release.tag, release.tag);
+            dropdown.setValue(selectedTag);
+            dropdown.setDisabled(false);
+            actionBtn.setDisabled(false);
+            refresh();
+        });
+    }
+
+    /** Null when GitHub could not be reached. */
+    private async loadReleases(): Promise<ReleaseInfo[] | null> {
+        try {
+            return await listReleases();
+        } catch {
+            return null;
+        }
+    }
+
+    /** Managed mode only: Obsidian never removes the server this plugin downloaded. */
+    private renderUninstallSection(containerEl: HTMLElement): void {
+        const plan = this.plugin.planServerUninstall();
+        if (!plan) return;
+
+        const heading = new Setting(containerEl).setName(MESSAGES.LABEL_UNINSTALL).setHeading();
+        heading.settingEl.addClass("lilbee-danger-heading");
+        heading.settingEl.setAttribute("aria-label", MESSAGES.TOOLTIP_UNINSTALL_SECTION);
+        heading.settingEl.setAttribute("title", MESSAGES.TOOLTIP_UNINSTALL_SECTION);
+
+        const callout = containerEl.createDiv({ cls: "lilbee-uninstall-callout" });
+        callout.createSpan({ cls: "lilbee-uninstall-callout-mark", text: "!" });
+        callout.createEl("p", { text: MESSAGES.CALLOUT_UNINSTALL_FIRST });
+
+        new Setting(containerEl)
+            .setName(MESSAGES.LABEL_UNINSTALL_SERVER)
+            .setDesc(MESSAGES.DESC_UNINSTALL_SERVER(formatBytes(plan.totalBytes)))
+            .addButton((btn) => {
+                btn.setButtonText(MESSAGES.BUTTON_UNINSTALL_SERVER).onClick(() => void this.confirmUninstall(plan));
+                btn.buttonEl.addClass("mod-warning");
+            });
+    }
+
+    private async confirmUninstall(plan: UninstallPlan): Promise<void> {
+        const modal = new UninstallModal(this.app, plan);
+        modal.open();
+        if (!(await modal.result)) return;
+        try {
+            const freed = await this.plugin.uninstallServer(plan);
+            new Notice(MESSAGES.NOTICE_UNINSTALLED(formatBytes(freed)));
+        } catch (err) {
+            new Notice(errorMessage(err, MESSAGES.ERROR_UNINSTALL_FAILED));
+            console.error("[lilbee] uninstall failed:", err);
+        }
+        this.render();
+    }
+
+    /** Recovery path after an uninstall: pick a release and pull the server back. */
+    private renderInstallServer(containerEl: HTMLElement): void {
+        new Setting(containerEl).setName(MESSAGES.LABEL_SERVER_STATUS).setDesc(MESSAGES.DESC_SERVER_NOT_INSTALLED);
+
+        const setting = new Setting(containerEl)
+            .setName(MESSAGES.LABEL_INSTALL_SERVER)
+            .setDesc(MESSAGES.DESC_SERVER_VERSION_LOADING);
+        const progress = this.renderUpdateProgress(containerEl);
+
+        let releases: ReleaseInfo[] = [];
+        let selectedTag = "";
+        // addDropdown / addButton run their callback synchronously, so both are set below.
+        let dropdown!: DropdownComponent;
+        let installBtn!: ButtonComponent;
+
+        const describe = (): void => {
+            const release = releases.find((r) => r.tag === selectedTag);
+            /* v8 ignore next -- the dropdown only ever offers tags from `releases` */
+            if (!release) return;
+            setting.setDesc(MESSAGES.DESC_INSTALL_SERVER(formatBytes(release.sizeBytes)));
+        };
+
+        setting.addDropdown((dd) => {
+            dropdown = dd;
+            dd.setDisabled(true);
+            dd.onChange((value) => {
+                selectedTag = value;
+                describe();
+            });
+        });
+
+        setting.addButton((btn) => {
+            installBtn = btn;
+            btn.setDisabled(true);
+            btn.buttonEl.addClass("mod-cta");
+            btn.setButtonText(MESSAGES.BUTTON_INSTALL_SERVER).onClick(async () => {
+                const release = releases.find((r) => r.tag === selectedTag);
+                if (!release) return;
+                await this.runServerInstall(release, btn, progress);
+            });
+        });
+
+        void this.loadReleases().then((loaded) => {
+            if (loaded === null) {
+                setting.setDesc(MESSAGES.ERROR_RELEASE_LIST);
+                return;
+            }
+            releases = loaded;
+            if (releases.length === 0) return;
+            selectedTag = releases[0].tag;
+            for (const release of releases) dropdown.addOption(release.tag, release.tag);
+            dropdown.setValue(selectedTag);
+            dropdown.setDisabled(false);
+            installBtn.setDisabled(false);
+            describe();
+        });
+    }
+
+    private async runServerInstall(
+        release: ReleaseInfo,
+        btn: ButtonComponent,
+        progress: UpdateProgressEls,
+    ): Promise<void> {
+        btn.setDisabled(true);
+        btn.setButtonText(MESSAGES.STATUS_DOWNLOADING);
+        progress.panel.show();
+        progress.size.setText(MESSAGES.STATUS_UPDATE_SIZE(release.tag, formatBytes(release.sizeBytes)));
+        try {
+            await this.plugin.installServer(release, (msg) => progress.phase.setText(msg));
+            new Notice(MESSAGES.NOTICE_INSTALLED(release.tag));
+            this.render();
+        } catch (err) {
+            new Notice(errorMessage(err, MESSAGES.ERROR_INSTALL_FAILED));
+            console.error("[lilbee] install failed:", err);
+            progress.panel.hide();
+            btn.setButtonText(MESSAGES.BUTTON_INSTALL_SERVER);
+            btn.setDisabled(false);
+        }
     }
 
     /** Indeterminate progress panel for the managed-server update; hidden until an update runs. */
@@ -310,14 +477,15 @@ export class LilbeeSettingTab extends PluginSettingTab {
         return { panel, phase, size };
     }
 
-    /** Download and install a server update, surfacing phase + total download size. Returns false on failure. */
+    /** Download and install *release*, surfacing phase + total download size. Returns false on failure. */
     private async runServerUpdate(
         release: ReleaseInfo,
-        checkBtn: ButtonComponent,
+        actionBtn: ButtonComponent,
         progress: UpdateProgressEls,
+        restoreLabel: string,
     ): Promise<boolean> {
-        checkBtn.setDisabled(true);
-        checkBtn.setButtonText(MESSAGES.STATUS_DOWNLOADING);
+        actionBtn.setDisabled(true);
+        actionBtn.setButtonText(MESSAGES.STATUS_DOWNLOADING);
         progress.panel.show();
         progress.size.setText(MESSAGES.STATUS_UPDATE_SIZE(release.tag, formatBytes(release.sizeBytes)));
         try {
@@ -330,8 +498,8 @@ export class LilbeeSettingTab extends PluginSettingTab {
             new Notice(errorMessage(err, MESSAGES.ERROR_FAILED_UPDATE));
             console.error("[lilbee] update failed:", err);
             progress.panel.hide();
-            checkBtn.setButtonText(MESSAGES.BUTTON_CHECK_UPDATES);
-            checkBtn.setDisabled(false);
+            actionBtn.setButtonText(restoreLabel);
+            actionBtn.setDisabled(false);
             return false;
         }
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -467,7 +467,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         progress: UpdateProgressEls,
     ): Promise<void> {
         btn.setDisabled(true);
-        btn.setButtonText(MESSAGES.STATUS_DOWNLOADING);
+        btn.setButtonText(MESSAGES.BUTTON_DOWNLOADING);
         progress.panel.show();
         progress.size.setText(MESSAGES.STATUS_UPDATE_SIZE(release.tag, formatBytes(release.sizeBytes)));
         try {
@@ -502,7 +502,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         restoreLabel: string,
     ): Promise<boolean> {
         actionBtn.setDisabled(true);
-        actionBtn.setButtonText(MESSAGES.STATUS_DOWNLOADING);
+        actionBtn.setButtonText(MESSAGES.BUTTON_DOWNLOADING);
         progress.panel.show();
         progress.size.setText(MESSAGES.STATUS_UPDATE_SIZE(release.tag, formatBytes(release.sizeBytes)));
         try {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -289,6 +289,8 @@ export class LilbeeSettingTab extends PluginSettingTab {
         const setting = new Setting(containerEl)
             .setName(MESSAGES.LABEL_SERVER_VERSION)
             .setDesc(MESSAGES.DESC_SERVER_VERSION_LOADING);
+        setting.settingEl.setAttribute("aria-label", MESSAGES.TOOLTIP_SERVER_VERSION_SUPPORT);
+        setting.settingEl.setAttribute("title", MESSAGES.TOOLTIP_SERVER_VERSION_SUPPORT);
         const progress = this.renderUpdateProgress(containerEl);
 
         let releases: ReleaseInfo[] = [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -448,6 +448,8 @@ export interface SharedConfig {
     hfToken: string;
     /** Plugin version that last ran the automatic server-update check. */
     lastUpdateCheckPluginVersion: string;
+    /** The user removed the managed server; never download it again until they ask. */
+    serverUninstalled: boolean;
 }
 
 export const DEFAULT_SHARED_CONFIG: SharedConfig = {
@@ -455,7 +457,38 @@ export const DEFAULT_SHARED_CONFIG: SharedConfig = {
     lilbeeVariant: "",
     hfToken: "",
     lastUpdateCheckPluginVersion: "",
+    serverUninstalled: false,
 };
+
+/** What a managed-mode uninstall deletes. Documents in the vault are never a target. */
+export type UninstallTargetKind = "binary" | "models" | "index";
+
+export const UNINSTALL_TARGET = {
+    BINARY: "binary",
+    MODELS: "models",
+    INDEX: "index",
+} as const satisfies Record<string, UninstallTargetKind>;
+
+export interface UninstallTarget {
+    kind: UninstallTargetKind;
+    path: string;
+    bytes: number;
+}
+
+export interface UninstallPlan {
+    targets: UninstallTarget[];
+    totalBytes: number;
+}
+
+/** How the selected server version relates to the installed one. */
+export type VersionAction = "install" | "reinstall" | "update" | "downgrade";
+
+export const VERSION_ACTION = {
+    INSTALL: "install",
+    REINSTALL: "reinstall",
+    UPDATE: "update",
+    DOWNGRADE: "downgrade",
+} as const satisfies Record<string, VersionAction>;
 
 /** One row in `<shared-root>/registry.json` — one per Obsidian vault. */
 export interface VaultRegistryEntry {

--- a/src/utils/server-version.ts
+++ b/src/utils/server-version.ts
@@ -1,0 +1,49 @@
+import { MESSAGES } from "../locales/en";
+import { VERSION_ACTION, type VersionAction } from "../types";
+
+/**
+ * How installing *selectedTag* relates to *installedTag*, given release tags
+ * newest-first. An installed tag missing from the list (yanked release, hand
+ * -installed build) has no ordering, so any choice is a plain install.
+ */
+export function versionActionFor(tagsNewestFirst: string[], installedTag: string, selectedTag: string): VersionAction {
+    const installedIdx = tagsNewestFirst.indexOf(installedTag);
+    const selectedIdx = tagsNewestFirst.indexOf(selectedTag);
+    if (installedIdx === -1 || selectedIdx === -1) return VERSION_ACTION.INSTALL;
+    if (selectedIdx === installedIdx) return VERSION_ACTION.REINSTALL;
+    return selectedIdx < installedIdx ? VERSION_ACTION.UPDATE : VERSION_ACTION.DOWNGRADE;
+}
+
+export function versionButtonLabel(action: VersionAction, selectedTag: string): string {
+    switch (action) {
+        case VERSION_ACTION.REINSTALL:
+            return MESSAGES.BUTTON_REINSTALL;
+        case VERSION_ACTION.UPDATE:
+            return MESSAGES.BUTTON_UPDATE_TO(selectedTag);
+        case VERSION_ACTION.DOWNGRADE:
+            return MESSAGES.BUTTON_DOWNGRADE_TO(selectedTag);
+        default:
+            return MESSAGES.BUTTON_INSTALL_TAG(selectedTag);
+    }
+}
+
+export function versionDescription(
+    action: VersionAction,
+    installedTag: string,
+    selectedTag: string,
+    installedIsLatest: boolean,
+): string {
+    if (!installedTag) return MESSAGES.DESC_SERVER_VERSION_UNKNOWN;
+    switch (action) {
+        case VERSION_ACTION.UPDATE:
+            return MESSAGES.DESC_SERVER_VERSION_UPDATE(installedTag, selectedTag);
+        case VERSION_ACTION.DOWNGRADE:
+            return MESSAGES.DESC_SERVER_VERSION_DOWNGRADE(installedTag);
+        case VERSION_ACTION.REINSTALL:
+            return installedIsLatest
+                ? MESSAGES.DESC_SERVER_VERSION_INSTALLED(installedTag)
+                : MESSAGES.DESC_SERVER_VERSION_OUTDATED(installedTag);
+        default:
+            return MESSAGES.DESC_SERVER_VERSION_PLAIN(installedTag);
+    }
+}

--- a/src/views/uninstall-modal.ts
+++ b/src/views/uninstall-modal.ts
@@ -1,0 +1,85 @@
+import { App, Modal } from "obsidian";
+import { MESSAGES } from "../locales/en";
+import { formatBytes } from "../storage-stats";
+import { UNINSTALL_TARGET, type UninstallPlan, type UninstallTargetKind } from "../types";
+import { bindEscapeToClose } from "../utils";
+
+const TARGET_LABELS: Record<UninstallTargetKind, string> = {
+    [UNINSTALL_TARGET.BINARY]: MESSAGES.LABEL_UNINSTALL_BINARY,
+    [UNINSTALL_TARGET.MODELS]: MESSAGES.LABEL_UNINSTALL_MODELS,
+    [UNINSTALL_TARGET.INDEX]: MESSAGES.LABEL_UNINSTALL_INDEX,
+};
+
+/** Confirms a managed-server uninstall by naming and sizing everything it deletes. */
+export class UninstallModal extends Modal {
+    private plan: UninstallPlan;
+    private _resolve: ((value: boolean) => void) | null = null;
+    private decided = false;
+    readonly result: Promise<boolean>;
+
+    constructor(app: App, plan: UninstallPlan) {
+        super(app);
+        this.plan = plan;
+        this.result = new Promise<boolean>((resolve) => {
+            this._resolve = resolve;
+        });
+        bindEscapeToClose(this);
+    }
+
+    onOpen(): void {
+        const { contentEl } = this;
+        contentEl.empty();
+        contentEl.addClass("lilbee-uninstall-modal");
+
+        contentEl.createEl("h3", { text: MESSAGES.CONFIRM_UNINSTALL_TITLE });
+        contentEl.createEl("p", { text: MESSAGES.CONFIRM_UNINSTALL_BODY });
+
+        const ledger = contentEl.createDiv({ cls: "lilbee-uninstall-ledger" });
+        for (const target of this.plan.targets) {
+            this.appendRow(
+                ledger,
+                MESSAGES.LABEL_UNINSTALL_DELETE_TAG,
+                TARGET_LABELS[target.kind],
+                formatBytes(target.bytes),
+            );
+        }
+        const keep = this.appendRow(
+            ledger,
+            MESSAGES.LABEL_UNINSTALL_KEEP_TAG,
+            MESSAGES.LABEL_UNINSTALL_KEEP,
+            MESSAGES.LABEL_UNINSTALL_KEEP_VALUE,
+        );
+        keep.addClass("is-keep");
+
+        const actions = contentEl.createDiv({ cls: "lilbee-confirm-actions" });
+        const cancelBtn = actions.createEl("button", { text: MESSAGES.BUTTON_CANCEL });
+        cancelBtn.addEventListener("click", () => this.decide(false));
+
+        const uninstallBtn = actions.createEl("button", { text: MESSAGES.BUTTON_UNINSTALL, cls: "mod-warning" });
+        uninstallBtn.addEventListener("click", () => this.decide(true));
+    }
+
+    private appendRow(parent: HTMLElement, tag: string, label: string, value: string): HTMLElement {
+        const row = parent.createDiv({ cls: "lilbee-uninstall-row" });
+        row.createSpan({ cls: "lilbee-uninstall-tag", text: tag });
+        row.createSpan({ cls: "lilbee-uninstall-label", text: label });
+        row.createSpan({ cls: "lilbee-uninstall-size", text: value });
+        return row;
+    }
+
+    onClose(): void {
+        this.decide(false);
+    }
+
+    private decide(confirmed: boolean): void {
+        if (this.decided) return;
+        this.decided = true;
+        /* v8 ignore next -- `decided` guards re-entry, so `_resolve` is always set here */
+        if (this._resolve) {
+            const resolve = this._resolve;
+            this._resolve = null;
+            resolve(confirmed);
+        }
+        this.close();
+    }
+}

--- a/src/views/uninstall-modal.ts
+++ b/src/views/uninstall-modal.ts
@@ -29,7 +29,6 @@ export class UninstallModal extends Modal {
     onOpen(): void {
         const { contentEl } = this;
         contentEl.empty();
-        contentEl.addClass("lilbee-uninstall-modal");
 
         contentEl.createEl("h3", { text: MESSAGES.CONFIRM_UNINSTALL_TITLE });
         contentEl.createEl("p", { text: MESSAGES.CONFIRM_UNINSTALL_BODY });

--- a/styles.css
+++ b/styles.css
@@ -4439,3 +4439,81 @@ button.lilbee-model-chip-select:focus-visible {
 .lilbee-clickable {
     cursor: pointer;
 }
+
+/* Managed-mode uninstall: the section heading, its warning callout, and the
+   confirmation's delete/keep ledger. */
+.lilbee-danger-heading .setting-item-name {
+    color: var(--text-error);
+}
+
+.lilbee-uninstall-callout {
+    display: flex;
+    gap: var(--size-4-3, 12px);
+    align-items: flex-start;
+    margin: var(--size-4-2, 8px) 0 var(--size-4-1, 4px);
+    padding: var(--size-4-3, 12px) var(--size-4-3, 12px);
+    border: 1px solid var(--background-modifier-border);
+    border-left: 3px solid var(--text-warning);
+    border-radius: var(--radius-s, 4px);
+    background: var(--background-secondary);
+    font-size: var(--font-small, 13px);
+    line-height: 1.5;
+}
+
+.lilbee-uninstall-callout p {
+    margin: 0;
+    color: var(--text-muted);
+}
+
+.lilbee-uninstall-callout-mark {
+    flex: 0 0 auto;
+    font-weight: bold;
+    color: var(--text-warning);
+}
+
+.lilbee-uninstall-ledger {
+    margin: var(--size-4-3, 12px) 0;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-s, 4px);
+    overflow: hidden;
+    font-size: var(--font-small, 13px);
+}
+
+.lilbee-uninstall-row {
+    display: flex;
+    align-items: center;
+    gap: var(--size-4-2, 8px);
+    padding: var(--size-4-2, 8px) var(--size-4-3, 12px);
+    border-top: 1px solid var(--background-modifier-border);
+    font-variant-numeric: tabular-nums;
+}
+
+.lilbee-uninstall-row:first-child {
+    border-top: none;
+}
+
+.lilbee-uninstall-row.is-keep {
+    background: var(--background-secondary);
+}
+
+.lilbee-uninstall-tag {
+    flex: 0 0 auto;
+    min-width: 4.5em;
+    font-size: var(--font-smallest, 11px);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-error);
+}
+
+.lilbee-uninstall-row.is-keep .lilbee-uninstall-tag {
+    color: var(--text-success);
+}
+
+.lilbee-uninstall-label {
+    flex: 1 1 auto;
+}
+
+.lilbee-uninstall-size {
+    flex: 0 0 auto;
+    color: var(--text-muted);
+}

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -811,7 +811,14 @@ class MockDropdownComponent {
     private _onChange: ((v: string) => void) | null = null;
     private _value = "";
     selectEl = { disabled: false, title: "" };
-    addOption(_value: string, _label: string): this {
+    disabled = false;
+    options: string[] = [];
+    setDisabled(disabled: boolean): this {
+        this.disabled = disabled;
+        return this;
+    }
+    addOption(value: string, _label: string): this {
+        this.options.push(value);
         return this;
     }
     addOptions(_opts: Record<string, string>): this {
@@ -855,10 +862,15 @@ class MockToggleComponent {
 class MockButtonComponent {
     private _onClick: (() => void) | null = null;
     warning = false;
-    setButtonText(_text: string): this {
+    text = "";
+    disabled = false;
+    buttonEl = new MockElement();
+    setButtonText(text: string): this {
+        this.text = text;
         return this;
     }
-    setDisabled(_disabled: boolean): this {
+    setDisabled(disabled: boolean): this {
+        this.disabled = disabled;
         return this;
     }
     setTooltip(_text: string): this {

--- a/tests/binary-manager.test.ts
+++ b/tests/binary-manager.test.ts
@@ -5,6 +5,7 @@ import {
     node,
     getPlatformAssetName,
     getLatestRelease,
+    listReleases,
     checkForUpdate,
     detectCudaTag,
     BinaryManager,
@@ -654,5 +655,91 @@ describe("BinaryManager.download digest verification", () => {
         const mgr = new BinaryManager("/plugins/lilbee/bin");
         await expect(mgr.download("https://example.com/dl", 4, null)).rejects.toThrow(/checksum/i);
         expect(writeSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe("listReleases", () => {
+    let restore: () => void;
+    afterEach(() => restore?.());
+
+    /** One GitHub release entry carrying the default linux asset. */
+    function release(tag: string, extra: Record<string, unknown> = {}) {
+        return {
+            tag_name: tag,
+            assets: [{ name: "lilbee-linux-x86_64", browser_download_url: `https://e/${tag}`, size: 10, digest: null }],
+            ...extra,
+        };
+    }
+
+    it("returns installable releases newest first", async () => {
+        restore = stubPlatform("linux", "x64");
+        stubNoNvidia();
+        vi.spyOn(node, "requestUrl").mockResolvedValue(releaseResponse([release("v1.1.0"), release("v1.0.0")]));
+
+        const releases = await listReleases();
+
+        expect(releases.map((r) => r.tag)).toEqual(["v1.1.0", "v1.0.0"]);
+        expect(releases[0]).toEqual({
+            tag: "v1.1.0",
+            assetUrl: "https://e/v1.1.0",
+            variant: "default",
+            sizeBytes: 10,
+            digest: null,
+        });
+    });
+
+    it("asks GitHub for the requested number of releases", async () => {
+        restore = stubPlatform("linux", "x64");
+        stubNoNvidia();
+        const requestUrl = vi.spyOn(node, "requestUrl").mockResolvedValue(releaseResponse([]));
+
+        await listReleases(3);
+
+        expect(requestUrl.mock.calls[0][0].url).toContain("per_page=3");
+    });
+
+    it("leaves out drafts and prereleases", async () => {
+        restore = stubPlatform("linux", "x64");
+        stubNoNvidia();
+        vi.spyOn(node, "requestUrl").mockResolvedValue(
+            releaseResponse([
+                release("v2.0.0-rc1", { prerelease: true }),
+                release("v2.0.0-draft", { draft: true }),
+                release("v1.0.0"),
+            ]),
+        );
+
+        expect((await listReleases()).map((r) => r.tag)).toEqual(["v1.0.0"]);
+    });
+
+    it("leaves out releases that ship no build for this platform", async () => {
+        restore = stubPlatform("linux", "x64");
+        stubNoNvidia();
+        vi.spyOn(node, "requestUrl").mockResolvedValue(
+            releaseResponse([{ tag_name: "v1.0.0", assets: [] }, release("v0.9.0")]),
+        );
+
+        expect((await listReleases()).map((r) => r.tag)).toEqual(["v0.9.0"]);
+    });
+
+    it("falls back to the default build without warning when a CUDA asset is missing", async () => {
+        restore = stubPlatform("linux", "x64");
+        vi.spyOn(node, "execFile").mockResolvedValue({ stdout: "CUDA Version: 12.5", stderr: "" });
+        vi.spyOn(node, "requestUrl").mockResolvedValue(releaseResponse([release("v1.0.0")]));
+        const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        const releases = await listReleases();
+
+        expect(releases[0].variant).toBe("default");
+        expect(warn).not.toHaveBeenCalled();
+        warn.mockRestore();
+    });
+
+    it("throws when GitHub rejects the request", async () => {
+        restore = stubPlatform("linux", "x64");
+        stubNoNvidia();
+        vi.spyOn(node, "requestUrl").mockResolvedValue({ status: 403, json: [], arrayBuffer: new ArrayBuffer(0) });
+
+        await expect(listReleases()).rejects.toThrow("GitHub API responded 403");
     });
 });

--- a/tests/locales/en.test.ts
+++ b/tests/locales/en.test.ts
@@ -28,7 +28,6 @@ describe("MESSAGES", () => {
             expect(MESSAGES.BUTTON_TEST).toBe("Test");
             expect(MESSAGES.BUTTON_RESET_MANAGED).toBe("Reset to managed");
             expect(MESSAGES.BUTTON_RUN_SETUP_WIZARD).toBe("Run setup wizard");
-            expect(MESSAGES.BUTTON_CHECK_UPDATES).toBe("Check for updates");
             expect(MESSAGES.BUTTON_CLEAR_TASKS).toBe("Clear");
             expect(MESSAGES.BUTTON_CLEAR_CHAT).toBe("Clear chat");
             expect(MESSAGES.BUTTON_SEND).toBe("Send");

--- a/tests/main-shared.test.ts
+++ b/tests/main-shared.test.ts
@@ -645,3 +645,166 @@ describe("SHARED_PATH names used by the registry", () => {
         expect(fsState.files.has(expected)).toBe(true);
     });
 });
+
+describe("managed-server uninstall", () => {
+    /** Seed the shared root with a binary, a model cache, and this vault's index. */
+    function seedInstall(plugin: LilbeePlugin): string {
+        const root = plugin.vaultRegistry!.sharedRoot;
+        fsState.dirs.add(`${root}/bin`);
+        fsState.dirs.add(`${root}/models`);
+        fsState.dirs.add(`${root}/vaults/${plugin.vaultId}`);
+        fsState.files.set(`${root}/bin/lilbee`, "x".repeat(10));
+        fsState.files.set(`${root}/models/a.gguf`, "y".repeat(20));
+        fsState.files.set(`${root}/vaults/${plugin.vaultId}/index.db`, "z".repeat(30));
+        return root;
+    }
+
+    it("plans the binary, the models, and this vault's index", async () => {
+        const plugin = await createPlugin();
+        const root = seedInstall(plugin);
+
+        const plan = plugin.planServerUninstall()!;
+
+        expect(plan.targets.map((t) => t.path)).toEqual([
+            `${root}/bin`,
+            `${root}/models`,
+            `${root}/vaults/${plugin.vaultId}`,
+        ]);
+    });
+
+    it("has no plan without a vault registry", async () => {
+        const plugin = await createPlugin();
+        (plugin as any).vaultRegistry = null;
+
+        expect(plugin.planServerUninstall()).toBeNull();
+    });
+
+    it("deletes the planned paths, forgets the version, and remembers the choice", async () => {
+        const plugin = await createPlugin();
+        const root = seedInstall(plugin);
+        plugin.setSharedLilbeeVersion("v0.5.1");
+        const plan = plugin.planServerUninstall()!;
+
+        const freed = await plugin.uninstallServer(plan);
+
+        expect(freed).toBe(plan.totalBytes);
+        expect(fsState.dirs.has(`${root}/bin`)).toBe(false);
+        expect(fsState.dirs.has(`${root}/models`)).toBe(false);
+        expect(plugin.getSharedLilbeeVersion()).toBe("");
+        expect(plugin.isServerUninstalled()).toBe(true);
+        expect(plugin.vaultRegistry!.loadConfig().serverUninstalled).toBe(true);
+    });
+
+    it("stops the running server and releases the shared lock", async () => {
+        const plugin = await createPlugin();
+        seedInstall(plugin);
+        const stop = vi.fn().mockResolvedValue(undefined);
+        (plugin as any).serverManager = { stop };
+        const releaseLock = vi.spyOn(plugin.vaultRegistry!, "releaseLock");
+
+        await plugin.uninstallServer(plugin.planServerUninstall()!);
+
+        expect(stop).toHaveBeenCalled();
+        expect(releaseLock).toHaveBeenCalledWith(plugin.vaultId);
+        expect(plugin.serverManager).toBeNull();
+    });
+
+    it("returns nothing to free without a vault registry", async () => {
+        const plugin = await createPlugin();
+        const plan = plugin.planServerUninstall()!;
+        (plugin as any).vaultRegistry = null;
+
+        expect(await plugin.uninstallServer(plan)).toBe(0);
+    });
+
+    it("never starts the managed server once uninstalled", async () => {
+        const plugin = await createPlugin();
+        seedInstall(plugin);
+        await plugin.uninstallServer(plugin.planServerUninstall()!);
+
+        await plugin.startManagedServer();
+
+        expect(plugin.serverManager).toBeNull();
+    });
+
+    it("skips the automatic server update once uninstalled", async () => {
+        const plugin = await createPlugin();
+        seedInstall(plugin);
+        await plugin.uninstallServer(plugin.planServerUninstall()!);
+        const checkForUpdate = vi.spyOn(plugin, "checkForUpdate");
+
+        await (plugin as any).autoUpdateServerBinary();
+
+        expect(checkForUpdate).not.toHaveBeenCalled();
+    });
+
+    it("remembers the uninstall across a reload", async () => {
+        const plugin = await createPlugin();
+        seedInstall(plugin);
+        await plugin.uninstallServer(plugin.planServerUninstall()!);
+
+        const reloaded = await createPlugin();
+
+        expect(reloaded.isServerUninstalled()).toBe(true);
+    });
+
+    it("installing a release clears the uninstall and downloads it", async () => {
+        const plugin = await createPlugin();
+        seedInstall(plugin);
+        await plugin.uninstallServer(plugin.planServerUninstall()!);
+        const updateServer = vi.spyOn(plugin, "updateServer").mockResolvedValue(undefined);
+        const release = { tag: "v0.5.1", assetUrl: "https://e/dl", variant: "default", sizeBytes: 1, digest: null };
+
+        await plugin.installServer(release as any);
+
+        expect(plugin.isServerUninstalled()).toBe(false);
+        expect(plugin.vaultRegistry!.loadConfig().serverUninstalled).toBe(false);
+        expect(updateServer).toHaveBeenCalledWith(release, undefined);
+    });
+
+    it("tracks whether a binary is on disk", async () => {
+        const plugin = await createPlugin();
+
+        expect(plugin.isServerInstalled()).toBe(true);
+
+        (plugin as any).vaultRegistry = null;
+        expect(plugin.isServerInstalled()).toBe(false);
+    });
+
+    it("keeps the uninstalled flag out of the shared config when there is no registry", async () => {
+        const plugin = await createPlugin();
+        (plugin as any).vaultRegistry = null;
+
+        plugin.setServerUninstalled(true);
+
+        expect(plugin.isServerUninstalled()).toBe(true);
+    });
+});
+
+describe("status bar after an uninstall", () => {
+    it("reads 'server not installed' instead of 'stopped'", async () => {
+        const plugin = await createPlugin();
+        plugin.settings.serverMode = "managed";
+        const texts: string[] = [];
+        (plugin as any).statusBarEl = null;
+        const updateStatusBar = vi
+            .spyOn(plugin as any, "updateStatusBar")
+            .mockImplementation((text: unknown) => texts.push(String(text)));
+
+        plugin.setServerUninstalled(true);
+        (plugin as any).setStatusReady();
+
+        expect(texts).toEqual(["lilbee: server not installed"]);
+        updateStatusBar.mockRestore();
+    });
+
+    it("does not probe a server that is not installed", async () => {
+        const plugin = await createPlugin();
+        plugin.setServerUninstalled(true);
+        const health = vi.spyOn(plugin.api, "health");
+
+        await (plugin as any).probeServerHealth();
+
+        expect(health).not.toHaveBeenCalled();
+    });
+});

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -2,7 +2,7 @@ import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { windowStub } from "./window-stub";
 import { Notice } from "obsidian";
 import { App, MockElement, WorkspaceLeaf } from "./__mocks__/obsidian";
-import { SETUP_OUTCOME, SSE_EVENT } from "../src/types";
+import { DEFAULT_SHARED_CONFIG, SETUP_OUTCOME, SSE_EVENT } from "../src/types";
 import { VaultRegistry } from "../src/vault-registry";
 import { FileProgressTracker } from "../src/main";
 import { MESSAGES } from "../src/locales/en";
@@ -339,6 +339,32 @@ describe("LilbeePlugin", () => {
             } finally {
                 (globalThis as { activeDocument?: unknown }).activeDocument = stash;
             }
+        });
+
+        it("stays out of the way on load when the managed server was uninstalled", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            const loadConfig = vi.spyOn(VaultRegistry.prototype, "loadConfig").mockReturnValue({
+                ...DEFAULT_SHARED_CONFIG,
+                serverUninstalled: true,
+            });
+            const consent = vi.spyOn(plugin, "ensureManagedConsentThenStart");
+
+            await plugin.onload();
+
+            expect(consent).not.toHaveBeenCalled();
+            expect(plugin.isServerUninstalled()).toBe(true);
+            loadConfig.mockRestore();
+        });
+
+        it("starts the managed server on load when it is installed", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            const consent = vi
+                .spyOn(plugin, "ensureManagedConsentThenStart")
+                .mockResolvedValue({ kind: "canceled" } as any);
+
+            await plugin.onload();
+
+            expect(consent).toHaveBeenCalled();
         });
 
         it("swallows duplicate-view-type errors from registerView so a stale view registration doesn't crash onload", async () => {

--- a/tests/server-uninstall.test.ts
+++ b/tests/server-uninstall.test.ts
@@ -1,0 +1,97 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+const { rmSync, existsSync, readdirSync, statSync } = vi.hoisted(() => ({
+    rmSync: vi.fn(),
+    existsSync: vi.fn(),
+    readdirSync: vi.fn(),
+    statSync: vi.fn(),
+}));
+
+vi.mock("../src/binary-manager", () => ({
+    node: {
+        rmSync,
+        existsSync,
+        readdirSync,
+        statSync,
+        join: (...parts: string[]) => parts.join("/"),
+    },
+}));
+
+import { executeUninstall, planUninstall } from "../src/server-uninstall";
+import { UNINSTALL_TARGET } from "../src/types";
+
+/** Mount a flat {path: sizeBytes} filesystem of files, plus the dirs holding them. */
+function mountFiles(files: Record<string, number>): void {
+    const dirs = new Set<string>();
+    for (const path of Object.keys(files)) {
+        const parts = path.split("/");
+        for (let i = 1; i < parts.length; i++) dirs.add(parts.slice(0, i).join("/"));
+    }
+    existsSync.mockImplementation((p: string) => dirs.has(p) || p in files);
+    readdirSync.mockImplementation((p: string) => {
+        const names = new Set<string>();
+        for (const path of [...Object.keys(files), ...dirs]) {
+            if (path.startsWith(`${p}/`)) names.add(path.slice(p.length + 1).split("/")[0]);
+        }
+        return [...names];
+    });
+    statSync.mockImplementation((p: string) => ({
+        isDirectory: () => dirs.has(p),
+        size: files[p] ?? 0,
+    }));
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe("planUninstall", () => {
+    it("sizes the binary, the models, and this vault's index", () => {
+        mountFiles({
+            "/root/bin/lilbee": 400,
+            "/root/models/a.gguf": 1000,
+            "/root/models/nested/b.gguf": 24,
+            "/root/vaults/abc/index.db": 76,
+        });
+
+        const plan = planUninstall("/root", "/root/vaults/abc");
+
+        expect(plan.targets).toEqual([
+            { kind: UNINSTALL_TARGET.BINARY, path: "/root/bin", bytes: 400 },
+            { kind: UNINSTALL_TARGET.MODELS, path: "/root/models", bytes: 1024 },
+            { kind: UNINSTALL_TARGET.INDEX, path: "/root/vaults/abc", bytes: 76 },
+        ]);
+        expect(plan.totalBytes).toBe(1500);
+    });
+
+    it("sizes a missing path as zero rather than failing", () => {
+        mountFiles({});
+
+        const plan = planUninstall("/root", "/root/vaults/abc");
+
+        expect(plan.totalBytes).toBe(0);
+    });
+
+    it("never targets the Obsidian vault itself", () => {
+        mountFiles({ "/root/bin/lilbee": 1 });
+
+        const plan = planUninstall("/root", "/root/vaults/abc");
+
+        expect(plan.targets.map((t) => t.path)).not.toContain("/vault");
+    });
+});
+
+describe("executeUninstall", () => {
+    it("removes every planned path recursively and tolerates missing ones", () => {
+        mountFiles({});
+        const plan = planUninstall("/root", "/root/vaults/abc");
+
+        executeUninstall(plan);
+
+        expect(rmSync.mock.calls).toEqual([
+            ["/root/bin", { recursive: true, force: true }],
+            ["/root/models", { recursive: true, force: true }],
+            ["/root/vaults/abc", { recursive: true, force: true }],
+        ]);
+    });
+});

--- a/tests/settings-vault-sections.test.ts
+++ b/tests/settings-vault-sections.test.ts
@@ -15,6 +15,7 @@ const mockGetLatestRelease = vi.fn();
 const mockCheckForUpdate = vi.fn();
 
 vi.mock("../src/binary-manager", () => ({
+    listReleases: vi.fn(async () => []),
     BinaryManager: vi.fn().mockImplementation(function () {
         return {
             ensureBinary: mockEnsureBinary,
@@ -97,6 +98,10 @@ function makePlugin(settings: Partial<LilbeeSettings> = {}, registry: any = null
         vaultRegistry: registry,
         getSharedLilbeeVersion: () => "",
         setSharedLilbeeVersion: vi.fn(),
+        isServerInstalled: () => true,
+        planServerUninstall: () => ({ targets: [], totalBytes: 0 }),
+        uninstallServer: vi.fn().mockResolvedValue(0),
+        installServer: vi.fn().mockResolvedValue(undefined),
         getSharedHfToken: () => "",
         setSharedHfToken: vi.fn(),
         activeModel: "",

--- a/tests/settings-vault-sections.test.ts
+++ b/tests/settings-vault-sections.test.ts
@@ -99,6 +99,7 @@ function makePlugin(settings: Partial<LilbeeSettings> = {}, registry: any = null
         getSharedLilbeeVersion: () => "",
         setSharedLilbeeVersion: vi.fn(),
         isServerInstalled: () => true,
+        isServerUninstalled: () => false,
         planServerUninstall: () => ({ targets: [], totalBytes: 0 }),
         uninstallServer: vi.fn().mockResolvedValue(0),
         installServer: vi.fn().mockResolvedValue(undefined),

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -12,10 +12,12 @@ import { ConfirmPullModal } from "../src/views/confirm-pull-modal";
 
 const mockGetLatestRelease = vi.fn();
 const mockCheckForUpdate = vi.fn();
+const mockListReleases = vi.fn(async () => [] as unknown[]);
 
 vi.mock("../src/binary-manager", () => ({
     getLatestRelease: (...args: any[]) => mockGetLatestRelease(...args),
     checkForUpdate: (...args: any[]) => mockCheckForUpdate(...args),
+    listReleases: (...args: any[]) => mockListReleases(...args),
     BinaryManager: vi.fn(),
     node: {
         existsSync: vi.fn(() => false),
@@ -41,6 +43,19 @@ vi.mock("../src/binary-manager", () => ({
         }),
         processKill: vi.fn(),
     },
+}));
+
+let mockUninstallConfirmed = true;
+vi.mock("../src/views/uninstall-modal", () => ({
+    UninstallModal: vi.fn().mockImplementation(function () {
+        return {
+            open: vi.fn(),
+            get result() {
+                return Promise.resolve(mockUninstallConfirmed);
+            },
+            close: vi.fn(),
+        };
+    }),
 }));
 
 let mockConfirmResult = true;
@@ -144,6 +159,11 @@ function makePlugin(overrides: Partial<LilbeeSettings> & { lilbeeVersion?: strin
         setSharedLilbeeVersion: (v: string) => {
             sharedVersion = v;
         },
+        isServerInstalled: () => true,
+        planServerUninstall: () => ({ targets: [], totalBytes: 0 }),
+        uninstallServer: vi.fn().mockResolvedValue(0),
+        installServer: vi.fn().mockResolvedValue(undefined),
+        updateServer: vi.fn().mockResolvedValue(undefined),
         getSharedHfToken: () => sharedHfToken,
         setSharedHfToken: (t: string) => {
             sharedHfToken = t;
@@ -239,7 +259,16 @@ interface Captured {
     dropdownSetValues: string[][];
     toggleOnChanges: ToggleOnChange[];
     buttonOnClicks: ButtonOnClick[];
+    buttons: FakeButton[];
     extraButtonOnClicks: ButtonOnClick[];
+}
+
+/** Records what the code under test did to a ButtonComponent. */
+interface FakeButton {
+    /** Name of the Setting row the button belongs to. */
+    name: string;
+    text: string;
+    disabled: boolean;
 }
 
 function captureSettingCallbacks(fn: () => void): Captured {
@@ -252,6 +281,7 @@ function captureSettingCallbacks(fn: () => void): Captured {
     const dropdownSetValues: string[][] = [];
     const toggleOnChanges: ToggleOnChange[] = [];
     const buttonOnClicks: ButtonOnClick[] = [];
+    const buttons: FakeButton[] = [];
     const extraButtonOnClicks: ButtonOnClick[] = [];
 
     const origAddText = Setting.prototype.addText;
@@ -342,6 +372,7 @@ function captureSettingCallbacks(fn: () => void): Captured {
                 setValues.push(v);
                 return fakeDropdown;
             },
+            setDisabled: () => fakeDropdown,
             onChange: (handler: DropdownOnChange) => {
                 dropdownOnChanges.push(handler);
                 return fakeDropdown;
@@ -375,10 +406,19 @@ function captureSettingCallbacks(fn: () => void): Captured {
     };
 
     Setting.prototype.addButton = function (cb: (btn: any) => void) {
+        const record: FakeButton = { name: (this as any)._name ?? "", text: "", disabled: false };
+        buttons.push(record);
         const fakeBtn = {
-            setButtonText: () => fakeBtn,
-            setDisabled: () => fakeBtn,
+            setButtonText: (text: string) => {
+                record.text = text;
+                return fakeBtn;
+            },
+            setDisabled: (disabled: boolean) => {
+                record.disabled = disabled;
+                return fakeBtn;
+            },
             setWarning: () => fakeBtn,
+            buttonEl: new MockElement(),
             setClass: () => fakeBtn,
             onClick: (handler: ButtonOnClick) => {
                 buttonOnClicks.push(handler);
@@ -424,8 +464,16 @@ function captureSettingCallbacks(fn: () => void): Captured {
         dropdownSetValues,
         toggleOnChanges,
         buttonOnClicks,
+        buttons,
         extraButtonOnClicks,
     };
+}
+
+/** Click the button belonging to the Setting row named *name*. */
+async function clickButton(captured: Captured, name: string): Promise<void> {
+    const index = captured.buttons.findIndex((b) => b.name === name);
+    if (index === -1) throw new Error(`no button on a setting named "${name}"`);
+    await captured.buttonOnClicks[index]();
 }
 
 function captureDropdownOptions(fn: () => void): Array<Record<string, string>> {
@@ -756,9 +804,8 @@ describe("LilbeeSettingTab", () => {
             mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { dropdownOnChanges } = captureSettingCallbacks(() => tab.display());
-            // Generation-section chat_mode is the first dropdown rendered there;
-            // 0=serverMode (in connection), 1=chat_mode (in generation).
-            await dropdownOnChanges[1]("chat");
+            // 0=serverMode, 1=server version (both in connection), 2=chat_mode (in generation).
+            await dropdownOnChanges[2]("chat");
             expect(plugin.api.updateConfig).toHaveBeenCalledWith({ chat_mode: "chat" });
         });
 
@@ -769,7 +816,7 @@ describe("LilbeeSettingTab", () => {
             mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { dropdownOnChanges } = captureSettingCallbacks(() => tab.display());
-            await dropdownOnChanges[1]("chat");
+            await dropdownOnChanges[2]("chat");
             expect(Notice.instances.some((n) => n.message.includes("Chat mode"))).toBe(true);
         });
 
@@ -934,8 +981,9 @@ describe("LilbeeSettingTab", () => {
             const tab = makeTab(plugin);
             const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
-            // Setup wizard + Start + Check for updates + Refresh + Browse Catalog + Wiki Lint + Wiki Prune + Export diagnostics + Reset all = 9
-            expect(buttonOnClicks.length).toBe(9);
+            // Setup wizard + Start + Server version + Refresh + Browse Catalog + Wiki Lint + Wiki Prune
+            // + Export diagnostics + Reset all + Uninstall server = 10
+            expect(buttonOnClicks.length).toBe(10);
             // Refresh is the fourth button (index 3)
             await expect(buttonOnClicks[3]()).resolves.not.toThrow();
         });
@@ -2229,94 +2277,78 @@ describe("managed mode settings", () => {
         expect(plugin.saveSettings).toHaveBeenCalled();
         expect(displaySpy).toHaveBeenCalled();
     });
+    const RELEASES = [
+        { tag: "v0.3.0", assetUrl: "https://example.com/3", variant: "default", sizeBytes: 266000000, digest: null },
+        { tag: "v0.2.0", assetUrl: "https://example.com/2", variant: "default", sizeBytes: 265000000, digest: null },
+        { tag: "v0.1.0", assetUrl: "https://example.com/1", variant: "default", sizeBytes: 264000000, digest: null },
+    ];
 
-    it("check for updates button offers update when newer version exists", async () => {
-        Notice.clear();
+    /** The release list loads asynchronously; let its promise settle. */
+    async function settleReleases(): Promise<void> {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    }
 
-        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.1.0" });
-        (plugin as any).checkForUpdate = vi
-            .fn()
-            .mockResolvedValue({ available: true, release: { tag: "v0.2.0", assetUrl: "https://example.com" } });
+    it("version dropdown offers the recent releases newest first", async () => {
+        mockListReleases.mockResolvedValue(RELEASES);
+        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.2.0" });
         mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
-        const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+        const { dropdownOptions } = captureSettingCallbacks(() => tab.display());
+        await settleReleases();
 
-        // buttonOnClicks[0] = Setup wizard, [1] = Start (server controls), [2] = Check for updates
-        await buttonOnClicks[2]();
-
-        // No notice on check — button transforms to "Update to vX.Y.Z" instead
-        expect(Notice.instances.some((n) => n.message.includes("update available"))).toBe(false);
+        // dropdownOptions[0] is the server-mode dropdown; [1] is the version picker.
+        expect(Object.keys(dropdownOptions[1])).toEqual(["v0.3.0", "v0.2.0", "v0.1.0"]);
     });
 
-    it("51g: check for updates with no newer version surfaces a 'up to date' Notice naming the current version", async () => {
-        Notice.clear();
-
-        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.1.0" });
-        (plugin as any).checkForUpdate = vi.fn().mockResolvedValue({ available: false });
+    it("selecting an older release turns the button into a downgrade", async () => {
+        mockListReleases.mockResolvedValue(RELEASES);
+        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.2.0" });
         mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
-        const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+        const { dropdownOnChanges, buttons } = captureSettingCallbacks(() => tab.display());
+        await settleReleases();
+        dropdownOnChanges[1]("v0.1.0");
 
-        // buttonOnClicks[0] = Setup wizard, [1] = Start, [2] = Check for updates
-        await buttonOnClicks[2]();
-
-        // Notice mentions the current version so the click visibly registered.
-        expect(Notice.instances.some((n) => n.message.includes("up to date") && n.message.includes("v0.1.0"))).toBe(
-            true,
-        );
+        expect(buttons[2].text).toBe("Downgrade to v0.1.0");
     });
 
-    it("51g: check for updates with no version persisted falls back to a generic 'unknown version' label", async () => {
-        Notice.clear();
-
-        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "" });
-        (plugin as any).checkForUpdate = vi.fn().mockResolvedValue({ available: false });
+    it("selecting a newer release turns the button into an update", async () => {
+        mockListReleases.mockResolvedValue(RELEASES);
+        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.2.0" });
         mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
-        const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+        const { dropdownOnChanges, buttons } = captureSettingCallbacks(() => tab.display());
+        await settleReleases();
+        dropdownOnChanges[1]("v0.3.0");
 
-        await buttonOnClicks[2]();
-
-        expect(Notice.instances.some((n) => n.message.includes("unknown version"))).toBe(true);
+        expect(buttons[2].text).toBe("Update to v0.3.0");
     });
 
-    it("update button calls updateServer and shows success notice", async () => {
-        Notice.clear();
-
-        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.1.0" });
-        (plugin as any).checkForUpdate = vi
-            .fn()
-            .mockResolvedValue({ available: true, release: { tag: "v0.2.0", assetUrl: "https://example.com" } });
-        (plugin as any).updateServer = vi
-            .fn()
-            .mockImplementation(async (_release: any, onProgress?: (msg: string) => void) => {
-                onProgress?.("Downloading...");
-            });
+    it("the installed release reads Reinstall and installs the same tag", async () => {
+        mockListReleases.mockResolvedValue(RELEASES);
+        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.3.0" });
+        const updateServer = vi.fn().mockResolvedValue(undefined);
+        (plugin as any).updateServer = updateServer;
         mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
-        const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+        const { buttonOnClicks, buttons } = captureSettingCallbacks(() => tab.display());
+        await settleReleases();
+        expect(buttons[2].text).toBe("Reinstall");
 
-        // First click: check for updates (sets pendingRelease)
-        await buttonOnClicks[2]();
-        // Same handler clicked again: now triggers update via pendingRelease
+        vi.spyOn(tab, "render").mockImplementation(() => {});
         await buttonOnClicks[2]();
 
-        expect((plugin as any).updateServer).toHaveBeenCalled();
-        expect(Notice.instances.some((n) => n.message.includes("updated to v0.2.0"))).toBe(true);
+        expect(updateServer.mock.calls[0][0].tag).toBe("v0.3.0");
     });
 
     it("update progress panel surfaces the phase message and the total download size", async () => {
         Notice.clear();
-
-        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.1.0" });
-        (plugin as any).checkForUpdate = vi.fn().mockResolvedValue({
-            available: true,
-            release: { tag: "v0.2.0", assetUrl: "https://example.com", variant: "default", sizeBytes: 266000000 },
-        });
+        mockListReleases.mockResolvedValue(RELEASES);
+        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.2.0" });
         (plugin as any).updateServer = vi
             .fn()
             .mockImplementation(async (_release: any, onProgress?: (msg: string) => void) => {
@@ -2325,79 +2357,71 @@ describe("managed mode settings", () => {
         mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
-        const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+        const { dropdownOnChanges, buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+        await settleReleases();
+        dropdownOnChanges[1]("v0.3.0");
         // Stop the post-update re-render so the in-progress panel persists for assertion.
         const displaySpy = vi.spyOn(tab, "render").mockImplementation(() => {});
 
-        await buttonOnClicks[2](); // check → sets pendingRelease
-        await buttonOnClicks[2](); // update → drives the progress panel
+        await buttonOnClicks[2]();
 
         const panel = tab.containerEl.find("lilbee-update-progress")!;
         expect(panel.style.display).toBe("");
         expect(panel.find("lilbee-update-progress-phase")!.textContent).toBe("Downloading...");
-        expect(panel.find("lilbee-update-progress-size")!.textContent).toBe("Updating to v0.2.0 · 266 MB download");
+        expect(panel.find("lilbee-update-progress-size")!.textContent).toBe("Updating to v0.3.0 · 266 MB download");
         displaySpy.mockRestore();
     });
 
-    it("update button does not add duplicate click handlers", async () => {
+    it("a failed install surfaces the reason and restores the button label", async () => {
         Notice.clear();
-
-        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.1.0" });
-        (plugin as any).checkForUpdate = vi
-            .fn()
-            .mockResolvedValue({ available: true, release: { tag: "v0.2.0", assetUrl: "https://example.com" } });
-        mockChatPicker(plugin);
-        const tab = makeTab(plugin);
-
-        const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
-        const countBefore = buttonOnClicks.length;
-
-        // Click check for updates — should NOT add a new handler
-        await buttonOnClicks[2]();
-
-        expect(buttonOnClicks.length).toBe(countBefore);
-    });
-
-    it("update button shows failure notice when updateServer throws", async () => {
-        Notice.clear();
-
-        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.1.0" });
-        (plugin as any).checkForUpdate = vi.fn().mockResolvedValue({
-            available: true,
-            release: { tag: "v0.2.0", assetUrl: "https://example.com", variant: "default", sizeBytes: 262144000 },
-        });
+        mockListReleases.mockResolvedValue(RELEASES);
+        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.2.0" });
         (plugin as any).updateServer = vi
             .fn()
             .mockRejectedValue(new Error("Not enough disk space for the lilbee server"));
         mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
-        const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+        const { dropdownOnChanges, buttonOnClicks, buttons } = captureSettingCallbacks(() => tab.display());
+        await settleReleases();
+        dropdownOnChanges[1]("v0.1.0");
 
-        // First click: check (sets pendingRelease); second click: update (fails)
-        await buttonOnClicks[2]();
         await buttonOnClicks[2]();
 
-        // The notice surfaces the actual reason (e.g. disk space), not just a generic failure.
         expect(Notice.instances.some((n) => n.message.includes("Not enough disk space"))).toBe(true);
-        // A failed update collapses the progress panel rather than leaving a dead bar up.
+        // A failed install collapses the progress panel rather than leaving a dead bar up.
         expect(tab.containerEl.find("lilbee-update-progress")!.style.display).toBe("none");
+        expect(buttons[2].text).toBe("Downgrade to v0.1.0");
     });
 
-    it("check for updates button shows error on failure", async () => {
-        Notice.clear();
+    it("an unreachable GitHub leaves the version button disabled and says so", async () => {
+        mockListReleases.mockRejectedValue(new Error("network error"));
+        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.2.0" });
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
 
-        const plugin = makePlugin({ serverMode: "managed" });
-        (plugin as any).checkForUpdate = vi.fn().mockRejectedValue(new Error("network error"));
+        const setDesc = vi.spyOn(Setting.prototype, "setDesc");
+        const { buttons } = captureSettingCallbacks(() => tab.display());
+        await settleReleases();
+
+        expect(buttons[2].disabled).toBe(true);
+        expect(setDesc.mock.calls.some(([desc]) => String(desc).includes("could not be read from GitHub"))).toBe(true);
+        setDesc.mockRestore();
+    });
+
+    it("clicking the version button with no matching release does nothing", async () => {
+        mockListReleases.mockResolvedValue([]);
+        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.2.0" });
+        const updateServer = vi.fn();
+        (plugin as any).updateServer = updateServer;
         mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
         const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
-
-        // buttonOnClicks[0] = Setup wizard, [1] = Start, [2] = Check for updates
+        await settleReleases();
         await buttonOnClicks[2]();
 
-        expect(Notice.instances.some((n) => n.message.includes("could not check"))).toBe(true);
+        expect(updateServer).not.toHaveBeenCalled();
     });
 
     it("renders server status indicator in managed mode", () => {
@@ -3567,10 +3591,10 @@ describe("managed mode settings", () => {
             const plugin = makePlugin();
             mockChatPicker(plugin);
             const tab = makeTab(plugin);
-            const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+            const captured = captureSettingCallbacks(() => tab.display());
             (tab as any).configDefaults = { chunk_size: 512 };
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockClear();
-            await buttonOnClicks[buttonOnClicks.length - 1]();
+            await clickButton(captured, MESSAGES.LABEL_RESET_ALL_SETTINGS);
             expect(plugin.api.updateConfig).not.toHaveBeenCalled();
             mockGenericConfirmResult = true;
         });
@@ -3581,7 +3605,7 @@ describe("managed mode settings", () => {
             const plugin = makePlugin();
             mockChatPicker(plugin);
             const tab = makeTab(plugin);
-            const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+            const captured = captureSettingCallbacks(() => tab.display());
             (tab as any).configDefaults = {
                 chunk_size: 512,
                 crawl_max_depth: 2,
@@ -3589,7 +3613,7 @@ describe("managed mode settings", () => {
                 hf_token: "",
             };
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockClear();
-            await buttonOnClicks[buttonOnClicks.length - 1]();
+            await clickButton(captured, MESSAGES.LABEL_RESET_ALL_SETTINGS);
             expect(plugin.api.updateConfig).toHaveBeenCalledWith({ chunk_size: 512, crawl_max_depth: 2 });
             expect(Notice.instances.some((n) => n.message.includes("reset to defaults"))).toBe(true);
         });
@@ -3599,10 +3623,10 @@ describe("managed mode settings", () => {
             const plugin = makePlugin();
             mockChatPicker(plugin);
             const tab = makeTab(plugin);
-            const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+            const captured = captureSettingCallbacks(() => tab.display());
             (tab as any).configDefaults = { openai_api_key: "", hf_token: "" };
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockClear();
-            await buttonOnClicks[buttonOnClicks.length - 1]();
+            await clickButton(captured, MESSAGES.LABEL_RESET_ALL_SETTINGS);
             expect(plugin.api.updateConfig).not.toHaveBeenCalled();
         });
 
@@ -3613,9 +3637,9 @@ describe("managed mode settings", () => {
             mockChatPicker(plugin);
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("boom"));
             const tab = makeTab(plugin);
-            const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+            const captured = captureSettingCallbacks(() => tab.display());
             (tab as any).configDefaults = { chunk_size: 512 };
-            await buttonOnClicks[buttonOnClicks.length - 1]();
+            await clickButton(captured, MESSAGES.LABEL_RESET_ALL_SETTINGS);
             expect(Notice.instances.some((n) => n.message.includes("failed to reset"))).toBe(true);
         });
     });
@@ -4214,12 +4238,9 @@ describe("managed mode settings", () => {
             (plugin as any).wikiEnabled = true;
             mockChatPicker(plugin);
             const tab = makeTab(plugin);
-            const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+            const captured = captureSettingCallbacks(() => tab.display());
 
-            // Wiki section renders before the Diagnostics and Advanced sections, so lint/prune sit
-            // 4th/3rd from the end: … lint, prune, export-diagnostics, reset-all.
-            const lintIdx = buttonOnClicks.length - 4;
-            await buttonOnClicks[lintIdx]();
+            await clickButton(captured, MESSAGES.LABEL_WIKI_RUN_LINT);
             expect(plugin.runWikiLint).toHaveBeenCalled();
         });
 
@@ -4228,10 +4249,9 @@ describe("managed mode settings", () => {
             (plugin as any).wikiEnabled = true;
             mockChatPicker(plugin);
             const tab = makeTab(plugin);
-            const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+            const captured = captureSettingCallbacks(() => tab.display());
 
-            const pruneIdx = buttonOnClicks.length - 3;
-            await buttonOnClicks[pruneIdx]();
+            await clickButton(captured, MESSAGES.LABEL_WIKI_RUN_PRUNE);
             expect(plugin.runWikiPrune).toHaveBeenCalled();
         });
 
@@ -6173,6 +6193,7 @@ describe("managed mode settings", () => {
                     setButtonText: () => fakeBtn,
                     setDisabled: () => fakeBtn,
                     setWarning: () => fakeBtn,
+                    buttonEl: new MockElement(),
                     setClass: () => fakeBtn,
                     onClick: (handler: ButtonOnClick) => {
                         buttonOnClicks.push(handler);
@@ -6887,6 +6908,7 @@ describe("Export diagnostics button", () => {
                 setButtonText: () => fakeBtn,
                 setDisabled: () => fakeBtn,
                 setWarning: () => fakeBtn,
+                buttonEl: new MockElement(),
                 setClass: () => fakeBtn,
                 onClick: (handler: () => unknown) => {
                     namedButtons.push({ name, onClick: handler });
@@ -6908,5 +6930,257 @@ describe("Export diagnostics button", () => {
 
         expect(plugin.diagnosticsContext).toHaveBeenCalledTimes(1);
         expect(exportDiagnostics).toHaveBeenCalledWith(ctx);
+    });
+});
+
+describe("managed-mode uninstall section", () => {
+    const PLAN = {
+        targets: [{ kind: "binary", path: "/root/bin", bytes: 412_000_000 }],
+        totalBytes: 13_632_000_000,
+    };
+
+    beforeEach(() => {
+        Notice.clear();
+        mockUninstallConfirmed = true;
+        mockListReleases.mockResolvedValue([]);
+    });
+
+    it("names the freed space and warns that removing the plugin leaves the server behind", () => {
+        const plugin = makePlugin({ serverMode: "managed" });
+        (plugin as any).planServerUninstall = () => PLAN;
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+
+        const captured = captureSettingCallbacks(() => tab.display());
+
+        const uninstall = captured.buttons.find((b) => b.name === MESSAGES.LABEL_UNINSTALL_SERVER);
+        expect(uninstall?.text).toBe("Uninstall server");
+        const callout = tab.containerEl.find("lilbee-uninstall-callout");
+        expect(callout?.textContent).toContain("Removing the plugin does not remove the server");
+    });
+
+    it("uninstalls and reports the freed space when the user confirms", async () => {
+        const plugin = makePlugin({ serverMode: "managed" });
+        (plugin as any).planServerUninstall = () => PLAN;
+        const uninstallServer = vi.fn().mockResolvedValue(13_632_000_000);
+        (plugin as any).uninstallServer = uninstallServer;
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+
+        const captured = captureSettingCallbacks(() => tab.display());
+        vi.spyOn(tab, "render").mockImplementation(() => {});
+        await clickButton(captured, MESSAGES.LABEL_UNINSTALL_SERVER);
+
+        expect(uninstallServer).toHaveBeenCalledWith(PLAN);
+        expect(Notice.instances.some((n) => n.message.includes("13.6 GB freed"))).toBe(true);
+    });
+
+    it("does nothing when the user cancels", async () => {
+        mockUninstallConfirmed = false;
+        const plugin = makePlugin({ serverMode: "managed" });
+        (plugin as any).planServerUninstall = () => PLAN;
+        const uninstallServer = vi.fn();
+        (plugin as any).uninstallServer = uninstallServer;
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+
+        const captured = captureSettingCallbacks(() => tab.display());
+        await clickButton(captured, MESSAGES.LABEL_UNINSTALL_SERVER);
+
+        expect(uninstallServer).not.toHaveBeenCalled();
+    });
+
+    it("surfaces the reason when the uninstall fails", async () => {
+        const plugin = makePlugin({ serverMode: "managed" });
+        (plugin as any).planServerUninstall = () => PLAN;
+        (plugin as any).uninstallServer = vi.fn().mockRejectedValue(new Error("permission denied"));
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+
+        const captured = captureSettingCallbacks(() => tab.display());
+        vi.spyOn(tab, "render").mockImplementation(() => {});
+        await clickButton(captured, MESSAGES.LABEL_UNINSTALL_SERVER);
+
+        expect(Notice.instances.some((n) => n.message.includes("permission denied"))).toBe(true);
+    });
+
+    it("is skipped when there is nothing to plan", () => {
+        const plugin = makePlugin({ serverMode: "managed" });
+        (plugin as any).planServerUninstall = () => null;
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+
+        const captured = captureSettingCallbacks(() => tab.display());
+
+        expect(captured.buttons.some((b) => b.name === MESSAGES.LABEL_UNINSTALL_SERVER)).toBe(false);
+    });
+
+    it("is absent in external mode", () => {
+        const plugin = makePlugin({ serverMode: "external" });
+        (plugin as any).planServerUninstall = () => PLAN;
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+
+        const captured = captureSettingCallbacks(() => tab.display());
+
+        expect(captured.buttons.some((b) => b.name === MESSAGES.LABEL_UNINSTALL_SERVER)).toBe(false);
+        expect(tab.containerEl.find("lilbee-uninstall-callout")).toBeNull();
+    });
+});
+
+describe("managed mode with no server installed", () => {
+    const RELEASES = [
+        { tag: "v0.3.0", assetUrl: "https://e/3", variant: "default", sizeBytes: 412_000_000, digest: null },
+        { tag: "v0.2.0", assetUrl: "https://e/2", variant: "default", sizeBytes: 410_000_000, digest: null },
+    ];
+
+    async function settle(): Promise<void> {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    function makeUninstalledPlugin() {
+        const plugin = makePlugin({ serverMode: "managed" });
+        (plugin as any).isServerInstalled = () => false;
+        mockChatPicker(plugin);
+        return plugin;
+    }
+
+    beforeEach(() => {
+        Notice.clear();
+        mockListReleases.mockResolvedValue(RELEASES);
+    });
+
+    it("explains that the server is missing and offers to install the newest release", async () => {
+        const plugin = makeUninstalledPlugin();
+        const tab = makeTab(plugin);
+
+        const captured = captureSettingCallbacks(() => tab.display());
+        await settle();
+
+        const install = captured.buttons.find((b) => b.name === MESSAGES.LABEL_INSTALL_SERVER)!;
+        expect(install.text).toBe("Install server");
+        expect(install.disabled).toBe(false);
+        expect(Object.keys(captured.dropdownOptions[1])).toEqual(["v0.3.0", "v0.2.0"]);
+    });
+
+    it("hides the uninstall section while nothing is installed", async () => {
+        const plugin = makeUninstalledPlugin();
+        const tab = makeTab(plugin);
+
+        const captured = captureSettingCallbacks(() => tab.display());
+        await settle();
+
+        expect(captured.buttons.some((b) => b.name === MESSAGES.LABEL_UNINSTALL_SERVER)).toBe(false);
+    });
+
+    it("installs the selected release and announces it", async () => {
+        const plugin = makeUninstalledPlugin();
+        const installServer = vi.fn().mockResolvedValue(undefined);
+        (plugin as any).installServer = installServer;
+        const tab = makeTab(plugin);
+
+        const captured = captureSettingCallbacks(() => tab.display());
+        await settle();
+        captured.dropdownOnChanges[1]("v0.2.0");
+        vi.spyOn(tab, "render").mockImplementation(() => {});
+        await clickButton(captured, MESSAGES.LABEL_INSTALL_SERVER);
+
+        expect(installServer.mock.calls[0][0].tag).toBe("v0.2.0");
+        expect(Notice.instances.some((n) => n.message.includes("v0.2.0 installed"))).toBe(true);
+    });
+
+    it("surfaces the phase and size while installing", async () => {
+        const plugin = makeUninstalledPlugin();
+        (plugin as any).installServer = vi
+            .fn()
+            .mockImplementation(async (_r: any, onProgress?: (msg: string) => void) => {
+                onProgress?.("Downloading...");
+            });
+        const tab = makeTab(plugin);
+
+        const captured = captureSettingCallbacks(() => tab.display());
+        await settle();
+        vi.spyOn(tab, "render").mockImplementation(() => {});
+        await clickButton(captured, MESSAGES.LABEL_INSTALL_SERVER);
+
+        const panel = tab.containerEl.find("lilbee-update-progress")!;
+        expect(panel.find("lilbee-update-progress-phase")!.textContent).toBe("Downloading...");
+        expect(panel.find("lilbee-update-progress-size")!.textContent).toBe("Updating to v0.3.0 · 412 MB download");
+    });
+
+    it("restores the install button when the download fails", async () => {
+        const plugin = makeUninstalledPlugin();
+        (plugin as any).installServer = vi.fn().mockRejectedValue(new Error("Not enough disk space"));
+        const tab = makeTab(plugin);
+
+        const captured = captureSettingCallbacks(() => tab.display());
+        await settle();
+        await clickButton(captured, MESSAGES.LABEL_INSTALL_SERVER);
+
+        expect(Notice.instances.some((n) => n.message.includes("Not enough disk space"))).toBe(true);
+        expect(tab.containerEl.find("lilbee-update-progress")!.style.display).toBe("none");
+        const install = captured.buttons.find((b) => b.name === MESSAGES.LABEL_INSTALL_SERVER)!;
+        expect(install.text).toBe("Install server");
+        expect(install.disabled).toBe(false);
+    });
+
+    it("does nothing when clicked before the release list arrives", async () => {
+        mockListReleases.mockResolvedValue([]);
+        const plugin = makeUninstalledPlugin();
+        const installServer = vi.fn();
+        (plugin as any).installServer = installServer;
+        const tab = makeTab(plugin);
+
+        const captured = captureSettingCallbacks(() => tab.display());
+        await settle();
+        await clickButton(captured, MESSAGES.LABEL_INSTALL_SERVER);
+
+        expect(installServer).not.toHaveBeenCalled();
+    });
+
+    it("says so when the release list cannot be read", async () => {
+        mockListReleases.mockRejectedValue(new Error("offline"));
+        const plugin = makeUninstalledPlugin();
+        const tab = makeTab(plugin);
+        const setDesc = vi.spyOn(Setting.prototype, "setDesc");
+
+        const captured = captureSettingCallbacks(() => tab.display());
+        await settle();
+
+        expect(setDesc.mock.calls.some(([d]) => String(d) === MESSAGES.ERROR_RELEASE_LIST)).toBe(true);
+        expect(captured.buttons.find((b) => b.name === MESSAGES.LABEL_INSTALL_SERVER)!.disabled).toBe(true);
+        setDesc.mockRestore();
+    });
+});
+
+describe("version picker when the installed tag is unknown to GitHub", () => {
+    it("selects the newest release instead", async () => {
+        mockListReleases.mockResolvedValue([
+            { tag: "v0.3.0", assetUrl: "https://e/3", variant: "default", sizeBytes: 1, digest: null },
+        ]);
+        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v9.9.9-local" });
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+
+        const { dropdownSetValues } = captureSettingCallbacks(() => tab.display());
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(dropdownSetValues[1]).toContain("v0.3.0");
+    });
+});
+
+describe("version picker with no version recorded", () => {
+    it("says the version is unknown when GitHub cannot be reached", async () => {
+        mockListReleases.mockRejectedValue(new Error("offline"));
+        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "" });
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+        const setDesc = vi.spyOn(Setting.prototype, "setDesc");
+
+        captureSettingCallbacks(() => tab.display());
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(setDesc.mock.calls.some(([d]) => String(d) === MESSAGES.DESC_SERVER_VERSION_UNKNOWN)).toBe(true);
+        setDesc.mockRestore();
     });
 });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -160,6 +160,7 @@ function makePlugin(overrides: Partial<LilbeeSettings> & { lilbeeVersion?: strin
             sharedVersion = v;
         },
         isServerInstalled: () => true,
+        isServerUninstalled: () => false,
         planServerUninstall: () => ({ targets: [], totalBytes: 0 }),
         uninstallServer: vi.fn().mockResolvedValue(0),
         installServer: vi.fn().mockResolvedValue(undefined),
@@ -7047,6 +7048,20 @@ describe("managed mode with no server installed", () => {
         mockChatPicker(plugin);
         return plugin;
     }
+
+    it("offers to install even when a binary was put back by hand", async () => {
+        const plugin = makePlugin({ serverMode: "managed" });
+        (plugin as any).isServerInstalled = () => true;
+        (plugin as any).isServerUninstalled = () => true;
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+
+        const captured = captureSettingCallbacks(() => tab.display());
+        await settle();
+
+        expect(captured.buttons.some((b) => b.name === MESSAGES.LABEL_INSTALL_SERVER)).toBe(true);
+        expect(captured.buttons.some((b) => b.name === MESSAGES.LABEL_UNINSTALL_SERVER)).toBe(false);
+    });
 
     beforeEach(() => {
         Notice.clear();

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -2289,6 +2289,21 @@ describe("managed mode settings", () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
     }
 
+    it("warns that only the latest server release is supported", () => {
+        mockListReleases.mockResolvedValue(RELEASES);
+        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.2.0" });
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+        const setAttribute = vi.spyOn(MockElement.prototype, "setAttribute");
+
+        tab.display();
+
+        const tooltips = setAttribute.mock.calls.filter(([name]) => name === "title").map(([, value]) => value);
+        expect(tooltips).toContain(MESSAGES.TOOLTIP_SERVER_VERSION_SUPPORT);
+        expect(MESSAGES.TOOLTIP_SERVER_VERSION_SUPPORT).toContain("not supported");
+        setAttribute.mockRestore();
+    });
+
     it("version dropdown offers the recent releases newest first", async () => {
         mockListReleases.mockResolvedValue(RELEASES);
         const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.2.0" });

--- a/tests/utils/server-version.test.ts
+++ b/tests/utils/server-version.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { versionActionFor, versionButtonLabel, versionDescription } from "../../src/utils/server-version";
+import { VERSION_ACTION } from "../../src/types";
+
+const TAGS = ["v0.3.0", "v0.2.0", "v0.1.0"];
+
+describe("versionActionFor", () => {
+    it("reads the installed tag as a reinstall", () => {
+        expect(versionActionFor(TAGS, "v0.2.0", "v0.2.0")).toBe(VERSION_ACTION.REINSTALL);
+    });
+
+    it("reads a newer tag as an update", () => {
+        expect(versionActionFor(TAGS, "v0.2.0", "v0.3.0")).toBe(VERSION_ACTION.UPDATE);
+    });
+
+    it("reads an older tag as a downgrade", () => {
+        expect(versionActionFor(TAGS, "v0.2.0", "v0.1.0")).toBe(VERSION_ACTION.DOWNGRADE);
+    });
+
+    it("falls back to a plain install when the installed tag is not in the list", () => {
+        expect(versionActionFor(TAGS, "v0.0.9", "v0.1.0")).toBe(VERSION_ACTION.INSTALL);
+    });
+
+    it("falls back to a plain install when the selected tag is not in the list", () => {
+        expect(versionActionFor(TAGS, "v0.2.0", "v9.9.9")).toBe(VERSION_ACTION.INSTALL);
+    });
+});
+
+describe("versionButtonLabel", () => {
+    it("names the action for every variant", () => {
+        expect(versionButtonLabel(VERSION_ACTION.REINSTALL, "v0.2.0")).toBe("Reinstall");
+        expect(versionButtonLabel(VERSION_ACTION.UPDATE, "v0.3.0")).toBe("Update to v0.3.0");
+        expect(versionButtonLabel(VERSION_ACTION.DOWNGRADE, "v0.1.0")).toBe("Downgrade to v0.1.0");
+        expect(versionButtonLabel(VERSION_ACTION.INSTALL, "v0.1.0")).toBe("Install v0.1.0");
+    });
+});
+
+describe("versionDescription", () => {
+    it("says nothing is known when no version is installed", () => {
+        expect(versionDescription(VERSION_ACTION.INSTALL, "", "v0.1.0", false)).toBe("Unknown");
+    });
+
+    it("calls the installed-and-newest case the latest release", () => {
+        expect(versionDescription(VERSION_ACTION.REINSTALL, "v0.3.0", "v0.3.0", true)).toBe(
+            "v0.3.0 installed. This is the latest release.",
+        );
+    });
+
+    it("points out newer releases when reinstalling an older build", () => {
+        expect(versionDescription(VERSION_ACTION.REINSTALL, "v0.2.0", "v0.2.0", false)).toBe(
+            "v0.2.0 installed. Newer releases are available.",
+        );
+    });
+
+    it("names the available release when updating", () => {
+        expect(versionDescription(VERSION_ACTION.UPDATE, "v0.2.0", "v0.3.0", false)).toBe(
+            "v0.2.0 installed. v0.3.0 is available.",
+        );
+    });
+
+    it("warns that a downgrade replaces the build", () => {
+        expect(versionDescription(VERSION_ACTION.DOWNGRADE, "v0.2.0", "v0.1.0", false)).toBe(
+            "v0.2.0 installed. Downgrading replaces it with an older build.",
+        );
+    });
+
+    it("states the installed tag plainly for an unordered install", () => {
+        expect(versionDescription(VERSION_ACTION.INSTALL, "v0.0.9", "v0.1.0", false)).toBe("v0.0.9 installed.");
+    });
+});

--- a/tests/vault-registry.test.ts
+++ b/tests/vault-registry.test.ts
@@ -148,6 +148,7 @@ describe("VaultRegistry.loadConfig", () => {
             lilbeeVariant: "",
             hfToken: "",
             lastUpdateCheckPluginVersion: "",
+            serverUninstalled: false,
         });
     });
 
@@ -160,6 +161,7 @@ describe("VaultRegistry.loadConfig", () => {
             lilbeeVariant: "",
             hfToken: "",
             lastUpdateCheckPluginVersion: "",
+            serverUninstalled: false,
         });
     });
 
@@ -172,6 +174,7 @@ describe("VaultRegistry.loadConfig", () => {
             lilbeeVariant: "",
             hfToken: "",
             lastUpdateCheckPluginVersion: "",
+            serverUninstalled: false,
         });
     });
 });
@@ -187,6 +190,7 @@ describe("VaultRegistry.saveConfig", () => {
             lilbeeVariant: "cu125",
             hfToken: "tok",
             lastUpdateCheckPluginVersion: "",
+            serverUninstalled: false,
         });
         expect(fs.exists("/r/config.json")).toBe(true);
         expect(fs.exists("/r/config.json.tmp")).toBe(false);
@@ -195,6 +199,7 @@ describe("VaultRegistry.saveConfig", () => {
             lilbeeVariant: "cu125",
             hfToken: "tok",
             lastUpdateCheckPluginVersion: "",
+            serverUninstalled: false,
         });
     });
 
@@ -206,6 +211,7 @@ describe("VaultRegistry.saveConfig", () => {
             lilbeeVariant: "",
             hfToken: "",
             lastUpdateCheckPluginVersion: "",
+            serverUninstalled: false,
         });
         expect(fs.dirs.has("/r")).toBe(true);
     });

--- a/tests/views/uninstall-modal.test.ts
+++ b/tests/views/uninstall-modal.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { App } from "obsidian";
+import { MockElement } from "../__mocks__/obsidian";
+import { UninstallModal } from "../../src/views/uninstall-modal";
+import { UNINSTALL_TARGET, type UninstallPlan } from "../../src/types";
+
+function collectTexts(el: MockElement): string[] {
+    const texts: string[] = [el.textContent];
+    for (const child of el.children) texts.push(...collectTexts(child));
+    return texts;
+}
+
+function findButtons(el: MockElement): MockElement[] {
+    const buttons: MockElement[] = [];
+    if (el.tagName === "BUTTON") buttons.push(el);
+    for (const child of el.children) buttons.push(...findButtons(child));
+    return buttons;
+}
+
+const PLAN: UninstallPlan = {
+    targets: [
+        { kind: UNINSTALL_TARGET.BINARY, path: "/root/bin", bytes: 412_000_000 },
+        { kind: UNINSTALL_TARGET.MODELS, path: "/root/models", bytes: 12_400_000_000 },
+        { kind: UNINSTALL_TARGET.INDEX, path: "/root/vaults/abc", bytes: 820_000_000 },
+    ],
+    totalBytes: 13_632_000_000,
+};
+
+function open(plan: UninstallPlan = PLAN) {
+    const modal = new UninstallModal(new App() as any, plan);
+    modal.onOpen();
+    return modal;
+}
+
+describe("UninstallModal", () => {
+    it("names and sizes every path it will delete", () => {
+        const texts = collectTexts(open().contentEl as unknown as MockElement);
+
+        expect(texts).toContain("Server executable");
+        expect(texts).toContain("412 MB");
+        expect(texts).toContain("Downloaded models");
+        expect(texts).toContain("12.4 GB");
+        expect(texts).toContain("Search index for this vault");
+        expect(texts).toContain("820 MB");
+    });
+
+    it("promises the vault is untouched", () => {
+        const contentEl = open().contentEl as unknown as MockElement;
+
+        expect(collectTexts(contentEl)).toContain("Your notes and attachments");
+        expect(contentEl.findAll("is-keep")).toHaveLength(1);
+    });
+
+    it("resolves true when the user confirms", async () => {
+        const modal = open();
+        const buttons = findButtons(modal.contentEl as unknown as MockElement);
+
+        buttons.find((b) => b.textContent === "Uninstall")!.trigger("click");
+
+        await expect(modal.result).resolves.toBe(true);
+    });
+
+    it("resolves false when the user cancels", async () => {
+        const modal = open();
+        const buttons = findButtons(modal.contentEl as unknown as MockElement);
+
+        buttons.find((b) => b.textContent === "Cancel")!.trigger("click");
+
+        await expect(modal.result).resolves.toBe(false);
+    });
+
+    it("resolves false when the modal is dismissed", async () => {
+        const modal = open();
+
+        modal.onClose();
+
+        await expect(modal.result).resolves.toBe(false);
+    });
+
+    it("ignores a second decision", async () => {
+        const modal = open();
+        const buttons = findButtons(modal.contentEl as unknown as MockElement);
+
+        buttons.find((b) => b.textContent === "Uninstall")!.trigger("click");
+        modal.onClose();
+
+        await expect(modal.result).resolves.toBe(true);
+    });
+});


### PR DESCRIPTION
## Problem

In managed mode the plugin downloads a lilbee server executable and a Hugging Face model cache, both of which live outside the vault, under the plugin's own data root. Obsidian knows nothing about either. Removing the plugin from Community plugins therefore leaves the executable, the models, and the vault's search index on disk, often more than ten gigabytes of it, with no way to find or remove them from inside Obsidian.

There was also no way back down. The server version control was upgrade-only: a Check for updates button that either offered the newest release or told you that you were up to date. A release that misbehaves on your machine left you stuck on it, and a corrupted download had no repair path.

## Solution

Settings gains an Uninstall section, managed mode only, at the bottom of the tab where a destructive action belongs. It leads with the reason it exists: a callout, plus a tooltip on the heading, saying that removing the plugin does not remove the server and that you should uninstall here first. Clicking Uninstall server opens a confirmation that lists every path it will delete with its size, the executable, the downloaded models, and this vault's index, alongside one line promising that your notes and attachments are untouched.

Uninstalling is remembered. Without that, the next Obsidian launch would see a missing binary and ask to download it again, which is exactly the prompt someone who just uninstalled does not want. Instead the status bar reads "server not installed", server-dependent controls disable rather than vanish, and Settings offers an Install server button that pulls the server back and re-indexes.

The upgrade-only button becomes a version picker over recent GitHub releases. Selecting the installed release reads Reinstall, which doubles as the repair path for a corrupted download. Selecting an older one reads Downgrade to 0.6.72, selecting a newer one reads Update to 0.6.76. One control, three jobs, and the installed version is now visible rather than implied. Drafts, prereleases, and releases that ship no build for your platform are left out of the list.

External mode is untouched throughout: the plugin downloads nothing there, so it has nothing to uninstall.

The README's server section now covers changing versions in both directions and gains an Uninstalling section, including the data directory paths for people who removed the plugin before reading it.
