### PR TITLE
Stop an Obsidian API change from breaking the wizard's Open chat button

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,9 +26,22 @@ export function bindEscapeToClose(modal: Modal): void {
     tagModalChrome(modal);
 }
 
-/** Dismiss Obsidian's settings surface. `app.setting` is undocumented on the public App type. */
+/**
+ * Dismiss Obsidian's settings surface — the only way to put a workspace view in front of it.
+ *
+ * Obsidian 1.13 renders settings in its own window. The public API cannot reach past it: `App` does
+ * not declare `setting`, `SettingTab.hide()` only reports that settings closed, `revealLeaf` stops
+ * at the leaf and its sidebar, and focusing the workspace window (`getContainer().win.focus()`)
+ * leaves settings in front. `app.setting.close()` is undocumented but is what the ecosystem uses
+ * (obsidian-extra ships it as its `unsafe` closeSettings), and it takes `this.app`, not the global
+ * `app` the plugin guidelines rule out.
+ *
+ * The shape is checked rather than assumed, so an Obsidian that drops or renames it leaves settings
+ * open instead of throwing at the caller.
+ */
 export function closeSettings(app: App): void {
-    (app as unknown as { setting?: { close: () => void } }).setting?.close();
+    const setting = (app as unknown as { setting?: { close?: () => void } }).setting;
+    if (typeof setting?.close === "function") setting.close();
 }
 
 export function debounce<T extends (...args: unknown[]) => unknown>(

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -1247,10 +1247,11 @@ export class SetupWizard extends Modal {
         this.plugin.settings.setupCompleted = true;
         await this.plugin.saveSettings();
         this.close();
-        // Launched from the settings tab, the wizard renders over settings, which would cover the chat view.
-        closeSettings(this.app);
         // The done step's action is an explicit "Open chat", so land the user
         // in the chat panel once. Nothing else is force-opened.
         void this.plugin.activateChatView();
+        // Opening the view is not enough when the wizard was launched from the settings tab: settings
+        // renders in front of the workspace and nothing public can raise a view above it.
+        closeSettings(this.app);
     }
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -73,6 +73,13 @@ describe("closeSettings", () => {
     it("does nothing when the settings surface is unavailable", () => {
         expect(() => closeSettings({} as unknown as App)).not.toThrow();
     });
+
+    // An Obsidian that renames or drops close() degrades to leaving settings open, never to a throw
+    // in the caller — the wizard's completion path runs through here.
+    it("does nothing when the settings surface has no close method", () => {
+        expect(() => closeSettings({ setting: {} } as unknown as App)).not.toThrow();
+        expect(() => closeSettings({ setting: { close: "gone" } } as unknown as App)).not.toThrow();
+    });
 });
 
 describe("formatBytes", () => {

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -1849,6 +1849,26 @@ describe("SetupWizard", () => {
             expect(plugin.activateChatView).toHaveBeenCalled();
         });
 
+        // Dismissing settings is best-effort on an undocumented API; opening chat is the promise the
+        // button makes, so it must survive an Obsidian that no longer exposes the settings surface.
+        it("Open chat still opens the chat view when the settings surface is gone", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            (plugin.app as unknown as App).setting = undefined;
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 6;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            findButtons(el)
+                .find((b) => b.textContent === "Open chat")!
+                .trigger("click");
+            await tick();
+
+            expect(plugin.activateChatView).toHaveBeenCalled();
+            expect(plugin.settings.setupCompleted).toBe(true);
+        });
+
         it("shows tips about what to try", () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);


### PR DESCRIPTION
## Problem

Making the setup wizard's "Open chat" land the user in the chat panel means dismissing Obsidian's settings surface, and that only exists as an undocumented API. `App` does not declare `setting` in the shipped type definitions, `SettingTab.hide()` only reports that settings closed after the fact, `revealLeaf` stops at the leaf and its sidebar, and focusing the workspace window through the public `getContainer().win` leaves settings in front. Every route the public API offers was tried; none of them can put a view above the settings window.

The call we settled on was written as if the API were guaranteed. If a future Obsidian renames or drops it, the call throws inside the wizard's completion handler, that rejection is swallowed, and the chat view never opens at all: the original bug, worse, and silent.

## Solution

The shape is now checked before use, so an Obsidian without it leaves settings open rather than throwing, and the wizard opens chat before it touches settings, so the promise the button makes cannot be blocked by the part that is best-effort. Worst case if the internal ever disappears is cosmetic: chat opens, settings stays in front, and the user closes it themselves.

The helper carries the reasoning in a comment, including which public APIs were ruled out and why the one we use is acceptable (it takes `this.app`, not the global `app` the plugin guidelines rule out, and is the same call the community's obsidian-extra ships as its unsafe `closeSettings`). Two tests pin the behaviour: the degrade path never throws, and completing the wizard still opens chat when the settings surface is gone.
