### PR TITLE
Fix the server version picker so stable releases stay selectable

### DIFF
--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -175,15 +175,17 @@ export function isDevBuild(tag: string): boolean {
 }
 
 /**
- * Up to *limit* published releases, newest first, that ship a build for this machine and
- * match the dev-build preference. Drafts, prereleases, releases without a matching asset,
- * and (when includeDev is false) dev builds are left out. Pages through the releases API so a
- * long run of dev builds cannot push every stable release out of view; stops once it has
- * *limit*, reaches a short (final) page, or exhausts the page budget.
+ * Published releases that ship a build for this machine, newest first: up to *limit* stable
+ * releases, plus up to *limit* dev builds when includeDev is set. The quotas are per kind so a
+ * long run of dev builds cannot push every stable release out of view. Drafts, prereleases,
+ * and releases without a matching asset are left out. Pages through the releases API until
+ * both quotas are filled, a short (final) page arrives, or the page budget is exhausted.
  */
 async function fetchInstallableReleases(limit: number, includeDev: boolean): Promise<ReleaseInfo[]> {
     const cudaTag = await detectCudaTag();
     const releases: ReleaseInfo[] = [];
+    let stableCount = 0;
+    let devCount = 0;
     for (let page = 1; page <= RELEASE_PAGE_BUDGET; page++) {
         const res = await node.requestUrl({
             url: `${RELEASE_LIST_API}?per_page=${RELEASE_PAGE_SIZE}&page=${page}`,
@@ -193,20 +195,28 @@ async function fetchInstallableReleases(limit: number, includeDev: boolean): Pro
         const pageData = res.json as GitHubRelease[];
         for (const data of pageData) {
             if (data.draft || data.prerelease) continue;
-            if (!includeDev && isDevBuild(data.tag_name)) continue;
+            const dev = isDevBuild(data.tag_name);
+            if (dev && !includeDev) continue;
+            if (dev ? devCount >= limit : stableCount >= limit) continue;
             try {
                 releases.push(toReleaseInfo(data, cudaTag));
             } catch {
                 // Release ships no build for this platform; it isn't installable here.
+                continue;
             }
-            if (releases.length >= limit) return releases;
+            if (dev) devCount++;
+            else stableCount++;
+            if (stableCount >= limit && (!includeDev || devCount >= limit)) return releases;
         }
         if (pageData.length < RELEASE_PAGE_SIZE) break; // last page
     }
     return releases;
 }
 
-/** Installable releases for the version picker, newest first; dev builds left out unless includeDev. */
+/**
+ * Installable releases for the version picker, newest first: up to *limit* stable releases,
+ * plus up to *limit* dev builds when includeDev is set.
+ */
 export async function listReleases(includeDev: boolean, limit = RELEASE_HISTORY_LIMIT): Promise<ReleaseInfo[]> {
     return fetchInstallableReleases(limit, includeDev);
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -425,7 +425,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         });
     }
 
