### PR TITLE
pin transitive dev-dependency CVEs via npm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,11 @@
   },
   "dependencies": {
     "fflate": "^0.8.3"
+  },
+  "overrides": {
+    "brace-expansion@<1.1.16": "1.1.16",
+    "brace-expansion@>=2.0.0 <2.1.2": "2.1.2",
+    "brace-expansion@>=3.0.0 <5.0.7": "5.0.7",
+    "js-yaml@<4.3.0": "4.3.0"
   }
 }


### PR DESCRIPTION
Add npm overrides to force safe versions of brace-expansion and js-yaml, resolving two high-severity DoS CVEs found by OSV-Scanner and npm audit:

- **CVE-2026-13149**: brace-expansion DoS via exponential `{}` expansion (fixed in 1.1.16, 2.1.2, 5.0.7)
- **CVE-2026-59869**: js-yaml YAML merge-key quadratic CPU consumption (fixed in 4.3.0)

The package-lock.json already pinned these versions in 0389c0a; the overrides prevent regression when the lockfile is regenerated.