### PR TITLE
Make the setup wizard's Open chat button actually show the chat panel

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { Notice, type Modal } from "obsidian";
+import { Notice, type App, type Modal } from "obsidian";
 import { ServerStartingError, SessionTokenError } from "./api";
 import { MESSAGES } from "./locales/en";
 import { SERVER_MODE } from "./types";
@@ -24,6 +24,11 @@ export function bindEscapeToClose(modal: Modal): void {
         return false;
     });
     tagModalChrome(modal);
+}
+
+/** Dismiss Obsidian's settings surface. `app.setting` is undocumented on the public App type. */
+export function closeSettings(app: App): void {
+    (app as unknown as { setting?: { close: () => void } }).setting?.close();
 }
 
 export function debounce<T extends (...args: unknown[]) => unknown>(

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -26,6 +26,7 @@ import { MESSAGES, FILTERS } from "../locales/en";
 import { renderModelCard } from "../components/model-card";
 import {
     bindEscapeToClose,
+    closeSettings,
     extractSseErrorMessage,
     getSystemMemoryGB,
     percentFromSse,
@@ -1246,6 +1247,8 @@ export class SetupWizard extends Modal {
         this.plugin.settings.setupCompleted = true;
         await this.plugin.saveSettings();
         this.close();
+        // Launched from the settings tab, the wizard renders over settings, which would cover the chat view.
+        closeSettings(this.app);
         // The done step's action is an explicit "Open chat", so land the user
         // in the chat panel once. Nothing else is force-opened.
         void this.plugin.activateChatView();

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -309,9 +309,16 @@ export class App {
     // Undocumented-but-stable Obsidian API used by plugins to open their
     // own Settings tab. Tests may replace this with `undefined` to exercise
     // the defensive guard.
-    setting: { open: ReturnType<typeof vi.fn>; openTabById: ReturnType<typeof vi.fn> } | undefined = {
+    setting:
+        | {
+              open: ReturnType<typeof vi.fn>;
+              openTabById: ReturnType<typeof vi.fn>;
+              close: ReturnType<typeof vi.fn>;
+          }
+        | undefined = {
         open: vi.fn(),
         openTabById: vi.fn(),
+        close: vi.fn(),
     };
     vault = {
         on: vi.fn().mockReturnValue({ id: "mock-vault-event" }),

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,9 +1,10 @@
 import { MockElement } from "./__mocks__/obsidian";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { Notice } from "obsidian";
+import { Notice, type App } from "obsidian";
 import {
     StreamIdleError,
     _resetServerUnreachableDebounce,
+    closeSettings,
     ensureUrlScheme,
     errorMessage,
     extractServerErrorDetail,
@@ -59,6 +60,18 @@ describe("ensureUrlScheme", () => {
 
     it("prepends https:// for URLs with subdomains but no scheme", () => {
         expect(ensureUrlScheme("www.example.com")).toBe("https://www.example.com");
+    });
+});
+
+describe("closeSettings", () => {
+    it("closes the settings surface when Obsidian exposes it", () => {
+        const close = vi.fn();
+        closeSettings({ setting: { close } } as unknown as App);
+        expect(close).toHaveBeenCalled();
+    });
+
+    it("does nothing when the settings surface is unavailable", () => {
+        expect(() => closeSettings({} as unknown as App)).not.toThrow();
     });
 });
 

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -1828,6 +1828,27 @@ describe("SetupWizard", () => {
             expect(closeSpy).toHaveBeenCalled();
         });
 
+        // The wizard can be launched from the settings tab, where Obsidian
+        // stacks it on the settings surface. Leaving settings open hides the
+        // chat view the button just opened.
+        it("Open chat closes the settings surface", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const app = plugin.app as unknown as App;
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 6;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            findButtons(el)
+                .find((b) => b.textContent === "Open chat")!
+                .trigger("click");
+            await tick();
+
+            expect(app.setting?.close).toHaveBeenCalled();
+            expect(plugin.activateChatView).toHaveBeenCalled();
+        });
+
         it("shows tips about what to try", () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);


### PR DESCRIPTION
## Problem

The "Open chat" button on the last step of the setup wizard looked like it did nothing. The wizard closed and the screen stayed exactly where it was, with no chat panel anywhere.

The chat view was in fact opening every time. The wizard is usually reached from Settings → lilbee → Run setup wizard, and Obsidian renders it on top of the settings surface (a separate window since 1.13). Finishing the wizard closed the wizard alone, so settings stayed in front and the chat view opened in the workspace behind it, out of sight. Anyone who ran the wizard from the command palette or on a fresh install saw it work, which is why it looked so inconsistent.

That has been the only way chat opens on its own since the plugin stopped force-opening its views at startup, so a new user finishing setup from the settings tab was left with nothing to show for it.

## Solution

Completing the wizard now dismisses the settings surface before it reveals chat, so the user lands in the chat panel whichever way the wizard was started. Skipping the wizard is unchanged and still returns you to settings, where you came from.

Verified against a live vault in Obsidian 1.13.3: before the change, finishing the wizard from the settings tab left the settings window up with no chat; after it, settings closes and the chat panel is on screen.
