### PR TITLE
Hide saved conversations on servers that predate the session routes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -73,6 +73,7 @@ import {
     NOTICE_PERMANENT,
     percentOfBytes,
     sessionTokenInvalidMessage,
+    supportsSessions,
     STREAM_IDLE_TIMEOUT_MS,
     StreamIdleError,
     withIdleTimeout,
@@ -310,6 +311,9 @@ export default class LilbeePlugin extends Plugin {
     private chatInFlight = 0;
     // Counts consecutive failed probes against HEALTH_FAILURE_STREAK_THRESHOLD.
     private healthFailureStreak = 0;
+    // External-mode server version, cached from the health probe; managed mode
+    // reads the recorded install version instead.
+    private externalServerVersion = "";
     // The managed server has reached READY at least once this session. Until
     // it has, a failing health probe means "still coming up", not "error" —
     // so a fresh install / first-run wizard doesn't flash a red error pill
@@ -1671,6 +1675,7 @@ export default class LilbeePlugin extends Plugin {
         const health = await this.api.health().catch(() => null);
         if (health?.isOk()) {
             this.healthFailureStreak = 0;
+            if (this.settings.serverMode === SERVER_MODE.EXTERNAL) this.externalServerVersion = health.value.version;
             if (this.serverUnreachable) {
                 this.serverUnreachable = false;
                 void this.fetchActiveModel();
@@ -1912,6 +1917,17 @@ export default class LilbeePlugin extends Plugin {
         if (!this.chatWarming) return true;
         new Notice(MESSAGES.NOTICE_FLEET_WARMING);
         return false;
+    }
+
+    /** Saved conversations need the /api/sessions routes, which pre-0.6.90 servers
+     *  don't have. Managed mode knows the install version up front; external mode
+     *  fails open until the first health probe reports one. */
+    serverSupportsSessions(): boolean {
+        const version =
+            this.settings.serverMode === SERVER_MODE.MANAGED
+                ? this.getSharedLilbeeVersion()
+                : this.externalServerVersion;
+        return supportsSessions(version);
     }
 
     private async confirmReindexIfNeeded(name: string): Promise<boolean> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -139,6 +139,15 @@ export function isVersionOlder(current: string, latest: string): boolean {
     return false;
 }
 
+/** Oldest server with the /api/sessions routes; the 0.6.66 stable line predates them. */
+export const SESSIONS_MIN_SERVER_VERSION = "0.6.90b420";
+
+/** Unknown versions fail open: the chat path already degrades gracefully on a 404. */
+export function supportsSessions(version: string): boolean {
+    if (!version) return true;
+    return !isVersionOlder(version, SESSIONS_MIN_SERVER_VERSION);
+}
+
 /**
  * Render the server's ISO-8601 timestamp ("2026-05-09T05:49:38.800771+00:00")
  * as a human "5m ago" / "3d ago" string. Returns the raw value when parsing

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -349,10 +349,13 @@ export class ChatView extends ItemView {
         gpuBtn.setAttribute("aria-label", MESSAGES.LABEL_OPEN_GPU_ACTIVITY);
         gpuBtn.addEventListener("click", () => void revealPlacementBeside(this.app, this.leaf));
 
-        const sessionsBtn = actions.createEl("button", { cls: "lilbee-chat-sessions" });
-        setIcon(sessionsBtn, "history");
-        sessionsBtn.setAttribute("aria-label", MESSAGES.LABEL_OPEN_SESSIONS);
-        sessionsBtn.addEventListener("click", () => this.openSessions());
+        // Saved conversations are hidden outright on servers without the routes.
+        if (this.plugin.serverSupportsSessions()) {
+            const sessionsBtn = actions.createEl("button", { cls: "lilbee-chat-sessions" });
+            setIcon(sessionsBtn, "history");
+            sessionsBtn.setAttribute("aria-label", MESSAGES.LABEL_OPEN_SESSIONS);
+            sessionsBtn.addEventListener("click", () => this.openSessions());
+        }
 
         const saveBtn = actions.createEl("button", { cls: "lilbee-chat-save" });
         setIcon(saveBtn, "save");
@@ -921,6 +924,8 @@ export class ChatView extends ItemView {
 
     /** Queue a session write. Never awaited by the chat path: persistence must not stall the answer. */
     private queuePersist(write: () => Promise<void>): void {
+        // Servers without the session routes keep the conversation in memory only.
+        if (!this.plugin.serverSupportsSessions()) return;
         // Writes queued for one conversation must not touch the one open when they run.
         const epoch = this.conversationEpoch;
         this.persistQueue = this.persistQueue

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -3151,6 +3151,60 @@ describe("LilbeePlugin", () => {
         });
     });
 
+    describe("serverSupportsSessions", () => {
+        it("managed mode gates on the recorded install version", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            const loadConfig = vi.spyOn(VaultRegistry.prototype, "loadConfig").mockReturnValue({
+                ...DEFAULT_SHARED_CONFIG,
+                lilbeeVersion: "v0.6.66b507",
+            });
+            expect(plugin.serverSupportsSessions()).toBe(false);
+            loadConfig.mockReturnValue({ ...DEFAULT_SHARED_CONFIG, lilbeeVersion: "v0.6.90b420.dev724" });
+            expect(plugin.serverSupportsSessions()).toBe(true);
+            loadConfig.mockRestore();
+        });
+
+        it("managed mode fails open while no version is recorded", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            const loadConfig = vi.spyOn(VaultRegistry.prototype, "loadConfig").mockReturnValue({
+                ...DEFAULT_SHARED_CONFIG,
+            });
+            expect(plugin.serverSupportsSessions()).toBe(true);
+            loadConfig.mockRestore();
+        });
+
+        it("external mode fails open until a probe caches the server version", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            expect(plugin.serverSupportsSessions()).toBe(true);
+
+            plugin.api.health = vi
+                .fn()
+                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { version: "0.6.66b507" } });
+            await (plugin as any).probeServerHealth();
+            expect(plugin.serverSupportsSessions()).toBe(false);
+
+            plugin.api.health = vi
+                .fn()
+                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { version: "0.6.90b420" } });
+            await (plugin as any).probeServerHealth();
+            expect(plugin.serverSupportsSessions()).toBe(true);
+        });
+
+        it("managed probes leave the external version cache alone", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            vi.spyOn(plugin, "ensureManagedConsentThenStart").mockResolvedValue({ kind: "canceled" } as any);
+            await plugin.onload();
+            plugin.api.health = vi
+                .fn()
+                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { version: "0.6.66b507" } });
+            await (plugin as any).probeServerHealth();
+            expect((plugin as any).externalServerVersion).toBe("");
+        });
+    });
+
     describe("triggerSync event handling", () => {
         it("handles EXTRACT events by updating taskQueue", async () => {
             const plugin = await createPlugin();

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -26,6 +26,7 @@ import {
     sessionTokenInvalidMessage,
     setDeterminateProgress,
     streamInterruptedMessage,
+    supportsSessions,
     withIdleTimeout,
 } from "../src/utils";
 import { ServerStartingError, SessionTokenError } from "../src/api";
@@ -173,6 +174,25 @@ describe("isVersionOlder", () => {
     it("treats a digitless version as zero, so anything real is newer", () => {
         expect(isVersionOlder("", "0.6.74")).toBe(true);
         expect(isVersionOlder("dev", "dev")).toBe(false);
+    });
+});
+
+describe("supportsSessions", () => {
+    it("rejects the 0.6.66 stable line and everything older", () => {
+        expect(supportsSessions("v0.6.66b507")).toBe(false);
+        expect(supportsSessions("0.6.66b507")).toBe(false);
+        expect(supportsSessions("0.6.9")).toBe(false);
+        expect(supportsSessions("0.6.90b419")).toBe(false);
+    });
+
+    it("accepts the first sessions build, its dev builds, and anything newer", () => {
+        expect(supportsSessions("0.6.90b420")).toBe(true);
+        expect(supportsSessions("v0.6.90b420.dev724")).toBe(true);
+        expect(supportsSessions("0.6.91b1")).toBe(true);
+    });
+
+    it("fails open when the version is unknown", () => {
+        expect(supportsSessions("")).toBe(true);
     });
 });
 

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -248,6 +248,7 @@ function makePlugin(): LilbeePlugin {
         notifyChatStart: vi.fn(),
         notifyChatEnd: vi.fn(),
         assertFleetReady: vi.fn().mockReturnValue(true),
+        serverSupportsSessions: vi.fn().mockReturnValue(true),
         refreshMemoryViews: vi.fn(),
         taskQueue: new TaskQueue(),
         app: {
@@ -5725,6 +5726,34 @@ describe("ChatView — sessions toolbar button", () => {
 
         expect(messagesEl.children).toHaveLength(0);
         expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_SESSION_NEW)).toBe(true);
+    });
+
+    it("hides the button when the server predates the session routes", async () => {
+        const plugin = makePlugin();
+        (plugin.serverSupportsSessions as ReturnType<typeof vi.fn>).mockReturnValue(false);
+        const { container } = await openChat(plugin);
+
+        expect(container.find("lilbee-chat-sessions")).toBeNull();
+    });
+
+    it("keeps the conversation in memory only when the server predates the session routes", async () => {
+        const plugin = makePlugin();
+        (plugin.serverSupportsSessions as ReturnType<typeof vi.fn>).mockReturnValue(false);
+        const { mockFn, done } = makeStream([
+            { event: SSE_EVENT.TOKEN, data: "a" },
+            { event: SSE_EVENT.DONE, data: {} },
+        ]);
+        plugin.api.chatStream = mockFn;
+        const { container } = await openChat(plugin);
+        container.find("lilbee-chat-textarea")!.value = "q";
+        container.find("lilbee-chat-send")!.trigger("click");
+        await done;
+        await tick();
+        await tick();
+
+        expect(plugin.api.createSession).not.toHaveBeenCalled();
+        expect(plugin.api.appendSessionMessage).not.toHaveBeenCalled();
+        expect(mockFn.mock.calls[0][6]).toEqual({ summary: "", sessionId: null });
     });
 });
 


### PR DESCRIPTION
## Problem

Stable lilbee (0.6.66b507) has no /api/sessions routes — they arrived in the 0.6.90 dev line. The chat view shows the saved-conversations button anyway and tries to persist every turn against 404s; the modal even offers to enable a config key the old server doesn't have.

## Solution

Gate saved conversations on the server version: new SESSIONS_MIN_SERVER_VERSION (0.6.90b420) compared via the existing isVersionOlder. Managed mode reads the recorded install version; external mode caches it from the health probe. Below the floor the button is not rendered and queuePersist no-ops, so chats stay in memory and the server never sees a session request. Unknown versions fail open, with the existing 404 unbind as backstop. The gate opens automatically once a stable >= 0.6.90 ships.