### PR TITLE
Typecheck the source in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           node-version: "20"
           cache: npm
       - run: npm ci
+      - run: npm run typecheck
       - run: npm run lint
         if: matrix.os == 'ubuntu-latest'
       - run: npm run format:check

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test": "vitest run --coverage",
     "test:watch": "vitest",
     "test:integration": "vitest run --config vitest.integration.config.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint src/ tests/",
     "lint:fix": "eslint src/ tests/ --fix",
     "format": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -102,7 +102,10 @@ export class LilbeeSettingTab extends PluginSettingTab {
     plugin: LilbeePlugin;
     /** Total bytes of the shared install, set by the storage report each render. */
     private storageTotalBytes = 0;
-    private serverConfigInputs: Map<string, HTMLInputElement> = new Map();
+    // Textareas live here too: the prompt fields are multi-line but are filled
+    // from a plain string like every other input, and both element types carry
+    // the value and placeholder this map is read for.
+    private serverConfigInputs: Map<string, HTMLInputElement | HTMLTextAreaElement> = new Map();
     private serverConfigToggles: Map<string, { setValue: (v: boolean) => unknown }> = new Map();
     private memoryToggles: Map<string, { setValue: (v: boolean) => unknown }> = new Map();
     private serverConfigTextAreas: Map<string, HTMLTextAreaElement> = new Map();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,16 @@
         "strict": true,
         "outDir": "./dist",
         "sourceMap": false,
-        "lib": ["DOM", "ES2022"],
-        "types": ["node"]
+        "lib": [
+            "DOM",
+            "ES2022"
+        ],
+        "types": [
+            "node"
+        ],
+        "skipLibCheck": true
     },
-    "include": ["src/**/*.ts"]
+    "include": [
+        "src/**/*.ts"
+    ]
 }


### PR DESCRIPTION
## Problem

Nothing typechecked. `esbuild` strips types without checking them, and CI ran lint, test, and build only. So a type error could ship, and one did: the wiki view read `event.type` on an `SSEEvent`, which has no `type` field, making every branch of the generate handler dead. The unit tests passed because the mocks were written to match the bug.

## What this adds

A `typecheck` script, and a CI step ahead of lint.

`skipLibCheck`, because Obsidian's own `.d.ts` does not typecheck and its three errors would otherwise drown ours.

One real fix it immediately found: a textarea was being registered into a `Map<string, HTMLInputElement>`. The map is only ever read for `value` and `placeholder`, which both element types carry, so it is widened rather than the field moved.

## Proof it catches the class

Reintroducing the shipped bug makes it fail:

```
src/views/wiki-view.ts(205,27): error TS2339: Property 'type' does not exist on type 'SSEEvent'.
```

## Not covered: the tests themselves

`tests/` still is not typechecked, which is the other half of how that bug hid. It is not a config flag away. vitest aliases `obsidian` to a mock, so a test program must use the same mapping or every mock helper reads as a missing property (1419 errors). Apply the mapping and `src` loses Obsidian's DOM augmentations instead (1029). Declaring those augmentations brings it to 662, and what remains is structural: `MockElement` and `HTMLElement` are used interchangeably across the boundary, and the mock exports neither `MenuItem` nor `activeDocument`.

Making the mock a type-faithful stand-in is real work and belongs on its own. Measurements are recorded on obl-axa so whoever picks it up starts from data rather than a guess.
