### PR TITLE
Route stable-server users to dev builds when they open GPU placement

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -986,6 +986,8 @@ export const MESSAGES = {
     PLACEMENT_APPLY_NOT_ENABLED: "Applying placement isn't enabled on this lilbee server.",
     PLACEMENT_APPLY_FAILED: (msg: string): string => `Couldn't apply placement: ${msg}`,
     PLACEMENT_LOAD_FAILED: (msg: string): string => `Couldn't load placement: ${msg}`,
+    PLACEMENT_NEEDS_NEWER_SERVER:
+        "GPU placement and monitoring aren't available on this lilbee server yet. For now they ship in the dev builds: turn on Include dev builds under Settings, install the newest dev build from the Server version picker, and reopen this view.",
     PLACEMENT_WAITING_SERVER: "Waiting for the lilbee server to start. This view loads automatically once it's up.",
 
     // Hardware / fleet settings

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -986,6 +986,8 @@ export const MESSAGES = {
     PLACEMENT_APPLY_NOT_ENABLED: "Applying placement isn't enabled on this lilbee server.",
     PLACEMENT_APPLY_FAILED: (msg: string): string => `Couldn't apply placement: ${msg}`,
     PLACEMENT_LOAD_FAILED: (msg: string): string => `Couldn't load placement: ${msg}`,
+    PLACEMENT_DEV_BUILDS_PROMPT:
+        "GPU placement and monitoring run on the lilbee dev builds for now, while the multi-GPU server is being stabilized. Continue to Settings to turn on Include dev builds and install the newest dev build from the Server version picker.",
     PLACEMENT_NEEDS_NEWER_SERVER:
         "GPU placement and monitoring aren't available on this lilbee server yet. For now they ship in the dev builds: turn on Include dev builds under Settings, install the newest dev build from the Server version picker, and reopen this view.",
     PLACEMENT_WAITING_SERVER: "Waiting for the lilbee server to start. This view loads automatically once it's up.",

--- a/src/main.ts
+++ b/src/main.ts
@@ -292,6 +292,8 @@ export default class LilbeePlugin extends Plugin {
     private openingChatLeaf = false;
     // Same re-entrancy guard for the placement view's main-area tab and beside-chat split.
     private openingPlacementLeaf = false;
+    /** Set by the placement dev-builds prompt so the settings tab scrolls to the toggle. */
+    revealDevBuildsInSettings = false;
     taskQueue: TaskQueue = new TaskQueue();
     /** Paths whose most-recent add failed — retry skips the reindex confirm. */
     private failedAddPaths = new Set<string>();
@@ -2253,7 +2255,10 @@ export default class LilbeePlugin extends Plugin {
         }
         const modal = new ConfirmModal(this.app, MESSAGES.PLACEMENT_DEV_BUILDS_PROMPT);
         modal.open();
-        if (await modal.result) this.openPluginSettings();
+        if (await modal.result) {
+            this.revealDevBuildsInSettings = true;
+            this.openPluginSettings();
+        }
     }
 
     /** Open the placement view in a main-area tab (it is wider than the sidebar views). */

--- a/src/main.ts
+++ b/src/main.ts
@@ -1118,7 +1118,7 @@ export default class LilbeePlugin extends Plugin {
             name: MESSAGES.COMMAND_PLACEMENT,
             checkCallback: (checking) => {
                 if (!this.isLilbeeReady()) return false;
-                if (!checking) void this.activatePlacementView();
+                if (!checking) void this.openPlacementGated(() => this.activatePlacementView());
                 return true;
             },
         });
@@ -1130,7 +1130,7 @@ export default class LilbeePlugin extends Plugin {
                 if (!this.isLilbeeReady()) return false;
                 const chatLeaf = this.app.workspace.getLeavesOfType(VIEW_TYPE_CHAT)[0];
                 if (!chatLeaf) return false;
-                if (!checking) void this.openPlacementBesideChat(chatLeaf);
+                if (!checking) void this.openPlacementGated(() => this.openPlacementBesideChat(chatLeaf));
                 return true;
             },
         });
@@ -2240,6 +2240,20 @@ export default class LilbeePlugin extends Plugin {
         for (const leaf of this.app.workspace.getLeavesOfType(VIEW_TYPE_MEMORIES)) {
             void (leaf.view as MemoriesView).reload();
         }
+    }
+
+    // TODO: remove this dev-builds gate once the multi-GPU server ships in a stable release.
+    /** GPU placement needs a dev-build server for now. Without the opt-in, explain
+     *  and offer to jump straight to Settings, where both the toggle and the
+     *  version picker live. */
+    private async openPlacementGated(open: () => Promise<void>): Promise<void> {
+        if (this.settings.includeDevBuilds) {
+            await open();
+            return;
+        }
+        const modal = new ConfirmModal(this.app, MESSAGES.PLACEMENT_DEV_BUILDS_PROMPT);
+        modal.open();
+        if (await modal.result) this.openPluginSettings();
     }
 
     /** Open the placement view in a main-area tab (it is wider than the sidebar views). */

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -57,6 +57,7 @@ import {
 } from "./utils";
 
 const CHECK_TIMEOUT_MS = 5000;