-    /** Every installable release (dev builds included); null when GitHub could not be reached. */
+    /** Recent installable releases, dev builds included; null when GitHub could not be reached. */
     private async loadReleases(): Promise<ReleaseInfo[] | null> {
         try {
             return await listReleases(true);

--- a/tests/binary-manager.test.ts
+++ b/tests/binary-manager.test.ts
@@ -1147,6 +1147,43 @@ describe("listReleases", () => {
         expect((await listReleases(true)).map((r) => r.tag)).toEqual(["v1.1.0.dev5", "v1.0.0"]);
     });
 
+    it("offers up to the limit of dev and stable builds each", async () => {
+        restore = stubPlatform("linux", "x64");
+        stubNoNvidia();
+        const dev = Array.from({ length: 12 }, (_, i) => release(`v1.1.0.dev${12 - i}`));
+        const stable = Array.from({ length: 12 }, (_, i) => release(`v1.0.${12 - i}`));
+        vi.spyOn(node, "requestUrl").mockResolvedValue(releaseResponse([...dev, ...stable]));
+
+        expect((await listReleases(true)).map((r) => r.tag)).toEqual([
+            ...dev.slice(0, 10).map((r) => r.tag_name),
+            ...stable.slice(0, 10).map((r) => r.tag_name),
+        ]);
+    });
+
+    it("keeps the merged list newest-first when dev and stable builds interleave", async () => {
+        restore = stubPlatform("linux", "x64");
+        stubNoNvidia();
+        vi.spyOn(node, "requestUrl").mockResolvedValue(
+            releaseResponse([release("v1.2.0.dev9"), release("v1.1.0"), release("v1.2.0.dev8"), release("v1.0.0")]),
+        );
+
+        expect((await listReleases(true)).map((r) => r.tag)).toEqual([
+            "v1.2.0.dev9",
+            "v1.1.0",
+            "v1.2.0.dev8",
+            "v1.0.0",
+        ]);
+    });
+
+    it("still surfaces every stable release when a run of dev builds exceeds the limit", async () => {
+        restore = stubPlatform("linux", "x64");
+        stubNoNvidia();
+        const dev = Array.from({ length: 14 }, (_, i) => release(`v1.1.0.dev${14 - i}`));
+        vi.spyOn(node, "requestUrl").mockResolvedValue(releaseResponse([...dev, release("v1.0.0"), release("v0.9.0")]));
+
+        expect((await listReleases(false)).map((r) => r.tag)).toEqual(["v1.0.0", "v0.9.0"]);
+    });
+
     it("leaves out releases that ship no build for this platform", async () => {
         restore = stubPlatform("linux", "x64");
         stubNoNvidia();

--- a/tests/settings-version-picker.test.ts
+++ b/tests/settings-version-picker.test.ts
@@ -1,0 +1,118 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+import { App, Setting } from "obsidian";
+import { MockElement } from "./__mocks__/obsidian";
+import { LilbeeSettingTab } from "../src/settings";
+import { node } from "../src/binary-manager";
+import { DEFAULT_SETTINGS, SERVER_MODE } from "../src/types";
+import { MESSAGES } from "../src/locales/en";
+import type LilbeePlugin from "../src/main";
+
+/**
+ * The release list tobocop2/lilbee serves: a run of published dev builds ahead
+ * of the stable line, all on one GitHub page.
+ */
+const DEV_RUN = Array.from({ length: 14 }, (_, i) => `v0.6.90b420.dev${723 - i}`);
+const STABLE_RUN = Array.from({ length: 12 }, (_, i) => `v0.6.66b${507 - i}`);
+
+/** The setup file pins platform to linux; pin arch to x64 for a supported pair. */
+const ASSET_NAME = "lilbee-linux-x86_64";
+
+function ghRelease(tag: string) {
+    return {
+        tag_name: tag,
+        assets: [
+            {
+                name: ASSET_NAME,
+                browser_download_url: `https://example.com/${tag}`,
+                size: 10,
+                digest: null,
+            },
+        ],
+    };
+}
+
+interface CapturedDropdown {
+    options: string[];
+    disabledStates: boolean[];
+    value: string | null;
+}
+
+describe("server version picker with the real release list", () => {
+    let dropdown: CapturedDropdown;
+    let descs: string[];
+    let originalAddDropdown: typeof Setting.prototype.addDropdown;
+    let originalArch: PropertyDescriptor | undefined;
+
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        originalArch = Object.getOwnPropertyDescriptor(process, "arch");
+        Object.defineProperty(process, "arch", { value: "x64", configurable: true });
+        dropdown = { options: [], disabledStates: [], value: null };
+        descs = [];
+
+        originalAddDropdown = Setting.prototype.addDropdown;
+        Setting.prototype.addDropdown = function (cb: (dd: any) => void) {
+            const dd = {
+                addOption: (v: string) => {
+                    dropdown.options.push(v);
+                    return dd;
+                },
+                addOptions: () => dd,
+                setValue: (v: string) => {
+                    dropdown.value = v;
+                    return dd;
+                },
+                setDisabled: (d: boolean) => {
+                    dropdown.disabledStates.push(d);
+                    return dd;
+                },
+                onChange: () => dd,
+            };
+            cb(dd);
+            return this;
+        };
+        vi.spyOn(Setting.prototype, "setDesc").mockImplementation(function (desc) {
+            descs.push(String(desc));
+            return this;
+        });
+
+        vi.spyOn(node, "execFile").mockRejectedValue(new Error("nvidia-smi not found"));
+        vi.spyOn(node, "requestUrl").mockResolvedValue({
+            status: 200,
+            json: [...DEV_RUN, ...STABLE_RUN].map(ghRelease),
+            arrayBuffer: new ArrayBuffer(0),
+            headers: {},
+        });
+    });
+
+    afterEach(() => {
+        Setting.prototype.addDropdown = originalAddDropdown;
+        if (originalArch) Object.defineProperty(process, "arch", originalArch);
+    });
+
+    async function renderPicker(includeDevBuilds: boolean): Promise<CapturedDropdown> {
+        const plugin = {
+            settings: { ...DEFAULT_SETTINGS, serverMode: SERVER_MODE.MANAGED, includeDevBuilds },
+            getSharedLilbeeVersion: () => STABLE_RUN[0],
+        } as unknown as LilbeePlugin;
+        const tab = new LilbeeSettingTab(new App(), plugin);
+        (tab as any).renderVersionSetting(new MockElement() as unknown as HTMLElement);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        return dropdown;
+    }
+
+    it("offers stable releases by default even when dev builds lead the release list", async () => {
+        const dd = await renderPicker(false);
+
+        expect(dd.options).toEqual(STABLE_RUN.slice(0, 10));
+        expect(dd.disabledStates).toContain(false);
+        expect(descs[descs.length - 1]).not.toBe(MESSAGES.DESC_SERVER_VERSION_LOADING);
+    });
+
+    it("offers dev and stable builds when dev builds are included", async () => {
+        const dd = await renderPicker(true);
+
+        expect(dd.options).toEqual([...DEV_RUN.slice(0, 10), ...STABLE_RUN.slice(0, 10)]);
+        expect(dd.disabledStates).toContain(false);
+    });
+});

--- a/tests/settings-version-picker.test.ts
+++ b/tests/settings-version-picker.test.ts
@@ -86,6 +86,7 @@ describe("server version picker with the real release list", () => {
     });
 
     afterEach(() => {
+        vi.restoreAllMocks();
         Setting.prototype.addDropdown = originalAddDropdown;
         if (originalArch) Object.defineProperty(process, "arch", originalArch);
     });
@@ -105,6 +106,7 @@ describe("server version picker with the real release list", () => {
         const dd = await renderPicker(false);
 
         expect(dd.options).toEqual(STABLE_RUN.slice(0, 10));
+        expect(dd.value).toBe(STABLE_RUN[0]);
         expect(dd.disabledStates).toContain(false);
         expect(descs[descs.length - 1]).not.toBe(MESSAGES.DESC_SERVER_VERSION_LOADING);
     });
@@ -113,6 +115,7 @@ describe("server version picker with the real release list", () => {
         const dd = await renderPicker(true);
 
         expect(dd.options).toEqual([...DEV_RUN.slice(0, 10), ...STABLE_RUN.slice(0, 10)]);
+        expect(dd.value).toBe(STABLE_RUN[0]);
         expect(dd.disabledStates).toContain(false);
     });
 });


### PR DESCRIPTION
## Problem

The managed-mode server version picker couldn't offer a downgrade. When loading the release list, the plugin scans GitHub's releases newest-first and stops as soon as it has 10 installable builds. The lilbee repo's release list is currently led by a long run of published dev builds, so those 10 slots fill with dev builds before any stable release is reached. With "Include dev builds" off (the default), the UI filters dev builds out of that list and is left with nothing: the dropdown stays disabled on "Reading the release list from GitHub…" forever. With dev builds on, the picker shows only those 10 dev builds — there is still no older stable release to select.

## Solution

The release fetch now budgets stable and dev builds separately: up to 10 stable releases, plus up to 10 dev builds when dev builds are included, merged newest-first. A run of dev builds can no longer push stable releases out of view, so the picker always offers the recent stable line, with dev builds added on top when the toggle is on. The auto-update target is unchanged: newest stable by default, newest overall when dev builds are included.