### PR TITLE
Surface the Intel GPU monitoring notice in the placement view

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -21,7 +21,7 @@ import type {
     DocumentResult,
     DocumentsResponse,
     GenerationOptions,
-    GpuInfo,
+    GpuListResponse,
     HealthResponse,
     InstalledResponse,
     PlacementResponse,
@@ -121,6 +121,18 @@ export class RateLimitedError extends Error {
  */
 export function isHttpStatus(error: Error, status: number): boolean {
     return error.message.startsWith(`Server responded ${status}`);
+}
+
+/** Wraps a pre-PR-564 bare-list `GET /api/gpus` response in the new envelope. */
+function normalizeGpuList(parsed: unknown): GpuListResponse {
+    if (Array.isArray(parsed)) {
+        return { gpus: parsed as GpuListResponse["gpus"], notice: null };
+    }
+    const obj = parsed as Partial<GpuListResponse>;
+    return {
+        gpus: Array.isArray(obj?.gpus) ? (obj.gpus as GpuListResponse["gpus"]) : [],
+        notice: typeof obj?.notice === "string" ? obj.notice : null,
+    };
 }
 
 export class LilbeeClient {
@@ -766,9 +778,12 @@ export class LilbeeClient {
     }
 
     /** Detected GPUs with current free/total VRAM. Cheaper than placement() for
-     * polling live memory usage (no plan re-resolve of roles). */
-    async gpus(): Promise<Result<GpuInfo[], Error>> {
-        return this.fetchResult<GpuInfo[]>(`${this.baseUrl}/api/gpus`, { headers: this.authHeaders() });
+     * polling live memory usage (no plan re-resolve of roles). Normalizes the
+     * pre-PR-564 bare-list response to the new envelope shape. */
+    async gpus(): Promise<Result<GpuListResponse, Error>> {
+        const result = await this.fetchResult<unknown>(`${this.baseUrl}/api/gpus`, { headers: this.authHeaders() });
+        if (result.isErr()) return err(result.error);
+        return ok(normalizeGpuList(result.value));
     }
 
     /** Live per-GPU utilization + free memory, streamed as SSE until aborted. */

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1034,6 +1034,9 @@ export const MESSAGES = {
     PLACEMENT_NEEDS_NEWER_SERVER:
         "GPU placement and monitoring aren't available on this lilbee server yet. For now they ship in the dev builds: turn on Include dev builds under Settings, install the newest dev build from the Server version picker, and reopen this view.",
     PLACEMENT_WAITING_SERVER: "Waiting for the lilbee server to start. This view loads automatically once it's up.",
+    PLACEMENT_GPU_NOTICE: (notice: string): string => `GPU monitoring: ${notice}`,
+    PLACEMENT_GPU_NOTICE_TOOLTIP:
+        "The lilbee server can't read GPU utilization on this host. The hint below tells you which tool to install or permission to grant.",
 
     // Hardware / fleet settings
     LABEL_FLEET: "Hardware / fleet",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1066,9 +1066,19 @@ export interface GpuStat {
     total_bytes: number;
 }
 
-/** Payload of a `gpu_stats` SSE event: a snapshot for every detected GPU. */
+/** Server-issued hint when GPU monitoring is degraded (e.g. Intel hosts without intel_gpu_top). */
+export type GpuNotice = string | null;
+
+/** Payload of a `gpu_stats` SSE event. `notice` is omitted on healthy hosts. */
 export interface GpuStatsPayload {
     gpus: GpuStat[];
+    notice?: GpuNotice;
+}
+
+/** Envelope of `GET /api/gpus` since lilbee PR #564; client normalizes old bare-list responses into it. */
+export interface GpuListResponse {
+    gpus: GpuInfo[];
+    notice: GpuNotice;
 }
 
 /** Where one role's model is placed in the resolved plan. Mirrors RolePlacementResponse. */
@@ -1090,6 +1100,8 @@ export interface PlacementResponse {
     unplaceable: string[];
     manual: boolean;
     spec_json: string | null;
+    /** Host-level fix instruction, present only when GPU monitoring is degraded. */
+    notice?: GpuNotice;
 }
 
 /** One role entry in a manual placement spec. */

--- a/src/views/placement-view.ts
+++ b/src/views/placement-view.ts
@@ -233,11 +233,13 @@ export class PlacementView extends ItemView {
     /** Server-issued host fix hint, rendered verbatim under a localized label. */
     private renderNotice(container: HTMLElement, notice: string | null): void {
         this.gpuNotice = notice;
-        this.gpuNoticeEl = null;
-        if (!notice) return;
+        this.gpuNoticeEl = notice ? this.createNoticeEl(container, notice) : null;
+    }
+
+    private createNoticeEl(container: HTMLElement, notice: string): HTMLElement {
         const el = container.createDiv({ cls: "lilbee-placement-notice", text: MESSAGES.PLACEMENT_GPU_NOTICE(notice) });
         this.tip(el, MESSAGES.PLACEMENT_GPU_NOTICE_TOOLTIP);
-        this.gpuNoticeEl = el;
+        return el;
     }
 
     private renderSectionTitle(container: HTMLElement, text: string): void {
@@ -483,12 +485,8 @@ export class PlacementView extends ItemView {
             return;
         }
         if (!notice || !this.bodyEl) return;
-        const el = this.bodyEl.createDiv({
-            cls: "lilbee-placement-notice",
-            text: MESSAGES.PLACEMENT_GPU_NOTICE(notice),
-        });
-        this.tip(el, MESSAGES.PLACEMENT_GPU_NOTICE_TOOLTIP);
-        // Insert right after the header; append if the header somehow isn't first.
+        const el = this.createNoticeEl(this.bodyEl, notice);
+        // Insert right after the header; append when nothing follows it yet.
         this.bodyEl.insertBefore(el, (this.bodyEl.children[1] as HTMLElement | undefined) ?? null);
         this.gpuNoticeEl = el;
     }

--- a/src/views/placement-view.ts
+++ b/src/views/placement-view.ts
@@ -76,6 +76,8 @@ export class PlacementView extends ItemView {
     private startupRetryTimer: number | null = null;
     private waitingForServer = false;
     private statsController: AbortController | null = null;
+    private gpuNotice: string | null = null;
+    private gpuNoticeEl: HTMLElement | null = null;
     /** Live util + vram bars and their text per device index, updated in place by the stats stream. */
     // vramFill/memText are absent on unified-memory rows, which render a static capacity label.
     private gpuBars: Map<
@@ -200,8 +202,10 @@ export class PlacementView extends ItemView {
         if (!this.bodyEl || !data) return;
         this.multiDevice = data.gpus.length >= 2;
         this.gpuBars.clear();
+        this.gpuNoticeEl = null;
         this.bodyEl.empty();
         this.renderHeader(this.bodyEl, data);
+        this.renderNotice(this.bodyEl, data.notice ?? null);
         if (data.gpus.length < 2) {
             this.renderSingleDevice(this.bodyEl, data);
         } else {
@@ -224,6 +228,16 @@ export class PlacementView extends ItemView {
         header.createEl("h2", { text: MESSAGES.PLACEMENT_TITLE });
         const state = this.applying ? "applying" : this.mode;
         header.createSpan({ cls: `lilbee-placement-state is-${state}`, text: this.stateLabel(data) });
+    }
+
+    /** Server-issued host fix hint, rendered verbatim under a localized label. */
+    private renderNotice(container: HTMLElement, notice: string | null): void {
+        this.gpuNotice = notice;
+        this.gpuNoticeEl = null;
+        if (!notice) return;
+        const el = container.createDiv({ cls: "lilbee-placement-notice", text: MESSAGES.PLACEMENT_GPU_NOTICE(notice) });
+        this.tip(el, MESSAGES.PLACEMENT_GPU_NOTICE_TOOLTIP);
+        this.gpuNoticeEl = el;
     }
 
     private renderSectionTitle(container: HTMLElement, text: string): void {
@@ -444,12 +458,39 @@ export class PlacementView extends ItemView {
         try {
             for await (const event of this.plugin.api.gpuStatsStream(this.statsController.signal)) {
                 if (event.event === SSE_EVENT.GPU_STATS) {
-                    this.applyStats((event.data as GpuStatsPayload).gpus);
+                    const payload = event.data as GpuStatsPayload;
+                    this.applyStats(payload.gpus);
+                    this.applyNotice(payload.notice ?? null);
                 }
             }
         } catch {
             // Stream aborted (view closed) or failed (server gone): leave the bars as they are.
         }
+    }
+
+    /** Move the notice banner in place without rebuilding the rest of the view. */
+    private applyNotice(notice: string | null): void {
+        if (notice === this.gpuNotice) return;
+        this.gpuNotice = notice;
+        if (this.gpuNoticeEl) {
+            if (notice) {
+                this.gpuNoticeEl.setText(MESSAGES.PLACEMENT_GPU_NOTICE(notice));
+                this.tip(this.gpuNoticeEl, MESSAGES.PLACEMENT_GPU_NOTICE_TOOLTIP);
+                return;
+            }
+            this.gpuNoticeEl.detach();
+            this.gpuNoticeEl = null;
+            return;
+        }
+        if (!notice || !this.bodyEl) return;
+        const el = this.bodyEl.createDiv({
+            cls: "lilbee-placement-notice",
+            text: MESSAGES.PLACEMENT_GPU_NOTICE(notice),
+        });
+        this.tip(el, MESSAGES.PLACEMENT_GPU_NOTICE_TOOLTIP);
+        // Insert right after the header; append if the header somehow isn't first.
+        this.bodyEl.insertBefore(el, (this.bodyEl.children[1] as HTMLElement | undefined) ?? null);
+        this.gpuNoticeEl = el;
     }
 
     /** Move each card's utilization bar and util/memory text from a live snapshot.

--- a/styles.css
+++ b/styles.css
@@ -4280,6 +4280,16 @@ button.lilbee-model-chip-select:focus-visible {
     padding: 28px 0;
     text-align: center;
 }
+.lilbee-placement-notice {
+    margin: 0 0 var(--size-4-2, 8px);
+    padding: var(--size-4-2, 8px) var(--size-4-3, 12px);
+    border-left: 3px solid var(--text-warning);
+    border-radius: 0 var(--radius-s, 4px) var(--radius-s, 4px) 0;
+    background: var(--background-secondary);
+    color: var(--text-muted);
+    font-size: var(--font-small, 13px);
+    line-height: var(--line-height-normal, 1.5);
+}
 .lilbee-placement-waiting {
     display: flex;
     flex-direction: column;

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -264,6 +264,10 @@ export class MockElement {
         }
     }
 
+    detach(): void {
+        this.remove();
+    }
+
     scrollIntoView(_opts?: unknown): void {
         /* noop */
     }

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -2530,11 +2530,43 @@ const PLACEMENT: PlacementResponse = {
 };
 
 describe("gpus()", () => {
-    it("GETs /api/gpus and returns the detected GPUs", async () => {
-        fetchMock.mockResolvedValue(jsonResponse(PLACEMENT.gpus));
+    it("GETs /api/gpus and returns the envelope with detected GPUs", async () => {
+        const envelope = { gpus: PLACEMENT.gpus, notice: null };
+        fetchMock.mockResolvedValue(jsonResponse(envelope));
         const result = await client.gpus();
         expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/api/gpus`, expect.objectContaining({}));
-        expect(result._unsafeUnwrap()).toEqual(PLACEMENT.gpus);
+        expect(result._unsafeUnwrap()).toEqual(envelope);
+    });
+
+    it("wraps a pre-PR-564 bare list in the envelope for backward compat", async () => {
+        fetchMock.mockResolvedValue(jsonResponse(PLACEMENT.gpus));
+        const result = await client.gpus();
+        expect(result._unsafeUnwrap()).toEqual({ gpus: PLACEMENT.gpus, notice: null });
+    });
+
+    it("returns the server-issued Intel util notice when present", async () => {
+        const notice = "install igt-gpu-tools and grant CAP_PERFMON to lilbee";
+        fetchMock.mockResolvedValue(jsonResponse({ gpus: PLACEMENT.gpus, notice }));
+        const result = await client.gpus();
+        expect(result._unsafeUnwrap().notice).toBe(notice);
+    });
+
+    it("returns an empty gpus array and null notice for an unexpected shape", async () => {
+        fetchMock.mockResolvedValue(jsonResponse({ unexpected: true }));
+        const result = await client.gpus();
+        expect(result._unsafeUnwrap()).toEqual({ gpus: [], notice: null });
+    });
+
+    it("returns err when the server responds non-ok", async () => {
+        fetchMock.mockResolvedValue({
+            ok: false,
+            status: 500,
+            text: () => Promise.resolve("boom"),
+            headers: { get: () => null },
+        } as unknown as Response);
+        const result = await client.gpus();
+        expect(result.isErr()).toBe(true);
+        expect(result._unsafeUnwrapErr().message).toContain("500");
     });
 });
 
@@ -2553,6 +2585,18 @@ describe("gpuStatsStream()", () => {
             data: { gpus: [{ index: 0, utilization_pct: 55, free_bytes: 1, total_bytes: 2 }] },
         });
     });
+
+    it("carries the per-event notice on the gpu_stats payload", async () => {
+        const notice = "grant CAP_PERFMON to lilbee";
+        fetchMock.mockResolvedValue(
+            sseResponse([
+                `event: gpu_stats\ndata: {"gpus": [{"index": 0, "utilization_pct": null, "free_bytes": 1, "total_bytes": 2}], "notice": ${JSON.stringify(notice)}}\n\n`,
+            ]),
+        );
+        const events = await collect(client.gpuStatsStream());
+        const payload = events[0].data as { gpus: unknown[]; notice?: string };
+        expect(payload.notice).toBe(notice);
+    });
 });
 
 describe("placement()", () => {
@@ -2561,6 +2605,13 @@ describe("placement()", () => {
         const result = await client.placement();
         expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/api/placement`, expect.objectContaining({}));
         expect(result._unsafeUnwrap()).toEqual(PLACEMENT);
+    });
+
+    it("exposes the host-level notice when the server includes one", async () => {
+        const notice = "install igt-gpu-tools and grant CAP_PERFMON to lilbee";
+        fetchMock.mockResolvedValue(jsonResponse({ ...PLACEMENT, notice }));
+        const result = await client.placement();
+        expect(result._unsafeUnwrap().notice).toBe(notice);
     });
 });
 

--- a/tests/views/placement-view.test.ts
+++ b/tests/views/placement-view.test.ts
@@ -950,6 +950,105 @@ describe("PlacementView live usage bars", () => {
         await view.onClose();
     });
 
+    it("renders a notice banner when the placement response carries one", async () => {
+        const notice = "install igt-gpu-tools and grant CAP_PERFMON to lilbee";
+        const api = makeApi({ placement: vi.fn().mockResolvedValue(ok({ ...multi(), notice })) });
+        const view = new PlacementView(new WorkspaceLeaf(), makePlugin(api));
+        await view.onOpen();
+        await flush();
+        const contentEl = (view as unknown as { contentEl: MockElement }).contentEl;
+        const banner = contentEl.find("lilbee-placement-notice");
+        expect(banner).toBeTruthy();
+        expect(banner.textContent).toContain(notice);
+        await view.onClose();
+    });
+
+    it("renders a notice banner when an SSE event carries one", async () => {
+        const notice = "grant CAP_PERFMON to lilbee";
+        const api = makeApi({
+            gpuStatsStream: vi.fn(() => statsStream({ event: "gpu_stats", data: { gpus: [], notice } })),
+        });
+        const view = new PlacementView(new WorkspaceLeaf(), makePlugin(api));
+        await view.onOpen();
+        await flush();
+        const contentEl = (view as unknown as { contentEl: MockElement }).contentEl;
+        expect(contentEl.find("lilbee-placement-notice")?.textContent).toContain(notice);
+        await view.onClose();
+    });
+
+    it("clears the notice banner when a later SSE event has no notice", async () => {
+        const notice = "install igt-gpu-tools";
+        const api = makeApi({
+            gpuStatsStream: vi.fn(() =>
+                statsStream(
+                    { event: "gpu_stats", data: { gpus: [], notice } },
+                    { event: "gpu_stats", data: { gpus: [] } },
+                ),
+            ),
+        });
+        const view = new PlacementView(new WorkspaceLeaf(), makePlugin(api));
+        await view.onOpen();
+        await flush();
+        const contentEl = (view as unknown as { contentEl: MockElement }).contentEl;
+        expect(contentEl.find("lilbee-placement-notice")).toBeFalsy();
+        await view.onClose();
+    });
+
+    it("updates the banner text in place when the notice changes between events", async () => {
+        const api = makeApi({
+            gpuStatsStream: vi.fn(() =>
+                statsStream(
+                    { event: "gpu_stats", data: { gpus: [], notice: "install igt-gpu-tools" } },
+                    { event: "gpu_stats", data: { gpus: [], notice: "grant CAP_PERFMON to lilbee" } },
+                ),
+            ),
+        });
+        const view = new PlacementView(new WorkspaceLeaf(), makePlugin(api));
+        await view.onOpen();
+        await flush();
+        const contentEl = (view as unknown as { contentEl: MockElement }).contentEl;
+        const banner = contentEl.find("lilbee-placement-notice");
+        expect(banner?.textContent).toContain("grant CAP_PERFMON to lilbee");
+        expect(contentEl.findAll("lilbee-placement-notice")).toHaveLength(1);
+        await view.onClose();
+    });
+
+    it("omits the notice banner when no notice is present", async () => {
+        const api = makeApi();
+        const view = new PlacementView(new WorkspaceLeaf(), makePlugin(api));
+        await view.onOpen();
+        await flush();
+        const contentEl = (view as unknown as { contentEl: MockElement }).contentEl;
+        expect(contentEl.find("lilbee-placement-notice")).toBeFalsy();
+        await view.onClose();
+    });
+
+    it("drops streamed notices that arrive when the view body is gone", async () => {
+        const { view, contentEl } = await openView(makePlugin(makeApi()));
+        const internal = view as unknown as {
+            bodyEl: HTMLElement | null;
+            gpuNotice: string | null;
+            applyNotice(notice: string | null): void;
+        };
+        internal.bodyEl = null;
+        internal.applyNotice("install igt-gpu-tools");
+        expect(internal.gpuNotice).toBe("install igt-gpu-tools");
+        internal.applyNotice(null);
+        expect(internal.gpuNotice).toBeNull();
+        expect(contentEl.find("lilbee-placement-notice")).toBeFalsy();
+    });
+
+    it("appends the notice banner when there is no header to anchor after", async () => {
+        const { view, contentEl } = await openView(makePlugin(makeApi()));
+        const internal = view as unknown as {
+            bodyEl: MockElement | null;
+            applyNotice(notice: string | null): void;
+        };
+        internal.bodyEl?.empty();
+        internal.applyNotice("install igt-gpu-tools");
+        expect(contentEl.find("lilbee-placement-notice")?.textContent).toContain("install igt-gpu-tools");
+    });
+
     it("opens a stats stream on open and aborts it on close", async () => {
         const api = makeApi();
         const view = new PlacementView(new WorkspaceLeaf(), makePlugin(api));


### PR DESCRIPTION
## Problem

lilbee PR #564 adds a host-level fix hint to every GPU surface for hosts where GPU utilization can't be read — Intel machines missing igt-gpu-tools or the CAP_PERFMON grant. The server now returns GET /api/gpus as an envelope {gpus, notice} instead of a bare list, adds an optional notice to each gpu_stats SSE event, and carries notice on all placement responses. Without this change the plugin silently drops the hint, so an Intel user staring at a "--" utilization readout gets no guidance on how to fix it.

## Solution

Consume the notice end to end. The API client's gpus() returns the new envelope and normalizes the pre-PR-564 bare-list response, so external mode pointed at an older server keeps working. GpuStatsPayload and PlacementResponse expose the optional notice field. The placement view renders the notice as a warning banner under the header — from the placement snapshot on load and from the live stats stream — updates it in place when the text changes, and removes it once the host reports healthy again. The banner renders the server's actionable command verbatim under a localized "GPU monitoring:" label, styled after the existing warning callout pattern.

External-mode compatibility is handled by shape detection in the client rather than a version gate: a bare array response is wrapped as {gpus, notice: null}, an envelope is passed through.