+const DEV_BUILDS_FLASH_MS = 2400;
 const CLS_MODELS_CONTAINER = "lilbee-models-container";
 const RERANKER_DISABLED_KEY = "";
 const VISION_DISABLED_KEY = "";
@@ -165,6 +166,18 @@ export class LilbeeSettingTab extends PluginSettingTab {
         this.loadServerDefaults();
         this.loadConfigDefaults();
         void this.applyCapabilityGating();
+        this.revealDevBuildsIfRequested(containerEl);
+    }
+
+    /** When the placement prompt routed here, land on the dev-builds toggle itself. */
+    private revealDevBuildsIfRequested(containerEl: HTMLElement): void {
+        if (!this.plugin.revealDevBuildsInSettings) return;
+        this.plugin.revealDevBuildsInSettings = false;
+        const row = containerEl.querySelector<HTMLElement>(".lilbee-dev-builds-setting");
+        if (!row) return;
+        row.scrollIntoView({ block: "center" });
+        row.addClass("lilbee-setting-flash");
+        window.setTimeout(() => row.removeClass("lilbee-setting-flash"), DEV_BUILDS_FLASH_MS);
     }
 
     private async applyCapabilityGating(): Promise<void> {
@@ -315,8 +328,9 @@ export class LilbeeSettingTab extends PluginSettingTab {
         const setting = new Setting(containerEl)
             .setName(MESSAGES.LABEL_SERVER_VERSION)
             .setDesc(MESSAGES.DESC_SERVER_VERSION_LOADING);
+        // aria-label only: Obsidian renders its styled tooltip from it, and a
+        // title attribute would stack the native browser tooltip on top.
         setting.settingEl.setAttribute("aria-label", MESSAGES.TOOLTIP_SERVER_VERSION_SUPPORT);
-        setting.settingEl.setAttribute("title", MESSAGES.TOOLTIP_SERVER_VERSION_SUPPORT);
         const progress = this.renderUpdateProgress(containerEl);
 
         let releases: ReleaseInfo[] = [];
@@ -401,7 +415,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
 
     /** Opt in to in-development builds. */
     private renderDevBuildsToggle(containerEl: HTMLElement): void {
-        new Setting(containerEl)
+        const setting = new Setting(containerEl)
             .setName(MESSAGES.LABEL_INCLUDE_DEV_BUILDS)
             .setDesc(MESSAGES.DESC_INCLUDE_DEV_BUILDS)
             .addToggle((toggle) =>
@@ -411,6 +425,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
                     this.render();
                 }),
             );
+        setting.settingEl.addClass("lilbee-dev-builds-setting");
     }
 
     /** Where bug reports go. Rendered at the top of the settings view in both server modes. */
