### PR TITLE
Fix the managed server never starting and the plugin failing every request against recent dev builds

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,6 @@
 import {
     CAPABILITY,
+    bearerHeaders,
     JSON_HEADERS,
     OCTET_STREAM_HEADERS,
     REQUEST_OUTCOME,
@@ -174,17 +175,18 @@ export class LilbeeClient {
     /** Reachability probe for an arbitrary URL. True on an ok response, false on
      * any error or timeout. Keeps browser fetch inside this module.
      *
-     * *token* is required for a real verdict: the server authenticates every
+     * *token* is explicit rather than optional: the server authenticates every
      * route, so a bare probe of a healthy server comes back 401 and reads as
-     * unreachable. Null is still allowed — a probe with no token in hand is
-     * better than none, and a foreign URL may not want one. */
-    static async probe(url: string, timeoutMs: number, token: string | null = null): Promise<boolean> {
+     * unreachable. Pass null only when there is genuinely no token to send —
+     * making it a required argument keeps a future caller from defaulting its
+     * way back into that bug. */
+    static async probe(url: string, timeoutMs: number, token: string | null): Promise<boolean> {
         const controller = new AbortController();
         const timer = window.setTimeout(() => controller.abort(), timeoutMs);
         try {
             const res = await window.fetch(url, {
                 signal: controller.signal,
-                ...(token ? { headers: { Authorization: `Bearer ${token}` } } : {}),
+                ...(token ? { headers: bearerHeaders(token) } : {}),
             });
             return res.ok;
         } catch {
@@ -196,7 +198,7 @@ export class LilbeeClient {
 
     private authHeaders(): Record<string, string> {
         if (!this.token) return {};
-        return { Authorization: `Bearer ${this.token}` };
+        return bearerHeaders(this.token);
     }
 
     private refreshTokenFromProvider(): boolean {
@@ -211,7 +213,7 @@ export class LilbeeClient {
         const base = { ...init };
         const existing = (base.headers ?? {}) as Record<string, string>;
         if (existing.Authorization) {
-            base.headers = { ...existing, Authorization: `Bearer ${this.token}` };
+            base.headers = { ...existing, ...this.authHeaders() };
         }
         return base;
     }

--- a/src/api.ts
+++ b/src/api.ts
@@ -209,15 +209,6 @@ export class LilbeeClient {
         return true;
     }
 
-    private applyRefreshedToken(init: RequestInit | undefined): RequestInit {
-        const base = { ...init };
-        const existing = (base.headers ?? {}) as Record<string, string>;
-        if (existing.Authorization) {
-            base.headers = { ...existing, ...this.authHeaders() };
-        }
-        return base;
-    }
-
     private async assertOk(res: Response): Promise<Response> {
         if (res.status === 429) {
             const header = res.headers.get("Retry-After");
@@ -283,7 +274,18 @@ export class LilbeeClient {
                 await new Promise((r) => window.setTimeout(r, RETRY_BACKOFF_MS * attempt));
             }
             try {
-                const fetchInit = { ...init };
+                // Auth is attached here rather than at each call site: the
+                // server authenticates every route, and a caller that forgot
+                // the header would see a 401 that reads as an unreachable or
+                // broken server. Re-read per attempt so the retry below picks
+                // up a token refreshed after a 401 with no extra bookkeeping.
+                const fetchInit: RequestInit = {
+                    ...init,
+                    headers: {
+                        ...((init?.headers as Record<string, string> | undefined) ?? {}),
+                        ...this.authHeaders(),
+                    },
+                };
                 let timer: number | undefined;
                 if (opts?.signal) {
                     fetchInit.signal = opts.signal;
@@ -296,7 +298,6 @@ export class LilbeeClient {
                     const res = await window.fetch(url, fetchInit);
                     if ((res.status === 401 || res.status === 403) && !authRetried && this.refreshTokenFromProvider()) {
                         authRetried = true;
-                        init = this.applyRefreshedToken(init);
                         continue;
                     }
                     if (res.status === 401 || res.status === 403) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -172,12 +172,20 @@ export class LilbeeClient {
     }
 
     /** Reachability probe for an arbitrary URL. True on an ok response, false on
-     * any error or timeout. Keeps browser fetch inside this module. */
-    static async probe(url: string, timeoutMs: number): Promise<boolean> {
+     * any error or timeout. Keeps browser fetch inside this module.
+     *
+     * *token* is required for a real verdict: the server authenticates every
+     * route, so a bare probe of a healthy server comes back 401 and reads as
+     * unreachable. Null is still allowed — a probe with no token in hand is
+     * better than none, and a foreign URL may not want one. */
+    static async probe(url: string, timeoutMs: number, token: string | null = null): Promise<boolean> {
         const controller = new AbortController();
         const timer = window.setTimeout(() => controller.abort(), timeoutMs);
         try {
-            const res = await window.fetch(url, { signal: controller.signal });
+            const res = await window.fetch(url, {
+                signal: controller.signal,
+                ...(token ? { headers: { Authorization: `Bearer ${token}` } } : {}),
+            });
             return res.ok;
         } catch {
             return false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1093,7 +1093,7 @@ export default class LilbeePlugin extends Plugin {
      * External mode: auto-discovers the user's data root the same way lilbee
      * itself does (LILBEE_DATA env > .lilbee walk-up > platform default).
      */
-    private readCurrentToken(): string | null {
+    readCurrentToken(): string | null {
         if (this.settings.serverMode === SERVER_MODE.MANAGED) {
             return this.serverManager ? readSessionToken(this.serverManager.dataDir) : null;
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1635,6 +1635,11 @@ export default class LilbeePlugin extends Plugin {
     }
 
     private setStatusReady(): void {
+        // Running work owns the pill. Every successful response lands here, so
+        // without this a sync's progress text is repainted as "ready" between
+        // queue ticks and the status bar visibly flickers between the two.
+        // The queue republishes on every change, so there is nothing to restore.
+        if (this.taskQueue.activeAll.length > 0 || this.taskQueue.queued.length > 0) return;
         if (this.settings.serverMode === SERVER_MODE.MANAGED && this.serverUninstalled) {
             this.showNotInstalledStatus();
             return;

--- a/src/server-manager.ts
+++ b/src/server-manager.ts
@@ -1,7 +1,7 @@
 import type { ChildProcess } from "child_process";
 import type { Readable } from "stream";
 import type { ServerState } from "./types";
-import { LOG_FILE, LOGS_DIR, PLATFORM, SERVER_STATE } from "./types";
+import { LOG_FILE, LOGS_DIR, PLATFORM, SERVER_STATE, bearerHeaders } from "./types";
 import { node } from "./binary-manager";
 import { appendCapped } from "./utils/capped-log";
 
@@ -70,15 +70,6 @@ export interface ServerSession {
     token: string;
 }
 
-/**
- * Header carrying a server's session token. Every local request needs it: the
- * server authenticates all of its routes, `/api/health` included, so a probe
- * sent without this reads as dead rather than unauthenticated.
- */
-function bearer(token: string): Record<string, string> {
-    return { Authorization: `Bearer ${token}` };
-}
-
 /** Port + bearer token of the server serving *dataDir*, from its session files. */
 export function readServerSession(dataDir: string): ServerSession | null {
     try {
@@ -106,7 +97,7 @@ export async function requestServerShutdown(dataDir: string): Promise<boolean> {
     try {
         const res = await node.fetch(`http://127.0.0.1:${session.port}/api/shutdown`, {
             method: "POST",
-            headers: bearer(session.token),
+            headers: bearerHeaders(session.token),
             signal: AbortSignal.timeout(SERVER_MANAGER_CONFIG.SHUTDOWN_REQUEST_TIMEOUT_MS),
         });
         return res.ok;
@@ -129,7 +120,7 @@ async function reportedVersion(res: Response): Promise<string> {
 async function probeLilbeeHealth(session: ServerSession): Promise<{ version: string } | null> {
     try {
         const res = await node.fetch(`http://127.0.0.1:${session.port}/api/health`, {
-            headers: bearer(session.token),
+            headers: bearerHeaders(session.token),
             signal: AbortSignal.timeout(SERVER_MANAGER_CONFIG.ADOPT_PROBE_TIMEOUT_MS),
         });
         if (!res.ok) return null;
@@ -164,7 +155,7 @@ export async function awaitServerGone(dataDir: string, timeoutMs: number): Promi
     while (Date.now() < deadline) {
         try {
             await node.fetch(`http://127.0.0.1:${session.port}/api/health`, {
-                headers: bearer(session.token),
+                headers: bearerHeaders(session.token),
                 signal: AbortSignal.timeout(SERVER_MANAGER_CONFIG.ADOPT_PROBE_TIMEOUT_MS),
             });
         } catch {
@@ -548,10 +539,12 @@ export class ServerManager {
 
     private async checkAdopted(): Promise<void> {
         if (!this.adopted || this._actualPort === null) return;
-        // Re-read the token every tick rather than caching the one adoption saw:
-        // a server that restarted under us mints a fresh one. The port stays the
-        // adopted server's own, so a rewritten port file cannot silently
-        // re-point the watch at somebody else.
+        // Read the session per tick rather than caching what adoption saw. The
+        // server persists its token across restarts, so this is not about
+        // rotation: a data dir that was reset leaves no session behind, and a
+        // watch holding a stale token would read that as a live server. The
+        // port stays the adopted server's own, so a rewritten port file cannot
+        // silently re-point the watch at somebody else.
         const session = readServerSession(this.opts.dataDir);
         const live =
             session !== null && (await probeLilbeeHealth({ port: this._actualPort, token: session.token })) !== null;
@@ -576,13 +569,15 @@ export class ServerManager {
                 try {
                     // Bootstrap probe via the injectable node abstraction: runs during
                     // spawn before any LilbeeClient exists, and stays test-swappable.
-                    // The token is read per attempt, not once up front: the server
-                    // writes server.json while booting, so the early polls precede it
-                    // and go out bare. They 401 and the loop simply tries again.
+                    // The server writes server.json during lifespan startup and the
+                    // port file only once it is listening, so by the time this loop
+                    // runs the token is there. Read per attempt rather than hoisted,
+                    // and probe bare if it is somehow missing: a 401 just retries,
+                    // whereas skipping the request would stall the loop outright.
                     const session = readServerSession(this.opts.dataDir);
                     const res = await node.fetch(
                         `${url}/api/health`,
-                        session === null ? undefined : { headers: bearer(session.token) },
+                        session === null ? undefined : { headers: bearerHeaders(session.token) },
                     );
                     if (res.ok) {
                         this._spawnedVersion = await reportedVersion(res);

--- a/src/server-manager.ts
+++ b/src/server-manager.ts
@@ -539,12 +539,12 @@ export class ServerManager {
 
     private async checkAdopted(): Promise<void> {
         if (!this.adopted || this._actualPort === null) return;
-        // Read the session per tick rather than caching what adoption saw. The
-        // server persists its token across restarts, so this is not about
-        // rotation: a data dir that was reset leaves no session behind, and a
-        // watch holding a stale token would read that as a live server. The
-        // port stays the adopted server's own, so a rewritten port file cannot
-        // silently re-point the watch at somebody else.
+        // Read the session per tick rather than caching what adoption saw: the
+        // server deletes server.json on shutdown and mints a fresh token on
+        // every boot, so a cached one goes stale the moment it restarts and
+        // would report a live server as dead. The port stays the adopted
+        // server's own, so a rewritten port file cannot silently re-point the
+        // watch at somebody else.
         const session = readServerSession(this.opts.dataDir);
         const live =
             session !== null && (await probeLilbeeHealth({ port: this._actualPort, token: session.token })) !== null;

--- a/src/server-manager.ts
+++ b/src/server-manager.ts
@@ -64,8 +64,23 @@ export function readScopeOwner(sharedRoot: string): ScopeOwner | null {
     }
 }
 
+/** A running server's port and the bearer token it mints at boot. */
+export interface ServerSession {
+    port: number;
+    token: string;
+}
+
+/**
+ * Header carrying a server's session token. Every local request needs it: the
+ * server authenticates all of its routes, `/api/health` included, so a probe
+ * sent without this reads as dead rather than unauthenticated.
+ */
+function bearer(token: string): Record<string, string> {
+    return { Authorization: `Bearer ${token}` };
+}
+
 /** Port + bearer token of the server serving *dataDir*, from its session files. */
-export function readServerSession(dataDir: string): { port: number; token: string } | null {
+export function readServerSession(dataDir: string): ServerSession | null {
     try {
         const portRaw = node.readFileSync(node.join(dataDir, "data", "server.port"), "utf-8");
         const port = parseInt(portRaw.trim(), 10);
@@ -91,7 +106,7 @@ export async function requestServerShutdown(dataDir: string): Promise<boolean> {
     try {
         const res = await node.fetch(`http://127.0.0.1:${session.port}/api/shutdown`, {
             method: "POST",
-            headers: { Authorization: `Bearer ${session.token}` },
+            headers: bearer(session.token),
             signal: AbortSignal.timeout(SERVER_MANAGER_CONFIG.SHUTDOWN_REQUEST_TIMEOUT_MS),
         });
         return res.ok;
@@ -110,10 +125,11 @@ async function reportedVersion(res: Response): Promise<string> {
     }
 }
 
-/** lilbee's health report on *port*, or null when it is dead or answers with a foreign shape. */
-async function probeLilbeeHealth(port: number): Promise<{ version: string } | null> {
+/** lilbee's health report for *session*, or null when it is dead or answers with a foreign shape. */
+async function probeLilbeeHealth(session: ServerSession): Promise<{ version: string } | null> {
     try {
-        const res = await node.fetch(`http://127.0.0.1:${port}/api/health`, {
+        const res = await node.fetch(`http://127.0.0.1:${session.port}/api/health`, {
+            headers: bearer(session.token),
             signal: AbortSignal.timeout(SERVER_MANAGER_CONFIG.ADOPT_PROBE_TIMEOUT_MS),
         });
         if (!res.ok) return null;
@@ -131,7 +147,7 @@ async function probeLilbeeHealth(port: number): Promise<{ version: string } | nu
 export async function serverIsLive(dataDir: string): Promise<boolean> {
     const session = readServerSession(dataDir);
     if (session === null) return false;
-    return (await probeLilbeeHealth(session.port)) !== null;
+    return (await probeLilbeeHealth(session)) !== null;
 }
 
 /** Ask the server serving *dataDir* to exit and wait until it is gone; false when it will not go. */
@@ -148,6 +164,7 @@ export async function awaitServerGone(dataDir: string, timeoutMs: number): Promi
     while (Date.now() < deadline) {
         try {
             await node.fetch(`http://127.0.0.1:${session.port}/api/health`, {
+                headers: bearer(session.token),
                 signal: AbortSignal.timeout(SERVER_MANAGER_CONFIG.ADOPT_PROBE_TIMEOUT_MS),
             });
         } catch {
@@ -488,7 +505,7 @@ export class ServerManager {
     private async tryAdopt(): Promise<boolean> {
         const session = readServerSession(this.opts.dataDir);
         if (session === null) return false;
-        const health = await probeLilbeeHealth(session.port);
+        const health = await probeLilbeeHealth(session);
         if (health === null) return false;
         if (this.versionDiffers(health.version) && (await this.replaceMismatched(health.version))) return false;
         this._actualPort = session.port;
@@ -531,7 +548,14 @@ export class ServerManager {
 
     private async checkAdopted(): Promise<void> {
         if (!this.adopted || this._actualPort === null) return;
-        if ((await probeLilbeeHealth(this._actualPort)) !== null) return;
+        // Re-read the token every tick rather than caching the one adoption saw:
+        // a server that restarted under us mints a fresh one. The port stays the
+        // adopted server's own, so a rewritten port file cannot silently
+        // re-point the watch at somebody else.
+        const session = readServerSession(this.opts.dataDir);
+        const live =
+            session !== null && (await probeLilbeeHealth({ port: this._actualPort, token: session.token })) !== null;
+        if (live) return;
         if (!this.adopted || this.desired === DESIRED.STOPPED) return;
         this.stopAdoptedWatch();
         this.adopted = false;
@@ -552,7 +576,14 @@ export class ServerManager {
                 try {
                     // Bootstrap probe via the injectable node abstraction: runs during
                     // spawn before any LilbeeClient exists, and stays test-swappable.
-                    const res = await node.fetch(`${url}/api/health`);
+                    // The token is read per attempt, not once up front: the server
+                    // writes server.json while booting, so the early polls precede it
+                    // and go out bare. They 401 and the loop simply tries again.
+                    const session = readServerSession(this.opts.dataDir);
+                    const res = await node.fetch(
+                        `${url}/api/health`,
+                        session === null ? undefined : { headers: bearer(session.token) },
+                    );
                     if (res.ok) {
                         this._spawnedVersion = await reportedVersion(res);
                         return;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2528,7 +2528,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         statusEl.empty();
         statusEl.classList.remove("lilbee-health-ok", "lilbee-health-error");
         const dot = statusEl.createDiv({ cls: "lilbee-health-dot" });
-        const ok = await LilbeeClient.probe(url, CHECK_TIMEOUT_MS);
+        const ok = await LilbeeClient.probe(url, CHECK_TIMEOUT_MS, this.plugin.readCurrentToken());
         dot.classList.add(ok ? "is-ok" : "is-error");
         statusEl.classList.add(ok ? "lilbee-health-ok" : "lilbee-health-error");
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -753,6 +753,15 @@ export interface BatchProgressPayload {
 export const JSON_HEADERS = { "Content-Type": "application/json" } as const;
 export const OCTET_STREAM_HEADERS = { "Content-Type": "application/octet-stream" } as const;
 
+/**
+ * Authorization header carrying a lilbee session token. The server
+ * authenticates every route, `/api/health` included, so a request sent without
+ * this comes back 401 — which a probe reads as "dead" rather than "unauthorized".
+ */
+export function bearerHeaders(token: string): Record<string, string> {
+    return { Authorization: `Bearer ${token}` };
+}
+
 /** MIME content types referenced across click dispatch + preview rendering. */
 export const CONTENT_TYPE = {
     PDF: "application/pdf",

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1662,12 +1662,13 @@ describe("fetchWithRetry() — token provider + 401/403 retry", () => {
         expect(headers.Authorization).toBe("Bearer fresh");
     });
 
-    it("retry without prior Authorization header leaves headers untouched", async () => {
+    it("retry carries the refreshed token even on a call that sets no headers", async () => {
         const c = new LilbeeClient(BASE_URL);
         c.setToken("old");
         c.setTokenProvider(() => "new");
-        // search() does not set Authorization, so the retry path exercises the
-        // branch where existing.Authorization is undefined.
+        // search() passes no headers of its own. Auth is attached centrally, so
+        // the refreshed token still reaches the retry; before that it did not,
+        // and every read-only route 401'd once the server began authenticating.
         fetchMock
             .mockResolvedValueOnce({
                 ok: false,
@@ -1684,7 +1685,7 @@ describe("fetchWithRetry() — token provider + 401/403 retry", () => {
         expect(fetchMock).toHaveBeenCalledTimes(2);
         const retryInit = fetchMock.mock.calls[1][1] as RequestInit;
         const headers = (retryInit.headers ?? {}) as Record<string, string>;
-        expect(headers.Authorization).toBeUndefined();
+        expect(headers.Authorization).toBe("Bearer new");
     });
 
     it("setTokenProvider(null) clears the provider", async () => {
@@ -2725,4 +2726,41 @@ describe("LilbeeClient.probe()", () => {
         await expect(LilbeeClient.probe(`${BASE_URL}/api/health`, 1000, null)).resolves.toBe(true);
         expect(fetchSpy.mock.calls[0][1].headers).toBeUndefined();
     });
+});
+
+describe("every client request carries the session token", () => {
+    // Server PR #570 made all routes authenticated. Endpoints that used to be
+    // read-only were called without a token and now 401, which the UI shows as
+    // "auth error" on a healthy server. Auth is injected centrally so no call
+    // site can omit it; these pin the ones that were missing it.
+    let c: LilbeeClient;
+
+    beforeEach(() => {
+        c = new LilbeeClient(BASE_URL, "tok-x");
+    });
+
+    function sentAuth(): string | undefined {
+        const init = fetchMock.mock.calls[0][1] as RequestInit | undefined;
+        return (init?.headers as Record<string, string> | undefined)?.Authorization;
+    }
+
+    const cases: Array<[string, () => Promise<unknown>]> = [
+        ["health", () => c.health()],
+        ["status", () => c.status()],
+        ["config", () => c.config()],
+        ["configDefaults", () => c.configDefaults()],
+        ["catalog", () => c.catalog()],
+        ["installedModels", () => c.installedModels()],
+        ["listModels", () => c.listModels()],
+        ["listSessions", () => c.listSessions()],
+        ["listMemories", () => c.listMemories()],
+    ];
+
+    for (const [name, call] of cases) {
+        it(`${name}() sends the bearer token`, async () => {
+            fetchMock.mockResolvedValue(jsonResponse({}));
+            await call().catch(() => undefined);
+            expect(sentAuth()).toBe("Bearer tok-x");
+        });
+    }
 });

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -2698,3 +2698,31 @@ describe("crawl() include_subdomains", () => {
         expect(body).toMatchObject({ url: "https://x.com", max_pages: 0, include_subdomains: true });
     });
 });
+
+describe("LilbeeClient.probe()", () => {
+    let origFetch: typeof globalThis.fetch;
+
+    beforeEach(() => {
+        origFetch = globalThis.fetch;
+    });
+
+    afterEach(() => {
+        globalThis.fetch = origFetch;
+    });
+
+    it("sends the session token so an authenticated server answers", async () => {
+        // The server authenticates /api/health, so a probe without the token
+        // reads as unreachable and the settings dot lies about a live server.
+        const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+        globalThis.fetch = fetchSpy;
+        await expect(LilbeeClient.probe(`${BASE_URL}/api/health`, 1000, "tok-9")).resolves.toBe(true);
+        expect(fetchSpy.mock.calls[0][1]).toMatchObject({ headers: { Authorization: "Bearer tok-9" } });
+    });
+
+    it("probes bare when there is no token to send", async () => {
+        const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+        globalThis.fetch = fetchSpy;
+        await expect(LilbeeClient.probe(`${BASE_URL}/api/health`, 1000, null)).resolves.toBe(true);
+        expect(fetchSpy.mock.calls[0][1].headers).toBeUndefined();
+    });
+});

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -4604,6 +4604,23 @@ describe("LilbeePlugin", () => {
             expect(text).toContain("Sync vault");
         });
 
+        it("a successful request does not repaint over a running task", async () => {
+            // handleRequestOutcome(OK) fires on every response. During a sync
+            // that repainted "ready" over the progress text, and the queue's
+            // next tick restored it, so the pill flickered between the two.
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "";
+
+            plugin.taskQueue.enqueue("Sync vault", "sync");
+            const during = (plugin as any).statusBarEl?.textContent;
+            expect(during).toContain("Sync vault");
+
+            (plugin as any).handleRequestOutcome("ok");
+
+            expect((plugin as any).statusBarEl?.textContent).toBe(during);
+        });
+
         it("status bar shows queued-only count when no active tasks remain", async () => {
             const plugin = await createPlugin();
             await plugin.onload();

--- a/tests/server-manager.test.ts
+++ b/tests/server-manager.test.ts
@@ -191,6 +191,18 @@ describe("server-manager helpers", () => {
             fetchSpy.mockResolvedValueOnce({ ok: true, json: async () => ({ hello: "world" }) } as any);
             await expect(serverIsLive("/tmp/data")).resolves.toBe(false);
         });
+
+        it("probes health with the server's own bearer token", async () => {
+            vi.spyOn(node, "readFileSync").mockImplementation(fileRouter("present"));
+            const fetchSpy = vi
+                .spyOn(node, "fetch")
+                .mockResolvedValue({ ok: true, json: async () => ({ status: "ok" }) } as any);
+            await expect(serverIsLive("/tmp/data")).resolves.toBe(true);
+            expect(fetchSpy).toHaveBeenCalledWith(
+                "http://127.0.0.1:9999/api/health",
+                expect.objectContaining({ headers: { Authorization: "Bearer tok-1" } }),
+            );
+        });
     });
 
     describe("awaitServerGone", () => {
@@ -203,6 +215,16 @@ describe("server-manager helpers", () => {
             vi.spyOn(node, "readFileSync").mockImplementation(fileRouter("present"));
             vi.spyOn(node, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
             await expect(awaitServerGone("/tmp/data", 1000)).resolves.toBe(true);
+        });
+
+        it("polls health with the server's own bearer token", async () => {
+            vi.spyOn(node, "readFileSync").mockImplementation(fileRouter("present"));
+            const fetchSpy = vi.spyOn(node, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+            await expect(awaitServerGone("/tmp/data", 1000)).resolves.toBe(true);
+            expect(fetchSpy).toHaveBeenCalledWith(
+                "http://127.0.0.1:9999/api/health",
+                expect.objectContaining({ headers: { Authorization: "Bearer tok-1" } }),
+            );
         });
 
         it("is false while the server keeps answering past the deadline", async () => {
@@ -329,6 +351,46 @@ describe("ServerManager", () => {
             const env = (spawnSpy.mock.calls[0][2] as { env: Record<string, string> }).env;
             expect(env).not.toHaveProperty("LILBEE_RAG_SYSTEM_PROMPT");
             expect(env).not.toHaveProperty("LILBEE_GENERAL_SYSTEM_PROMPT");
+        });
+
+        it("sends the session token on the readiness probe", async () => {
+            readFileSyncSpy.mockImplementation(fileRouter("present"));
+            fetchSpy.mockRejectedValueOnce(new Error("ECONNREFUSED")); // adopt probe fails → spawn
+            await startFresh();
+            const health = fetchSpy.mock.calls.filter((c) => String(c[0]).endsWith("/api/health"));
+            expect(health.length).toBeGreaterThan(0);
+            expect(health.at(-1)?.[1]).toMatchObject({ headers: { Authorization: "Bearer tok-1" } });
+        });
+
+        it("probes unauthenticated while the server has yet to write its session file", async () => {
+            // server.json lands during boot, so the first polls have no token
+            // to send. They must still go out rather than stall the loop.
+            await startFresh();
+            const health = fetchSpy.mock.calls.filter((c) => String(c[0]).endsWith("/api/health"));
+            expect(health.length).toBeGreaterThan(0);
+            expect(health.at(-1)?.[1]?.headers).toBeUndefined();
+        });
+
+        it("becomes ready against a server that rejects unauthenticated probes", async () => {
+            // lilbee dev726 onward requires the session token on /api/health.
+            // Without it the readiness poll only ever sees 401, so start()
+            // times out and tears down a perfectly healthy server.
+            readFileSyncSpy.mockImplementation(fileRouter("present"));
+            let adoptProbe = true;
+            fetchSpy.mockImplementation((_url: unknown, init?: RequestInit) => {
+                if (adoptProbe) {
+                    adoptProbe = false;
+                    return Promise.reject(new Error("ECONNREFUSED")); // nothing running yet
+                }
+                const headers = init?.headers as Record<string, string> | undefined;
+                if (headers?.Authorization !== "Bearer tok-1") {
+                    return Promise.resolve({ ok: false, status: 401 } as any);
+                }
+                return Promise.resolve({ ok: true, json: async () => ({ status: "ok" }) } as any);
+            });
+            const mgr = new ServerManager(defaultOpts());
+            await mgr.start();
+            expect(mgr.state).toBe("ready");
         });
 
         it("removes a leftover port file before spawning", async () => {
@@ -517,6 +579,23 @@ describe("ServerManager", () => {
         it("a healthy adopted server keeps its watch quiet", async () => {
             const mgr = new ServerManager(defaultOpts());
             await mgr.start();
+            await vi.advanceTimersByTimeAsync(30_000);
+            expect(mgr.state).toBe("ready");
+            expect(appendFileSyncSpy).not.toHaveBeenCalled();
+        });
+
+        it("the watch keeps an adopted server that requires the token", async () => {
+            // An unauthenticated watch probe reads 401 as death, so a healthy
+            // adopted server would be torn down and restarted every tick.
+            const mgr = new ServerManager(defaultOpts());
+            await mgr.start();
+            fetchSpy.mockImplementation((_url: unknown, init?: RequestInit) => {
+                const headers = init?.headers as Record<string, string> | undefined;
+                if (headers?.Authorization !== "Bearer tok-1") {
+                    return Promise.resolve({ ok: false, status: 401 } as any);
+                }
+                return Promise.resolve({ ok: true, json: async () => ({ status: "ok" }) } as any);
+            });
             await vi.advanceTimersByTimeAsync(30_000);
             expect(mgr.state).toBe("ready");
             expect(appendFileSyncSpy).not.toHaveBeenCalled();

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -119,11 +119,14 @@ vi.mock("../src/views/confirm-modal", () => ({
     }),
 }));
 
-function makePlugin(overrides: Partial<LilbeeSettings> & { lilbeeVersion?: string; hfToken?: string } = {}) {
-    const { lilbeeVersion: ver, hfToken: hf, ...settingsOverrides } = overrides;
+function makePlugin(
+    overrides: Partial<LilbeeSettings> & { lilbeeVersion?: string; hfToken?: string; sessionToken?: string } = {},
+) {
+    const { lilbeeVersion: ver, hfToken: hf, sessionToken: tok, ...settingsOverrides } = overrides;
     const settings: LilbeeSettings = { ...DEFAULT_SETTINGS, wikiEnabled: true, ...settingsOverrides };
     let sharedVersion = ver ?? "";
     let sharedHfToken = hf ?? "";
+    const sessionToken = tok ?? null;
     const api = {
         listModels: vi.fn(),
         setChatModel: vi.fn(),
@@ -156,6 +159,7 @@ function makePlugin(overrides: Partial<LilbeeSettings> & { lilbeeVersion?: strin
         journal,
         settings,
         api,
+        readCurrentToken: () => sessionToken,
         saveSettings,
         statusBarEl,
         fetchActiveModel,
@@ -1904,6 +1908,19 @@ describe("LilbeeSettingTab", () => {
             expect(dot!.classList.contains("is-ok")).toBe(true);
             expect((statusEl as unknown as MockElement).classList.contains("lilbee-health-ok")).toBe(true);
             expect((statusEl as unknown as MockElement).classList.contains("lilbee-health-error")).toBe(false);
+        });
+
+        it("probes with the plugin's session token", async () => {
+            // Without it the dot reports a healthy authenticated server as down.
+            const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+            globalThis.fetch = fetchSpy;
+            const plugin = makePlugin({ sessionToken: "tok-7" });
+            const tab = makeTab(plugin);
+            const statusEl = new MockElement("span") as unknown as HTMLSpanElement;
+
+            await tab.checkEndpoint("http://localhost:7433/api/health", statusEl);
+
+            expect(fetchSpy.mock.calls[0][1]).toMatchObject({ headers: { Authorization: "Bearer tok-7" } });
         });
 
         it("shows red dot when fetch returns non-ok response", async () => {


### PR DESCRIPTION
## Problem

The managed server will not start on recent dev builds, and once it does the plugin is unusable. Both come from the same change: every server route now requires the session token, including the ones that used to be read-only.

**The server never looks ready.** Start it and it spins for two minutes, then fails with "Server did not become ready within timeout". The server is fine the whole time; the readiness poll sent no token, so it only ever saw 401 and then killed a healthy server. Reported on macOS and Linux with matching diagnostics.

**Nothing loads once it is running.** Thirteen client calls sent no token either, among them models, catalog, installed, config, status, search, sessions and memories. The chat panel showed "No models installed" against a fully working server and the status pill read "auth error".

Two quieter breakages, same cause: adoption could not recognise a healthy server, so a plugin reload spawned a duplicate instead of re-attaching; and the settings status dot reported a healthy server as down.

**The status pill flickers during a sync.** Every successful response repainted "ready" over the progress text, and the queue's next tick put it back.

## Solution

Auth is attached in one place, inside the client's retry loop, so no call site can omit it and a token refreshed after a 401 is picked up automatically. That deleted the header-rewriting helper the retry used to need.

The bootstrap probes in the server supervisor read the token from the session file the server writes at boot. The readiness poll reads it per attempt and still probes bare if it is missing, so a 401 retries instead of stalling. The adopted-server watchdog re-reads the session each tick, because the server deletes its session file on shutdown and mints a new token on every boot.

One helper builds the Authorization header for the whole plugin, replacing four hand-written copies. That surfaced a latent path that could send a literal "Bearer null". `LilbeeClient.probe` now takes the token as a required argument so a future caller cannot default back into this bug.

The status bar defers to the task queue while work is running.

## Verified

Driven end to end against dev726 in a real vault: server reaches ready in seconds, chat streams, search returns answers with clickable sources, GPU placement shows live hardware, and a crawl ingests and embeds. A sweep of the read-only endpoints returns 200 across the board.

## Note

Rolling the server back to dev723 works as a stopgap. That build predates the change.
