### PR TITLE
Fix the PDF source preview rendering a blank viewer

### DIFF
--- a/src/utils/source-click.ts
+++ b/src/utils/source-click.ts
@@ -16,9 +16,9 @@ export const SOURCE_ACTION = {
  * - `vault-markdown`: open the markdown file and scroll to a specific line.
  * - `vault-note`: open the vault file without deep-linking.
  * - `preview`: file is not in the vault, OR is a PDF — fetch via `/api/source`
- *   and show the source-preview modal so we can deep-link to a page via
- *   `<object data="...?page=N">` (Obsidian's PDF viewer doesn't honour the
- *   `#page=N` fragment in `openLinkText`).
+ *   and show the source-preview modal, whose embedded viewer can deep-link to
+ *   a page (Obsidian's PDF viewer doesn't honour the `#page=N` fragment in
+ *   `openLinkText`).
  */
 export type SourceClickAction =
     | { kind: typeof SOURCE_ACTION.VAULT_MARKDOWN; path: string; line: number }
@@ -45,9 +45,8 @@ function vaultAction(source: Source, path: string): SourceClickAction {
  *
  * PDFs always route to the preview modal — Obsidian's built-in PDF viewer
  * does not honour `#page=N` fragments passed through `openLinkText`, so we
- * use the modal's `<object data="…?page=N">` path that does. The modal
- * exposes an "Open in vault" button for users who want the file opened in
- * the main pane.
+ * use the modal's embedded viewer, which does. The modal exposes an "Open in
+ * vault" button for users who want the file opened in the main pane.
  *
  * For non-PDFs, prefer the server-supplied `vault_path`. If absent (older
  * server builds, or external-server mode), fall back to `source.source` —

--- a/src/views/source-preview-modal.ts
+++ b/src/views/source-preview-modal.ts
@@ -21,12 +21,13 @@ const TEXT_INLINE_RENDER_DENY = new Set([
 /**
  * Read-only preview for sources that aren't in the local vault (external
  * server mode, or a vault-bound source whose file was removed). Fetches
- * content via `/api/source` and renders markdown inline. For PDFs the modal
- * embeds an `<object type="application/pdf">` pointing at the `raw=1`
- * endpoint with a `#page=N` fragment — Chromium's built-in PDFium viewer
- * honours that fragment, which lets the preview jump directly to the
- * chunk's page. The type-locked `<object>` tag narrows the rendering
- * surface for any non-PDF bytes the server might return.
+ * content via `/api/source` and renders markdown inline. PDFs render as a blob
+ * URL in a type-locked `<object type="application/pdf">` with a `#page=N`
+ * fragment, which Chromium's PDFium viewer opens at that page. The type lock
+ * narrows the rendering surface for any non-PDF bytes.
+ *
+ * The blob is required: every server route needs the session token, and an
+ * `<object data>` load cannot send an `Authorization` header.
  *
  * A future "Save to vault" button will push the content into `<vault>/lilbee/`
  * once the server exposes the write path — disabled for now with a tooltip.
@@ -35,6 +36,9 @@ export class SourcePreviewModal extends Modal {
     private api: LilbeeClient;
     private source: Source;
     private renderComponent: Component;
+    /** Live blob URL backing the embedded PDF; revoked when the modal closes. */
+    private pdfObjectUrl: string | null = null;
+    private closed = false;
 
     constructor(app: App, api: LilbeeClient, source: Source) {
         super(app);
@@ -75,6 +79,8 @@ export class SourcePreviewModal extends Modal {
     }
 
     onClose(): void {
+        this.closed = true;
+        this.releasePdfObjectUrl();
         this.renderComponent.unload();
         this.contentEl.empty();
         if (this.dragMoveHandler) {
@@ -185,18 +191,22 @@ export class SourcePreviewModal extends Modal {
             host.empty();
             this.renderBody(host, content);
         } catch (err) {
-            const reason = errorMessage(err, String(err));
-            host.empty();
-            host.createEl("p", { text: MESSAGES.ERROR_PREVIEW_LOAD(reason), cls: "lilbee-preview-error" });
-            new Notice(MESSAGES.ERROR_PREVIEW_LOAD(reason));
+            this.showLoadError(host, err);
         }
+    }
+
+    private showLoadError(host: HTMLElement, err: unknown): void {
+        const message = MESSAGES.ERROR_PREVIEW_LOAD(errorMessage(err, String(err)));
+        host.empty();
+        host.createEl("p", { text: message, cls: "lilbee-preview-error" });
+        new Notice(message);
     }
 
     private renderBody(host: HTMLElement, content: SourceContent): void {
         const ct = content.content_type;
         const isPdf = isPdfContentType(this.source.content_type) || isPdfContentType(ct);
         if (isPdf) {
-            this.renderPdf(host);
+            void this.renderPdf(host);
             return;
         }
         // Mirror the server's raw-content allowlist: any text/* may render through
@@ -227,19 +237,33 @@ export class SourcePreviewModal extends Modal {
         host.scrollTop = citedLineScrollTop(body.scrollHeight, code.split("\n").length, this.source.line_start);
     }
 
-    private renderPdf(host: HTMLElement): void {
+    /** Fetch the PDF bytes through the authenticated client into a blob URL. */
+    private async renderPdf(host: HTMLElement): Promise<void> {
+        let url: string;
+        try {
+            const res = await this.api.getSourceRaw(this.source.source);
+            url = URL.createObjectURL(await res.blob());
+        } catch (err) {
+            this.showLoadError(host, err);
+            return;
+        }
+        if (this.closed) {
+            // Dismissed mid-fetch: onClose already ran and never saw this URL.
+            URL.revokeObjectURL(url);
+            return;
+        }
+        this.pdfObjectUrl = url;
         const body = host.createDiv({ cls: "lilbee-preview-body" });
         const frame = body.createEl("object", { cls: "lilbee-preview-pdf-frame" });
         frame.setAttribute("type", CONTENT_TYPE.PDF);
-        frame.setAttribute("data", this.rawSourceUrl(this.source.page_start));
+        // `#page=N` makes Chromium's PDFium viewer open at the chunk's page.
+        const page = this.source.page_start;
+        frame.setAttribute("data", page && page > 0 ? `${url}#page=${page}` : url);
     }
 
-    private rawSourceUrl(page: number | null): string {
-        // Direct URL to the raw PDF bytes for the embedded viewer to fetch.
-        // Appending `#page=N` makes Chromium's PDFium viewer open at that page.
-        const params = new URLSearchParams({ source: this.source.source, raw: "1" });
-        const base = (this.api as unknown as { baseUrl?: string }).baseUrl ?? "";
-        const fragment = page && page > 0 ? `#page=${page}` : "";
-        return `${base}/api/source?${params.toString()}${fragment}`;
+    private releasePdfObjectUrl(): void {
+        if (this.pdfObjectUrl === null) return;
+        URL.revokeObjectURL(this.pdfObjectUrl);
+        this.pdfObjectUrl = null;
     }
 }

--- a/tests/views/source-preview-modal.test.ts
+++ b/tests/views/source-preview-modal.test.ts
@@ -260,14 +260,21 @@ describe("SourcePreviewModal — loading + success (markdown)", () => {
     });
 });
 
+/** A `getSourceRaw` stand-in returning PDF bytes, like the real Response would. */
+function pdfResponse(bytes = new Uint8Array([0x25, 0x50, 0x44, 0x46])): unknown {
+    return { blob: async () => new Blob([bytes], { type: CONTENT_TYPE.PDF }) };
+}
+
 describe("SourcePreviewModal — success (PDF)", () => {
-    it('renders an <object type="application/pdf"> pointing to the raw URL', async () => {
+    it('renders an <object type="application/pdf"> fed by an authenticated blob fetch', async () => {
         const app = new App();
+        const getSourceRaw = vi.fn().mockResolvedValue(pdfResponse());
         const api = makeApi({
             getSource: vi.fn().mockResolvedValue({
                 markdown: "",
                 content_type: CONTENT_TYPE.PDF,
             }),
+            getSourceRaw,
         });
         const modal = new SourcePreviewModal(
             app as never,
@@ -283,7 +290,11 @@ describe("SourcePreviewModal — success (PDF)", () => {
         // a malicious .html source as text/html inside the plugin origin.
         expect(frame!.tagName).toBe("OBJECT");
         expect(frame!.attributes["type"]).toBe("application/pdf");
-        expect(frame!.attributes["data"]).toContain("book.pdf");
+        // An <object> cannot send an Authorization header, so a direct
+        // /api/source URL is a guaranteed 401; the bytes must come via the client.
+        expect(getSourceRaw).toHaveBeenCalledWith("crawled/example.com/book.pdf");
+        expect(frame!.attributes["data"]).toMatch(/^blob:/);
+        expect(frame!.attributes["data"]).not.toContain("/api/source");
         expect(el.find("lilbee-preview-iframe")).toBeNull();
     });
 
@@ -294,6 +305,7 @@ describe("SourcePreviewModal — success (PDF)", () => {
                 markdown: "",
                 content_type: "text/plain",
             }),
+            getSourceRaw: vi.fn().mockResolvedValue(pdfResponse()),
         });
         const modal = new SourcePreviewModal(app as never, api, makeSource({ content_type: CONTENT_TYPE.PDF }));
         modal.open();
@@ -303,13 +315,14 @@ describe("SourcePreviewModal — success (PDF)", () => {
         expect(frame.tagName).toBe("OBJECT");
     });
 
-    it("appends #page=N to the object data URL when page_start is set", async () => {
+    it("appends #page=N to the blob URL when page_start is set", async () => {
         const app = new App();
         const api = makeApi({
             getSource: vi.fn().mockResolvedValue({
                 markdown: "",
                 content_type: CONTENT_TYPE.PDF,
             }),
+            getSourceRaw: vi.fn().mockResolvedValue(pdfResponse()),
         });
         const modal = new SourcePreviewModal(
             app as never,
@@ -324,7 +337,7 @@ describe("SourcePreviewModal — success (PDF)", () => {
         await tick();
         const el = modal.contentEl as unknown as MockElement;
         const frame = el.find("lilbee-preview-pdf-frame")!;
-        expect(frame.attributes["data"]).toContain("#page=42");
+        expect(frame.attributes["data"]).toMatch(/^blob:.*#page=42$/);
     });
 
     it("omits the #page= fragment when page_start is null", async () => {
@@ -334,6 +347,7 @@ describe("SourcePreviewModal — success (PDF)", () => {
                 markdown: "",
                 content_type: CONTENT_TYPE.PDF,
             }),
+            getSourceRaw: vi.fn().mockResolvedValue(pdfResponse()),
         });
         const modal = new SourcePreviewModal(
             app as never,
@@ -345,6 +359,71 @@ describe("SourcePreviewModal — success (PDF)", () => {
         const el = modal.contentEl as unknown as MockElement;
         const frame = el.find("lilbee-preview-pdf-frame")!;
         expect(frame.attributes["data"]).not.toContain("#page=");
+    });
+
+    it("revokes the blob URL when the modal closes so the bytes are not retained", async () => {
+        const app = new App();
+        const api = makeApi({
+            getSource: vi.fn().mockResolvedValue({
+                markdown: "",
+                content_type: CONTENT_TYPE.PDF,
+            }),
+            getSourceRaw: vi.fn().mockResolvedValue(pdfResponse()),
+        });
+        const revoke = vi.spyOn(URL, "revokeObjectURL");
+        const modal = new SourcePreviewModal(app as never, api, makeSource({ content_type: CONTENT_TYPE.PDF }));
+        modal.open();
+        await tick();
+        const el = modal.contentEl as unknown as MockElement;
+        const url = el.find("lilbee-preview-pdf-frame")!.attributes["data"];
+        modal.close();
+        expect(revoke).toHaveBeenCalledWith(url);
+        revoke.mockRestore();
+    });
+
+    it("releases the bytes when the modal is dismissed mid-fetch", async () => {
+        const app = new App();
+        let release!: (r: unknown) => void;
+        const api = makeApi({
+            getSource: vi.fn().mockResolvedValue({
+                markdown: "",
+                content_type: CONTENT_TYPE.PDF,
+            }),
+            getSourceRaw: vi.fn(() => new Promise((r) => (release = r))),
+        });
+        const revoke = vi.spyOn(URL, "revokeObjectURL");
+        const modal = new SourcePreviewModal(app as never, api, makeSource({ content_type: CONTENT_TYPE.PDF }));
+        modal.open();
+        await tick();
+        modal.close();
+        release(pdfResponse());
+        await tick();
+        // The frame is never built, and the blob URL created after close is
+        // revoked rather than left holding the file in memory.
+        const el = modal.contentEl as unknown as MockElement;
+        expect(el.find("lilbee-preview-pdf-frame")).toBeNull();
+        expect(revoke).toHaveBeenCalledWith(expect.stringMatching(/^blob:/));
+        revoke.mockRestore();
+    });
+
+    it("surfaces an error instead of a blank viewer when the raw fetch fails", async () => {
+        const app = new App();
+        const api = makeApi({
+            getSource: vi.fn().mockResolvedValue({
+                markdown: "",
+                content_type: CONTENT_TYPE.PDF,
+            }),
+            getSourceRaw: vi.fn().mockRejectedValue(new Error("Server responded 401: Missing or invalid bearer token")),
+        });
+        const modal = new SourcePreviewModal(app as never, api, makeSource({ content_type: CONTENT_TYPE.PDF }));
+        modal.open();
+        await tick();
+        await tick();
+        const el = modal.contentEl as unknown as MockElement;
+        expect(el.find("lilbee-preview-pdf-frame")).toBeNull();
+        const error = el.find("lilbee-preview-error");
+        expect(error).not.toBeNull();
+        expect(error!.textContent).toContain("401");
     });
 });
 


### PR DESCRIPTION
## Problem

Clicking a PDF citation opened the source preview with an empty viewer. The modal embeds the file as `<object data="…/api/source?raw=1#page=N">`, and an `<object>` load cannot send an `Authorization` header. Since the server began requiring the session token on every route, that request always returns 401 and the tag fails silently, so nothing renders.

Confirmed against a running server: the same URL returns 401 with no header and 200 with a bearer token. The source path was never the problem.

## Solution

Fetch the bytes through the API client, which attaches the token, and hand the viewer a blob URL. `#page=N` still works on a blob URL, so a citation keeps landing on the page it cites.

This uses `getSourceRaw()`, which already existed with tests but no callers. Request URLs are now built only inside the API client, so no view can accidentally construct an unauthenticated one. Removes `rawSourceUrl()` and its cast into the client's private `baseUrl`.

The blob URL is revoked when the modal closes, including when the modal is dismissed while the fetch is still in flight.

A failed fetch now shows the existing load error instead of a blank frame.