@@ -436,7 +451,6 @@ export class LilbeeSettingTab extends PluginSettingTab {
         const heading = new Setting(containerEl).setName(MESSAGES.LABEL_UNINSTALL).setHeading();
         heading.settingEl.addClass("lilbee-danger-heading");
         heading.settingEl.setAttribute("aria-label", MESSAGES.TOOLTIP_UNINSTALL_SECTION);
-        heading.settingEl.setAttribute("title", MESSAGES.TOOLTIP_UNINSTALL_SECTION);
 
         const callout = containerEl.createDiv({ cls: "lilbee-uninstall-callout" });
         const mark = callout.createSpan({ cls: "lilbee-uninstall-callout-mark", text: "!" });

--- a/src/views/placement-view.ts
+++ b/src/views/placement-view.ts
@@ -39,6 +39,7 @@ export async function revealPlacementBeside(app: App, sourceLeaf: WorkspaceLeaf)
 
 const PREVIEW_DEBOUNCE_MS = 350;
 const STARTUP_RETRY_MS = 2000;
+const HTTP_NOT_FOUND = 404;
 const HTTP_CONFLICT = 409;
 const HTTP_UNPROCESSABLE = 422;
 const GB = 1_000_000_000;
@@ -122,6 +123,12 @@ export class PlacementView extends ItemView {
                 return;
             }
             this.waitingForServer = false;
+            // No /api/placement route: a stable server. The feature ships in the
+            // dev builds for now, so point at the opt-in instead of a raw 404.
+            if (isHttpStatus(result.error, HTTP_NOT_FOUND)) {
+                this.renderMessage(MESSAGES.PLACEMENT_NEEDS_NEWER_SERVER);
+                return;
+            }
             this.renderMessage(
                 MESSAGES.PLACEMENT_LOAD_FAILED(
                     errorMessage(result.error, MESSAGES.ERROR_UNKNOWN, this.plugin.settings.serverMode),

--- a/styles.css
+++ b/styles.css
@@ -4763,3 +4763,24 @@ button.lilbee-model-chip-select:focus-visible {
     color: var(--text-error);
     border-color: var(--text-error);
 }
+
+/* Flash the dev-builds row when the placement prompt lands the user on it. */
+.lilbee-setting-flash {
+    animation: lilbee-setting-flash 1.2s ease-in-out 2;
+    border-radius: var(--radius-s, 4px);
+}
+@keyframes lilbee-setting-flash {
+    0%,
+    100% {
+        background: transparent;
+    }
+    50% {
+        background: color-mix(in srgb, var(--interactive-accent) 18%, transparent);
+    }
+}
+@media (prefers-reduced-motion: reduce) {
+    .lilbee-setting-flash {
+        animation: none;
+        background: color-mix(in srgb, var(--interactive-accent) 14%, transparent);
+    }
+}

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -489,7 +489,7 @@ describe("LilbeePlugin", () => {
         });
 
         it("open-placement-beside-chat returns false when lilbee is not ready", async () => {
-            const plugin = await createPlugin();
+            const plugin = await createPlugin({ includeDevBuilds: true });
             await plugin.onload();
             vi.spyOn(plugin as any, "isLilbeeReady").mockReturnValue(false);
             const cmd = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.find(
@@ -499,8 +499,9 @@ describe("LilbeePlugin", () => {
         });
 
         it("open-placement-beside-chat returns false when no chat view is open", async () => {
-            const plugin = await createPlugin();
+            const plugin = await createPlugin({ includeDevBuilds: true });
             await plugin.onload();
+            vi.spyOn(plugin as any, "isLilbeeReady").mockReturnValue(true);
             plugin.app.workspace.getLeavesOfType = vi.fn().mockReturnValue([]);
             const cmd = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.find(
                 (c: any[]) => c[0].id === "open-placement-beside-chat",
@@ -509,8 +510,9 @@ describe("LilbeePlugin", () => {
         });
 
         it("open-placement-beside-chat splits placement beside the chat leaf", async () => {
-            const plugin = await createPlugin();
+            const plugin = await createPlugin({ includeDevBuilds: true });
             await plugin.onload();
+            vi.spyOn(plugin as any, "isLilbeeReady").mockReturnValue(true);
             const chatLeaf = new WorkspaceLeaf();
             const splitLeaf = new WorkspaceLeaf();
             plugin.app.workspace.getLeavesOfType = vi.fn((t: string) => (t === "lilbee-chat" ? [chatLeaf] : []));
@@ -1170,7 +1172,7 @@ describe("LilbeePlugin", () => {
         });
 
         it("open-placement command activates the placement view", async () => {
-            const plugin = await createPlugin();
+            const plugin = await createPlugin({ includeDevBuilds: true });
             await plugin.onload();
             vi.spyOn(plugin as any, "isLilbeeReady").mockReturnValue(true);
             const activate = vi.spyOn(plugin as any, "activatePlacementView").mockResolvedValue(undefined);
@@ -1179,8 +1181,33 @@ describe("LilbeePlugin", () => {
             expect(activate).toHaveBeenCalled();
         });
 
-        it("open-placement command is gated when lilbee is not ready", async () => {
+        it("open-placement without dev builds prompts and continues to Settings", async () => {
             const plugin = await createPlugin();
+            await plugin.onload();
+            vi.spyOn(plugin as any, "isLilbeeReady").mockReturnValue(true);
+            const activate = vi.spyOn(plugin as any, "activatePlacementView").mockResolvedValue(undefined);
+            const openSettings = vi.spyOn(plugin as any, "openPluginSettings").mockImplementation(() => {});
+            mockConfirmModalResult = true;
+            expect(findCmd(plugin, "open-placement").checkCallback(true)).toBe(true);
+            findCmd(plugin, "open-placement").checkCallback(false);
+            await flush();
+            expect(activate).not.toHaveBeenCalled();
+            expect(openSettings).toHaveBeenCalled();
+        });
+
+        it("open-placement without dev builds stays put when the prompt is cancelled", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            vi.spyOn(plugin as any, "isLilbeeReady").mockReturnValue(true);
+            const openSettings = vi.spyOn(plugin as any, "openPluginSettings").mockImplementation(() => {});
+            mockConfirmModalResult = false;
+            findCmd(plugin, "open-placement").checkCallback(false);
+            await flush();
+            expect(openSettings).not.toHaveBeenCalled();
+        });
+
+        it("open-placement command is gated when lilbee is not ready", async () => {
+            const plugin = await createPlugin({ includeDevBuilds: true });
             await plugin.onload();
             vi.spyOn(plugin as any, "isLilbeeReady").mockReturnValue(false);
             expect(findCmd(plugin, "open-placement").checkCallback(false)).toBe(false);

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -2299,10 +2299,56 @@ describe("managed mode settings", () => {
 
         tab.display();
 
-        const tooltips = setAttribute.mock.calls.filter(([name]) => name === "title").map(([, value]) => value);
+        const tooltips = setAttribute.mock.calls.filter(([name]) => name === "aria-label").map(([, value]) => value);
         expect(tooltips).toContain(MESSAGES.TOOLTIP_SERVER_VERSION_SUPPORT);
+        // aria-label only: a title attribute would stack the native tooltip on Obsidian's.
+        const titles = setAttribute.mock.calls.filter(([name]) => name === "title").map(([, value]) => value);
+        expect(titles).not.toContain(MESSAGES.TOOLTIP_SERVER_VERSION_SUPPORT);
         expect(MESSAGES.TOOLTIP_SERVER_VERSION_SUPPORT).toContain("not supported");
         setAttribute.mockRestore();
+    });
+
+    it("scrolls to and flashes the dev-builds toggle when the placement prompt routed here", () => {
+        vi.useFakeTimers();
+        try {
+            mockListReleases.mockResolvedValue(RELEASES);
+            const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.3.0" });
+            (plugin as any).revealDevBuildsInSettings = true;
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const scrolled = vi.spyOn(MockElement.prototype, "scrollIntoView");
+
+            tab.display();
+
+            expect((plugin as any).revealDevBuildsInSettings).toBe(false);
+            expect(scrolled).toHaveBeenCalled();
+            const row = tab.containerEl.querySelector(".lilbee-dev-builds-setting")!;
+            expect(row.classList.contains("lilbee-setting-flash")).toBe(true);
+            vi.advanceTimersByTime(2500);
+            expect(row.classList.contains("lilbee-setting-flash")).toBe(false);
+            scrolled.mockRestore();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+    it("leaves the settings scroll alone when the reveal flag is off and when the row is absent", () => {
+        mockListReleases.mockResolvedValue(RELEASES);
+        const plugin = makePlugin({ serverMode: "external" });
+        (plugin as any).revealDevBuildsInSettings = true;
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+        const scrolled = vi.spyOn(MockElement.prototype, "scrollIntoView");
+        // External mode renders no dev-builds row: the flag clears, nothing scrolls.
+        tab.display();
+        expect(scrolled).not.toHaveBeenCalled();
+
+        // Flag off: display leaves everything alone.
+        const plugin2 = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.3.0" });
+        mockChatPicker(plugin2);
+        const tab2 = makeTab(plugin2);
+        tab2.display();
+        expect(scrolled).not.toHaveBeenCalled();
+        scrolled.mockRestore();
     });
 
     it("version dropdown offers the recent releases newest first", async () => {

--- a/tests/views/placement-view.test.ts
+++ b/tests/views/placement-view.test.ts
@@ -387,6 +387,15 @@ describe("PlacementView load failure", () => {
         }
     });
 
+    it("points at dev builds when the server has no placement API (404)", async () => {
+        const api = makeApi({
+            placement: vi.fn().mockResolvedValue(err(new Error("Server responded 404: Not Found"))),
+        });
+        const { contentEl } = await openView(makePlugin(api));
+        expect(contentEl.find("lilbee-placement-empty")!.textContent).toContain("Include dev builds");
+        expect(contentEl.find("lilbee-placement-empty")!.textContent).not.toContain("404");
+    });
+
     it("waiting state before onOpen is a no-op (no body element)", async () => {
         vi.useFakeTimers();
         try {


### PR DESCRIPTION
## Problem

The GPU placement view shipped to main, but the placement API only exists in lilbee dev builds while the multi-GPU server is stabilized. A user on a stable server who runs the placement commands lands on a raw "Server responded 404" dead end with no way to know the feature exists but needs opting in.

## Solution

Temporary gating until the multi-GPU server ships stable (TODO markers in place to remove it):

- Running a placement command without "Include dev builds" enabled opens a modal explaining that GPU placement and monitoring run on the dev builds for now, with a Continue button that jumps straight to the plugin's Settings tab, where both the toggle and the Server version picker live.
- If dev builds are enabled but the server still has no placement API, the view renders the same guidance instead of the raw 404.
