### PR TITLE
Document the coding-agent pairing in the README and site

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,16 @@ From then on you search or chat with that copy offline. The citations click back
 
 <p align="center"><a href="https://obsidian.lilbee.sh/tutorial/#crawl"><img alt="crawl a Wikipedia page into the vault, ask a cited question, and jump to the cited section" src="https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/crawl.gif" width="640"></a></p>
 
+### Pair a coding agent with your library
+
+> **Watch it:** [pair a coding agent with lilbee](https://obsidian.lilbee.sh/tutorial/#claudian). One click connects the agent to your models and your library; it crawls a page in, answers a cited question, and writes a note back to your vault.
+
+The rest of the plugin searches and answers with citations. This takes those same local models further: it puts them behind a coding agent that can *act* on your vault, not just answer questions. The agent crawls new pages into your library, searches it, and writes notes and code back — multi-step work on your knowledge base, driven by models you host.
+
+Install a coding-agent plugin like [Claudian](https://obsidian.md/plugins?id=realclaudian) alongside lilbee and pair them in one click from a first-use prompt. The agent thinks on the models lilbee manages and reaches your library through lilbee's tools. No API key, no account, nothing leaves your machine. lilbee writes the agent's config with the live server address and token and keeps it fresh on every start, so the pairing never goes stale. Switch which agent or model it uses any time in Settings.
+
+<p align="center"><a href="https://obsidian.lilbee.sh/tutorial/#claudian"><img alt="pair Claudian with lilbee, crawl a Wikipedia page into the library, ask a cited question, and have the agent write a summary note back to the vault" src="https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/claudian.gif" width="640"></a></p>
+
 ### An encyclopedia of your documents
 
 > **Watch it:** [an encyclopedia of your documents](https://obsidian.lilbee.sh/tutorial/#wiki). Browse the pages as notes, follow a link, then ask for a subject it hasn't written and watch it write one.

--- a/site/index.html
+++ b/site/index.html
@@ -183,6 +183,7 @@
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-vision"    aria-controls="tutorial-pane-vision"    aria-selected="false" tabindex="-1">scanned PDF</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-crawl"     aria-controls="tutorial-pane-crawl"     aria-selected="false" tabindex="-1">crawl</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-crawlsite" aria-controls="tutorial-pane-crawlsite" aria-selected="false" tabindex="-1">crawl a site</button>
+          <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-claudian"  aria-controls="tutorial-pane-claudian"  aria-selected="false" tabindex="-1">coding agent</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-wiki"      aria-controls="tutorial-pane-wiki"      aria-selected="false" tabindex="-1">wiki</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-catalog"   aria-controls="tutorial-pane-catalog"   aria-selected="false" tabindex="-1">catalog</button>
           <button type="button" class="tutorialtab" role="tab" id="tutorial-tab-download"  aria-controls="tutorial-pane-download"  aria-selected="false" tabindex="-1">download a model</button>
@@ -265,6 +266,13 @@
             <video src="https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/crawl_site.webm" controls loop muted autoplay playsinline preload="metadata"></video>
           </div>
           <p class="tutorial-caption">Crawl a whole site one link deep into an empty vault, hundreds of pages streaming into the explorer as they index, then ask one multi-part question that only makes sense across all of it. A local model answers with reranking and cites several of the crawled pages.</p>
+        </div>
+
+        <div class="tutorialpane" role="tabpanel" id="tutorial-pane-claudian" aria-labelledby="tutorial-tab-claudian" hidden>
+          <div class="tutorial-clip">
+            <video src="https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/demos/claudian.webm" controls loop muted autoplay playsinline preload="metadata"></video>
+          </div>
+          <p class="tutorial-caption">The plugin searches and answers with citations; this takes lilbee's models further, putting them behind an agent that <em>acts</em> on your vault instead of just answering. Pair a coding agent in one click, then set it to work on your library: it crawls a Wikipedia page in, answers a cited question about it, takes a grounded follow-up, and writes a summary note back into your vault — on the same local models lilbee manages, shown live on the GPU beside the chat.</p>
         </div>
 
         <div class="tutorialpane" role="tabpanel" id="tutorial-pane-catalog" aria-labelledby="tutorial-tab-catalog" hidden>

--- a/site/tutorial/tutorial.js
+++ b/site/tutorial/tutorial.js
@@ -18,6 +18,13 @@ const groups = [
     ],
   },
   {
+    id: "put-your-models-to-work",
+    heading: "Put your models behind an agent",
+    reels: [
+      { id: "claudian", name: "claudian", title: "Pair a coding agent with your library", desc: "The rest of the plugin searches and answers with citations. This takes the same local models further, putting them behind a coding agent that acts on your vault instead of just answering. Pair it in one click from the first-use prompt, pick the model, and set it to work: it crawls a Wikipedia page into your library, answers a cited question about the 1994 Caprice V8 engines, takes a grounded follow-up, and writes a summary note back into your vault. It runs on the same models lilbee manages, shown live on the GPU placement view beside the chat, with no API key and nothing leaving your machine." },
+    ],
+  },
+  {
     id: "an-encyclopedia-of-your-own",
     heading: "An encyclopedia of your own",
     reels: [


### PR DESCRIPTION
Adds an agent-integration section to the README and a matching tutorial to the marketing site, pointing at the new reel now published on gh-pages.

The framing is that pairing a coding agent takes lilbee's local models beyond the plugin's own search-and-cite, putting them behind an agent that acts on your vault: it crawls a page into your library, answers a cited question, and writes a note back.

The README gets a "Pair a coding agent with your library" section with the reel gif. The site gets a "coding agent" tutorial tab on the landing page and its own entry on the full tutorial page under a new "Put your models behind an agent" section.
