### PR TITLE
Stream the server download so it shows real progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Whichever you pick, one click stops the running server, downloads the build, ver
 
 The plugin is built and tested against the latest server release. Older releases still install and run, but they are not supported, and features the plugin expects may be missing.
 
-This changes only the lilbee **server**, never the plugin itself. The plugin's own code is updated through Obsidian like any other community plugin. Each server download is checked against the SHA256 digest GitHub publishes for the release before it runs, so a corrupted or tampered download is discarded instead of executed.
+This changes only the lilbee **server**, never the plugin itself. The plugin's own code is updated through Obsidian like any other community plugin. The download streams to disk and reports its progress as a percentage, and every server download is checked against the SHA256 digest GitHub publishes for the release before it runs. A corrupted or tampered download is discarded instead of executed, and a failed download never replaces the server you already have.
 
 ## Uninstalling
 

--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -219,6 +219,16 @@ const DOWNLOAD_IDLE_TIMEOUT_MS = 60_000;
 
 const DOWNLOAD_STALLED = "The lilbee server download stalled. Check your connection and try again.";
 
+export const DOWNLOAD_CANCELED = "The lilbee server download was cancelled.";
+
+/** Thrown when the caller aborts the download; callers treat it as a no-op, not a failure. */
+export class DownloadCanceledError extends Error {
+    constructor() {
+        super(DOWNLOAD_CANCELED);
+        this.name = "DownloadCanceledError";
+    }
+}
+
 /** Suffix of the partial download; renamed onto the real path only after the digest checks out. */
 const PART_SUFFIX = ".part";
 
