### PR TITLE
Gate GPU placement on the server version, not the dev-builds opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,10 +216,6 @@ Turn reranking on in Settings when answers keep citing almost-right notes. It co
 
 ### Run a model bigger than one card
 
-> **Temporary note.** The multi-GPU features on this page need a lilbee dev build. The multi-GPU server is still being stabilized, which is why it's opt-in for now.
->
-> To try it: open **Settings → lilbee**, turn on **Include dev builds**, then pick the newest dev build under **Server version** and install it. The plugin tracks dev builds for updates from then on, and you can switch back to a stable release from the same picker at any time. This note goes away once the multi-GPU server ships in a stable release.
-
 When a chat model won't fit on one GPU, lilbee spreads it across the cards you have. It places the embedding, vision, and reranking models alongside it.
 
 The plugin's GPU placement view shows it all live: every card's utilization and memory, and which role runs where. The same view works on a single card. The demo at the top of this page is an Apple Silicon Mac with its one GPU doing everything.

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1118,10 +1118,10 @@ export const MESSAGES = {
     PLACEMENT_APPLY_NOT_ENABLED: "Applying placement isn't enabled on this lilbee server.",
     PLACEMENT_APPLY_FAILED: (msg: string): string => `Couldn't apply placement: ${msg}`,
     PLACEMENT_LOAD_FAILED: (msg: string): string => `Couldn't load placement: ${msg}`,
-    PLACEMENT_DEV_BUILDS_PROMPT:
-        "GPU placement and monitoring run on the lilbee dev builds for now, while the multi-GPU server is being stabilized. Continue to Settings to turn on Include dev builds and install the newest dev build from the Server version picker.",
+    PLACEMENT_UPDATE_SERVER_PROMPT:
+        "GPU placement and monitoring need lilbee server 0.6.90 or newer. Continue to Settings to update the server.",
     PLACEMENT_NEEDS_NEWER_SERVER:
-        "GPU placement and monitoring aren't available on this lilbee server yet. For now they ship in the dev builds: turn on Include dev builds under Settings, install the newest dev build from the Server version picker, and reopen this view.",
+        "GPU placement and monitoring aren't available on this lilbee server. Update the server to 0.6.90 or newer, then reopen this view.",
     PLACEMENT_WAITING_SERVER: "Waiting for the lilbee server to start. This view loads automatically once it's up.",
     PLACEMENT_GPU_NOTICE: (notice: string): string => `GPU monitoring: ${notice}`,
     PLACEMENT_GPU_NOTICE_TOOLTIP:

--- a/src/main.ts
+++ b/src/main.ts
@@ -90,6 +90,7 @@ import {
     openPluginSettingsById,
     percentOfBytes,
     sessionTokenInvalidMessage,
+    supportsPlacement,
     supportsSessions,
     STREAM_IDLE_TIMEOUT_MS,
     StreamIdleError,
@@ -302,8 +303,6 @@ export default class LilbeePlugin extends Plugin {
     private openingChatLeaf = false;
     // Same re-entrancy guard for the placement view's main-area tab and beside-chat split.
     private openingPlacementLeaf = false;
-    /** Set by the placement dev-builds prompt so the settings tab scrolls to the toggle. */
-    revealDevBuildsInSettings = false;
     taskQueue: TaskQueue = new TaskQueue();
     /** Paths whose most-recent add failed — retry skips the reindex confirm. */
     private failedAddPaths = new Set<string>();
@@ -2035,15 +2034,22 @@ export default class LilbeePlugin extends Plugin {
         return false;
     }
 
-    /** Saved conversations need the /api/sessions routes, which pre-0.6.90 servers
-     *  don't have. Managed mode knows the install version up front; external mode
-     *  fails open until the first health probe reports one. */
+    /** Saved conversations need the /api/sessions routes, which pre-0.6.90 servers don't have. */
     serverSupportsSessions(): boolean {
-        const version =
-            this.settings.serverMode === SERVER_MODE.MANAGED
-                ? this.getSharedLilbeeVersion()
-                : this.externalServerVersion;
-        return supportsSessions(version);
+        return supportsSessions(this.runningServerVersion());
+    }
+
+    /** GPU placement needs the /api/placement routes, which pre-0.6.90 servers don't have. */
+    serverSupportsPlacement(): boolean {
+        return supportsPlacement(this.runningServerVersion());
+    }
+
+    /** Managed mode knows the install version up front; external mode reports ""
+     *  (which fails open) until the first health probe caches one. */
+    private runningServerVersion(): string {
+        return this.settings.serverMode === SERVER_MODE.MANAGED
+            ? this.getSharedLilbeeVersion()
+            : this.externalServerVersion;
     }
 
     private async confirmReindexIfNeeded(name: string): Promise<boolean> {
@@ -2459,21 +2465,16 @@ export default class LilbeePlugin extends Plugin {
         }
     }
 
-    // TODO: remove this dev-builds gate once the multi-GPU server ships in a stable release.
-    /** GPU placement needs a dev-build server for now. Without the opt-in, explain
-     *  and offer to jump straight to Settings, where both the toggle and the
-     *  version picker live. */
+    /** When the running server predates the /api/placement routes, explain and
+     *  offer to jump straight to Settings, where the version picker lives. */
     private async openPlacementGated(open: () => Promise<void>): Promise<void> {
-        if (this.settings.includeDevBuilds) {
+        if (this.serverSupportsPlacement()) {
             await open();
             return;
         }
-        const modal = new ConfirmModal(this.app, MESSAGES.PLACEMENT_DEV_BUILDS_PROMPT);
+        const modal = new ConfirmModal(this.app, MESSAGES.PLACEMENT_UPDATE_SERVER_PROMPT);
         modal.open();
-        if (await modal.result) {
-            this.revealDevBuildsInSettings = true;
-            this.openPluginSettings();
-        }
+        if (await modal.result) this.openPluginSettings();
     }
 
     /** Open the placement view in a main-area tab (it is wider than the sidebar views). */

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -69,7 +69,6 @@ import {
 } from "./utils";
 
 const CHECK_TIMEOUT_MS = 5000;
-const DEV_BUILDS_FLASH_MS = 2400;
 /** GitHub's unauthenticated releases API allows 60 requests/hour per IP, so renders share one fetch. */
 const RELEASES_CACHE_TTL_MS = 10 * 60 * 1000;
 const CLS_MODELS_CONTAINER = "lilbee-models-container";
@@ -189,18 +188,6 @@ export class LilbeeSettingTab extends PluginSettingTab {
         this.loadServerDefaults();
         this.loadConfigDefaults();
         void this.applyCapabilityGating();
-        this.revealDevBuildsIfRequested(containerEl);
-    }
-
-    /** When the placement prompt routed here, land on the dev-builds toggle itself. */
-    private revealDevBuildsIfRequested(containerEl: HTMLElement): void {
-        if (!this.plugin.revealDevBuildsInSettings) return;
-        this.plugin.revealDevBuildsInSettings = false;
-        const row = containerEl.querySelector<HTMLElement>(".lilbee-dev-builds-setting");
-        if (!row) return;
-        row.scrollIntoView({ block: "center" });
-        row.addClass("lilbee-setting-flash");
-        window.setTimeout(() => row.removeClass("lilbee-setting-flash"), DEV_BUILDS_FLASH_MS);
     }
 
     private async applyCapabilityGating(): Promise<void> {
@@ -642,7 +629,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
 
     /** Opt in to in-development builds. */
     private renderDevBuildsToggle(containerEl: HTMLElement): void {
-        const setting = new Setting(containerEl)
+        new Setting(containerEl)
             .setName(MESSAGES.LABEL_INCLUDE_DEV_BUILDS)
             .setDesc(MESSAGES.DESC_INCLUDE_DEV_BUILDS)
             .addToggle((toggle) =>
@@ -652,7 +639,6 @@ export class LilbeeSettingTab extends PluginSettingTab {
                     this.render();
                 }),
             );
-        setting.settingEl.addClass("lilbee-dev-builds-setting");
     }
 
     /** Where bug reports go. Rendered at the top of the settings view in both server modes. */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -185,12 +185,21 @@ export function isVersionOlder(current: string, latest: string): boolean {
 }
 
 /** Oldest server with the /api/sessions routes; the 0.6.66 stable line predates them. */
-export const SESSIONS_MIN_SERVER_VERSION = "0.6.90b420";
+const SESSIONS_MIN_SERVER_VERSION = "0.6.90b420";
+
+/** Oldest server with the /api/placement routes; also new in the 0.6.90 line. */
+const PLACEMENT_MIN_SERVER_VERSION = "0.6.90b420";
 
 /** Unknown versions fail open: the chat path already degrades gracefully on a 404. */
 export function supportsSessions(version: string): boolean {
     if (!version) return true;
     return !isVersionOlder(version, SESSIONS_MIN_SERVER_VERSION);
+}
+
+/** Unknown versions fail open: the placement view renders its own explainer on a 404. */
+export function supportsPlacement(version: string): boolean {
+    if (!version) return true;
+    return !isVersionOlder(version, PLACEMENT_MIN_SERVER_VERSION);
 }
 
 /**

--- a/src/views/placement-view.ts
+++ b/src/views/placement-view.ts
@@ -125,8 +125,8 @@ export class PlacementView extends ItemView {
                 return;
             }
             this.waitingForServer = false;
-            // No /api/placement route: a stable server. The feature ships in the
-            // dev builds for now, so point at the opt-in instead of a raw 404.
+            // No /api/placement route: a pre-0.6.90 server. Point at the server
+            // update instead of a raw 404.
             if (isHttpStatus(result.error, HTTP_NOT_FOUND)) {
                 this.renderMessage(MESSAGES.PLACEMENT_NEEDS_NEWER_SERVER);
                 return;

--- a/styles.css
+++ b/styles.css
@@ -4758,27 +4758,6 @@ button.lilbee-model-chip-select:focus-visible {
     border-color: var(--text-error);
 }
 
-/* Flash the dev-builds row when the placement prompt lands the user on it. */
-.lilbee-setting-flash {
-    animation: lilbee-setting-flash 1.2s ease-in-out 2;
-    border-radius: var(--radius-s, 4px);
-}
-@keyframes lilbee-setting-flash {
-    0%,
-    100% {
-        background: transparent;
-    }
-    50% {
-        background: color-mix(in srgb, var(--interactive-accent) 18%, transparent);
-    }
-}
-@media (prefers-reduced-motion: reduce) {
-    .lilbee-setting-flash {
-        animation: none;
-        background: color-mix(in srgb, var(--interactive-accent) 14%, transparent);
-    }
-}
-
 .lilbee-sessions-modal {
     padding: var(--size-4-3, 12px);
 }

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -524,7 +524,7 @@ describe("LilbeePlugin", () => {
         });
 
         it("open-placement-beside-chat returns false when lilbee is not ready", async () => {
-            const plugin = await createPlugin({ includeDevBuilds: true });
+            const plugin = await createPlugin();
             await plugin.onload();
             vi.spyOn(plugin as any, "isLilbeeReady").mockReturnValue(false);
             const cmd = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.find(
@@ -534,7 +534,7 @@ describe("LilbeePlugin", () => {
         });
 
         it("open-placement-beside-chat returns false when no chat view is open", async () => {
-            const plugin = await createPlugin({ includeDevBuilds: true });
+            const plugin = await createPlugin();
             await plugin.onload();
             vi.spyOn(plugin as any, "isLilbeeReady").mockReturnValue(true);
             plugin.app.workspace.getLeavesOfType = vi.fn().mockReturnValue([]);
@@ -545,7 +545,7 @@ describe("LilbeePlugin", () => {
         });
 
         it("open-placement-beside-chat splits placement beside the chat leaf", async () => {
-            const plugin = await createPlugin({ includeDevBuilds: true });
+            const plugin = await createPlugin();
             await plugin.onload();
             vi.spyOn(plugin as any, "isLilbeeReady").mockReturnValue(true);
             const chatLeaf = new WorkspaceLeaf();
@@ -1216,7 +1216,7 @@ describe("LilbeePlugin", () => {
         });
 
         it("open-placement command activates the placement view", async () => {
-            const plugin = await createPlugin({ includeDevBuilds: true });
+            const plugin = await createPlugin();
             await plugin.onload();
             vi.spyOn(plugin as any, "isLilbeeReady").mockReturnValue(true);
             const activate = vi.spyOn(plugin as any, "activatePlacementView").mockResolvedValue(undefined);
@@ -1225,10 +1225,11 @@ describe("LilbeePlugin", () => {
             expect(activate).toHaveBeenCalled();
         });
 
-        it("open-placement without dev builds prompts and continues to Settings", async () => {
+        it("open-placement on a pre-placement server prompts and continues to Settings", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
             vi.spyOn(plugin as any, "isLilbeeReady").mockReturnValue(true);
+            vi.spyOn(plugin, "serverSupportsPlacement").mockReturnValue(false);
             const activate = vi.spyOn(plugin as any, "activatePlacementView").mockResolvedValue(undefined);
             const openSettings = vi.spyOn(plugin as any, "openPluginSettings").mockImplementation(() => {});
             mockConfirmModalResult = true;
@@ -1239,10 +1240,11 @@ describe("LilbeePlugin", () => {
             expect(openSettings).toHaveBeenCalled();
         });
 
-        it("open-placement without dev builds stays put when the prompt is cancelled", async () => {
+        it("open-placement on a pre-placement server stays put when the prompt is cancelled", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
             vi.spyOn(plugin as any, "isLilbeeReady").mockReturnValue(true);
+            vi.spyOn(plugin, "serverSupportsPlacement").mockReturnValue(false);
             const openSettings = vi.spyOn(plugin as any, "openPluginSettings").mockImplementation(() => {});
             mockConfirmModalResult = false;
             findCmd(plugin, "open-placement").checkCallback(false);
@@ -1251,7 +1253,7 @@ describe("LilbeePlugin", () => {
         });
 
         it("open-placement command is gated when lilbee is not ready", async () => {
-            const plugin = await createPlugin({ includeDevBuilds: true });
+            const plugin = await createPlugin();
             await plugin.onload();
             vi.spyOn(plugin as any, "isLilbeeReady").mockReturnValue(false);
             expect(findCmd(plugin, "open-placement").checkCallback(false)).toBe(false);
@@ -3227,6 +3229,31 @@ describe("LilbeePlugin", () => {
                 .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { version: "0.6.66b507" } });
             await (plugin as any).probeServerHealth();
             expect((plugin as any).externalServerVersion).toBe("");
+        });
+    });
+
+    describe("serverSupportsPlacement", () => {
+        it("managed mode gates on the recorded install version", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            const loadConfig = vi.spyOn(VaultRegistry.prototype, "loadConfig").mockReturnValue({
+                ...DEFAULT_SHARED_CONFIG,
+                lilbeeVersion: "v0.6.66b507",
+            });
+            expect(plugin.serverSupportsPlacement()).toBe(false);
+            loadConfig.mockReturnValue({ ...DEFAULT_SHARED_CONFIG, lilbeeVersion: "v0.6.90b420" });
+            expect(plugin.serverSupportsPlacement()).toBe(true);
+            loadConfig.mockRestore();
+        });
+
+        it("fails open while no version is recorded", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            const loadConfig = vi.spyOn(VaultRegistry.prototype, "loadConfig").mockReturnValue({
+                ...DEFAULT_SHARED_CONFIG,
+            });
+            expect(plugin.serverSupportsPlacement()).toBe(true);
+            loadConfig.mockRestore();
         });
     });
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -2355,49 +2355,6 @@ describe("managed mode settings", () => {
         setAttribute.mockRestore();
     });
 
-    it("scrolls to and flashes the dev-builds toggle when the placement prompt routed here", () => {
-        vi.useFakeTimers();
-        try {
-            mockListReleases.mockResolvedValue(RELEASES);
-            const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.3.0" });
-            (plugin as any).revealDevBuildsInSettings = true;
-            mockChatPicker(plugin);
-            const tab = makeTab(plugin);
-            const scrolled = vi.spyOn(MockElement.prototype, "scrollIntoView");
-
-            tab.display();
-
-            expect((plugin as any).revealDevBuildsInSettings).toBe(false);
-            expect(scrolled).toHaveBeenCalled();
-            const row = tab.containerEl.querySelector(".lilbee-dev-builds-setting")!;
-            expect(row.classList.contains("lilbee-setting-flash")).toBe(true);
-            vi.advanceTimersByTime(2500);
-            expect(row.classList.contains("lilbee-setting-flash")).toBe(false);
-            scrolled.mockRestore();
-        } finally {
-            vi.useRealTimers();
-        }
-    });
-    it("leaves the settings scroll alone when the reveal flag is off and when the row is absent", () => {
-        mockListReleases.mockResolvedValue(RELEASES);
-        const plugin = makePlugin({ serverMode: "external" });
-        (plugin as any).revealDevBuildsInSettings = true;
-        mockChatPicker(plugin);
-        const tab = makeTab(plugin);
-        const scrolled = vi.spyOn(MockElement.prototype, "scrollIntoView");
-        // External mode renders no dev-builds row: the flag clears, nothing scrolls.
-        tab.display();
-        expect(scrolled).not.toHaveBeenCalled();
-
-        // Flag off: display leaves everything alone.
-        const plugin2 = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.3.0" });
-        mockChatPicker(plugin2);
-        const tab2 = makeTab(plugin2);
-        tab2.display();
-        expect(scrolled).not.toHaveBeenCalled();
-        scrolled.mockRestore();
-    });
-
     it("version dropdown offers the recent releases newest first", async () => {
         mockListReleases.mockResolvedValue(RELEASES);
         const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.2.0" });

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -27,6 +27,7 @@ import {
     sessionTokenInvalidMessage,
     setDeterminateProgress,
     streamInterruptedMessage,
+    supportsPlacement,
     supportsSessions,
     withIdleTimeout,
 } from "../src/utils";
@@ -213,6 +214,24 @@ describe("supportsSessions", () => {
 
     it("fails open when the version is unknown", () => {
         expect(supportsSessions("")).toBe(true);
+    });
+});
+
+describe("supportsPlacement", () => {
+    it("rejects the 0.6.66 stable line and everything older", () => {
+        expect(supportsPlacement("v0.6.66b507")).toBe(false);
+        expect(supportsPlacement("0.6.66b507")).toBe(false);
+        expect(supportsPlacement("0.6.90b419")).toBe(false);
+    });
+
+    it("accepts the first placement build, its dev builds, and anything newer", () => {
+        expect(supportsPlacement("0.6.90b420")).toBe(true);
+        expect(supportsPlacement("v0.6.90b420.dev724")).toBe(true);
+        expect(supportsPlacement("0.6.91b1")).toBe(true);
+    });
+
+    it("fails open when the version is unknown", () => {
+        expect(supportsPlacement("")).toBe(true);
     });
 });
 

--- a/tests/views/placement-view.test.ts
+++ b/tests/views/placement-view.test.ts
@@ -387,12 +387,12 @@ describe("PlacementView load failure", () => {
         }
     });
 
-    it("points at dev builds when the server has no placement API (404)", async () => {
+    it("points at the server update when the server has no placement API (404)", async () => {
         const api = makeApi({
             placement: vi.fn().mockResolvedValue(err(new Error("Server responded 404: Not Found"))),
         });
         const { contentEl } = await openView(makePlugin(api));
-        expect(contentEl.find("lilbee-placement-empty")!.textContent).toContain("Include dev builds");
+        expect(contentEl.find("lilbee-placement-empty")!.textContent).toContain("Update the server");
         expect(contentEl.find("lilbee-placement-empty")!.textContent).not.toContain("404");
     });
 


### PR DESCRIPTION
## Problem

The GPU placement view is gated on the Include dev builds setting. Now that the multi-GPU server ships in a stable release, that gate blocks stable-channel users whose server already has the placement routes, and it checks a local setting rather than the server that is actually running.

## Solution

Placement now gates on the running server's version, the same way saved conversations do: managed mode checks the installed version, external mode checks the version from the health probe, and an unknown version fails open. When the server is too old, the prompt and the placement view's 404 message both say to update the server instead of pointing at the dev-builds toggle.

## Removed

The dev-builds reveal plumbing (the settings scroll-and-flash and its CSS) and the temporary README note that told readers to install a dev build for multi-GPU.