### PR TITLE
Add a sticky mega-nav with deep links into the demo tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center"><a href="https://obsidian.lilbee.sh/">Project site</a> &nbsp;·&nbsp; <a href="https://obsidian.lilbee.sh/tutorial">Tutorial reel</a> &nbsp;·&nbsp; <a href="https://github.com/tobocop2/obsidian-lilbee/releases">Releases</a> &nbsp;·&nbsp; <a href="https://lilbee.sh/">lilbee engine</a></p>
 
-This plugin runs **[lilbee](https://lilbee.sh/)** against your vault and gives you chat, a web crawler that saves sites into your vault, an auto-generated wiki, click-to-source citations, and a model catalog, all inside Obsidian. It downloads and manages the lilbee server and the AI models for you, with nothing to install separately and no Ollama required, or works with your own Ollama, LM Studio, or cloud models. Everything runs on your computer; cloud models are opt-in, per role. In practice, it makes your vault a private, self-hosted NotebookLM alternative, without a terminal or a Docker file in sight.
+This plugin runs **[lilbee](https://lilbee.sh/)** against your vault and gives you chat, a web crawler that saves sites into your vault, an auto-generated wiki, click-to-source citations, and a model catalog, all inside Obsidian. It downloads and manages the lilbee server and the AI models for you, with nothing to install separately and no Ollama required, or works with your own Ollama, LM Studio, or cloud models. Everything runs on your computer; cloud models are opt-in, per role.
 
 <p align="center">
   <a href="https://github.com/tobocop2/obsidian-lilbee/actions/workflows/ci.yml"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/tobocop2/obsidian-lilbee/ci.yml?branch=main&label=CI&logo=githubactions&logoColor=9ccfd8&style=flat-square&labelColor=191724&color=9ccfd8"></a>

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 	"name": "lilbee",
 	"version": "0.6.87",
 	"minAppVersion": "1.8.7",
-	"description": "A private, self-hosted NotebookLM alternative for your vault: a local AI search engine and native model manager. One-click local models, cited answers (local RAG), and a web crawler. Works with Ollama, LM Studio, and frontier models too.",
+	"description": "A local AI search engine and native model manager for your vault. One-click local models, cited answers (local RAG), and a web crawler. Works with Ollama, LM Studio, and frontier models too.",
 	"author": "tobocop2",
 	"authorUrl": "https://obsidian.lilbee.sh/",
 	"isDesktopOnly": true

--- a/site/index.html
+++ b/site/index.html
@@ -75,6 +75,60 @@
 <script src="main.js" defer></script>
 </head>
 <body>
+<header class="nav">
+  <div class="nav-inner">
+    <a class="nav-brand" href="/">lilbee <span class="nav-brand-sub">for Obsidian</span></a>
+    <nav class="nav-menus" aria-label="Site">
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">demos</button>
+        <div class="menu-panel menu-cols">
+          <div class="menu-col">
+            <div class="menu-group">the plugin</div>
+            <a href="/#demo-onlilbee">what is lilbee</a>
+            <a href="/#demo-firststart">first run</a>
+            <a href="/#demo-ask">ask &amp; cite</a>
+            <a href="/#demo-tour">tour</a>
+            <a href="/#demo-settings">settings</a>
+          </div>
+          <div class="menu-col">
+            <div class="menu-group">your sources</div>
+            <a href="/#demo-vision">scanned PDF</a>
+            <a href="/#demo-crawl">crawl</a>
+            <a href="/#demo-crawlsite">crawl a site</a>
+            <a href="/#demo-multipart">multi-part</a>
+          </div>
+          <div class="menu-col">
+            <div class="menu-group">models</div>
+            <a href="/#demo-catalog">catalog</a>
+            <a href="/#demo-download">download a model</a>
+            <a href="/#demo-models">model rail</a>
+            <a href="/#demo-placement">multi-GPU</a>
+            <a href="/#demo-ollama">Ollama</a>
+            <a href="/#demo-lmstudio">LM Studio</a>
+            <a href="/#demo-gemini">cloud</a>
+          </div>
+        </div>
+      </div>
+      <a class="nav-link" href="/#install">install</a>
+      <a class="nav-link" href="/tutorial/">tutorial reel</a>
+      <a class="nav-link" href="/notebooklm-alternative/">vs notebooklm</a>
+      <div class="menu align-right">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">more</button>
+        <div class="menu-panel">
+          <div class="menu-group">project</div>
+          <a href="https://github.com/tobocop2/obsidian-lilbee">github</a>
+          <a href="https://community.obsidian.md/plugins/lilbee">plugin store</a>
+          <a href="https://github.com/tobocop2/obsidian-lilbee/releases">releases</a>
+          <a href="/coverage/">coverage</a>
+          <div class="menu-group">docs</div>
+          <a href="https://github.com/tobocop2/obsidian-lilbee/blob/main/docs/usage.md">usage guide</a>
+          <a href="https://lilbee.sh/">lilbee (the engine)</a>
+        </div>
+      </div>
+    </nav>
+    <a class="nav-star" href="https://github.com/tobocop2/obsidian-lilbee">&#9733; star</a>
+  </div>
+</header>
 <h1 class="sr">A local AI search engine for your Obsidian vault: a private, self-hosted NotebookLM alternative with chat, one-click local models, and web crawling</h1>
 <div class="layout">
   <main class="main">
@@ -117,7 +171,7 @@
       <p class="dl-note"><strong>Heads up: it downloads to your computer.</strong> The lilbee server (a few hundred MB) on first launch, plus whatever models you pick from the catalog (a few hundred MB up to several GB each). It all stays local.</p>
     </section>
 
-    <section>
+    <section id="demos">
       <div class="label">see it</div>
 
       <div class="tutorial">
@@ -257,7 +311,7 @@
       </div>
     </section>
 
-    <section>
+    <section id="install">
       <div class="label">install</div>
       <div class="install">
         <span class="prompt">store:</span>

--- a/site/index.html
+++ b/site/index.html
@@ -111,7 +111,6 @@
       </div>
       <a class="nav-link" href="/#install">install</a>
       <a class="nav-link" href="/tutorial/">tutorial reel</a>
-      <a class="nav-link" href="/notebooklm-alternative/">vs notebooklm</a>
       <div class="menu align-right">
         <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">more</button>
         <div class="menu-panel">
@@ -129,7 +128,7 @@
     <a class="nav-star" href="https://github.com/tobocop2/obsidian-lilbee">&#9733; star</a>
   </div>
 </header>
-<h1 class="sr">A local AI search engine for your Obsidian vault: a private, self-hosted NotebookLM alternative with chat, one-click local models, and web crawling</h1>
+<h1 class="sr">A local AI search engine for your Obsidian vault with chat, one-click local models, and web crawling</h1>
 <div class="layout">
   <main class="main">
 
@@ -157,7 +156,7 @@
 |  _/ _ \ '_| | (_) | '_ (_-&lt; / _` | / _` | ' \
 |_| \___/_|    \___/|_.__/__/_\__,_|_\__,_|_||_|</pre>
       <h2 class="tagline">Obsidian's interface to <strong><a href="https://lilbee.sh/">lilbee</a></strong>, a local AI search engine: find, run, and manage local AI models, and search your vault and the sites you crawl with them.</h2>
-      <p class="sub">Browse a model catalog and pull a model that runs on your own machine, then ask questions about anything in your vault (notes, PDFs, ebooks, code, scans, <strong>150+ file types</strong> in all) and get answers with the source one click away.</p>
+      <p class="sub">Browse a model catalog and pull a model that runs on your own machine, then ask questions about anything in your vault (notes, PDFs, ebooks, code, scans: 150+ file types) and get answers with the source one click away.</p>
       <div class="surfaces">
         <span class="surfaces-label">one plugin, inside obsidian</span>
         <span class="surface">chat sidebar</span>
@@ -318,7 +317,7 @@
         <a class="cmd" href="obsidian://show-plugin?id=lilbee">obsidian://show-plugin?id=lilbee</a>
       </div>
       <div class="steps">
-        <div class="step"><span class="n">1</span><span>lilbee is in the official <a href="https://community.obsidian.md/plugins/lilbee">Obsidian community plugin store</a>. In Obsidian, go to <em>Settings → Community plugins → Browse</em>, search for <em>lilbee</em>, then <em>Install</em> and <em>Enable</em>. The link above jumps straight to the plugin page in Obsidian.</span></div>
+        <div class="step"><span class="n">1</span><span>Install lilbee from the official <a href="https://community.obsidian.md/plugins/lilbee">community plugin store</a>: <em>Settings → Community plugins → Browse</em>, search <em>lilbee</em>, <em>Install</em>, <em>Enable</em>. The link above jumps straight there.</span></div>
         <div class="step"><span class="n">2</span><span>A setup wizard opens: pick a chat model and run the first sync. That's it; lilbee brings its own engine, nothing else to install.</span></div>
       </div>
       <p class="extras">lilbee is in active development, with frequent releases; updates arrive through Obsidian's plugin updater. <a href="https://community.obsidian.md/plugins/lilbee">view the store listing &rarr;</a></p>
@@ -377,27 +376,11 @@
         </div>
         <div class="cap">
           <h3>remembers what you tell it</h3>
-          <p>Turn on memory and lilbee holds onto durable facts about you and how you like your answers, then recalls the relevant ones in later chats, no matter which conversation they came from. Off by default, managed from a Memories view, and never mixed into your citations.</p>
+          <p>Turn on memory and lilbee holds onto durable facts about you and how you like your answers, then recalls the relevant ones in later chats. Off by default, managed from a Memories view, never mixed into your citations.</p>
         </div>
         <div class="cap">
           <h3>writes a wiki of your knowledge <span class="exp">experimental</span></h3>
           <p>lilbee can draft linked wiki pages from your library; they land in your vault as ordinary notes and show up in the graph view, alongside your own.</p>
-        </div>
-      </div>
-    </section>
-
-    <section>
-      <div class="label">across your GPUs</div>
-      <div class="gpu">
-        <div class="gpu-copy">
-          <h3>one box, many GPUs, no flags</h3>
-          <p>Got more than one graphics card? lilbee finds them all. The placement view draws every GPU and what's running on it, chat, embedding, vision, reranking, and lets you spread a model across cards or pin a worker to one with a click.</p>
-          <p>Spread one model's layers across several cards, or pin embedding, vision and reranking workers to the GPUs you choose, then apply and the fleet rebuilds to match. The usage bars update live, so you can see each card's load in real time. On a single machine it stays simple: one card, everything together, nothing to configure.</p>
-        </div>
-        <div class="gpu-clip">
-          <div class="tutorial-clip">
-            <video src="https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/gpu-placement-manual.webm" controls loop muted autoplay playsinline preload="metadata"></video>
-          </div>
         </div>
       </div>
     </section>

--- a/site/main.js
+++ b/site/main.js
@@ -1,7 +1,12 @@
-// Interactivity for the lilbee for Obsidian landing page: the tutorial reel tabs.
+// Interactivity for the lilbee for Obsidian site: the mega-nav menus, the
+// tutorial reel tabs, and hash deep links that activate a tab.
 
 (function () {
   'use strict';
+
+  // tab element -> the select() of the tablist that owns it, so deep links
+  // can activate a tab without synthesizing clicks.
+  var tabSelects = new Map();
 
   /** Wire every [role="tablist"] on the page (the tutorial reel, anything else
       with the same ARIA shape). Click selection plus left/right arrow-key
@@ -20,6 +25,8 @@
           if (pane) pane.hidden = !active;
         });
       }
+
+      tabs.forEach(function (tab) { tabSelects.set(tab, select); });
 
       tablist.addEventListener('click', function (event) {
         var tab = event.target.closest('[role="tab"]');
@@ -41,5 +48,109 @@
     });
   }
 
+  /** Mega-nav dropdowns: click to toggle, Escape or an outside click closes,
+      up/down arrows move through the items, Tab moves on and closes. */
+  function initMenus() {
+    var menus = Array.prototype.slice.call(document.querySelectorAll('.menu'));
+
+    function close(menu) {
+      menu.classList.remove('open');
+      menu.querySelector('.menu-btn').setAttribute('aria-expanded', 'false');
+    }
+    function closeAll() { menus.forEach(close); }
+
+    menus.forEach(function (menu) {
+      var button = menu.querySelector('.menu-btn');
+      var links = Array.prototype.slice.call(menu.querySelectorAll('.menu-panel a'));
+
+      button.addEventListener('click', function () {
+        var willOpen = !menu.classList.contains('open');
+        closeAll();
+        if (willOpen) {
+          menu.classList.add('open');
+          button.setAttribute('aria-expanded', 'true');
+        }
+      });
+
+      menu.addEventListener('keydown', function (event) {
+        if (event.key === 'Escape') {
+          close(menu);
+          button.focus();
+          return;
+        }
+        if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
+        event.preventDefault();
+        if (!menu.classList.contains('open')) {
+          menu.classList.add('open');
+          button.setAttribute('aria-expanded', 'true');
+          links[event.key === 'ArrowDown' ? 0 : links.length - 1].focus();
+          return;
+        }
+        var index = links.indexOf(document.activeElement);
+        var step = event.key === 'ArrowDown' ? 1 : -1;
+        var next = links[(index + step + links.length) % links.length] || links[0];
+        next.focus();
+      });
+
+      menu.addEventListener('focusout', function (event) {
+        if (event.relatedTarget && menu.contains(event.relatedTarget)) return;
+        close(menu);
+      });
+    });
+
+    document.addEventListener('click', function (event) {
+      if (!event.target.closest('.menu')) closeAll();
+    });
+  }
+
+  function prefersReducedMotion() {
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  }
+
+  /** Map a "#demo-chat" hash to the tab it names. */
+  function tabForHash(hash) {
+    var match = /^#demo-(.+)$/.exec(hash || '');
+    if (!match) return null;
+    return document.getElementById('tutorial-tab-' + match[1]);
+  }
+
+  /** Activate the tab a hash names and scroll its section into view. */
+  function activateHash(hash, smooth) {
+    var tab = tabForHash(hash);
+    if (!tab) return false;
+    var select = tabSelects.get(tab);
+    if (select) select(tab);
+    var section = tab.closest('section');
+    if (section) section.scrollIntoView({ behavior: smooth ? 'smooth' : 'auto', block: 'start' });
+    return true;
+  }
+
+  /** Mega-nav deep links: when the link points at a tab on this page, activate
+      it in place; otherwise let the browser carry the hash to the other page,
+      where the load-time activateHash picks it up. */
+  function initDeepLinks() {
+    document.addEventListener('click', function (event) {
+      var link = event.target.closest('.menu-panel a[href*="/#"]');
+      if (!link) return;
+      var url = new URL(link.href, location.href);
+      if (url.pathname !== location.pathname || !tabForHash(url.hash)) return;
+      event.preventDefault();
+      activateHash(url.hash, !prefersReducedMotion());
+      history.pushState(null, '', url.hash);
+      var menu = link.closest('.menu');
+      if (menu) {
+        menu.classList.remove('open');
+        menu.querySelector('.menu-btn').setAttribute('aria-expanded', 'false');
+      }
+    });
+
+    activateHash(location.hash, false);
+    window.addEventListener('hashchange', function () {
+      activateHash(location.hash, !prefersReducedMotion());
+    });
+  }
+
   initTablists();
+  initMenus();
+  initDeepLinks();
 })();

--- a/site/notebooklm-alternative/index.html
+++ b/site/notebooklm-alternative/index.html
@@ -75,6 +75,60 @@
 <script src="../main.js" defer></script>
 </head>
 <body>
+<header class="nav">
+  <div class="nav-inner">
+    <a class="nav-brand" href="/">lilbee <span class="nav-brand-sub">for Obsidian</span></a>
+    <nav class="nav-menus" aria-label="Site">
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">demos</button>
+        <div class="menu-panel menu-cols">
+          <div class="menu-col">
+            <div class="menu-group">the plugin</div>
+            <a href="/#demo-onlilbee">what is lilbee</a>
+            <a href="/#demo-firststart">first run</a>
+            <a href="/#demo-ask">ask &amp; cite</a>
+            <a href="/#demo-tour">tour</a>
+            <a href="/#demo-settings">settings</a>
+          </div>
+          <div class="menu-col">
+            <div class="menu-group">your sources</div>
+            <a href="/#demo-vision">scanned PDF</a>
+            <a href="/#demo-crawl">crawl</a>
+            <a href="/#demo-crawlsite">crawl a site</a>
+            <a href="/#demo-multipart">multi-part</a>
+          </div>
+          <div class="menu-col">
+            <div class="menu-group">models</div>
+            <a href="/#demo-catalog">catalog</a>
+            <a href="/#demo-download">download a model</a>
+            <a href="/#demo-models">model rail</a>
+            <a href="/#demo-placement">multi-GPU</a>
+            <a href="/#demo-ollama">Ollama</a>
+            <a href="/#demo-lmstudio">LM Studio</a>
+            <a href="/#demo-gemini">cloud</a>
+          </div>
+        </div>
+      </div>
+      <a class="nav-link" href="/#install">install</a>
+      <a class="nav-link" href="/tutorial/">tutorial reel</a>
+      <a class="nav-link" href="/notebooklm-alternative/">vs notebooklm</a>
+      <div class="menu align-right">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">more</button>
+        <div class="menu-panel">
+          <div class="menu-group">project</div>
+          <a href="https://github.com/tobocop2/obsidian-lilbee">github</a>
+          <a href="https://community.obsidian.md/plugins/lilbee">plugin store</a>
+          <a href="https://github.com/tobocop2/obsidian-lilbee/releases">releases</a>
+          <a href="/coverage/">coverage</a>
+          <div class="menu-group">docs</div>
+          <a href="https://github.com/tobocop2/obsidian-lilbee/blob/main/docs/usage.md">usage guide</a>
+          <a href="https://lilbee.sh/">lilbee (the engine)</a>
+        </div>
+      </div>
+    </nav>
+    <a class="nav-star" href="https://github.com/tobocop2/obsidian-lilbee">&#9733; star</a>
+  </div>
+</header>
 
 <h1 class="sr">A private, self-hosted NotebookLM alternative that runs on your own computer, inside Obsidian</h1>
 

--- a/site/notebooklm-alternative/index.html
+++ b/site/notebooklm-alternative/index.html
@@ -111,7 +111,6 @@
       </div>
       <a class="nav-link" href="/#install">install</a>
       <a class="nav-link" href="/tutorial/">tutorial reel</a>
-      <a class="nav-link" href="/notebooklm-alternative/">vs notebooklm</a>
       <div class="menu align-right">
         <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">more</button>
         <div class="menu-panel">

--- a/site/style.css
+++ b/site/style.css
@@ -92,6 +92,7 @@ h1.sr {
   from { opacity: 0; }
 }
 @media (prefers-reduced-motion: no-preference) {
+  .nav { animation: lb-fade 400ms ease both; }
   .topstrip,
   .main > section { animation: lb-rise 560ms cubic-bezier(0.22, 1, 0.36, 1) both; }
   .topstrip                       { animation-delay: 0ms; }
@@ -117,6 +118,126 @@ h1.sr {
 }
 
 .main { min-width: 0; }
+
+/* mega-nav -------------------------------------------------------------
+   Sticky site header. Full-bleed bar: the negative margins cancel the body
+   padding so the border runs edge to edge, while .nav-inner keeps the
+   content on the same 1240px column as .layout. */
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 60;
+  margin: -2.5rem calc(-1 * var(--gutter)) 1.7rem;
+  padding: 0 var(--gutter);
+  background: var(--bg);
+  border-bottom: 1px solid var(--rule);
+}
+.nav-inner {
+  max-width: 1240px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.35rem 1rem;
+  padding: 0.4rem 0;
+}
+.nav-brand {
+  font-size: 13.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  border-bottom: none;
+}
+.nav-brand:hover { color: var(--accent-hot); }
+.nav-brand-sub { color: var(--ink-3); font-weight: 400; }
+.nav-menus {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.15rem;
+  flex: 1;
+}
+.menu { position: relative; }
+.menu.open { z-index: 70; }
+.menu-btn,
+.nav-link {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  letter-spacing: 0.02em;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--ink-2);
+  padding: 0.3rem 0.55rem;
+  cursor: pointer;
+  transition: color 130ms, border-color 130ms, background-color 130ms;
+}
+.menu-btn::after {
+  content: "▾";
+  margin-left: 0.45em;
+  font-size: 9px;
+  color: var(--ink-3);
+}
+.menu-btn:hover,
+.nav-link:hover { color: var(--ink); border-color: var(--rule-2); }
+.menu.open .menu-btn { color: var(--accent); border-color: var(--rule-2); background: var(--bg-elev); }
+.menu-btn:focus-visible,
+.nav-link:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.menu-panel {
+  display: none;
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  min-width: 11.5rem;
+  max-height: min(70vh, 32rem);
+  overflow-y: auto;
+  background: var(--bg-card);
+  border: 1px solid var(--rule-2);
+  border-radius: 4px;
+  padding: 0.5rem;
+  box-shadow: 0 22px 60px -26px rgba(0, 0, 0, 0.78);
+}
+.menu.open .menu-panel { display: block; }
+.menu.open .menu-panel.menu-cols { display: flex; gap: 1.2rem; }
+.menu-col { min-width: 10.5rem; }
+.menu.align-right .menu-panel { left: auto; right: 0; }
+.menu-group {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  margin: 0.45rem 0 0.2rem;
+  padding: 0 0.55rem;
+}
+.menu-panel > .menu-group:first-child,
+.menu-col > .menu-group:first-child { margin-top: 0; }
+.menu-panel a {
+  display: block;
+  padding: 0.26rem 0.55rem;
+  border-bottom: none;
+  border-radius: 3px;
+  color: var(--ink-2);
+  font-size: 12.5px;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+.menu-panel a:hover { color: var(--accent-hot); background: rgba(167, 139, 250, 0.08); }
+.menu-panel a:focus-visible { outline: 2px solid var(--accent); outline-offset: -1px; }
+.menu-panel a.menu-hl { color: var(--accent); }
+.nav-star {
+  font-size: 12.5px;
+  letter-spacing: 0.02em;
+  color: var(--ink-2);
+  border: 1px solid var(--rule-2);
+  border-radius: 4px;
+  padding: 0.26rem 0.6rem;
+  margin-left: auto;
+}
+.nav-star:hover { color: var(--accent-hot); border-color: var(--accent); background: rgba(167, 139, 250, 0.08); }
+
+/* keep anchored sections clear of the sticky nav when jumping to them */
+section[id] { scroll-margin-top: 4.2rem; }
 
 /* top strip ---------------------------------------------------------- */
 .topstrip {
@@ -594,7 +715,12 @@ footer .meta { text-align: right; font-size: 12px; }
   .bee-art { display: none; }
 }
 @media (max-width: 720px) {
+  :root { --gutter: 1.1rem; }
+  .nav-menus { order: 3; flex-basis: 100%; }
+  .menu-panel { max-width: calc(100vw - 2 * var(--gutter)); }
+  .menu.open .menu-panel.menu-cols { flex-wrap: wrap; }
   body { padding: 1.4rem 1.1rem 3rem; font-size: 14.5px; }
+  .nav-brand-sub { display: none; }
   .wordmark, .wordmark-sub { font-size: 9px; }
   .caps, .links, .shape, .gpu { grid-template-columns: 1fr; }
   .tagline { font-size: 18px; }

--- a/site/style.css
+++ b/site/style.css
@@ -224,7 +224,6 @@ h1.sr {
 }
 .menu-panel a:hover { color: var(--accent-hot); background: rgba(167, 139, 250, 0.08); }
 .menu-panel a:focus-visible { outline: 2px solid var(--accent); outline-offset: -1px; }
-.menu-panel a.menu-hl { color: var(--accent); }
 .nav-star {
   font-size: 12.5px;
   letter-spacing: 0.02em;
@@ -634,19 +633,6 @@ section[id] { scroll-margin-top: 4.2rem; }
 .cap p { font-size: 14px; color: var(--ink-2); line-height: 1.65; }
 .cap p code { background: var(--bg); border: 1px solid var(--rule); padding: 0 0.35rem; border-radius: 3px; color: var(--ink); }
 
-/* multi-GPU section -------------------------------------------------- */
-.gpu { display: grid; grid-template-columns: 1fr 1.1fr; gap: 1.6rem; align-items: center; }
-.gpu-copy h3 {
-  font-size: 16px;
-  font-weight: 700;
-  color: var(--accent);
-  letter-spacing: 0.01em;
-  margin-bottom: 0.6rem;
-}
-.gpu-copy p { font-size: 14px; color: var(--ink-2); line-height: 1.65; }
-.gpu-copy p + p { margin-top: 0.7rem; }
-.gpu-clip .tutorial-clip { margin: 0; }
-
 /* go-deeper links ---------------------------------------------------- */
 .links { display: grid; grid-template-columns: 1fr 1fr; gap: 4px 2.5rem; font-size: 14px; }
 .links a {
@@ -722,7 +708,7 @@ footer .meta { text-align: right; font-size: 12px; }
   body { padding: 1.4rem 1.1rem 3rem; font-size: 14.5px; }
   .nav-brand-sub { display: none; }
   .wordmark, .wordmark-sub { font-size: 9px; }
-  .caps, .links, .shape, .gpu { grid-template-columns: 1fr; }
+  .caps, .links, .shape { grid-template-columns: 1fr; }
   .tagline { font-size: 18px; }
 }
 

--- a/site/tutorial/index.html
+++ b/site/tutorial/index.html
@@ -49,7 +49,6 @@
       </div>
       <a class="nav-link" href="/#install">install</a>
       <a class="nav-link" href="/tutorial/">tutorial reel</a>
-      <a class="nav-link" href="/notebooklm-alternative/">vs notebooklm</a>
       <div class="menu align-right">
         <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">more</button>
         <div class="menu-panel">

--- a/site/tutorial/index.html
+++ b/site/tutorial/index.html
@@ -13,6 +13,60 @@
 <link rel="stylesheet" href="tutorial.css" />
 </head>
 <body>
+<header class="nav">
+  <div class="nav-inner">
+    <a class="nav-brand" href="/">lilbee <span class="nav-brand-sub">for Obsidian</span></a>
+    <nav class="nav-menus" aria-label="Site">
+      <div class="menu">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">demos</button>
+        <div class="menu-panel menu-cols">
+          <div class="menu-col">
+            <div class="menu-group">the plugin</div>
+            <a href="/#demo-onlilbee">what is lilbee</a>
+            <a href="/#demo-firststart">first run</a>
+            <a href="/#demo-ask">ask &amp; cite</a>
+            <a href="/#demo-tour">tour</a>
+            <a href="/#demo-settings">settings</a>
+          </div>
+          <div class="menu-col">
+            <div class="menu-group">your sources</div>
+            <a href="/#demo-vision">scanned PDF</a>
+            <a href="/#demo-crawl">crawl</a>
+            <a href="/#demo-crawlsite">crawl a site</a>
+            <a href="/#demo-multipart">multi-part</a>
+          </div>
+          <div class="menu-col">
+            <div class="menu-group">models</div>
+            <a href="/#demo-catalog">catalog</a>
+            <a href="/#demo-download">download a model</a>
+            <a href="/#demo-models">model rail</a>
+            <a href="/#demo-placement">multi-GPU</a>
+            <a href="/#demo-ollama">Ollama</a>
+            <a href="/#demo-lmstudio">LM Studio</a>
+            <a href="/#demo-gemini">cloud</a>
+          </div>
+        </div>
+      </div>
+      <a class="nav-link" href="/#install">install</a>
+      <a class="nav-link" href="/tutorial/">tutorial reel</a>
+      <a class="nav-link" href="/notebooklm-alternative/">vs notebooklm</a>
+      <div class="menu align-right">
+        <button type="button" class="menu-btn" aria-expanded="false" aria-haspopup="true">more</button>
+        <div class="menu-panel">
+          <div class="menu-group">project</div>
+          <a href="https://github.com/tobocop2/obsidian-lilbee">github</a>
+          <a href="https://community.obsidian.md/plugins/lilbee">plugin store</a>
+          <a href="https://github.com/tobocop2/obsidian-lilbee/releases">releases</a>
+          <a href="/coverage/">coverage</a>
+          <div class="menu-group">docs</div>
+          <a href="https://github.com/tobocop2/obsidian-lilbee/blob/main/docs/usage.md">usage guide</a>
+          <a href="https://lilbee.sh/">lilbee (the engine)</a>
+        </div>
+      </div>
+    </nav>
+    <a class="nav-star" href="https://github.com/tobocop2/obsidian-lilbee">&#9733; star</a>
+  </div>
+</header>
 <div class="layout">
   <main class="main">
 
@@ -35,6 +89,7 @@
 
   </main>
 </div>
+<script src="../main.js" defer></script>
 <script src="tutorial.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Problem

The demo reel sat below the fold with no header navigation, the site leaned too hard on NotebookLM-alternative positioning, and the "across your GPUs" section broke the layout.

## Solution

Adds a sticky mega-nav to every page, with a demos menu that deep-links into the reel tabs (/#demo-crawl activates and scrolls to the clip). NotebookLM stays in the head metadata and the comparison page but comes out of the h1, store manifest, README, and nav. The GPU section goes (the reel's multi-GPU tab covers it), and the prose is tightened.