@@ -299,11 +309,19 @@ export class BinaryManager {
     async ensureBinary(
         onProgress?: (msg: string, url?: string, progress?: DownloadProgress) => void,
         onQuarantineFailed?: () => void,
+        signal?: AbortSignal,
     ): Promise<string> {
         if (this.binaryExists()) return this.binaryPath;
         onProgress?.("Fetching latest release info...");
         const release = await getLatestRelease();
-        await this.download(release.assetUrl, release.sizeBytes, release.digest, onProgress, onQuarantineFailed);
+        await this.download(
+            release.assetUrl,
+            release.sizeBytes,
+            release.digest,
+            onProgress,
+            onQuarantineFailed,
+            signal,
+        );
         return this.binaryPath;
     }
 
@@ -334,7 +352,9 @@ export class BinaryManager {
         assetUrl: string,
         partPath: string,
         onBytes: (progress: DownloadProgress) => void,
+        signal?: AbortSignal,
     ): Promise<string> {
+        if (signal?.aborted) throw new DownloadCanceledError();
         const res = await openStream(assetUrl);
         const totalBytes = contentLength(res);
         const hash = node.createHash("sha256");
@@ -350,10 +370,13 @@ export class BinaryManager {
             };
             const fail = (err: Error): void => {
                 stopClock();
+                signal?.removeEventListener("abort", onAbort);
                 res.destroy();
                 file.destroy();
                 reject(err);
             };
+            const onAbort = (): void => fail(new DownloadCanceledError());
+            signal?.addEventListener("abort", onAbort, { once: true });
 
             res.on("data", (chunk: Buffer) => {
                 restartClock();
@@ -366,6 +389,7 @@ export class BinaryManager {
             res.pipe(file);
             file.on("finish", () => {
                 stopClock();
+                signal?.removeEventListener("abort", onAbort);
                 resolve(hash.digest("hex"));
             });
             restartClock();
@@ -378,6 +402,7 @@ export class BinaryManager {
         expectedDigest: string | null,
         onProgress?: (msg: string, url?: string, progress?: DownloadProgress) => void,
         onQuarantineFailed?: () => void,
+        signal?: AbortSignal,
     ): Promise<void> {
         if (!node.existsSync(this.binDir)) {
             node.mkdirSync(this.binDir, { recursive: true });
@@ -389,8 +414,11 @@ export class BinaryManager {
         const partPath = `${dest}${PART_SUFFIX}`;
         let renamed = false;
         try {
-            const actualHex = await this.streamToFile(assetUrl, partPath, (progress) =>
-                onProgress?.("Downloading...", assetUrl, progress),
+            const actualHex = await this.streamToFile(
+                assetUrl,
+                partPath,
+                (progress) => onProgress?.("Downloading...", assetUrl, progress),
+                signal,
             );
             this.assertDigest(actualHex, expectedDigest);
             node.renameSync(partPath, dest);

--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -214,6 +214,11 @@ const DISK_SPACE_FACTOR = 1.1;
 /** Redirects to follow before giving up (GitHub sends assets to objects.githubusercontent.com). */
 const MAX_REDIRECTS = 5;
 
+/** Give up when the asset host sends no bytes for this long, rather than hanging on a dead socket. */
+const DOWNLOAD_IDLE_TIMEOUT_MS = 60_000;
+
+const DOWNLOAD_STALLED = "The lilbee server download stalled. Check your connection and try again.";
+
 /** Suffix of the partial download; renamed onto the real path only after the digest checks out. */
 const PART_SUFFIX = ".part";
 
@@ -229,6 +234,7 @@ export interface DownloadProgress {
 function openStream(url: string, redirectsLeft = MAX_REDIRECTS): Promise<IncomingMessage> {
     return new Promise((resolve, reject) => {
         const req: ClientRequest = node.httpsGet(url, (res: IncomingMessage) => {
+            req.setTimeout?.(0);
             const status = res.statusCode ?? 0;
             const location = res.headers.location;
             if (REDIRECT_STATUSES.has(status) && location) {
@@ -250,6 +256,10 @@ function openStream(url: string, redirectsLeft = MAX_REDIRECTS): Promise<Incomin
             resolve(res);
         });
         req.on("error", reject);
+        // Covers a connect/headers stall. Once the body starts, streamToFile owns the clock.
+        req.setTimeout?.(DOWNLOAD_IDLE_TIMEOUT_MS, () => {
+            req.destroy(new Error(DOWNLOAD_STALLED));
+        });
     });
 }
 
@@ -332,12 +342,21 @@ export class BinaryManager {
         let receivedBytes = 0;
 
         return new Promise<string>((resolve, reject) => {
+            let idleTimer: ReturnType<typeof setTimeout>;
+            const stopClock = (): void => clearTimeout(idleTimer);
+            const restartClock = (): void => {
+                stopClock();
+                idleTimer = setTimeout(() => fail(new Error(DOWNLOAD_STALLED)), DOWNLOAD_IDLE_TIMEOUT_MS);
+            };
             const fail = (err: Error): void => {
+                stopClock();
                 res.destroy();
                 file.destroy();
                 reject(err);
             };
+
             res.on("data", (chunk: Buffer) => {
+                restartClock();
                 hash.update(chunk);
                 receivedBytes += chunk.length;
                 onBytes({ receivedBytes, totalBytes });
@@ -345,7 +364,11 @@ export class BinaryManager {
             res.on("error", fail);
             file.on("error", fail);
             res.pipe(file);
-            file.on("finish", () => resolve(hash.digest("hex")));
+            file.on("finish", () => {
+                stopClock();
+                resolve(hash.digest("hex"));
+            });
+            restartClock();
         });
     }
 

--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -1,7 +1,10 @@
 import { requestUrl } from "obsidian";
 import { execFile, spawn } from "child_process";
+import { get as httpsGet } from "https";
+import type { ClientRequest, IncomingMessage } from "http";
 import {
     appendFileSync,
+    createWriteStream,
     existsSync,
     mkdirSync,
     chmodSync,
@@ -42,6 +45,7 @@ export const node = {
     renameSync,
     readdirSync,
     rmSync,
+    createWriteStream,
     join,
     basename,
     resolve,
@@ -49,6 +53,10 @@ export const node = {
     createHash,
     processKill: process.kill.bind(process),
     requestUrl,
+    // Node's https, not the renderer's fetch: GitHub's asset redirect fails CORS
+    // in the renderer, which is why requestUrl was adopted for it originally.
+    // Unlike requestUrl, this streams, so the download reports real progress.
+    httpsGet,
     fetch: window.fetch.bind(window),
 };
 
@@ -200,8 +208,65 @@ export function checkForUpdate(currentVersion: string, latestTag: string): boole
     return currentVersion !== latestTag && latestTag !== "";
 }
 
-/** Headroom over the asset size: the whole file is buffered in memory before the write. */
-const DISK_SPACE_FACTOR = 1.5;
+/** Slack over the asset size: the download streams straight to disk, so only the file itself lands. */
+const DISK_SPACE_FACTOR = 1.1;
+
+/** Redirects to follow before giving up (GitHub sends assets to objects.githubusercontent.com). */
+const MAX_REDIRECTS = 5;
+
+/** Suffix of the partial download; renamed onto the real path only after the digest checks out. */
+const PART_SUFFIX = ".part";
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/** Bytes received so far, and the total when the server reports a Content-Length. */
+export interface DownloadProgress {
+    receivedBytes: number;
+    totalBytes: number | null;
+}
+
+/** Resolve *url* through redirects to the response that carries the body. */
+function openStream(url: string, redirectsLeft = MAX_REDIRECTS): Promise<IncomingMessage> {
+    return new Promise((resolve, reject) => {
+        const req: ClientRequest = node.httpsGet(url, (res: IncomingMessage) => {
+            const status = res.statusCode ?? 0;
+            const location = res.headers.location;
+            if (REDIRECT_STATUSES.has(status) && location) {
+                res.resume();
+                if (redirectsLeft === 0) {
+                    reject(new Error("Download failed: too many redirects"));
+                    return;
+                }
+                openStream(new URL(location, url).toString(), redirectsLeft - 1).then(resolve, reject);
+                return;
+            }
+            // Anything but a 2xx body: a bare redirect, an error, or a response
+            // with no status at all. None of them carry the asset.
+            if (status < 200 || status >= 300) {
+                res.resume();
+                reject(new Error(`Download failed: ${status}`));
+                return;
+            }
+            resolve(res);
+        });
+        req.on("error", reject);
+    });
+}
+
+/** Best-effort removal during error cleanup: a failure here must not mask the real error. */
+function discard(path: string): void {
+    try {
+        if (node.existsSync(path)) node.unlinkSync(path);
+    } catch {
+        // nothing else to do; the caller is already throwing
+    }
+}
+
+function contentLength(res: IncomingMessage): number | null {
+    const raw = res.headers["content-length"];
+    const parsed = Number(raw);
+    return raw !== undefined && Number.isFinite(parsed) ? parsed : null;
+}
 
 function formatBytes(bytes: number): string {
     const gb = bytes / 1024 ** 3;
@@ -222,7 +287,7 @@ export class BinaryManager {
     }
 
     async ensureBinary(
-        onProgress?: (msg: string, url?: string) => void,
+        onProgress?: (msg: string, url?: string, progress?: DownloadProgress) => void,
         onQuarantineFailed?: () => void,
     ): Promise<string> {
         if (this.binaryExists()) return this.binaryPath;
@@ -246,20 +311,49 @@ export class BinaryManager {
     }
 
     /** Reject the download unless its SHA256 matches the digest GitHub reports for the asset. */
-    private verifyDigest(data: Buffer, expectedDigest: string | null): void {
-        const actual = `sha256:${node.createHash("sha256").update(data).digest("hex")}`;
-        if (actual !== (expectedDigest ?? "").toLowerCase()) {
+    private assertDigest(actualHex: string, expectedDigest: string | null): void {
+        if (`sha256:${actualHex}` !== (expectedDigest ?? "").toLowerCase()) {
             throw new Error(
                 "The downloaded lilbee server could not be verified against its checksum and was discarded. Please try again.",
             );
         }
     }
 
+    /** Stream *assetUrl* to *partPath*, hashing as it goes. Returns the SHA256 of what landed. */
+    private async streamToFile(
+        assetUrl: string,
+        partPath: string,
+        onBytes: (progress: DownloadProgress) => void,
+    ): Promise<string> {
+        const res = await openStream(assetUrl);
+        const totalBytes = contentLength(res);
+        const hash = node.createHash("sha256");
+        const file = node.createWriteStream(partPath);
+        let receivedBytes = 0;
+
+        return new Promise<string>((resolve, reject) => {
+            const fail = (err: Error): void => {
+                res.destroy();
+                file.destroy();
+                reject(err);
+            };
+            res.on("data", (chunk: Buffer) => {
+                hash.update(chunk);
+                receivedBytes += chunk.length;
+                onBytes({ receivedBytes, totalBytes });
+            });
+            res.on("error", fail);
+            file.on("error", fail);
+            res.pipe(file);
+            file.on("finish", () => resolve(hash.digest("hex")));
+        });
+    }
+
     async download(
         assetUrl: string,
         sizeBytes: number,
         expectedDigest: string | null,
-        onProgress?: (msg: string, url?: string) => void,
+        onProgress?: (msg: string, url?: string, progress?: DownloadProgress) => void,
         onQuarantineFailed?: () => void,
     ): Promise<void> {
         if (!node.existsSync(this.binDir)) {
@@ -268,21 +362,24 @@ export class BinaryManager {
         await this.assertEnoughSpace(sizeBytes);
 
         onProgress?.("Downloading...", assetUrl);
-        const res = await node.requestUrl({ url: assetUrl });
-        if (res.status >= 400) throw new Error(`Download failed: ${res.status}`);
-
-        const data = Buffer.from(res.arrayBuffer);
-        this.verifyDigest(data, expectedDigest);
-
         const dest = this.binaryPath;
+        const partPath = `${dest}${PART_SUFFIX}`;
+        let renamed = false;
         try {
-            node.writeFileSync(dest, data);
+            const actualHex = await this.streamToFile(assetUrl, partPath, (progress) =>
+                onProgress?.("Downloading...", assetUrl, progress),
+            );
+            this.assertDigest(actualHex, expectedDigest);
+            node.renameSync(partPath, dest);
+            renamed = true;
             if (process.platform !== PLATFORM.WIN32) {
                 node.chmodSync(dest, 0o755);
             }
         } catch (err) {
-            // Leave no half-written binary behind; binaryExists() would treat it as good.
-            if (node.existsSync(dest)) node.unlinkSync(dest);
+            // Discard the partial. A failure before the rename leaves any previously
+            // installed binary alone; after it, dest is the new file and must go.
+            discard(partPath);
+            if (renamed) discard(dest);
             throw err;
         }
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -531,6 +531,9 @@ export const MESSAGES = {
     TITLE_RECOMMENDED: "Recommended",
 
     STATUS_DOWNLOADING: "lilbee: downloading...",
+    STATUS_DOWNLOAD_PROGRESS: (percent: number, received: string, total: string) =>
+        `Downloading... ${percent}% (${received} of ${total})`,
+    STATUS_DOWNLOAD_RECEIVED: (received: string) => `Downloading... ${received}`,
     STATUS_UPDATE_SIZE: (tag: string, size: string) => `Updating to ${tag} · ${size} download`,
     STATUS_STARTING: "lilbee: starting...",
     STATUS_READY: "lilbee: ready",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -48,6 +48,7 @@ export const MESSAGES = {
     BUTTON_UNINSTALL_SERVER: "Uninstall server",
     BUTTON_UNINSTALL: "Uninstall",
     BUTTON_DOWNLOADING: "Downloading...",
+    BUTTON_CANCEL_DOWNLOAD: "Cancel download",
     BUTTON_INSTALL_TAG: (tag: string) => `Install ${tag}`,
     BUTTON_UPDATE_TO: (tag: string) => `Update to ${tag}`,
     BUTTON_DOWNGRADE_TO: (tag: string) => `Downgrade to ${tag}`,
@@ -403,6 +404,7 @@ export const MESSAGES = {
         `Deletes the executable, the models, and this vault's index. Frees ${size}. Your notes are not touched.`,
     DESC_INSTALL_SERVER: (size: string) =>
         `Downloads the lilbee server, about ${size}. Models are pulled on demand afterwards.`,
+    DESC_SERVER_DOWNLOADING: "The lilbee server is downloading. Progress is in the status bar.",
     DESC_SERVER_NOT_INSTALLED:
         "The server is not installed. Chat, search, and sync are unavailable until you install it.",
 
@@ -420,6 +422,7 @@ export const MESSAGES = {
 
     NOTICE_UNINSTALLED: (size: string) => `lilbee server uninstalled. ${size} freed.`,
     NOTICE_INSTALLED: (tag: string) => `lilbee server ${tag} installed.`,
+    NOTICE_DOWNLOAD_CANCELED: "lilbee server download cancelled.",
     ERROR_UNINSTALL_FAILED: "Could not uninstall the lilbee server",
     ERROR_UNINSTALL_SERVER_IN_USE: (vaultName: string) =>
         `The lilbee server is running for ${vaultName}. Close that vault, then uninstall.`,
@@ -531,6 +534,7 @@ export const MESSAGES = {
     TITLE_RECOMMENDED: "Recommended",
 
     STATUS_DOWNLOADING: "lilbee: downloading...",
+    STATUS_DOWNLOADING_PERCENT: (percent: number) => `lilbee: downloading ${percent}%`,
     STATUS_DOWNLOAD_PROGRESS: (percent: number, received: string, total: string) =>
         `Downloading... ${percent}% (${received} of ${total})`,
     STATUS_DOWNLOAD_RECEIVED: (received: string) => `Downloading... ${received}`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { BinaryManager, getLatestRelease, checkForUpdate, node } from "./binary-
 import { exportDatasetToDisk, importDatasetFromDisk } from "./dataset-io";
 import { exportDiagnostics } from "./diagnostics-export";
 import { ErrorJournal } from "./error-journal";
+import { DownloadCanceledError } from "./binary-manager";
 import type { DownloadProgress, ReleaseInfo } from "./binary-manager";
 import { ServerManager, killServerTree } from "./server-manager";
 import { executeUninstall, planUninstall } from "./server-uninstall";
@@ -220,6 +221,13 @@ function downloadMessage(progress: DownloadProgress): string {
     const percent = percentOfBytes(progress.receivedBytes, progress.totalBytes);
     if (percent === undefined || progress.totalBytes === null) return MESSAGES.STATUS_DOWNLOAD_RECEIVED(received);
     return MESSAGES.STATUS_DOWNLOAD_PROGRESS(percent, received, formatBytes(progress.totalBytes));
+}
+
+/** The status bar is narrow: percent only, with the byte detail left to Settings. */
+function downloadStatusBar(progress: DownloadProgress): string {
+    const percent = percentOfBytes(progress.receivedBytes, progress.totalBytes);
+    if (percent === undefined) return MESSAGES.STATUS_DOWNLOADING;
+    return MESSAGES.STATUS_DOWNLOADING_PERCENT(percent);
 }
 
 export default class LilbeePlugin extends Plugin {
@@ -566,6 +574,28 @@ export default class LilbeePlugin extends Plugin {
         return false;
     }
 
+    /** Aborts the in-flight server download, if any. Set while a download runs. */
+    private downloadController: AbortController | null = null;
+
+    private startDownloadController(): AbortController {
+        this.downloadController = new AbortController();
+        return this.downloadController;
+    }
+
+    private finishDownload(): void {
+        this.downloadController = null;
+    }
+
+    /** True while a server binary is downloading, so the UI can offer to stop it. */
+    isDownloadingServer(): boolean {
+        return this.downloadController !== null;
+    }
+
+    /** Stop an in-flight server download. The partial file is discarded; any installed binary stays. */
+    cancelServerDownload(): void {
+        this.downloadController?.abort();
+    }
+
     private async ensureBinaryWithUi(onProgress?: ManagedServerProgressHandler): Promise<string | null> {
         const bm = this.binaryManager;
         if (!bm) return null;
@@ -575,31 +605,30 @@ export default class LilbeePlugin extends Plugin {
             this.setStatusClass("lilbee-status-downloading");
             onProgress?.({ phase: MANAGED_PHASE.DOWNLOADING, message: MESSAGES.STATUS_DOWNLOADING });
         }
-        let downloadNotice: Notice | undefined;
         try {
             const path = await bm.ensureBinary(
                 (rawMsg, url, progress) => {
                     const percent = progress ? percentOfBytes(progress.receivedBytes, progress.totalBytes) : undefined;
                     const msg = progress ? downloadMessage(progress) : rawMsg;
-                    this.updateStatusBar(`lilbee: ${msg}`, DOT_STATE.PRIMARY);
+                    this.updateStatusBar(progress ? downloadStatusBar(progress) : `lilbee: ${msg}`, DOT_STATE.PRIMARY);
                     onProgress?.({ phase: MANAGED_PHASE.DOWNLOADING, message: msg, url, percent });
-                    if (!downloadNotice && needsDownload) {
-                        const text = url ? `lilbee: ${msg}\n${url}` : `lilbee: ${msg}`;
-                        downloadNotice = new Notice(text, NOTICE_PERMANENT);
-                    } else if (downloadNotice) {
-                        const text = url ? `lilbee: ${msg}\n${url}` : `lilbee: ${msg}`;
-                        downloadNotice.setMessage(text);
-                    }
                 },
                 () => this.showGatekeeperHelp(),
+                this.startDownloadController().signal,
             );
-            downloadNotice?.hide();
+            this.finishDownload();
             this.setStatusClass(null);
             return path;
         } catch (err) {
-            downloadNotice?.hide();
+            this.finishDownload();
             this.setStatusClass(null);
-            this.showError("failed to download server", err);
+            // Cancelling is a choice, not a failure: say so plainly and skip the error journal.
+            if (err instanceof DownloadCanceledError) {
+                new Notice(MESSAGES.NOTICE_DOWNLOAD_CANCELED);
+                this.updateStatusBar(MESSAGES.STATUS_NOT_INSTALLED, DOT_STATE.MUTED, false);
+            } else {
+                this.showError("failed to download server", err);
+            }
             onProgress?.({ phase: MANAGED_PHASE.ERROR, message: errorMessage(err, String(err)) });
             return null;
         }
@@ -812,19 +841,27 @@ export default class LilbeePlugin extends Plugin {
 
         // Download the new binary (replaces the old one once its checksum clears)
         onProgress?.("Downloading...");
-        await this.binaryManager.download(
-            release.assetUrl,
-            release.sizeBytes,
-            release.digest,
-            (msg, _url, progress) => {
-                if (!progress) {
-                    onProgress?.(msg);
-                    return;
-                }
-                onProgress?.(downloadMessage(progress), percentOfBytes(progress.receivedBytes, progress.totalBytes));
-            },
-            () => this.showGatekeeperHelp(),
-        );
+        try {
+            await this.binaryManager.download(
+                release.assetUrl,
+                release.sizeBytes,
+                release.digest,
+                (msg, _url, progress) => {
+                    if (!progress) {
+                        onProgress?.(msg);
+                        return;
+                    }
+                    onProgress?.(
+                        downloadMessage(progress),
+                        percentOfBytes(progress.receivedBytes, progress.totalBytes),
+                    );
+                },
+                () => this.showGatekeeperHelp(),
+                this.startDownloadController().signal,
+            );
+        } finally {
+            this.finishDownload();
+        }
 
         // Save the new version and the build variant we just installed
         this.setSharedLilbeeVersion(release.tag);

--- a/src/main.ts
+++ b/src/main.ts
@@ -816,7 +816,7 @@ export default class LilbeePlugin extends Plugin {
         const release = result.release;
         const notice = new Notice(MESSAGES.NOTICE_SERVER_AUTO_UPDATING(release.tag), NOTICE_PERMANENT);
         try {
-            await this.updateServer(release, (msg) => notice.setMessage(msg));
+            await this.updateServer(release);
             new Notice(MESSAGES.NOTICE_SERVER_AUTO_UPDATED(release.tag));
         } catch {
             new Notice(MESSAGES.NOTICE_SERVER_AUTO_UPDATE_FAILED, NOTICE_ERROR_DURATION_MS);

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ import { BinaryManager, getLatestRelease, checkForUpdate, node } from "./binary-
 import { exportDatasetToDisk, importDatasetFromDisk } from "./dataset-io";
 import { exportDiagnostics } from "./diagnostics-export";
 import { ErrorJournal } from "./error-journal";
-import type { ReleaseInfo } from "./binary-manager";
+import type { DownloadProgress, ReleaseInfo } from "./binary-manager";
 import { ServerManager, killServerTree } from "./server-manager";
 import { executeUninstall, planUninstall } from "./server-uninstall";
 import { readSessionToken, resolveExternalDataRoot } from "./session-token";
@@ -64,11 +64,13 @@ import {
     NOTICE_DURATION_MS,
     NOTICE_ERROR_DURATION_MS,
     NOTICE_PERMANENT,
+    percentOfBytes,
     sessionTokenInvalidMessage,
     STREAM_IDLE_TIMEOUT_MS,
     StreamIdleError,
     withIdleTimeout,
 } from "./utils";
+import { formatBytes } from "./storage-stats";
 import { CatalogModal } from "./views/catalog-modal";
 import { ManagedConsentModal } from "./views/managed-consent-modal";
 import { ModelInfoModal } from "./views/model-info-modal";
@@ -207,6 +209,17 @@ function coerceSyncDone(obj: Record<string, unknown>): SyncDone | null {
         failed: Array.isArray(obj.failed) ? (obj.failed as string[]) : [],
         skipped: Array.isArray(obj.skipped) ? (obj.skipped as string[]) : [],
     };
+}
+
+/** Progress for a settings-driven install/update: a phase line plus a percent when known. */
+export type ServerDownloadProgressHandler = (msg: string, percent?: number) => void;
+
+/** "Downloading... 45% (128 MB of 283 MB)", or bytes-only when the server sends no length. */
+function downloadMessage(progress: DownloadProgress): string {
+    const received = formatBytes(progress.receivedBytes);
+    const percent = percentOfBytes(progress.receivedBytes, progress.totalBytes);
+    if (percent === undefined || progress.totalBytes === null) return MESSAGES.STATUS_DOWNLOAD_RECEIVED(received);
+    return MESSAGES.STATUS_DOWNLOAD_PROGRESS(percent, received, formatBytes(progress.totalBytes));
 }
 
 export default class LilbeePlugin extends Plugin {
@@ -565,9 +578,11 @@ export default class LilbeePlugin extends Plugin {
         let downloadNotice: Notice | undefined;
         try {
             const path = await bm.ensureBinary(
-                (msg, url) => {
+                (rawMsg, url, progress) => {
+                    const percent = progress ? percentOfBytes(progress.receivedBytes, progress.totalBytes) : undefined;
+                    const msg = progress ? downloadMessage(progress) : rawMsg;
                     this.updateStatusBar(`lilbee: ${msg}`, DOT_STATE.PRIMARY);
-                    onProgress?.({ phase: MANAGED_PHASE.DOWNLOADING, message: msg, url });
+                    onProgress?.({ phase: MANAGED_PHASE.DOWNLOADING, message: msg, url, percent });
                     if (!downloadNotice && needsDownload) {
                         const text = url ? `lilbee: ${msg}\n${url}` : `lilbee: ${msg}`;
                         downloadNotice = new Notice(text, NOTICE_PERMANENT);
@@ -730,7 +745,7 @@ export default class LilbeePlugin extends Plugin {
     }
 
     /** Download *release* and start it, clearing an earlier uninstall. */
-    async installServer(release: ReleaseInfo, onProgress?: (msg: string) => void): Promise<void> {
+    async installServer(release: ReleaseInfo, onProgress?: ServerDownloadProgressHandler): Promise<void> {
         this.setServerUninstalled(false);
         await this.updateServer(release, onProgress);
     }
@@ -781,7 +796,7 @@ export default class LilbeePlugin extends Plugin {
         }
     }
 
-    async updateServer(release: ReleaseInfo, onProgress?: (msg: string) => void): Promise<void> {
+    async updateServer(release: ReleaseInfo, onProgress?: ServerDownloadProgressHandler): Promise<void> {
         const registry = this.vaultRegistry;
         if (!registry) return;
         if (!this.binaryManager) {
@@ -795,10 +810,20 @@ export default class LilbeePlugin extends Plugin {
             this.serverManager = null;
         }
 
-        // Download the new binary (overwrites the old one)
+        // Download the new binary (replaces the old one once its checksum clears)
         onProgress?.("Downloading...");
-        await this.binaryManager.download(release.assetUrl, release.sizeBytes, release.digest, onProgress, () =>
-            this.showGatekeeperHelp(),
+        await this.binaryManager.download(
+            release.assetUrl,
+            release.sizeBytes,
+            release.digest,
+            (msg, _url, progress) => {
+                if (!progress) {
+                    onProgress?.(msg);
+                    return;
+                }
+                onProgress?.(downloadMessage(progress), percentOfBytes(progress.receivedBytes, progress.totalBytes));
+            },
+            () => this.showGatekeeperHelp(),
         );
 
         // Save the new version and the build variant we just installed

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,6 @@
 import { App, ButtonComponent, DropdownComponent, Notice, PluginSettingTab, setIcon, Setting } from "obsidian";
 import type LilbeePlugin from "./main";
-import { listReleases } from "./binary-manager";
+import { DownloadCanceledError, listReleases } from "./binary-manager";
 import type { ReleaseInfo } from "./binary-manager";
 import {
     CAPABILITY,
@@ -77,6 +77,7 @@ interface UpdateProgressEls {
     phase: HTMLElement;
     size: HTMLElement;
     fill: HTMLElement;
+    cancel: HTMLElement;
 }
 
 export class LilbeeSettingTab extends PluginSettingTab {
@@ -413,6 +414,22 @@ export class LilbeeSettingTab extends PluginSettingTab {
 
     /** Recovery path after an uninstall: pick a release and pull the server back. */
     private renderInstallServer(containerEl: HTMLElement): void {
+        // A download kicked off outside Settings (first run, consent modal) is still
+        // in flight: offer to stop it rather than a dead Install button.
+        if (this.plugin.isDownloadingServer()) {
+            new Setting(containerEl)
+                .setName(MESSAGES.LABEL_SERVER_STATUS)
+                .setDesc(MESSAGES.DESC_SERVER_DOWNLOADING)
+                .addButton((btn) => {
+                    btn.setButtonText(MESSAGES.BUTTON_CANCEL_DOWNLOAD).onClick(() => {
+                        this.plugin.cancelServerDownload();
+                        this.render();
+                    });
+                    btn.buttonEl.addClass("mod-warning");
+                });
+            return;
+        }
+
         new Setting(containerEl).setName(MESSAGES.LABEL_SERVER_STATUS).setDesc(MESSAGES.DESC_SERVER_NOT_INSTALLED);
 
         const setting = new Setting(containerEl)
@@ -483,8 +500,12 @@ export class LilbeeSettingTab extends PluginSettingTab {
             new Notice(MESSAGES.NOTICE_INSTALLED(release.tag));
             this.render();
         } catch (err) {
-            new Notice(errorMessage(err, MESSAGES.ERROR_INSTALL_FAILED));
-            console.error("[lilbee] install failed:", err);
+            if (err instanceof DownloadCanceledError) {
+                new Notice(MESSAGES.NOTICE_DOWNLOAD_CANCELED);
+            } else {
+                new Notice(errorMessage(err, MESSAGES.ERROR_INSTALL_FAILED));
+                console.error("[lilbee] install failed:", err);
+            }
             progress.panel.hide();
             btn.setButtonText(MESSAGES.BUTTON_INSTALL_SERVER);
             btn.setDisabled(false);
@@ -501,7 +522,12 @@ export class LilbeeSettingTab extends PluginSettingTab {
         });
         const phase = panel.createDiv({ cls: "lilbee-update-progress-phase" });
         const size = panel.createDiv({ cls: "lilbee-update-progress-size" });
-        return { panel, phase, size, fill };
+        const cancel = panel.createEl("button", {
+            cls: "lilbee-update-progress-cancel",
+            text: MESSAGES.BUTTON_CANCEL_DOWNLOAD,
+        });
+        cancel.addEventListener("click", () => this.plugin.cancelServerDownload());
+        return { panel, phase, size, fill, cancel };
     }
 
     /** Download and install *release*, surfacing phase + total download size. Returns false on failure. */
@@ -521,9 +547,13 @@ export class LilbeeSettingTab extends PluginSettingTab {
             this.render();
             return true;
         } catch (err) {
-            // errorMessage carries the server's reason, e.g. insufficient disk space.
-            new Notice(errorMessage(err, MESSAGES.ERROR_FAILED_UPDATE));
-            console.error("[lilbee] update failed:", err);
+            if (err instanceof DownloadCanceledError) {
+                new Notice(MESSAGES.NOTICE_DOWNLOAD_CANCELED);
+            } else {
+                // errorMessage carries the server's reason, e.g. insufficient disk space.
+                new Notice(errorMessage(err, MESSAGES.ERROR_FAILED_UPDATE));
+                console.error("[lilbee] update failed:", err);
+            }
             progress.panel.hide();
             actionBtn.setButtonText(restoreLabel);
             actionBtn.setDisabled(false);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -39,6 +39,7 @@ import {
     noticeForResultError,
     getRelevantSystemMemoryGB,
     noticeServerUnreachableIfApplicable,
+    setDeterminateProgress,
 } from "./utils";
 
 const CHECK_TIMEOUT_MS = 5000;
@@ -64,11 +65,18 @@ const CREDENTIAL_FIELDS = new Set([
 
 export { SEPARATOR_KEY, SEPARATOR_LABEL };
 
+/** Paint the phase line, and grow the bar once a real percentage arrives. */
+function showPhase(progress: UpdateProgressEls, message: string, percent?: number): void {
+    progress.phase.setText(message);
+    if (percent !== undefined) setDeterminateProgress(progress.fill, percent);
+}
+
 /** Elements of the managed-server update progress panel. */
 interface UpdateProgressEls {
     panel: HTMLElement;
     phase: HTMLElement;
     size: HTMLElement;
+    fill: HTMLElement;
 }
 
 export class LilbeeSettingTab extends PluginSettingTab {
@@ -471,7 +479,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         progress.panel.show();
         progress.size.setText(MESSAGES.STATUS_UPDATE_SIZE(release.tag, formatBytes(release.sizeBytes)));
         try {
-            await this.plugin.installServer(release, (msg) => progress.phase.setText(msg));
+            await this.plugin.installServer(release, (msg, percent) => showPhase(progress, msg, percent));
             new Notice(MESSAGES.NOTICE_INSTALLED(release.tag));
             this.render();
         } catch (err) {
@@ -488,10 +496,12 @@ export class LilbeeSettingTab extends PluginSettingTab {
         const panel = containerEl.createDiv({ cls: "lilbee-update-progress" });
         panel.hide();
         const bar = panel.createDiv({ cls: "lilbee-progress-bar-container" });
-        bar.createDiv({ cls: "lilbee-progress-bar lilbee-wizard-progress-fill lilbee-wizard-progress-indeterminate" });
+        const fill = bar.createDiv({
+            cls: "lilbee-progress-bar lilbee-wizard-progress-fill lilbee-wizard-progress-indeterminate",
+        });
         const phase = panel.createDiv({ cls: "lilbee-update-progress-phase" });
         const size = panel.createDiv({ cls: "lilbee-update-progress-size" });
-        return { panel, phase, size };
+        return { panel, phase, size, fill };
     }
 
     /** Download and install *release*, surfacing phase + total download size. Returns false on failure. */
@@ -506,7 +516,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         progress.panel.show();
         progress.size.setText(MESSAGES.STATUS_UPDATE_SIZE(release.tag, formatBytes(release.sizeBytes)));
         try {
-            await this.plugin.updateServer(release, (msg) => progress.phase.setText(msg));
+            await this.plugin.updateServer(release, (msg, percent) => showPhase(progress, msg, percent));
             new Notice(MESSAGES.NOTICE_UPDATED_TO(release.tag));
             this.render();
             return true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -278,6 +278,8 @@ export interface ManagedServerProgress {
     phase: ManagedServerProgressPhase;
     message: string;
     url?: string;
+    /** 0-100 while the server binary downloads; absent when the size is unknown. */
+    percent?: number;
 }
 
 export type ManagedServerProgressHandler = (event: ManagedServerProgress) => void;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -287,6 +287,18 @@ export function isModelUnavailableError(code: string | null, message: string): b
  * otherwise derives from `current/total`. Returns undefined when neither is usable
  * (e.g. total is zero/missing, or current is missing).
  */
+/** Hand a progress bar from its indeterminate animation to a real width. */
+export function setDeterminateProgress(fill: HTMLElement, percent: number): void {
+    fill.classList.remove("lilbee-wizard-progress-indeterminate");
+    fill.style.width = `${percent}%`;
+}
+
+/** Whole-number percent of *received* against *total*, or undefined when the total is unknown. */
+export function percentOfBytes(received: number, total: number | null): number | undefined {
+    if (!total || total <= 0) return undefined;
+    return Math.min(100, Math.round((received / total) * 100));
+}
+
 export function percentFromSse(data: { percent?: number; current?: number; total?: number }): number | undefined {
     if (data.percent !== undefined) return data.percent;
     if (data.total && data.current !== undefined) {

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -22,6 +22,7 @@ import {
     extractSseErrorMessage,
     getSystemMemoryGB,
     percentFromSse,
+    setDeterminateProgress,
     sessionTokenInvalidMessage,
 } from "../utils";
 
@@ -440,7 +441,7 @@ export class SetupWizard extends Modal {
     private async startManagedAndAdvance(
         step: HTMLElement,
         panel: HTMLElement,
-        setPhase: (phase: ManagedServerProgressPhase, message?: string) => void,
+        setPhase: (phase: ManagedServerProgressPhase, message?: string, percent?: number) => void,
         statusEl: HTMLElement,
         nextBtn: HTMLElement,
         selectExternal: () => void,
@@ -451,13 +452,13 @@ export class SetupWizard extends Modal {
         // so it stays hidden behind the consent modal while the user decides.
         let panelShown = false;
         let failed = false;
-        const onProgress = (event: { phase: ManagedServerProgressPhase; message?: string }): void => {
+        const onProgress = (event: { phase: ManagedServerProgressPhase; message?: string; percent?: number }): void => {
             if (!panelShown) {
                 panel.show();
                 step.querySelector<HTMLElement>(".lilbee-wizard-rail")?.classList.add("is-active");
                 panelShown = true;
             }
-            setPhase(event.phase, event.message);
+            setPhase(event.phase, event.message, event.percent);
             if (event.phase === MANAGED_PHASE.ERROR) failed = true;
         };
 
@@ -506,7 +507,7 @@ export class SetupWizard extends Modal {
      */
     private renderServerSetupPanel(step: HTMLElement): {
         panel: HTMLElement;
-        setPhase: (phase: ManagedServerProgressPhase, message?: string) => void;
+        setPhase: (phase: ManagedServerProgressPhase, message?: string, percent?: number) => void;
     } {
         const panel = step.createDiv({ cls: "lilbee-wizard-setup" });
         panel.hide();
@@ -524,9 +525,9 @@ export class SetupWizard extends Modal {
             const detail = row.createDiv({ cls: "lilbee-wizard-phase-detail" });
             detail.hide();
             const bar = detail.createDiv({ cls: "lilbee-progress-bar-container" });
-            bar.createDiv({ cls: "lilbee-wizard-progress-fill lilbee-wizard-progress-indeterminate" });
+            const fill = bar.createDiv({ cls: "lilbee-wizard-progress-fill lilbee-wizard-progress-indeterminate" });
             detail.createDiv({ cls: "lilbee-wizard-phase-hint", text: meta.hint });
-            return { meta, row, label, detail };
+            return { meta, row, label, detail, fill };
         });
 
         const gate = panel.createDiv({ cls: "lilbee-wizard-setup-gate", text: MESSAGES.WIZARD_SETUP_GATE });
@@ -536,8 +537,9 @@ export class SetupWizard extends Modal {
         sourceLink.setAttribute("href", LILBEE_REPO_URL);
 
         const order = SERVER_SETUP_PHASES.map((m) => m.key);
-        const setPhase = (phase: ManagedServerProgressPhase, message?: string): void => {
+        const setPhase = (phase: ManagedServerProgressPhase, message?: string, percent?: number): void => {
             const idx = order.indexOf(phase);
+            if (percent !== undefined && idx >= 0) setDeterminateProgress(rows[idx].fill, percent);
             // An unknown/error phase isn't one of the three rows: surface the
             // message in the header and leave the rows showing where progress
             // stalled rather than blanking them.

--- a/styles.css
+++ b/styles.css
@@ -4517,3 +4517,21 @@ button.lilbee-model-chip-select:focus-visible {
     flex: 0 0 auto;
     color: var(--text-muted);
 }
+
+/* Stop an in-flight server download from the progress panel. */
+.lilbee-update-progress-cancel {
+    align-self: flex-start;
+    margin-top: var(--size-4-2, 8px);
+    padding: 4px 10px;
+    font-size: var(--font-smallest, 11px);
+    color: var(--text-muted);
+    background: transparent;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-s, 4px);
+    cursor: pointer;
+}
+
+.lilbee-update-progress-cancel:hover {
+    color: var(--text-error);
+    border-color: var(--text-error);
+}

--- a/tests/binary-manager.test.ts
+++ b/tests/binary-manager.test.ts
@@ -3,6 +3,7 @@ import type { StatsFs } from "fs";
 import { createHash } from "crypto";
 import { Readable, Writable } from "stream";
 import {
+    DownloadCanceledError,
     node,
     getPlatformAssetName,
     getLatestRelease,
@@ -655,6 +656,50 @@ describe("BinaryManager", () => {
 
             const mgr = new BinaryManager("/plugins/lilbee/bin");
             await expect(mgr.download("https://example.com/dl", 4, null)).rejects.toThrow("connection reset");
+        });
+
+        it("aborts when the caller cancels mid-stream", async () => {
+            restore = stubPlatform("linux", "x64");
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            stubEnoughSpace();
+            const controller = new AbortController();
+            vi.spyOn(node, "httpsGet").mockImplementation(((_url: string, cb: (res: any) => void) => {
+                const res: any = new Readable({ read() {} });
+                res.statusCode = 200;
+                res.headers = { "content-length": "99" };
+                queueMicrotask(() => {
+                    cb(res);
+                    res.push(Buffer.from([1]));
+                    setTimeout(() => controller.abort(), 0);
+                });
+                return { on: () => {}, setTimeout: () => {}, destroy: () => {} } as any;
+            }) as any);
+            stubSinkStream();
+            const unlink = vi.spyOn(node, "unlinkSync").mockImplementation(() => {});
+
+            const mgr = new BinaryManager("/plugins/lilbee/bin");
+            await expect(
+                mgr.download("https://example.com/dl", 99, null, undefined, undefined, controller.signal),
+            ).rejects.toThrow(DownloadCanceledError);
+
+            expect(unlink).toHaveBeenCalledWith(`${mgr.binaryPath}.part`);
+            expect(unlink).not.toHaveBeenCalledWith(mgr.binaryPath);
+        });
+
+        it("does not start when the signal is already aborted", async () => {
+            restore = stubPlatform("linux", "x64");
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            stubEnoughSpace();
+            const get = vi.spyOn(node, "httpsGet");
+            vi.spyOn(node, "unlinkSync").mockImplementation(() => {});
+            const controller = new AbortController();
+            controller.abort();
+
+            const mgr = new BinaryManager("/plugins/lilbee/bin");
+            await expect(
+                mgr.download("https://example.com/dl", 1, null, undefined, undefined, controller.signal),
+            ).rejects.toThrow("was cancelled");
+            expect(get).not.toHaveBeenCalled();
         });
 
         it("gives up when the asset host never answers", async () => {

--- a/tests/binary-manager.test.ts
+++ b/tests/binary-manager.test.ts
@@ -1,6 +1,7 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { StatsFs } from "fs";
 import { createHash } from "crypto";
+import { Readable, Writable } from "stream";
 import {
     node,
     getPlatformAssetName,
@@ -32,14 +33,36 @@ function releaseResponse(json: unknown) {
     return { status: 200, json, arrayBuffer: new ArrayBuffer(0), headers: {} };
 }
 
-/** Build a fake requestUrl response for binary download. */
-function downloadResponse(data: Uint8Array) {
-    return { status: 200, json: {}, arrayBuffer: data.buffer, headers: {} };
-}
-
 /** The GitHub-style "sha256:<hex>" digest of some bytes. */
 function sha256Digest(data: Uint8Array): string {
     return `sha256:${createHash("sha256").update(Buffer.from(data)).digest("hex")}`;
+}
+
+/** Serve `data` over a fake https.get, with a content-length header. */
+function stubHttpsBody(data: Uint8Array) {
+    return vi.spyOn(node, "httpsGet").mockImplementation(((_url: string, cb: (res: any) => void) => {
+        const res: any = new Readable({ read() {} });
+        res.statusCode = 200;
+        res.headers = { "content-length": String(data.length) };
+        queueMicrotask(() => {
+            cb(res);
+            res.push(Buffer.from(data));
+            res.push(null);
+        });
+        return { on: () => {} } as any;
+    }) as any);
+}
+
+/** A write stream that swallows everything piped into it. */
+function stubSinkStream() {
+    return vi.spyOn(node, "createWriteStream").mockImplementation(
+        (() =>
+            new Writable({
+                write(_c, _e, cb) {
+                    cb();
+                },
+            })) as any,
+    );
 }
 
 /** A statfs result with `freeBytes` available (block size 1 keeps the math simple). */
@@ -355,22 +378,22 @@ describe("BinaryManager", () => {
             // existsSync: first call (binaryExists) => false, second call (binDir check in download) => true
             vi.spyOn(node, "existsSync").mockReturnValueOnce(false).mockReturnValueOnce(true);
             stubEnoughSpace();
-            vi.spyOn(node, "requestUrl")
-                .mockResolvedValueOnce(
-                    releaseResponse({
-                        tag_name: "v1.0.0",
-                        assets: [
-                            {
-                                name: "lilbee-macos-arm64",
-                                browser_download_url: "https://example.com/dl",
-                                size: 3,
-                                digest: sha256Digest(data),
-                            },
-                        ],
-                    }),
-                )
-                .mockResolvedValueOnce(downloadResponse(data));
-            vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
+            vi.spyOn(node, "requestUrl").mockResolvedValue(
+                releaseResponse({
+                    tag_name: "v1.0.0",
+                    assets: [
+                        {
+                            name: "lilbee-macos-arm64",
+                            browser_download_url: "https://example.com/dl",
+                            size: 3,
+                            digest: sha256Digest(data),
+                        },
+                    ],
+                }),
+            );
+            stubHttpsBody(data);
+            stubSinkStream();
+            vi.spyOn(node, "renameSync").mockImplementation(() => {});
             vi.spyOn(node, "chmodSync").mockImplementation(() => {});
             vi.spyOn(node, "execFile").mockResolvedValue({ stdout: "", stderr: "" });
 
@@ -385,15 +408,59 @@ describe("BinaryManager", () => {
     });
 
     describe("download", () => {
+        /** Chunks the fake https response yields, plus optional redirect hops. */
+        function stubHttps(
+            chunks: Uint8Array[],
+            opts: { status?: number; headers?: Record<string, string>; hops?: number } = {},
+        ) {
+            let hop = 0;
+            const hops = opts.hops ?? 0;
+            return vi.spyOn(node, "httpsGet").mockImplementation(((url: string, cb: (res: any) => void) => {
+                const res: any = new Readable({ read() {} });
+                if (hop < hops) {
+                    hop += 1;
+                    res.statusCode = 302;
+                    res.headers = { location: `https://cdn.example.com/hop${hop}` };
+                } else {
+                    res.statusCode = opts.status ?? 200;
+                    res.headers = {
+                        "content-length": String(chunks.reduce((n, c) => n + c.length, 0)),
+                        ...(opts.headers ?? {}),
+                    };
+                }
+                queueMicrotask(() => {
+                    cb(res);
+                    if ((res.statusCode ?? 200) < 300) {
+                        for (const c of chunks) res.push(Buffer.from(c));
+                        res.push(null);
+                    }
+                });
+                return { on: () => {} } as any;
+            }) as any);
+        }
+
+        /** Collects everything piped into the destination file. */
+        function stubWriteStream(sink: number[][]) {
+            return vi.spyOn(node, "createWriteStream").mockImplementation(
+                (() =>
+                    new Writable({
+                        write(chunk, _enc, cb) {
+                            sink.push([...Buffer.from(chunk)]);
+                            cb();
+                        },
+                    })) as any,
+            );
+        }
+
         it("creates binDir when it does not exist", async () => {
             restore = stubPlatform("linux", "x64");
             const data = new Uint8Array([10, 20]);
-
             vi.spyOn(node, "existsSync").mockReturnValue(false);
             vi.spyOn(node, "mkdirSync").mockImplementation(() => undefined as never);
             stubEnoughSpace();
-            vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(data));
-            vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
+            stubHttps([data]);
+            stubWriteStream([]);
+            vi.spyOn(node, "renameSync").mockImplementation(() => {});
             vi.spyOn(node, "chmodSync").mockImplementation(() => {});
 
             const mgr = new BinaryManager("/plugins/lilbee/bin");
@@ -402,158 +469,307 @@ describe("BinaryManager", () => {
             expect(node.mkdirSync).toHaveBeenCalledWith(expect.stringContaining("bin"), { recursive: true });
         });
 
-        it("skips mkdir when binDir already exists", async () => {
+        it("streams the asset to a .part file and renames it once the digest clears", async () => {
             restore = stubPlatform("linux", "x64");
-            const data = new Uint8Array([10, 20]);
-
+            const data = new Uint8Array([1, 2, 3, 4]);
+            const written: number[][] = [];
             vi.spyOn(node, "existsSync").mockReturnValue(true);
-            vi.spyOn(node, "mkdirSync").mockImplementation(() => undefined as never);
             stubEnoughSpace();
-            vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(data));
-            vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
+            stubHttps([data.slice(0, 2), data.slice(2)]);
+            const createStream = stubWriteStream(written);
+            const rename = vi.spyOn(node, "renameSync").mockImplementation(() => {});
             vi.spyOn(node, "chmodSync").mockImplementation(() => {});
 
             const mgr = new BinaryManager("/plugins/lilbee/bin");
-            await mgr.download("https://example.com/dl", 2, sha256Digest(data));
+            await mgr.download("https://example.com/dl", 4, sha256Digest(data));
 
-            expect(node.mkdirSync).not.toHaveBeenCalled();
+            expect(createStream).toHaveBeenCalledWith("/plugins/lilbee/bin/lilbee.part");
+            expect(written.flat()).toEqual([1, 2, 3, 4]);
+            expect(rename).toHaveBeenCalledWith("/plugins/lilbee/bin/lilbee.part", "/plugins/lilbee/bin/lilbee");
+            expect(node.chmodSync).toHaveBeenCalledWith("/plugins/lilbee/bin/lilbee", 0o755);
         });
 
-        it("throws and skips the fetch when there isn't enough disk space", async () => {
+        it("reports bytes received against the content length", async () => {
             restore = stubPlatform("linux", "x64");
-            vi.spyOn(node, "existsSync").mockReturnValue(true);
-            vi.spyOn(node, "statfs").mockResolvedValue(fakeStatfs(500 * 1024 ** 2)); // 500 MB free
-            const reqSpy = vi.spyOn(node, "requestUrl");
-            const writeSpy = vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
-
-            const mgr = new BinaryManager("/plugins/lilbee/bin");
-            // A 1 GB asset needs ~1.5 GB; the message reports GB for the requirement and MB for the free space.
-            await expect(mgr.download("https://example.com/dl", 1024 ** 3, null)).rejects.toThrow(
-                /need about 1\.5 GB free, but only 500 MB is available/,
-            );
-            expect(reqSpy).not.toHaveBeenCalled();
-            expect(writeSpy).not.toHaveBeenCalled();
-        });
-
-        it("writes binary data and calls chmod on non-win32", async () => {
-            restore = stubPlatform("linux", "x64");
-            const data = new Uint8Array([1, 2, 3, 4, 5, 6]);
-
+            const data = new Uint8Array([1, 2, 3, 4]);
             vi.spyOn(node, "existsSync").mockReturnValue(true);
             stubEnoughSpace();
-            vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(data));
-            vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
+            stubHttps([data.slice(0, 3), data.slice(3)]);
+            stubWriteStream([]);
+            vi.spyOn(node, "renameSync").mockImplementation(() => {});
             vi.spyOn(node, "chmodSync").mockImplementation(() => {});
 
-            const onProgress = vi.fn();
+            const seen: Array<{ receivedBytes: number; totalBytes: number | null }> = [];
             const mgr = new BinaryManager("/plugins/lilbee/bin");
-            await mgr.download("https://example.com/dl", 6, sha256Digest(data), onProgress);
+            await mgr.download("https://example.com/dl", 4, sha256Digest(data), (_m, _u, p) => {
+                if (p) seen.push(p);
+            });
 
-            expect(node.writeFileSync).toHaveBeenCalledWith(mgr.binaryPath, expect.any(Buffer));
-            const writtenBuffer = (node.writeFileSync as ReturnType<typeof vi.fn>).mock.calls[0][1] as Buffer;
-            expect([...writtenBuffer]).toEqual([1, 2, 3, 4, 5, 6]);
-            expect(node.chmodSync).toHaveBeenCalledWith(mgr.binaryPath, 0o755);
-            expect(onProgress).toHaveBeenCalledWith("Downloading...", expect.any(String));
-            expect(onProgress).toHaveBeenCalledWith("Download complete.", expect.any(String));
+            expect(seen).toEqual([
+                { receivedBytes: 3, totalBytes: 4 },
+                { receivedBytes: 4, totalBytes: 4 },
+            ]);
         });
 
-        it("removes a half-written binary when the write fails", async () => {
+        it("reports a null total when the server sends no content length", async () => {
+            restore = stubPlatform("linux", "x64");
+            const data = new Uint8Array([7]);
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            stubEnoughSpace();
+            vi.spyOn(node, "httpsGet").mockImplementation(((_url: string, cb: (res: any) => void) => {
+                const res: any = new Readable({ read() {} });
+                res.statusCode = 200;
+                res.headers = {};
+                queueMicrotask(() => {
+                    cb(res);
+                    res.push(Buffer.from(data));
+                    res.push(null);
+                });
+                return { on: () => {} } as any;
+            }) as any);
+            stubWriteStream([]);
+            vi.spyOn(node, "renameSync").mockImplementation(() => {});
+            vi.spyOn(node, "chmodSync").mockImplementation(() => {});
+
+            const seen: Array<{ receivedBytes: number; totalBytes: number | null }> = [];
+            const mgr = new BinaryManager("/plugins/lilbee/bin");
+            await mgr.download("https://example.com/dl", 1, sha256Digest(data), (_m, _u, p) => {
+                if (p) seen.push(p);
+            });
+
+            expect(seen).toEqual([{ receivedBytes: 1, totalBytes: null }]);
+        });
+
+        it("follows redirects to the asset host", async () => {
+            restore = stubPlatform("linux", "x64");
+            const data = new Uint8Array([9]);
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            stubEnoughSpace();
+            const get = stubHttps([data], { hops: 1 });
+            stubWriteStream([]);
+            vi.spyOn(node, "renameSync").mockImplementation(() => {});
+            vi.spyOn(node, "chmodSync").mockImplementation(() => {});
+
+            const mgr = new BinaryManager("/plugins/lilbee/bin");
+            await mgr.download("https://example.com/dl", 1, sha256Digest(data));
+
+            expect(get).toHaveBeenCalledTimes(2);
+            expect(get.mock.calls[1][0]).toBe("https://cdn.example.com/hop1");
+        });
+
+        it("gives up after too many redirects", async () => {
             restore = stubPlatform("linux", "x64");
             vi.spyOn(node, "existsSync").mockReturnValue(true);
             stubEnoughSpace();
-            vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(new Uint8Array([1, 2])));
-            vi.spyOn(node, "writeFileSync").mockImplementation(() => {
-                throw new Error("ENOSPC");
-            });
-            const unlinkSpy = vi.spyOn(node, "unlinkSync").mockImplementation(() => {});
+            stubHttps([new Uint8Array([1])], { hops: 99 });
+            stubWriteStream([]);
 
             const mgr = new BinaryManager("/plugins/lilbee/bin");
-            await expect(
-                mgr.download("https://example.com/dl", 2, sha256Digest(new Uint8Array([1, 2]))),
-            ).rejects.toThrow("ENOSPC");
-            expect(unlinkSpy).toHaveBeenCalledWith(mgr.binaryPath);
+            await expect(mgr.download("https://example.com/dl", 1, null)).rejects.toThrow("too many redirects");
         });
 
-        it("rethrows a write failure without unlinking when nothing was written", async () => {
+        it("throws and skips the download when there isn't enough disk space", async () => {
             restore = stubPlatform("linux", "x64");
-            // binDir exists (1st existsSync), dest missing in the catch (2nd existsSync)
-            vi.spyOn(node, "existsSync").mockReturnValueOnce(true).mockReturnValueOnce(false);
-            stubEnoughSpace();
-            vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(new Uint8Array([1])));
-            vi.spyOn(node, "writeFileSync").mockImplementation(() => {
-                throw new Error("boom");
-            });
-            const unlinkSpy = vi.spyOn(node, "unlinkSync").mockImplementation(() => {});
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            vi.spyOn(node, "statfs").mockResolvedValue(fakeStatfs(1));
+            const get = vi.spyOn(node, "httpsGet");
 
             const mgr = new BinaryManager("/plugins/lilbee/bin");
-            await expect(mgr.download("https://example.com/dl", 1, sha256Digest(new Uint8Array([1])))).rejects.toThrow(
-                "boom",
+            await expect(mgr.download("https://example.com/dl", 1_000_000, null)).rejects.toThrow(
+                "Not enough disk space",
             );
-            expect(unlinkSpy).not.toHaveBeenCalled();
+            expect(get).not.toHaveBeenCalled();
+        });
+
+        it("discards the partial file and keeps the installed binary when the digest is wrong", async () => {
+            restore = stubPlatform("linux", "x64");
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            stubEnoughSpace();
+            stubHttps([new Uint8Array([1, 2])]);
+            stubWriteStream([]);
+            const rename = vi.spyOn(node, "renameSync").mockImplementation(() => {});
+            const unlink = vi.spyOn(node, "unlinkSync").mockImplementation(() => {});
+
+            const mgr = new BinaryManager("/plugins/lilbee/bin");
+            await expect(mgr.download("https://example.com/dl", 2, "sha256:deadbeef")).rejects.toThrow(
+                "could not be verified",
+            );
+
+            expect(rename).not.toHaveBeenCalled();
+            expect(unlink).toHaveBeenCalledWith("/plugins/lilbee/bin/lilbee.part");
+            expect(unlink).not.toHaveBeenCalledWith("/plugins/lilbee/bin/lilbee");
+        });
+
+        it("removes the renamed binary when chmod fails", async () => {
+            restore = stubPlatform("linux", "x64");
+            const data = new Uint8Array([1]);
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            stubEnoughSpace();
+            stubHttps([data]);
+            stubWriteStream([]);
+            vi.spyOn(node, "renameSync").mockImplementation(() => {});
+            vi.spyOn(node, "chmodSync").mockImplementation(() => {
+                throw new Error("chmod boom");
+            });
+            const unlink = vi.spyOn(node, "unlinkSync").mockImplementation(() => {});
+
+            const mgr = new BinaryManager("/plugins/lilbee/bin");
+            await expect(mgr.download("https://example.com/dl", 1, sha256Digest(data))).rejects.toThrow("chmod boom");
+
+            expect(unlink).toHaveBeenCalledWith("/plugins/lilbee/bin/lilbee");
+        });
+
+        it("surfaces a transport error", async () => {
+            restore = stubPlatform("linux", "x64");
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            stubEnoughSpace();
+            vi.spyOn(node, "httpsGet").mockImplementation(((_url: string, _cb: unknown) => {
+                const req = {
+                    on: (event: string, handler: (e: Error) => void) => {
+                        if (event === "error") queueMicrotask(() => handler(new Error("socket hang up")));
+                    },
+                };
+                return req as any;
+            }) as any);
+
+            const mgr = new BinaryManager("/plugins/lilbee/bin");
+            await expect(mgr.download("https://example.com/dl", 1, null)).rejects.toThrow("socket hang up");
+        });
+
+        it("surfaces a mid-stream read error", async () => {
+            restore = stubPlatform("linux", "x64");
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            stubEnoughSpace();
+            vi.spyOn(node, "httpsGet").mockImplementation(((_url: string, cb: (res: any) => void) => {
+                const res: any = new Readable({ read() {} });
+                res.statusCode = 200;
+                res.headers = { "content-length": "4" };
+                queueMicrotask(() => {
+                    cb(res);
+                    setTimeout(() => res.emit("error", new Error("connection reset")), 0);
+                });
+                return { on: () => {} } as any;
+            }) as any);
+            stubWriteStream([]);
+            vi.spyOn(node, "unlinkSync").mockImplementation(() => {});
+
+            const mgr = new BinaryManager("/plugins/lilbee/bin");
+            await expect(mgr.download("https://example.com/dl", 4, null)).rejects.toThrow("connection reset");
+        });
+
+        it("surfaces a disk write error", async () => {
+            restore = stubPlatform("linux", "x64");
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            stubEnoughSpace();
+            stubHttps([new Uint8Array([1])]);
+            vi.spyOn(node, "createWriteStream").mockImplementation(
+                (() =>
+                    new Writable({
+                        write(_c, _e, cb) {
+                            cb(new Error("ENOSPC"));
+                        },
+                    })) as any,
+            );
+            vi.spyOn(node, "unlinkSync").mockImplementation(() => {});
+
+            const mgr = new BinaryManager("/plugins/lilbee/bin");
+            await expect(mgr.download("https://example.com/dl", 1, null)).rejects.toThrow("ENOSPC");
+        });
+
+        it("throws when the asset host answers with an error status", async () => {
+            restore = stubPlatform("linux", "x64");
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            stubEnoughSpace();
+            stubHttps([], { status: 404 });
+            stubWriteStream([]);
+
+            const mgr = new BinaryManager("/plugins/lilbee/bin");
+            await expect(mgr.download("https://example.com/dl", 1, null)).rejects.toThrow("Download failed: 404");
+        });
+
+        it("treats a response with no status code as an error", async () => {
+            restore = stubPlatform("linux", "x64");
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            stubEnoughSpace();
+            vi.spyOn(node, "httpsGet").mockImplementation(((_url: string, cb: (res: any) => void) => {
+                const res: any = new Readable({ read() {} });
+                res.headers = {};
+                queueMicrotask(() => cb(res));
+                return { on: () => {} } as any;
+            }) as any);
+            stubSinkStream();
+            vi.spyOn(node, "unlinkSync").mockImplementation(() => {});
+
+            const mgr = new BinaryManager("/plugins/lilbee/bin");
+            await expect(mgr.download("https://example.com/dl", 1, null)).rejects.toThrow("Download failed: 0");
+        });
+
+        it("leaves no partial behind when the download never created one", async () => {
+            restore = stubPlatform("linux", "x64");
+            // binDir exists, but the .part file never landed.
+            vi.spyOn(node, "existsSync").mockReturnValueOnce(true).mockReturnValue(false);
+            stubEnoughSpace();
+            stubHttps([], { status: 500 });
+            stubSinkStream();
+            const unlink = vi.spyOn(node, "unlinkSync").mockImplementation(() => {});
+
+            const mgr = new BinaryManager("/plugins/lilbee/bin");
+            await expect(mgr.download("https://example.com/dl", 1, null)).rejects.toThrow("Download failed: 500");
+            expect(unlink).not.toHaveBeenCalled();
+        });
+
+        it("names gigabyte-scale space requirements in GB", async () => {
+            restore = stubPlatform("linux", "x64");
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            vi.spyOn(node, "statfs").mockResolvedValue(fakeStatfs(1));
+
+            const mgr = new BinaryManager("/plugins/lilbee/bin");
+            await expect(mgr.download("https://example.com/dl", 4 * 1024 ** 3, null)).rejects.toThrow(/4\.4 GB free/);
         });
 
         it("calls xattr on darwin", async () => {
             restore = stubPlatform("darwin", "arm64");
             const data = new Uint8Array([1]);
-
             vi.spyOn(node, "existsSync").mockReturnValue(true);
             stubEnoughSpace();
-            vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(data));
-            vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
+            stubHttps([data]);
+            stubWriteStream([]);
+            vi.spyOn(node, "renameSync").mockImplementation(() => {});
             vi.spyOn(node, "chmodSync").mockImplementation(() => {});
             const execSpy = vi.spyOn(node, "execFile").mockResolvedValue({ stdout: "", stderr: "" });
 
+            const mgr = new BinaryManager("/plugins/lilbee/bin");
+            await mgr.download("https://example.com/dl", 1, sha256Digest(data));
+
+            expect(execSpy).toHaveBeenCalledWith("xattr", ["-cr", "/plugins/lilbee/bin/lilbee"]);
+        });
+
+        it("reports a quarantine failure without failing the download", async () => {
+            restore = stubPlatform("darwin", "arm64");
+            const data = new Uint8Array([1]);
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            stubEnoughSpace();
+            stubHttps([data]);
+            stubWriteStream([]);
+            vi.spyOn(node, "renameSync").mockImplementation(() => {});
+            vi.spyOn(node, "chmodSync").mockImplementation(() => {});
+            vi.spyOn(node, "execFile").mockRejectedValue(new Error("no xattr"));
             const onQuarantineFailed = vi.fn();
+
             const mgr = new BinaryManager("/plugins/lilbee/bin");
             await mgr.download("https://example.com/dl", 1, sha256Digest(data), undefined, onQuarantineFailed);
 
-            expect(execSpy).toHaveBeenCalledWith("xattr", ["-cr", mgr.binaryPath]);
-            expect(onQuarantineFailed).not.toHaveBeenCalled();
-        });
-
-        it("treats xattr failure as non-fatal but signals it on darwin", async () => {
-            restore = stubPlatform("darwin", "arm64");
-            const data = new Uint8Array([1]);
-
-            vi.spyOn(node, "existsSync").mockReturnValue(true);
-            stubEnoughSpace();
-            vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(data));
-            vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
-            vi.spyOn(node, "chmodSync").mockImplementation(() => {});
-            vi.spyOn(node, "execFile").mockRejectedValue(new Error("xattr not found"));
-
-            const onQuarantineFailed = vi.fn();
-            const mgr = new BinaryManager("/plugins/lilbee/bin");
-            // The download still resolves; the caller is told quarantine couldn't be cleared.
-            await expect(
-                mgr.download("https://example.com/dl", 1, sha256Digest(data), undefined, onQuarantineFailed),
-            ).resolves.toBeUndefined();
-            expect(onQuarantineFailed).toHaveBeenCalledTimes(1);
-        });
-
-        it("does not signal quarantine failure when the callback is omitted", async () => {
-            restore = stubPlatform("darwin", "arm64");
-            vi.spyOn(node, "existsSync").mockReturnValue(true);
-            stubEnoughSpace();
-            vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(new Uint8Array([1])));
-            vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
-            vi.spyOn(node, "chmodSync").mockImplementation(() => {});
-            vi.spyOn(node, "execFile").mockRejectedValue(new Error("xattr not found"));
-
-            const mgr = new BinaryManager("/plugins/lilbee/bin");
-            await expect(
-                mgr.download("https://example.com/dl", 1, sha256Digest(new Uint8Array([1]))),
-            ).resolves.toBeUndefined();
+            expect(onQuarantineFailed).toHaveBeenCalled();
         });
 
         it("skips chmod on win32", async () => {
             restore = stubPlatform("win32", "x64");
             const data = new Uint8Array([1]);
-
             vi.spyOn(node, "existsSync").mockReturnValue(true);
             stubEnoughSpace();
-            vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(data));
-            vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
+            stubHttps([data]);
+            stubWriteStream([]);
+            vi.spyOn(node, "renameSync").mockImplementation(() => {});
             vi.spyOn(node, "chmodSync").mockImplementation(() => {});
 
             const mgr = new BinaryManager("/plugins/lilbee/bin");
@@ -565,11 +781,11 @@ describe("BinaryManager", () => {
         it("does not call xattr on non-darwin platforms", async () => {
             restore = stubPlatform("linux", "x64");
             const data = new Uint8Array([1]);
-
             vi.spyOn(node, "existsSync").mockReturnValue(true);
             stubEnoughSpace();
-            vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(data));
-            vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
+            stubHttps([data]);
+            stubWriteStream([]);
+            vi.spyOn(node, "renameSync").mockImplementation(() => {});
             vi.spyOn(node, "chmodSync").mockImplementation(() => {});
             const execSpy = vi.spyOn(node, "execFile").mockResolvedValue({ stdout: "", stderr: "" });
 
@@ -577,35 +793,6 @@ describe("BinaryManager", () => {
             await mgr.download("https://example.com/dl", 1, sha256Digest(data));
 
             expect(execSpy).not.toHaveBeenCalled();
-        });
-
-        it("throws when download response has error status", async () => {
-            restore = stubPlatform("linux", "x64");
-            vi.spyOn(node, "existsSync").mockReturnValue(true);
-            stubEnoughSpace();
-            vi.spyOn(node, "requestUrl").mockResolvedValue({
-                status: 404,
-                json: {},
-                arrayBuffer: new ArrayBuffer(0),
-                headers: {},
-            });
-
-            const mgr = new BinaryManager("/plugins/lilbee/bin");
-            await expect(mgr.download("https://example.com/dl", 1, null)).rejects.toThrow("Download failed: 404");
-        });
-
-        it("works without onProgress callback", async () => {
-            restore = stubPlatform("linux", "x64");
-            const data = new Uint8Array([1]);
-
-            vi.spyOn(node, "existsSync").mockReturnValue(true);
-            stubEnoughSpace();
-            vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(data));
-            vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
-            vi.spyOn(node, "chmodSync").mockImplementation(() => {});
-
-            const mgr = new BinaryManager("/plugins/lilbee/bin");
-            await expect(mgr.download("https://example.com/dl", 1, sha256Digest(data))).resolves.toBeUndefined();
         });
     });
 });
@@ -617,44 +804,59 @@ describe("BinaryManager.download digest verification", () => {
     function stubDownload(data: Uint8Array) {
         vi.spyOn(node, "existsSync").mockReturnValue(true);
         stubEnoughSpace();
-        vi.spyOn(node, "requestUrl").mockResolvedValue(downloadResponse(data));
+        stubHttpsBody(data);
+        stubSinkStream();
+        vi.spyOn(node, "unlinkSync").mockImplementation(() => {});
         vi.spyOn(node, "chmodSync").mockImplementation(() => {});
     }
 
-    it("writes the binary when the digest matches the downloaded bytes", async () => {
+    it("installs the binary when the digest matches the downloaded bytes", async () => {
         restore = stubPlatform("linux", "x64");
         const data = new Uint8Array([1, 2, 3, 4]);
         stubDownload(data);
-        const writeSpy = vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
+        const rename = vi.spyOn(node, "renameSync").mockImplementation(() => {});
 
         const mgr = new BinaryManager("/plugins/lilbee/bin");
         await mgr.download("https://example.com/dl", 4, sha256Digest(data));
 
-        expect(writeSpy).toHaveBeenCalledWith(mgr.binaryPath, expect.any(Buffer));
+        expect(rename).toHaveBeenCalledWith(`${mgr.binaryPath}.part`, mgr.binaryPath);
     });
 
-    it("rejects and writes nothing when the digest does not match the bytes", async () => {
+    it("rejects and installs nothing when the digest does not match the bytes", async () => {
         restore = stubPlatform("linux", "x64");
         const data = new Uint8Array([1, 2, 3, 4]);
         stubDownload(data);
-        const writeSpy = vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
+        const rename = vi.spyOn(node, "renameSync").mockImplementation(() => {});
 
         const mgr = new BinaryManager("/plugins/lilbee/bin");
         await expect(
             mgr.download("https://example.com/dl", 4, sha256Digest(new Uint8Array([9, 9, 9]))),
         ).rejects.toThrow(/checksum/i);
-        expect(writeSpy).not.toHaveBeenCalled();
+        expect(rename).not.toHaveBeenCalled();
     });
 
-    it("rejects and writes nothing when the release provides no digest", async () => {
+    it("rejects and installs nothing when the release provides no digest", async () => {
         restore = stubPlatform("linux", "x64");
         const data = new Uint8Array([1, 2, 3, 4]);
         stubDownload(data);
-        const writeSpy = vi.spyOn(node, "writeFileSync").mockImplementation(() => {});
+        const rename = vi.spyOn(node, "renameSync").mockImplementation(() => {});
 
         const mgr = new BinaryManager("/plugins/lilbee/bin");
         await expect(mgr.download("https://example.com/dl", 4, null)).rejects.toThrow(/checksum/i);
-        expect(writeSpy).not.toHaveBeenCalled();
+        expect(rename).not.toHaveBeenCalled();
+    });
+
+    it("keeps the real error when discarding the partial file fails", async () => {
+        restore = stubPlatform("linux", "x64");
+        const data = new Uint8Array([1, 2, 3, 4]);
+        stubDownload(data);
+        vi.spyOn(node, "renameSync").mockImplementation(() => {});
+        vi.spyOn(node, "unlinkSync").mockImplementation(() => {
+            throw new Error("ENOENT: no such file");
+        });
+
+        const mgr = new BinaryManager("/plugins/lilbee/bin");
+        await expect(mgr.download("https://example.com/dl", 4, "sha256:bad")).rejects.toThrow(/checksum/i);
     });
 });
 

--- a/tests/binary-manager.test.ts
+++ b/tests/binary-manager.test.ts
@@ -657,6 +657,91 @@ describe("BinaryManager", () => {
             await expect(mgr.download("https://example.com/dl", 4, null)).rejects.toThrow("connection reset");
         });
 
+        it("gives up when the asset host never answers", async () => {
+            restore = stubPlatform("linux", "x64");
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            stubEnoughSpace();
+            // Mirrors Node: setTimeout arms a callback, destroy(err) surfaces on "error".
+            vi.spyOn(node, "httpsGet").mockImplementation(((_url: string, _cb: unknown) => {
+                let onError: ((e: Error) => void) | undefined;
+                const req = {
+                    on: (event: string, handler: (e: Error) => void) => {
+                        if (event === "error") onError = handler;
+                    },
+                    destroy: (err: Error) => onError?.(err),
+                    setTimeout: (_ms: number, cb: () => void) => queueMicrotask(cb),
+                };
+                return req as any;
+            }) as any);
+
+            const mgr = new BinaryManager("/plugins/lilbee/bin");
+            await expect(mgr.download("https://example.com/dl", 1, null)).rejects.toThrow("download stalled");
+        });
+
+        it("gives up when the asset host goes quiet mid-stream", async () => {
+            vi.useFakeTimers();
+            restore = stubPlatform("linux", "x64");
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            stubEnoughSpace();
+            vi.spyOn(node, "httpsGet").mockImplementation(((_url: string, cb: (res: any) => void) => {
+                const res: any = new Readable({ read() {} });
+                res.statusCode = 200;
+                res.headers = { "content-length": "999" };
+                queueMicrotask(() => {
+                    cb(res);
+                    res.push(Buffer.from([1])); // one chunk, then silence forever
+                });
+                return { on: () => {}, setTimeout: () => {}, destroy: () => {} } as any;
+            }) as any);
+            stubSinkStream();
+            const unlink = vi.spyOn(node, "unlinkSync").mockImplementation(() => {});
+
+            const mgr = new BinaryManager("/plugins/lilbee/bin");
+            const pending = mgr.download("https://example.com/dl", 999, null);
+            const assertion = expect(pending).rejects.toThrow("download stalled");
+            await vi.advanceTimersByTimeAsync(60_000);
+            await assertion;
+
+            expect(unlink).toHaveBeenCalledWith(`${mgr.binaryPath}.part`);
+            expect(unlink).not.toHaveBeenCalledWith(mgr.binaryPath);
+            vi.useRealTimers();
+        });
+
+        it("keeps waiting while bytes are still arriving", async () => {
+            vi.useFakeTimers();
+            restore = stubPlatform("linux", "x64");
+            vi.spyOn(node, "existsSync").mockReturnValue(true);
+            stubEnoughSpace();
+            const data = new Uint8Array([1, 2]);
+            let push!: (b: Buffer | null) => void;
+            vi.spyOn(node, "httpsGet").mockImplementation(((_url: string, cb: (res: any) => void) => {
+                const res: any = new Readable({ read() {} });
+                res.statusCode = 200;
+                res.headers = { "content-length": "2" };
+                push = (b) => res.push(b);
+                queueMicrotask(() => cb(res));
+                return { on: () => {}, setTimeout: () => {}, destroy: () => {} } as any;
+            }) as any);
+            stubSinkStream();
+            vi.spyOn(node, "renameSync").mockImplementation(() => {});
+            vi.spyOn(node, "chmodSync").mockImplementation(() => {});
+
+            const mgr = new BinaryManager("/plugins/lilbee/bin");
+            const pending = mgr.download("https://example.com/dl", 2, sha256Digest(data));
+            await vi.advanceTimersByTimeAsync(0);
+
+            // Each chunk lands just under the idle limit, so the clock keeps resetting.
+            push(Buffer.from([1]));
+            await vi.advanceTimersByTimeAsync(50_000);
+            push(Buffer.from([2]));
+            await vi.advanceTimersByTimeAsync(50_000);
+            push(null);
+            await vi.advanceTimersByTimeAsync(0);
+
+            await expect(pending).resolves.toBeUndefined();
+            vi.useRealTimers();
+        });
+
         it("surfaces a disk write error", async () => {
             restore = stubPlatform("linux", "x64");
             vi.spyOn(node, "existsSync").mockReturnValue(true);

--- a/tests/binary-manager.test.ts
+++ b/tests/binary-manager.test.ts
@@ -483,10 +483,10 @@ describe("BinaryManager", () => {
             const mgr = new BinaryManager("/plugins/lilbee/bin");
             await mgr.download("https://example.com/dl", 4, sha256Digest(data));
 
-            expect(createStream).toHaveBeenCalledWith("/plugins/lilbee/bin/lilbee.part");
+            expect(createStream).toHaveBeenCalledWith(`${mgr.binaryPath}.part`);
             expect(written.flat()).toEqual([1, 2, 3, 4]);
-            expect(rename).toHaveBeenCalledWith("/plugins/lilbee/bin/lilbee.part", "/plugins/lilbee/bin/lilbee");
-            expect(node.chmodSync).toHaveBeenCalledWith("/plugins/lilbee/bin/lilbee", 0o755);
+            expect(rename).toHaveBeenCalledWith(`${mgr.binaryPath}.part`, mgr.binaryPath);
+            expect(node.chmodSync).toHaveBeenCalledWith(mgr.binaryPath, 0o755);
         });
 
         it("reports bytes received against the content length", async () => {
@@ -596,8 +596,8 @@ describe("BinaryManager", () => {
             );
 
             expect(rename).not.toHaveBeenCalled();
-            expect(unlink).toHaveBeenCalledWith("/plugins/lilbee/bin/lilbee.part");
-            expect(unlink).not.toHaveBeenCalledWith("/plugins/lilbee/bin/lilbee");
+            expect(unlink).toHaveBeenCalledWith(`${mgr.binaryPath}.part`);
+            expect(unlink).not.toHaveBeenCalledWith(mgr.binaryPath);
         });
 
         it("removes the renamed binary when chmod fails", async () => {
@@ -616,7 +616,7 @@ describe("BinaryManager", () => {
             const mgr = new BinaryManager("/plugins/lilbee/bin");
             await expect(mgr.download("https://example.com/dl", 1, sha256Digest(data))).rejects.toThrow("chmod boom");
 
-            expect(unlink).toHaveBeenCalledWith("/plugins/lilbee/bin/lilbee");
+            expect(unlink).toHaveBeenCalledWith(mgr.binaryPath);
         });
 
         it("surfaces a transport error", async () => {
@@ -741,7 +741,7 @@ describe("BinaryManager", () => {
             const mgr = new BinaryManager("/plugins/lilbee/bin");
             await mgr.download("https://example.com/dl", 1, sha256Digest(data));
 
-            expect(execSpy).toHaveBeenCalledWith("xattr", ["-cr", "/plugins/lilbee/bin/lilbee"]);
+            expect(execSpy).toHaveBeenCalledWith("xattr", ["-cr", mgr.binaryPath]);
         });
 
         it("reports a quarantine failure without failing the download", async () => {

--- a/tests/locales/en.test.ts
+++ b/tests/locales/en.test.ts
@@ -183,6 +183,10 @@ describe("MESSAGES", () => {
     describe("STATUS_ constants", () => {
         it("has all status constants", () => {
             expect(MESSAGES.STATUS_DOWNLOADING).toBe("lilbee: downloading...");
+            expect(MESSAGES.STATUS_DOWNLOAD_PROGRESS(50, "128 MB", "256 MB")).toBe(
+                "Downloading... 50% (128 MB of 256 MB)",
+            );
+            expect(MESSAGES.STATUS_DOWNLOAD_RECEIVED("5.00 MB")).toBe("Downloading... 5.00 MB");
             expect(MESSAGES.STATUS_STARTING).toBe("lilbee: starting...");
             expect(MESSAGES.STATUS_READY).toBe("lilbee: ready");
             expect(MESSAGES.STATUS_READY_EXTERNAL).toBe("lilbee: ready [external]");

--- a/tests/main-shared.test.ts
+++ b/tests/main-shared.test.ts
@@ -81,6 +81,12 @@ vi.mock("../src/binary-manager", () => {
     };
     return {
         node: nodeMock,
+        DownloadCanceledError: class DownloadCanceledError extends Error {
+            constructor() {
+                super("The lilbee server download was cancelled.");
+                this.name = "DownloadCanceledError";
+            }
+        },
         BinaryManager: vi.fn().mockImplementation(function () {
             return {
                 binaryExists: vi.fn().mockReturnValue(true),
@@ -497,8 +503,9 @@ describe("ensureBinaryWithUi guards", () => {
         expect(events.find((e) => e.phase === "error")).toBeDefined();
     });
 
-    it("hides the download notice when ensureBinary throws after firing progress", async () => {
+    it("raises no progress toast when ensureBinary throws after firing progress", async () => {
         const plugin = await createPlugin();
+        Notice.clear?.();
         (plugin as any).binaryManager = {
             binaryExists: () => false,
             ensureBinary: vi.fn(async (cb: (m: string, u?: string) => void) => {
@@ -508,6 +515,43 @@ describe("ensureBinaryWithUi guards", () => {
         };
         const result = await (plugin as any).ensureBinaryWithUi();
         expect(result).toBeNull();
+        expect(Notice.instances.some((n) => n.duration === 0)).toBe(false);
+    });
+
+    it("cancelling a download is reported as a choice, not a failure", async () => {
+        const { DownloadCanceledError } = await import("../src/binary-manager");
+        const plugin = await createPlugin();
+        Notice.clear?.();
+        (plugin as any).binaryManager = {
+            binaryExists: () => false,
+            ensureBinary: vi.fn(async () => {
+                throw new DownloadCanceledError();
+            }),
+        };
+
+        const result = await (plugin as any).ensureBinaryWithUi();
+
+        expect(result).toBeNull();
+        expect(Notice.instances.map((n) => n.message)).toContain("lilbee server download cancelled.");
+    });
+
+    it("cancelServerDownload aborts the in-flight download", async () => {
+        const plugin = await createPlugin();
+        let seenSignal: AbortSignal | undefined;
+        (plugin as any).binaryManager = {
+            binaryExists: () => false,
+            ensureBinary: vi.fn(async (_cb: unknown, _q: unknown, signal: AbortSignal) => {
+                seenSignal = signal;
+                expect(plugin.isDownloadingServer()).toBe(true);
+                plugin.cancelServerDownload();
+                return "/fake/bin/lilbee";
+            }),
+        };
+
+        await (plugin as any).ensureBinaryWithUi();
+
+        expect(seenSignal?.aborted).toBe(true);
+        expect(plugin.isDownloadingServer()).toBe(false);
     });
 
     it("returns the path without creating a notice when the binary already exists", async () => {
@@ -522,20 +566,20 @@ describe("ensureBinaryWithUi guards", () => {
         expect(Notice.instances.length).toBe(before);
     });
 
-    it("hides the download notice in the finally block", async () => {
+    it("clears the download controller once the download finishes", async () => {
         const plugin = await createPlugin();
-        const fakeBm = {
+        Notice.clear?.();
+        (plugin as any).binaryManager = {
             binaryExists: () => false,
             ensureBinary: vi.fn(async (cb: (m: string, u?: string) => void) => {
                 cb("Downloading", "https://example.com");
                 return "/fake/bin/lilbee";
             }),
         };
-        (plugin as any).binaryManager = fakeBm;
         const result = await (plugin as any).ensureBinaryWithUi();
         expect(result).toBe("/fake/bin/lilbee");
-        // The Notice was constructed (counts in instances).
-        expect(Notice.instances.length).toBeGreaterThan(0);
+        expect(plugin.isDownloadingServer()).toBe(false);
+        expect(Notice.instances.some((n) => n.duration === 0)).toBe(false);
     });
 });
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -180,6 +180,12 @@ vi.mock("../src/binary-manager", () => ({
     }),
     getLatestRelease: vi.fn(),
     checkForUpdate: vi.fn(),
+    DownloadCanceledError: class DownloadCanceledError extends Error {
+        constructor() {
+            super("The lilbee server download was cancelled.");
+            this.name = "DownloadCanceledError";
+        }
+    },
     GITHUB_REPO: "tobocop2/lilbee",
     LILBEE_GITHUB_REPO_URL: "https://github.com/tobocop2/lilbee",
     node: {
@@ -4791,16 +4797,16 @@ describe("LilbeePlugin", () => {
             expect(phases).toContainEqual(
                 expect.objectContaining({ message: "Downloading... 50% (128 MB of 256 MB)", percent: 50 }),
             );
-            const notice = Notice.instances.find((n) => n.message.includes("50%"));
-            expect(notice).toBeDefined();
+            // The status bar carries the ambient percentage; no progress toast is raised.
+            expect((plugin as any).statusBarEl?.textContent).toContain("lilbee: downloading 50%");
+            expect(Notice.instances.some((n) => n.duration === 0)).toBe(false);
         });
 
-        it("shows download Notice with URL when binary is missing", async () => {
-            // Missing-binary flow checks binaryExists twice (consent gate + download UI).
+        it("raises no progress toast while the binary downloads", async () => {
             mockBinaryExists.mockReturnValue(false);
             mockEnsureBinary.mockImplementationOnce(async (cb: any) => {
-                cb?.("Downloading...", "https://example.com/dl");
-                cb?.("Download complete.", "https://example.com/dl");
+                cb?.("Downloading...", "https://example.com/dl", { receivedBytes: 1, totalBytes: 4 });
+                cb?.("Downloading...", "https://example.com/dl", { receivedBytes: 4, totalBytes: 4 });
                 return "/fake/bin/lilbee";
             });
 
@@ -4808,28 +4814,8 @@ describe("LilbeePlugin", () => {
             await plugin.onload();
             await flush();
 
-            const downloadNotice = Notice.instances.find((n) => n.duration === 0);
-            expect(downloadNotice).toBeDefined();
-            expect(downloadNotice!.message).toContain("Download complete.");
-            expect(downloadNotice!.message).toContain("https://example.com/dl");
-            expect(downloadNotice!.hidden).toBe(true);
-        });
-
-        it("shows download Notice without URL when url is not provided", async () => {
-            mockBinaryExists.mockReturnValue(false);
-            mockEnsureBinary.mockImplementationOnce(async (cb: any) => {
-                cb?.("Fetching latest release info...");
-                cb?.("Still going...");
-                return "/fake/bin/lilbee";
-            });
-
-            const plugin = await createPlugin({ serverMode: "managed" });
-            await plugin.onload();
-            await flush();
-
-            const downloadNotice = Notice.instances.find((n) => n.duration === 0);
-            expect(downloadNotice).toBeDefined();
-            expect(downloadNotice!.message).toBe("lilbee: Still going...");
+            // Progress is ambient (status bar). Outcomes, not progress, get toasts.
+            expect(Notice.instances.some((n) => n.duration === 0)).toBe(false);
         });
 
         it("does not show download Notice when binary already exists", async () => {
@@ -4843,20 +4829,19 @@ describe("LilbeePlugin", () => {
             expect(downloadNotice).toBeUndefined();
         });
 
-        it("hides download Notice on ensureBinary failure", async () => {
+        it("raises no progress toast when the download fails", async () => {
             mockBinaryExists.mockReturnValue(false);
             mockEnsureBinary.mockImplementationOnce(async (cb: any) => {
-                cb?.("Downloading...", "https://example.com/dl");
-                throw new Error("network error");
+                cb?.("Downloading...", "https://example.com/dl", { receivedBytes: 1, totalBytes: 4 });
+                throw new Error("network down");
             });
 
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
             await flush();
 
-            const downloadNotice = Notice.instances.find((n) => n.duration === 0);
-            expect(downloadNotice).toBeDefined();
-            expect(downloadNotice!.hidden).toBe(true);
+            expect(Notice.instances.some((n) => n.duration === 0)).toBe(false);
+            expect(Notice.instances.some((n) => n.message.includes("network down"))).toBe(true);
         });
 
         it("startManagedServer onProgress fires downloading/starting/ready during first boot", async () => {
@@ -6442,6 +6427,7 @@ describe("LilbeePlugin", () => {
                 "sha256:test",
                 expect.any(Function),
                 expect.any(Function),
+                expect.any(AbortSignal),
             );
             expect(setSpy).toHaveBeenCalledWith("v0.3.0");
             expect(variantSpy).toHaveBeenCalledWith("cu125");
@@ -6489,6 +6475,21 @@ describe("LilbeePlugin", () => {
             );
 
             expect(seen).toContainEqual(["Downloading... 5.00 MB", undefined]);
+        });
+
+        it("falls back to a plain downloading label when the size is unknown", async () => {
+            mockBinaryExists.mockReturnValue(false);
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            mockEnsureBinary.mockImplementationOnce(async (cb: any) => {
+                cb?.("Downloading...", undefined, { receivedBytes: 5, totalBytes: null });
+                return "/fake/bin/lilbee";
+            });
+            await (plugin as any).ensureBinaryWithUi();
+
+            expect((plugin as any).statusBarEl?.textContent).toContain("lilbee: downloading...");
         });
 
         it("opens the Gatekeeper help modal when an update can't clear quarantine", async () => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -4769,6 +4769,32 @@ describe("LilbeePlugin", () => {
             expect(mockEnsureBinary).toHaveBeenCalled();
         });
 
+        it("shows the download percentage in the status bar and the notice", async () => {
+            mockBinaryExists.mockReturnValue(false);
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+            Notice.clear();
+
+            // Re-run the download UI with a progress-carrying callback; onload's own
+            // call already consumed the default mock.
+            mockEnsureBinary.mockImplementationOnce(async (cb: any) => {
+                cb?.("Downloading...", "https://example.com/dl", {
+                    receivedBytes: 128_000_000,
+                    totalBytes: 256_000_000,
+                });
+                return "/fake/bin/lilbee";
+            });
+            const phases: Array<{ message: string; percent?: number }> = [];
+            await (plugin as any).ensureBinaryWithUi((e: any) => phases.push(e));
+
+            expect(phases).toContainEqual(
+                expect.objectContaining({ message: "Downloading... 50% (128 MB of 256 MB)", percent: 50 }),
+            );
+            const notice = Notice.instances.find((n) => n.message.includes("50%"));
+            expect(notice).toBeDefined();
+        });
+
         it("shows download Notice with URL when binary is missing", async () => {
             // Missing-binary flow checks binaryExists twice (consent gate + download UI).
             mockBinaryExists.mockReturnValue(false);
@@ -6423,6 +6449,46 @@ describe("LilbeePlugin", () => {
             expect(progress).toContain("Downloading...");
             expect(progress).toContain("Starting server...");
             expect(progress).toContain("Update complete.");
+        });
+
+        it("turns download bytes into a percentage and a human line", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            mockDownload.mockImplementationOnce(
+                async (_url: string, _size: number, _digest: string, onProgress: any) => {
+                    onProgress("Downloading...");
+                    onProgress("Downloading...", "https://e/dl", {
+                        receivedBytes: 128_000_000,
+                        totalBytes: 256_000_000,
+                    });
+                },
+            );
+
+            const seen: Array<[string, number | undefined]> = [];
+            await plugin.updateServer(
+                { tag: "v1", assetUrl: "https://e/dl", variant: "default", sizeBytes: 1, digest: null } as any,
+                (msg, percent) => seen.push([msg, percent]),
+            );
+
+            expect(seen).toContainEqual(["Downloading... 50% (128 MB of 256 MB)", 50]);
+        });
+
+        it("reports bytes only when the asset host sends no length", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            mockDownload.mockImplementationOnce(
+                async (_url: string, _size: number, _digest: string, onProgress: any) => {
+                    onProgress("Downloading...", "https://e/dl", { receivedBytes: 5_000_000, totalBytes: null });
+                },
+            );
+
+            const seen: Array<[string, number | undefined]> = [];
+            await plugin.updateServer(
+                { tag: "v1", assetUrl: "https://e/dl", variant: "default", sizeBytes: 1, digest: null } as any,
+                (msg, percent) => seen.push([msg, percent]),
+            );
+
+            expect(seen).toContainEqual(["Downloading... 5.00 MB", undefined]);
         });
 
         it("opens the Gatekeeper help modal when an update can't clear quarantine", async () => {

--- a/tests/settings-vault-sections.test.ts
+++ b/tests/settings-vault-sections.test.ts
@@ -16,6 +16,7 @@ const mockCheckForUpdate = vi.fn();
 
 vi.mock("../src/binary-manager", () => ({
     listReleases: vi.fn(async () => []),
+    DownloadCanceledError: class extends Error {},
     BinaryManager: vi.fn().mockImplementation(function () {
         return {
             ensureBinary: mockEnsureBinary,
@@ -100,6 +101,8 @@ function makePlugin(settings: Partial<LilbeeSettings> = {}, registry: any = null
         setSharedLilbeeVersion: vi.fn(),
         isServerInstalled: () => true,
         isServerUninstalled: () => false,
+        isDownloadingServer: () => false,
+        cancelServerDownload: vi.fn(),
         planServerUninstall: () => ({ targets: [], totalBytes: 0 }),
         uninstallServer: vi.fn().mockResolvedValue(0),
         installServer: vi.fn().mockResolvedValue(undefined),

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -14,10 +14,20 @@ const mockGetLatestRelease = vi.fn();
 const mockCheckForUpdate = vi.fn();
 const mockListReleases = vi.fn(async () => [] as unknown[]);
 
+const { FakeDownloadCanceledError } = vi.hoisted(() => ({
+    FakeDownloadCanceledError: class DownloadCanceledError extends Error {
+        constructor() {
+            super("The lilbee server download was cancelled.");
+            this.name = "DownloadCanceledError";
+        }
+    },
+}));
+
 vi.mock("../src/binary-manager", () => ({
     getLatestRelease: (...args: any[]) => mockGetLatestRelease(...args),
     checkForUpdate: (...args: any[]) => mockCheckForUpdate(...args),
     listReleases: (...args: any[]) => mockListReleases(...args),
+    DownloadCanceledError: FakeDownloadCanceledError,
     BinaryManager: vi.fn(),
     node: {
         existsSync: vi.fn(() => false),
@@ -161,6 +171,8 @@ function makePlugin(overrides: Partial<LilbeeSettings> & { lilbeeVersion?: strin
         },
         isServerInstalled: () => true,
         isServerUninstalled: () => false,
+        isDownloadingServer: () => false,
+        cancelServerDownload: vi.fn(),
         planServerUninstall: () => ({ targets: [], totalBytes: 0 }),
         uninstallServer: vi.fn().mockResolvedValue(0),
         installServer: vi.fn().mockResolvedValue(undefined),
@@ -7206,6 +7218,82 @@ describe("managed mode with no server installed", () => {
         expect(setDesc.mock.calls.some(([d]) => String(d) === MESSAGES.ERROR_RELEASE_LIST)).toBe(true);
         expect(captured.buttons.find((b) => b.name === MESSAGES.LABEL_INSTALL_SERVER)!.disabled).toBe(true);
         setDesc.mockRestore();
+    });
+});
+
+describe("cancelling a server download", () => {
+    const RELEASES = [
+        { tag: "v0.3.0", assetUrl: "https://e/3", variant: "default", sizeBytes: 412_000_000, digest: null },
+    ];
+
+    async function settle(): Promise<void> {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    beforeEach(() => {
+        Notice.clear();
+        mockListReleases.mockResolvedValue(RELEASES);
+    });
+
+    it("offers a cancel button on the progress panel", () => {
+        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.3.0" });
+        const cancelServerDownload = vi.fn();
+        (plugin as any).cancelServerDownload = cancelServerDownload;
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+
+        tab.display();
+        const cancel = tab.containerEl.find("lilbee-update-progress-cancel")!;
+        expect(cancel.textContent).toBe("Cancel download");
+
+        cancel.trigger("click");
+        expect(cancelServerDownload).toHaveBeenCalled();
+    });
+
+    it("reports a cancelled update as a choice, not a failure", async () => {
+        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.3.0" });
+        (plugin as any).updateServer = vi.fn().mockRejectedValue(new FakeDownloadCanceledError());
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+
+        const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+        await settle();
+        await buttonOnClicks[2]();
+
+        expect(Notice.instances.map((n) => n.message)).toContain("lilbee server download cancelled.");
+        expect(Notice.instances.some((n) => n.message.includes("Could not"))).toBe(false);
+        expect(tab.containerEl.find("lilbee-update-progress")!.style.display).toBe("none");
+    });
+
+    it("reports a cancelled first install as a choice, not a failure", async () => {
+        const plugin = makePlugin({ serverMode: "managed" });
+        (plugin as any).isServerInstalled = () => false;
+        (plugin as any).installServer = vi.fn().mockRejectedValue(new FakeDownloadCanceledError());
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+
+        const captured = captureSettingCallbacks(() => tab.display());
+        await settle();
+        await clickButton(captured, MESSAGES.LABEL_INSTALL_SERVER);
+
+        expect(Notice.instances.map((n) => n.message)).toContain("lilbee server download cancelled.");
+    });
+
+    it("offers to stop a download that started outside settings", async () => {
+        const plugin = makePlugin({ serverMode: "managed" });
+        (plugin as any).isServerInstalled = () => false;
+        (plugin as any).isDownloadingServer = () => true;
+        const cancelServerDownload = vi.fn();
+        (plugin as any).cancelServerDownload = cancelServerDownload;
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+
+        const captured = captureSettingCallbacks(() => tab.display());
+        vi.spyOn(tab, "render").mockImplementation(() => {});
+        await clickButton(captured, MESSAGES.LABEL_SERVER_STATUS);
+
+        expect(cancelServerDownload).toHaveBeenCalled();
+        expect(captured.buttons.some((b) => b.name === MESSAGES.LABEL_INSTALL_SERVER)).toBe(false);
     });
 });
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -2388,6 +2388,29 @@ describe("managed mode settings", () => {
         displaySpy.mockRestore();
     });
 
+    it("grows the progress bar as the download reports a percentage", async () => {
+        mockListReleases.mockResolvedValue(RELEASES);
+        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.2.0" });
+        (plugin as any).updateServer = vi
+            .fn()
+            .mockImplementation(async (_r: any, onProgress?: (msg: string, percent?: number) => void) => {
+                onProgress?.("Downloading... 50% (128 MB of 256 MB)", 50);
+            });
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+
+        const { dropdownOnChanges, buttonOnClicks } = captureSettingCallbacks(() => tab.display());
+        await settleReleases();
+        dropdownOnChanges[1]("v0.3.0");
+        vi.spyOn(tab, "render").mockImplementation(() => {});
+        await buttonOnClicks[2]();
+
+        const fill = tab.containerEl.find("lilbee-progress-bar")!;
+        expect(fill.style.width).toBe("50%");
+        expect(fill.classList.contains("lilbee-wizard-progress-indeterminate")).toBe(false);
+        expect(tab.containerEl.find("lilbee-update-progress-phase")!.textContent).toContain("50%");
+    });
+
     it("a failed install surfaces the reason and restores the button label", async () => {
         Notice.clear();
         mockListReleases.mockResolvedValue(RELEASES);

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,26 +1,29 @@
+import { MockElement } from "./__mocks__/obsidian";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Notice } from "obsidian";
 import {
+    StreamIdleError,
     _resetServerUnreachableDebounce,
     ensureUrlScheme,
     errorMessage,
     extractServerErrorDetail,
     extractSseErrorCode,
     extractSseErrorMessage,
-    isModelUnavailableError,
     formatBytes,
-    formatRate,
     formatElapsed,
+    formatRate,
     getRelevantSystemMemoryGB,
+    isModelUnavailableError,
     isRoleMismatchDetail,
     isStreamInterruptedError,
-    streamInterruptedMessage,
     noticeForResultError,
     noticeServerUnreachableIfApplicable,
     percentFromSse,
+    percentOfBytes,
     relativeTimeFromIso,
     sessionTokenInvalidMessage,
-    StreamIdleError,
+    setDeterminateProgress,
+    streamInterruptedMessage,
     withIdleTimeout,
 } from "../src/utils";
 import { ServerStartingError, SessionTokenError } from "../src/api";
@@ -481,5 +484,33 @@ describe("noticeServerUnreachableIfApplicable()", () => {
             Date.now = realDateNow;
         }
         expect(Notice.instances).toHaveLength(2);
+    });
+});
+
+describe("percentOfBytes", () => {
+    it("rounds to a whole percent", () => {
+        expect(percentOfBytes(1, 3)).toBe(33);
+        expect(percentOfBytes(2, 4)).toBe(50);
+    });
+
+    it("has no answer without a total", () => {
+        expect(percentOfBytes(10, null)).toBeUndefined();
+        expect(percentOfBytes(10, 0)).toBeUndefined();
+    });
+
+    it("never exceeds 100 when the server undercounts the length", () => {
+        expect(percentOfBytes(120, 100)).toBe(100);
+    });
+});
+
+describe("setDeterminateProgress", () => {
+    it("drops the indeterminate animation and sets the width", () => {
+        const fill = new MockElement() as unknown as HTMLElement;
+        fill.classList.add("lilbee-wizard-progress-indeterminate");
+
+        setDeterminateProgress(fill, 42);
+
+        expect(fill.classList.contains("lilbee-wizard-progress-indeterminate")).toBe(false);
+        expect(fill.style.width).toBe("42%");
     });
 });

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -496,6 +496,33 @@ describe("SetupWizard", () => {
         // see Downloading → Starting → Ready as three phase rows that light up.
         // We simulate the plugin firing each phase and assert the rows reach the
         // ready state before the wizard advances.
+        it("hands the download bar from indeterminate to a real width", () => {
+            const plugin = makePlugin({ serverManager: null });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            const step = new MockElement() as unknown as HTMLElement;
+
+            const { setPhase } = (wizard as any).renderServerSetupPanel(step);
+            const fill = (step as unknown as MockElement).findAll("lilbee-wizard-progress-fill")[0];
+            expect(fill.classList.contains("lilbee-wizard-progress-indeterminate")).toBe(true);
+
+            setPhase("downloading", "Downloading... 40%", 40);
+
+            expect(fill.style.width).toBe("40%");
+            expect(fill.classList.contains("lilbee-wizard-progress-indeterminate")).toBe(false);
+        });
+
+        it("leaves the bar indeterminate when no percentage is reported", () => {
+            const plugin = makePlugin({ serverManager: null });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            const step = new MockElement() as unknown as HTMLElement;
+
+            const { setPhase } = (wizard as any).renderServerSetupPanel(step);
+            setPhase("downloading", "Downloading...");
+
+            const fill = (step as unknown as MockElement).findAll("lilbee-wizard-progress-fill")[0];
+            expect(fill.classList.contains("lilbee-wizard-progress-indeterminate")).toBe(true);
+        });
+
         it("managed mode: surfaces each progress phase in the setup panel", async () => {
             const plugin = makePlugin({ serverManager: null });
             plugin.startManagedServer = vi


### PR DESCRIPTION
## Problem

Downloading the lilbee server went through Obsidian's `requestUrl`, which hands back a finished `arrayBuffer`. There was nothing to measure, so the progress panel could only say "Downloading..." and sit there. Pulling a 283 MB build takes about three minutes, and the version picker added in #176 made that wait much easier to hit: choose an older release and the UI looks frozen for minutes. The whole file also had to be held in memory before a single byte reached disk, which is why the free-space check demanded 1.5x the asset size.

The obvious fix is the wrong one. `requestUrl` is there on purpose: the renderer's `fetch` fails CORS on GitHub's asset redirect, which is exactly why b691222 replaced a streaming `fetch` download with `requestUrl` in the first place.

## Solution

The plugin is desktop-only and esbuild leaves Node's builtins external, so `https.get` runs in the renderer's Node context and is not a browser request at all. No CORS, and it streams.

The download now follows GitHub's redirect to its asset host itself, pipes the response straight into a `.part` file, and feeds the same chunks through an incremental SHA256. The digest is checked before the `.part` file is renamed into place, so a corrupted or interrupted download can never replace a server that already works, and a failure mid-download leaves the installed binary untouched. Bytes received and the reported content length travel up to the UI, so the settings panel and the setup wizard hand their progress bars from the indeterminate animation to a real width, and the status bar and notice read "Downloading... 50% (128 MB of 256 MB)".

Because nothing is buffered in memory any more, the free-space requirement drops from 1.5x the asset size to 1.1x.

Two defects turned up while testing this. A response carrying no status code was treated as a success and hung forever waiting for a body it would never get; anything outside 2xx is now an error. And when the cleanup `unlink` failed, its error replaced the real one, so a checksum mismatch surfaced as `ENOENT`; cleanup is now best-effort and the original error survives.

A stalled download no longer hangs. If the asset host stops sending bytes for sixty seconds, the download aborts, discards its partial file, and says so, rather than leaving a progress bar frozen forever. The clock resets on every chunk, so a slow connection is not mistaken for a dead one, and it covers both the connect and mid-stream cases.

The small JSON calls to the releases API still go through `requestUrl`. Only the asset download moved.
