### PR TITLE
Stop npm overrides from pinning dev dependencies to vulnerable versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -734,9 +734,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2966,9 +2966,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-n/node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3180,9 +3180,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-obsidianmd/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3602,9 +3602,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -5153,9 +5153,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -71,10 +71,11 @@
     "fflate": "^0.8.3"
   },
   "overrides": {
-    "brace-expansion@<1.1.17": "1.1.17",
-    "brace-expansion@>=2.0.0 <2.1.3": "2.1.3",
-    "brace-expansion@>=3.0.0 <5.0.8": "5.0.8",
-    "js-yaml@<4.3.0": "4.3.0",
-    "fast-uri": "3.1.4"
+    "brace-expansion@<1.1.18": "^1.1.18",
+    "brace-expansion@>=2.0.0 <2.1.4": "^2.1.4",
+    "brace-expansion@>=3.0.0 <5.0.9": "^5.0.9",
+    "js-yaml@<4.3.0": "^4.3.0",
+    "fast-uri": "^3.1.5",
+    "nanoid@<3.3.17": "^3.3.17"
   }
 }


### PR DESCRIPTION
## Problem

Four high-severity code scanning alerts, all in the dev toolchain: brace-expansion (CVE-2026-69152), fast-uri (CVE-2026-18446), and nanoid (CVE-2026-67213).

## The overrides caused this

Our `overrides` entries were exact versions, so they acted as ceilings rather than floors. `fast-uri` was held at exactly 3.1.4 and `brace-expansion` at exactly 1.1.17 and 2.1.3. Those were the patched versions when we pinned them, and the pins then blocked every later patch from reaching us. Two of the four alerts are follow-up CVEs on versions we pinned ourselves, which is why this is the third round of pinning in a row.

## Solution

Every override value becomes a caret range, so npm takes patch and minor releases as they ship. A clean resolve with no overrides at all already lands on patched versions, so these entries now only serve as a floor if some future transitive dependency asks for a narrow vulnerable range.

Added a nanoid floor alongside the existing ones. `npm audit` reports zero vulnerabilities.

## Scope

Dev dependencies only, nothing shipped in the plugin bundle. Five lockfile entries move; no other packages change.
