### PR TITLE
Fix the dead server version picker and remove the setup wizard's Task Center link

### DIFF
--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -74,6 +74,11 @@ const RELEASE_PAGE_SIZE = 100;
 /** Pages to scan before giving up, so a long stretch of dev builds can't hide every stable release. */
 const RELEASE_PAGE_BUDGET = 3;
 
+/** GitHub answers unauthenticated API calls past its per-IP hourly budget with 403 or 429. */
+const RATE_LIMIT_STATUSES = new Set([403, 429]);
+
+const GITHUB_RATE_LIMITED = "GitHub's rate limit was reached; release checks reset within the hour.";
+
 /** Run `nvidia-smi` and return its stdout, or null if it is absent or fails. */
 async function runNvidiaSmi(): Promise<string | null> {
     try {
@@ -191,6 +196,7 @@ async function fetchInstallableReleases(limit: number, includeDev: boolean): Pro
             url: `${RELEASE_LIST_API}?per_page=${RELEASE_PAGE_SIZE}&page=${page}`,
             headers: { Accept: "application/vnd.github.v3+json" },
         });
+        if (RATE_LIMIT_STATUSES.has(res.status)) throw new Error(GITHUB_RATE_LIMITED);
         if (res.status >= 400) throw new Error(`GitHub API responded ${res.status}`);
         const pageData = res.json as GitHubRelease[];
         for (const data of pageData) {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -56,6 +56,7 @@ export const MESSAGES = {
     BUTTON_RUN_SETUP_WIZARD: "Run setup wizard",
     BUTTON_INSTALL_SERVER: "Install server",
     BUTTON_REINSTALL: "Reinstall",
+    BUTTON_RETRY: "Retry",
     BUTTON_UNINSTALL_SERVER: "Uninstall server",
     BUTTON_UNINSTALL: "Uninstall",
     BUTTON_DOWNLOADING: "Downloading...",
@@ -67,7 +68,6 @@ export const MESSAGES = {
     BUTTON_CLEAR_TASKS: "Clear",
     BUTTON_SEND: "Send",
     BUTTON_OPEN_CHAT: "Open chat",
-    BUTTON_OPEN_TASK_CENTER: "→ Open Task Center",
 
     LABEL_NOT_SET: "Not set",
     LABEL_NO_MODEL_SELECTED: "no model selected",
@@ -387,7 +387,8 @@ export const MESSAGES = {
     DESC_SERVER_VERSION_DOWNGRADE: (installed: string) =>
         `${installed} installed. Downgrading replaces it with an older build and turns off automatic server updates.`,
     DESC_SERVER_VERSION_LOADING: "Reading the release list from GitHub...",
-    DESC_SERVER_VERSION_OFFLINE: (tag: string) => `${tag} installed. The release list could not be read from GitHub.`,
+    DESC_SERVER_VERSION_OFFLINE: (tag: string, reason: string) =>
+        `${tag} installed. The release list could not be read from GitHub: ${reason}`,
     DESC_DEV_BUILD_AVAILABLE: (tag: string) =>
         `A newer dev build (${tag}) is out. Turn on "Include dev builds" to try it.`,
     DESC_SERVER_AUTO_UPDATE:
@@ -402,7 +403,7 @@ export const MESSAGES = {
 
     TOOLTIP_SERVER_VERSION_SUPPORT:
         "This plugin is built and tested against the latest server release. Older releases still install and run, " +
-        "but they are not supported, and features the plugin expects may be missing.",
+        "but they are not supported, and features the plugin expects may be missing. Use a non-default release at your own risk.",
     TOOLTIP_UNINSTALL_SECTION:
         "Obsidian does not manage the lilbee server executable or its models, this plugin does. " +
         "Removing the plugin from Obsidian's Community plugins pane leaves both on disk. Uninstall here first.",
@@ -437,7 +438,7 @@ export const MESSAGES = {
     ERROR_UNINSTALL_SERVER_IN_USE: (vaultName: string) =>
         `The lilbee server is running for ${vaultName}. Close that vault, then uninstall.`,
     ERROR_INSTALL_FAILED: "Could not install the lilbee server",
-    ERROR_RELEASE_LIST: "Could not read the lilbee release list from GitHub",
+    ERROR_RELEASE_LIST: (reason: string) => `Could not read the lilbee release list from GitHub: ${reason}`,
     DESC_SERVER_URL_HELP: "Address of the lilbee HTTP server",
     LABEL_MANUAL_TOKEN: "Session token",
     DESC_MANUAL_TOKEN:
@@ -904,7 +905,7 @@ export const MESSAGES = {
     WIZARD_SYNC_HELP:
         "lilbee needs to read your notes once to make them searchable. This happens locally on your machine.",
     WIZARD_STEP_BADGE: "Step {num} · {label}",
-    WIZARD_PROGRESS_BACKGROUND: "Downloads continue in the background — track any time in the Task Center.",
+    WIZARD_PROGRESS_BACKGROUND: "Downloads continue in the background.",
     WIZARD_WIKI_TRADEOFFS_LABEL: "See the tradeoffs",
     WIZARD_SUMMARY_HEADING: "Setup complete",
     WIZARD_SUMMARY_MODEL: "Chat model: {model}",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -58,6 +58,8 @@ import {
 
 const CHECK_TIMEOUT_MS = 5000;
 const DEV_BUILDS_FLASH_MS = 2400;
+/** GitHub's unauthenticated releases API allows 60 requests/hour per IP, so renders share one fetch. */
+const RELEASES_CACHE_TTL_MS = 10 * 60 * 1000;
 const CLS_MODELS_CONTAINER = "lilbee-models-container";
 const RERANKER_DISABLED_KEY = "";
 const VISION_DISABLED_KEY = "";
@@ -115,6 +117,8 @@ export class LilbeeSettingTab extends PluginSettingTab {
     private apiKeysContainerEl: HTMLElement | null = null;
     private crawlingContainerEl: HTMLElement | null = null;
     private wikiContainerEl: HTMLElement | null = null;
+    /** Last successful release-list fetch; failures are not cached, so a retry always refetches. */
+    private releasesCache: { at: number; releases: ReleaseInfo[] } | null = null;
 
     constructor(app: App, plugin: LilbeePlugin) {
         super(app, plugin);
@@ -401,20 +405,24 @@ export class LilbeeSettingTab extends PluginSettingTab {
         });
 
         void this.loadReleases().then((loaded) => {
-            if (loaded === null) {
+            if (loaded.releases === null) {
                 setting.setDesc(
-                    installed ? MESSAGES.DESC_SERVER_VERSION_OFFLINE(installed) : MESSAGES.DESC_SERVER_VERSION_UNKNOWN,
+                    installed
+                        ? MESSAGES.DESC_SERVER_VERSION_OFFLINE(installed, loaded.error)
+                        : MESSAGES.DESC_SERVER_VERSION_UNKNOWN,
                 );
+                setting.addButton((btn) => btn.setButtonText(MESSAGES.BUTTON_RETRY).onClick(() => this.render()));
                 return;
             }
+            const all = loaded.releases;
             const includeDev = this.plugin.settings.includeDevBuilds;
-            // loaded holds every installable release (dev builds included); when dev builds are
+            // all holds every installable release (dev builds included); when dev builds are
             // off, hide them and nudge toward the newest one if it leads the stable line and the
             // user isn't already running it.
-            const newest = loaded[0];
+            const newest = all[0];
             newerDevTag =
                 !includeDev && newest && isDevBuild(newest.tag) && newest.tag !== installed ? newest.tag : null;
-            releases = includeDev ? loaded : loaded.filter((r) => !isDevBuild(r.tag));
+            releases = includeDev ? all : all.filter((r) => !isDevBuild(r.tag));
             if (releases.length === 0) return;
             if (!releases.some((r) => r.tag === selectedTag)) selectedTag = releases[0].tag;
             for (const release of releases) dropdown.addOption(release.tag, release.tag);
@@ -425,12 +433,17 @@ export class LilbeeSettingTab extends PluginSettingTab {
         });
     }
 
-    /** Recent installable releases, dev builds included; null when GitHub could not be reached. */
-    private async loadReleases(): Promise<ReleaseInfo[] | null> {
+    /** Recent installable releases, dev builds included, or why GitHub could not be read. */
+    private async loadReleases(): Promise<{ releases: ReleaseInfo[] } | { releases: null; error: string }> {
+        if (this.releasesCache && Date.now() - this.releasesCache.at < RELEASES_CACHE_TTL_MS) {
+            return { releases: this.releasesCache.releases };
+        }
         try {
-            return await listReleases(true);
-        } catch {
-            return null;
+            const releases = await listReleases(true);
+            this.releasesCache = { at: Date.now(), releases };
+            return { releases };
+        } catch (err) {
+            return { releases: null, error: errorMessage(err, String(err)) };
         }
     }
 
@@ -526,6 +539,9 @@ export class LilbeeSettingTab extends PluginSettingTab {
         const setting = new Setting(containerEl)
             .setName(MESSAGES.LABEL_INSTALL_SERVER)
             .setDesc(MESSAGES.DESC_SERVER_VERSION_LOADING);
+        // aria-label only: Obsidian renders its styled tooltip from it, and a
+        // title attribute would stack the native browser tooltip on top.
+        setting.settingEl.setAttribute("aria-label", MESSAGES.TOOLTIP_SERVER_VERSION_SUPPORT);
         const progress = this.renderUpdateProgress(containerEl);
 
         let releases: ReleaseInfo[] = [];
@@ -562,11 +578,12 @@ export class LilbeeSettingTab extends PluginSettingTab {
         });
 
         void this.loadReleases().then((loaded) => {
-            if (loaded === null) {
-                setting.setDesc(MESSAGES.ERROR_RELEASE_LIST);
+            if (loaded.releases === null) {
+                setting.setDesc(MESSAGES.ERROR_RELEASE_LIST(loaded.error));
+                setting.addButton((btn) => btn.setButtonText(MESSAGES.BUTTON_RETRY).onClick(() => this.render()));
                 return;
             }
-            releases = loaded;
+            releases = loaded.releases;
             if (releases.length === 0) return;
             selectedTag = releases[0].tag;
             for (const release of releases) dropdown.addOption(release.tag, release.tag);

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -619,9 +619,7 @@ export class SetupWizard extends Modal {
     /**
      * Build the shared download-progress panel used by steps 3–5. The panel
      * starts hidden; `activateProgressPanel` below flips it on once work
-     * begins. The Task Center CTA is always present but only *visible* while
-     * progress is active — users need the affordance the moment downloads
-     * start, never before.
+     * begins.
      */
     private renderProgressPanel(step: HTMLElement): {
         progressEl: HTMLElement;
@@ -641,15 +639,6 @@ export class SetupWizard extends Modal {
         footer.createDiv({
             cls: "lilbee-wizard-progress-hint",
             text: MESSAGES.WIZARD_PROGRESS_BACKGROUND,
-        });
-
-        const taskCenterBtn = footer.createEl("button", {
-            cls: "lilbee-wizard-task-center-cta",
-            text: MESSAGES.BUTTON_OPEN_TASK_CENTER,
-        });
-        taskCenterBtn.addEventListener("click", (e) => {
-            e.preventDefault();
-            void this.plugin.activateTaskView();
         });
 
         return { progressEl, progressFill, progressLabel };

--- a/styles.css
+++ b/styles.css
@@ -1984,34 +1984,6 @@
     margin-top: 2px;
 }
 
-/* Task Center CTA: styled like a task-type chip, colored by step. Visible
- * the moment a download starts so the user knows their next move if they
- * want to step out of the wizard. */
-.lilbee-wizard-task-center-cta {
-    display: inline-flex;
-    align-items: center;
-    padding: 5px 10px;
-    background-color: transparent;
-    color: var(--wizard-step-color, var(--interactive-accent));
-    border: 1px solid color-mix(in srgb, var(--wizard-step-color, var(--interactive-accent)) 40%, transparent);
-    border-radius: 8px;
-    font-size: 10px;
-    font-weight: var(--font-semibold, 600);
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    cursor: pointer;
-    transition:
-        background-color 150ms ease,
-        border-color 150ms ease,
-        color 150ms ease;
-    flex-shrink: 0;
-}
-
-.lilbee-wizard-task-center-cta:hover {
-    background-color: color-mix(in srgb, var(--wizard-step-color, var(--interactive-accent)) 12%, transparent);
-    border-color: var(--wizard-step-color, var(--interactive-accent));
-}
-
 /* Managed-server setup panel: a header + three phase rows whose dots light up
  * as the server moves Downloading → Starting → Ready. Mirrors the Task Center's
  * visual language so first-run setup feels like the rest of the plugin. */

--- a/tests/binary-manager.test.ts
+++ b/tests/binary-manager.test.ts
@@ -322,13 +322,26 @@ describe("getLatestRelease", () => {
 
     it("throws when GitHub API returns error status", async () => {
         vi.spyOn(node, "requestUrl").mockResolvedValue({
-            status: 403,
+            status: 500,
             json: [],
             arrayBuffer: new ArrayBuffer(0),
             headers: {},
         });
 
-        await expect(getLatestRelease(false)).rejects.toThrow("GitHub API responded 403");
+        await expect(getLatestRelease(false)).rejects.toThrow("GitHub API responded 500");
+    });
+
+    it("names the rate limit when GitHub answers 403 or 429", async () => {
+        for (const status of [403, 429]) {
+            vi.spyOn(node, "requestUrl").mockResolvedValue({
+                status,
+                json: [],
+                arrayBuffer: new ArrayBuffer(0),
+                headers: {},
+            });
+
+            await expect(getLatestRelease(false)).rejects.toThrow("rate limit");
+        }
     });
 
     it("paginates past a full first page of dev builds to reach a stable release", async () => {
@@ -1207,11 +1220,11 @@ describe("listReleases", () => {
         warn.mockRestore();
     });
 
-    it("throws when GitHub rejects the request", async () => {
+    it("names the rate limit when GitHub rejects the request", async () => {
         restore = stubPlatform("linux", "x64");
         stubNoNvidia();
         vi.spyOn(node, "requestUrl").mockResolvedValue({ status: 403, json: [], arrayBuffer: new ArrayBuffer(0) });
 
-        await expect(listReleases(false)).rejects.toThrow("GitHub API responded 403");
+        await expect(listReleases(false)).rejects.toThrow("rate limit");
     });
 });

--- a/tests/settings-version-picker.test.ts
+++ b/tests/settings-version-picker.test.ts
@@ -171,6 +171,20 @@ describe("server version picker with the real release list", () => {
 
         const labels = buttons.flatMap((b) => b.labels);
         expect(labels).toContain("Retry");
+        expect(descs[descs.length - 1]).toContain("network down");
+    });
+
+    it("clicking retry re-renders the settings tab", async () => {
+        vi.spyOn(node, "requestUrl").mockRejectedValue(new Error("network down"));
+        const tab = makeTab(false);
+        const renderSpy = vi.spyOn(tab, "render").mockImplementation(() => {});
+        (tab as any).renderVersionSetting(new MockElement() as unknown as HTMLElement);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        const retry = buttons.find((b) => b.labels.includes("Retry"));
+        expect(retry?.handler).toBeDefined();
+        retry!.handler!();
+        expect(renderSpy).toHaveBeenCalled();
     });
 
     it("names the GitHub rate limit when GitHub answers 403", async () => {

--- a/tests/settings-version-picker.test.ts
+++ b/tests/settings-version-picker.test.ts
@@ -37,10 +37,18 @@ interface CapturedDropdown {
     value: string | null;
 }
 
+interface CapturedButton {
+    labels: string[];
+    disabledStates: boolean[];
+    handler: (() => unknown) | null;
+}
+
 describe("server version picker with the real release list", () => {
     let dropdown: CapturedDropdown;
+    let buttons: CapturedButton[];
     let descs: string[];
     let originalAddDropdown: typeof Setting.prototype.addDropdown;
+    let originalAddButton: typeof Setting.prototype.addButton;
     let originalArch: PropertyDescriptor | undefined;
 
     beforeEach(() => {
@@ -48,6 +56,7 @@ describe("server version picker with the real release list", () => {
         originalArch = Object.getOwnPropertyDescriptor(process, "arch");
         Object.defineProperty(process, "arch", { value: "x64", configurable: true });
         dropdown = { options: [], disabledStates: [], value: null };
+        buttons = [];
         descs = [];
 
         originalAddDropdown = Setting.prototype.addDropdown;
@@ -71,6 +80,28 @@ describe("server version picker with the real release list", () => {
             cb(dd);
             return this;
         };
+        originalAddButton = Setting.prototype.addButton;
+        Setting.prototype.addButton = function (cb: (btn: any) => void) {
+            const captured: CapturedButton = { labels: [], disabledStates: [], handler: null };
+            const btn = {
+                setButtonText: (t: string) => {
+                    captured.labels.push(t);
+                    return btn;
+                },
+                setDisabled: (d: boolean) => {
+                    captured.disabledStates.push(d);
+                    return btn;
+                },
+                onClick: (h: () => unknown) => {
+                    captured.handler = h;
+                    return btn;
+                },
+                buttonEl: { toggleClass: () => {}, addClass: () => {} },
+            };
+            buttons.push(captured);
+            cb(btn);
+            return this;
+        };
         vi.spyOn(Setting.prototype, "setDesc").mockImplementation(function (desc) {
             descs.push(String(desc));
             return this;
@@ -88,15 +119,20 @@ describe("server version picker with the real release list", () => {
     afterEach(() => {
         vi.restoreAllMocks();
         Setting.prototype.addDropdown = originalAddDropdown;
+        Setting.prototype.addButton = originalAddButton;
         if (originalArch) Object.defineProperty(process, "arch", originalArch);
     });
 
-    async function renderPicker(includeDevBuilds: boolean): Promise<CapturedDropdown> {
+    function makeTab(includeDevBuilds: boolean): LilbeeSettingTab {
         const plugin = {
             settings: { ...DEFAULT_SETTINGS, serverMode: SERVER_MODE.MANAGED, includeDevBuilds },
             getSharedLilbeeVersion: () => STABLE_RUN[0],
         } as unknown as LilbeePlugin;
-        const tab = new LilbeeSettingTab(new App(), plugin);
+        return new LilbeeSettingTab(new App(), plugin);
+    }
+
+    async function renderPicker(includeDevBuilds: boolean): Promise<CapturedDropdown> {
+        const tab = makeTab(includeDevBuilds);
         (tab as any).renderVersionSetting(new MockElement() as unknown as HTMLElement);
         await new Promise((resolve) => setTimeout(resolve, 0));
         return dropdown;
@@ -117,5 +153,35 @@ describe("server version picker with the real release list", () => {
         expect(dd.options).toEqual([...DEV_RUN.slice(0, 10), ...STABLE_RUN.slice(0, 10)]);
         expect(dd.value).toBe(STABLE_RUN[0]);
         expect(dd.disabledStates).toContain(false);
+    });
+
+    it("fetches the release list only once across repeated renders", async () => {
+        const tab = makeTab(false);
+        (tab as any).renderVersionSetting(new MockElement() as unknown as HTMLElement);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        (tab as any).renderVersionSetting(new MockElement() as unknown as HTMLElement);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(node.requestUrl).toHaveBeenCalledTimes(1);
+    });
+
+    it("says why and offers a retry when the release list cannot be read", async () => {
+        vi.spyOn(node, "requestUrl").mockRejectedValue(new Error("network down"));
+        await renderPicker(false);
+
+        const labels = buttons.flatMap((b) => b.labels);
+        expect(labels).toContain("Retry");
+    });
+
+    it("names the GitHub rate limit when GitHub answers 403", async () => {
+        vi.spyOn(node, "requestUrl").mockResolvedValue({
+            status: 403,
+            json: { message: "API rate limit exceeded for 1.2.3.4." },
+            arrayBuffer: new ArrayBuffer(0),
+            headers: {},
+        });
+        await renderPicker(false);
+
+        expect(descs[descs.length - 1].toLowerCase()).toContain("rate limit");
     });
 });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -2310,6 +2310,7 @@ describe("managed mode settings", () => {
         const titles = setAttribute.mock.calls.filter(([name]) => name === "title").map(([, value]) => value);
         expect(titles).not.toContain(MESSAGES.TOOLTIP_SERVER_VERSION_SUPPORT);
         expect(MESSAGES.TOOLTIP_SERVER_VERSION_SUPPORT).toContain("not supported");
+        expect(MESSAGES.TOOLTIP_SERVER_VERSION_SUPPORT).toContain("own risk");
         setAttribute.mockRestore();
     });
 
@@ -7454,6 +7455,19 @@ describe("managed mode with no server installed", () => {
         expect(Object.keys(captured.dropdownOptions[1])).toEqual(["v0.3.0", "v0.2.0"]);
     });
 
+    it("warns on the install picker that only the latest server release is supported", async () => {
+        const plugin = makeUninstalledPlugin();
+        const tab = makeTab(plugin);
+        const setAttribute = vi.spyOn(MockElement.prototype, "setAttribute");
+
+        tab.display();
+        await settle();
+
+        const tooltips = setAttribute.mock.calls.filter(([name]) => name === "aria-label").map(([, value]) => value);
+        expect(tooltips).toContain(MESSAGES.TOOLTIP_SERVER_VERSION_SUPPORT);
+        setAttribute.mockRestore();
+    });
+
     it("hides the uninstall section while nothing is installed", async () => {
         const plugin = makeUninstalledPlugin();
         const tab = makeTab(plugin);
@@ -7538,9 +7552,35 @@ describe("managed mode with no server installed", () => {
         const captured = captureSettingCallbacks(() => tab.display());
         await settle();
 
-        expect(setDesc.mock.calls.some(([d]) => String(d) === MESSAGES.ERROR_RELEASE_LIST)).toBe(true);
+        expect(setDesc.mock.calls.some(([d]) => String(d) === MESSAGES.ERROR_RELEASE_LIST("offline"))).toBe(true);
         expect(captured.buttons.find((b) => b.name === MESSAGES.LABEL_INSTALL_SERVER)!.disabled).toBe(true);
         setDesc.mockRestore();
+    });
+
+    it("offers a retry that re-renders when the release list cannot be read", async () => {
+        mockListReleases.mockRejectedValue(new Error("offline"));
+        const plugin = makeUninstalledPlugin();
+        const tab = makeTab(plugin);
+        let retryBtn: { text: string; triggerClick: () => void } | null = null;
+        const origAddButton = Setting.prototype.addButton;
+        vi.spyOn(Setting.prototype, "addButton").mockImplementation(function (cb: (btn: any) => void) {
+            return origAddButton.call(this, (btn: any) => {
+                const setButtonText = btn.setButtonText.bind(btn);
+                btn.setButtonText = (t: string) => {
+                    if (t === MESSAGES.BUTTON_RETRY) retryBtn = btn;
+                    return setButtonText(t);
+                };
+                cb(btn);
+            });
+        });
+
+        captureSettingCallbacks(() => tab.display());
+        await settle();
+
+        expect(retryBtn).not.toBeNull();
+        const renderSpy = vi.spyOn(tab, "render").mockImplementation(() => {});
+        retryBtn!.triggerClick();
+        expect(renderSpy).toHaveBeenCalled();
     });
 });
 

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -3079,6 +3079,17 @@ describe("SetupWizard", () => {
             expect(plugin.activateTaskView).toHaveBeenCalled();
         });
 
+        it("does not offer a Task Center link inside the wizard", async () => {
+            const plugin = setupModelPickerActive();
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            expect(el.find("lilbee-wizard-task-center-cta")).toBeNull();
+        });
+
         it("clicking the Task Center CTA does not close the wizard", async () => {
             const plugin = setupModelPickerActive();
             const wizard = new SetupWizard(plugin.app as any, plugin as any);

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -81,7 +81,6 @@ function makePlugin(overrides: Record<string, unknown> = {}) {
         startManagedServer: vi.fn().mockResolvedValue(undefined),
         saveSettings: vi.fn().mockResolvedValue(undefined),
         activateChatView: vi.fn().mockResolvedValue(undefined),
-        activateTaskView: vi.fn().mockResolvedValue(undefined),
         ...overrides,
     };
     // Default consent gate: delegate to startManagedServer (so per-test
@@ -3025,7 +3024,7 @@ describe("SetupWizard", () => {
         });
     });
 
-    describe("Task Center CTA during progress", () => {
+    describe("progress panel", () => {
         function setupModelPickerActive() {
             const entries = [makeEntry({ name: "qwen/qwen3-0.6B" })];
             const plugin = makePlugin({ settings: { serverMode: "external" } });
@@ -3038,19 +3037,6 @@ describe("SetupWizard", () => {
             });
             return plugin;
         }
-
-        it("renders the Task Center CTA button inside the model picker progress panel", async () => {
-            const plugin = setupModelPickerActive();
-            const wizard = new SetupWizard(plugin.app as any, plugin as any);
-            wizard.open();
-            wizard.next();
-            await tick();
-
-            const el = wizard.contentEl as unknown as MockElement;
-            const cta = el.find("lilbee-wizard-task-center-cta");
-            expect(cta).not.toBeNull();
-            expect(cta!.textContent).toBe(MESSAGES.BUTTON_OPEN_TASK_CENTER);
-        });
 
         it("renders the background-processing helper line", async () => {
             const plugin = setupModelPickerActive();
@@ -3065,20 +3051,6 @@ describe("SetupWizard", () => {
             expect(hint!.textContent).toBe(MESSAGES.WIZARD_PROGRESS_BACKGROUND);
         });
 
-        it("clicking the Task Center CTA invokes plugin.activateTaskView", async () => {
-            const plugin = setupModelPickerActive();
-            const wizard = new SetupWizard(plugin.app as any, plugin as any);
-            wizard.open();
-            wizard.next();
-            await tick();
-
-            const el = wizard.contentEl as unknown as MockElement;
-            const cta = el.find("lilbee-wizard-task-center-cta");
-            expect(cta).not.toBeNull();
-            cta!.trigger("click", { preventDefault: () => {} });
-            expect(plugin.activateTaskView).toHaveBeenCalled();
-        });
-
         it("does not offer a Task Center link inside the wizard", async () => {
             const plugin = setupModelPickerActive();
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
@@ -3088,20 +3060,6 @@ describe("SetupWizard", () => {
 
             const el = wizard.contentEl as unknown as MockElement;
             expect(el.find("lilbee-wizard-task-center-cta")).toBeNull();
-        });
-
-        it("clicking the Task Center CTA does not close the wizard", async () => {
-            const plugin = setupModelPickerActive();
-            const wizard = new SetupWizard(plugin.app as any, plugin as any);
-            wizard.open();
-            wizard.next();
-            await tick();
-
-            const closeSpy = vi.spyOn(wizard, "close");
-            const el = wizard.contentEl as unknown as MockElement;
-            const cta = el.find("lilbee-wizard-task-center-cta");
-            cta!.trigger("click", { preventDefault: () => {} });
-            expect(closeSpy).not.toHaveBeenCalled();
         });
 
         it("activates the hero rail when a pull begins", async () => {


### PR DESCRIPTION
## Problem

Two managed-mode bugs, both pinned by the failing tests in the first commit of this branch:

The server release version picker died whenever GitHub's release API couldn't be read, and stayed dead for the whole session. The picker fetched the release list on every settings render, and GitHub's unauthenticated API budget is 60 requests/hour per IP — a budget shared with every other tool on the machine. Once a fetch failed (rate limit or offline), the dropdown stayed disabled behind a generic "could not be read" line: no reason, no retry, no way to pick a different server. From the user's side the picker simply never worked.

In the setup wizard, the download-progress panel offered an "Open Task Center" button. That button opens a sidebar view, which can never be visible behind the wizard's modal overlay, so the link was dead for as long as the wizard was up.

## Solution

The settings tab now caches a successful release-list fetch for ten minutes, so repeated renders share one API call instead of hammering the budget. When a fetch does fail, the picker says why — naming GitHub's rate limit on a 403 or 429 instead of swallowing it — and offers a Retry button that re-renders and refetches. The install picker shown after an uninstall gets the same treatment. Both pickers now carry the tooltip that any non-latest server release is unsupported and used at your own risk.

The wizard's progress panel drops the Task Center button and its hint no longer points there; downloads continuing in the background is the only claim it makes.