### PR TITLE
Make the tutorial's deep links land on the reel they name

### DIFF
--- a/site/tutorial/tutorial.js
+++ b/site/tutorial/tutorial.js
@@ -97,3 +97,21 @@ for (const g of groups) {
     list.appendChild(sec);
   }
 }
+
+// Every section on this page is built by the loop above, which runs after the
+// browser has already resolved the URL's hash. So arriving at /tutorial/#wiki
+// left you at the top of the page: the element the hash names did not exist
+// yet. Scroll to it once it does, and keep honouring the hash afterwards.
+function scrollToHash(behavior) {
+  const id = decodeURIComponent(location.hash.slice(1));
+  if (!id) return false;
+  const target = document.getElementById(id);
+  if (!target) return false;
+  target.scrollIntoView({ behavior: behavior, block: "start" });
+  return true;
+}
+
+scrollToHash("auto");
+window.addEventListener("hashchange", function () {
+  scrollToHash("smooth");
+});


### PR DESCRIPTION
## Problem

`https://obsidian.lilbee.sh/tutorial/#wiki` lands at the top of the page instead of the wiki reel. So does `#crawl`, and every other anchor, which means every "Watch it" link in the README goes to the wrong place.

Each section on that page is built in JavaScript. The browser resolves the hash while the page is still empty, finds nothing to scroll to, and gives up. Nothing ever revisits it.

## Fix

Scroll to the hash once the sections exist, and keep honouring it on `hashchange` so in-page links from the table of contents work too.

The script is `defer`red and the build loop is synchronous, so by the time this runs the target is in the document.
