### PR TITLE
Download the ROCm server build on AMD hardware it can serve

### DIFF
--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -22,7 +22,7 @@ import {
 import { basename, join, resolve, dirname } from "path";
 import { createHash } from "crypto";
 import { promisify } from "util";
-import { ARCH, PLATFORM, SERVER_VARIANT, type CudaTag, type ServerVariant } from "./types";
+import { ARCH, PLATFORM, SERVER_VARIANT, type CudaTag, type GpuTag, type ServerVariant } from "./types";
 import { formatDiskSize } from "./utils";
 
 const execFileAsync = promisify(execFile);
@@ -117,14 +117,85 @@ export async function detectCudaTag(): Promise<CudaTag | null> {
     return pickCudaTag(ceiling);
 }
 
-export function getPlatformAssetName(cudaTag?: CudaTag | null): string {
+/** The amdgpu compute device. Without it ROCm cannot run, whatever else sysfs says. */
+const KFD_DEVICE_PATH = "/dev/kfd";
+
+/** Where the amdgpu driver describes each compute device it exposes. */
+const KFD_TOPOLOGY_NODES = "/sys/class/kfd/kfd/topology/nodes";
+
+/** The gfx name for a KFD `gfx_target_version`; minor and step print as hex (90010 -> gfx90a). */
+function gfxTargetName(version: number): string {
+    const major = Math.floor(version / 10000);
+    const minor = Math.floor((version % 10000) / 100);
+    const step = version % 100;
+    return `gfx${major}${minor.toString(16)}${step.toString(16)}`;
+}
+
+/** The gfx target a KFD node reports, or null for a CPU node (which reports 0) and unreadable ones. */
+function nodeGfxTarget(nodeName: string): string | null {
+    let text: string;
+    try {
+        text = node.readFileSync(node.join(KFD_TOPOLOGY_NODES, nodeName, "properties"), "utf-8") as string;
+    } catch {
+        return null;
+    }
+    for (const line of text.split("\n")) {
+        const [name, value] = line.trim().split(/\s+/);
+        if (name !== "gfx_target_version") continue;
+        const version = Number(value);
+        if (Number.isInteger(version) && version > 0) return gfxTargetName(version);
+    }
+    return null;
+}
+
+/**
+ * The gfx targets of this host's AMD GPUs, read from the amdgpu driver's KFD topology.
+ * Empty on any platform but Linux, when the host has no AMD compute device, and on any
+ * read failure. Read from the driver rather than from rocm-smi or amd-smi: those ship
+ * with ROCm, which the ROCm build bundles, so the host needs only the amdgpu driver.
+ */
+export function detectAmdGfxTargets(): string[] {
+    if (process.platform !== PLATFORM.LINUX) return [];
+    if (!node.existsSync(KFD_DEVICE_PATH)) return [];
+    let nodes: string[];
+    try {
+        nodes = node.readdirSync(KFD_TOPOLOGY_NODES) as unknown as string[];
+    } catch {
+        return [];
+    }
+    const targets = new Set<string>();
+    for (const nodeName of nodes) {
+        const target = nodeGfxTarget(nodeName);
+        if (target) targets.add(target);
+    }
+    return [...targets].sort();
+}
+
+/** What this host can run, resolved once per release check. */
+interface HostGpu {
+    /** The newest CUDA build the NVIDIA driver supports, or null. */
+    cuda: CudaTag | null;
+    /** The gfx targets of the host's AMD GPUs; empty when there are none. */
+    amdGfxTargets: string[];
+}
+
+async function detectHostGpu(): Promise<HostGpu> {
+    return { cuda: await detectCudaTag(), amdGfxTargets: detectAmdGfxTargets() };
+}
+
+export function getPlatformAssetName(gpuTag?: GpuTag | null): string {
     const platform = process.platform;
     const arch = process.arch;
-    const cuda = cudaTag ? `-${cudaTag}` : "";
+    const gpu = gpuTag ? `-${gpuTag}` : "";
     if (platform === PLATFORM.DARWIN && arch === ARCH.ARM64) return "lilbee-macos-arm64";
-    if (platform === PLATFORM.LINUX && arch === ARCH.X64) return `lilbee-linux-x86_64${cuda}`;
-    if (platform === PLATFORM.WIN32 && arch === ARCH.X64) return `lilbee-windows-x86_64${cuda}.exe`;
+    if (platform === PLATFORM.LINUX && arch === ARCH.X64) return `lilbee-linux-x86_64${gpu}`;
+    if (platform === PLATFORM.WIN32 && arch === ARCH.X64) return `lilbee-windows-x86_64${gpu}.exe`;
     throw new Error(`Unsupported platform: ${platform}/${arch}`);
+}
+
+/** The asset name of a build, for showing which file an install downloads. */
+export function assetNameForVariant(variant: ServerVariant): string {
+    return getPlatformAssetName(variant === SERVER_VARIANT.DEFAULT ? null : variant);
 }
 
 interface GitHubAsset {
@@ -151,20 +222,70 @@ export interface ReleaseInfo {
     digest: string | null;
 }
 
-/** Choose the CUDA asset when detected and shipped; otherwise the default build. */
-function selectAsset(data: GitHubRelease, cudaTag: CudaTag | null): { variant: ServerVariant; asset: GitHubAsset } {
-    if (cudaTag) {
-        const cudaAsset = data.assets.find((a) => a.name === getPlatformAssetName(cudaTag));
-        if (cudaAsset) return { variant: cudaTag, asset: cudaAsset };
+/** Suffix of the manifest published beside a ROCm build, listing the targets it ships kernels for. */
+const GFX_MANIFEST_SUFFIX = ".gfx.txt";
+
+/**
+ * The gfx targets a release's ROCm build ships kernels for, or null when it makes no
+ * claim: no manifest, an unreachable one, or an empty one. Null is "unknown", never
+ * "supports nothing" — an unknown keeps the default build rather than risking a build
+ * the server would refuse to start.
+ */
+async function shippedGfxTargets(manifest: GitHubAsset | undefined): Promise<Set<string> | null> {
+    if (!manifest) return null;
+    try {
+        const res = await node.requestUrl({ url: manifest.browser_download_url });
+        if (res.status >= 400) return null;
+        const targets = res.text
+            .split("\n")
+            .map((line) => line.trim())
+            .filter(Boolean);
+        return targets.length > 0 ? new Set(targets) : null;
+    } catch {
+        return null;
     }
-    const defaultName = getPlatformAssetName(null);
-    const asset = data.assets.find((a) => a.name === defaultName);
-    if (!asset) throw new Error(`No asset "${defaultName}" in release ${data.tag_name}`);
-    return { variant: SERVER_VARIANT.DEFAULT, asset };
 }
 
-function toReleaseInfo(data: GitHubRelease, cudaTag: CudaTag | null): ReleaseInfo {
-    const { variant, asset } = selectAsset(data, cudaTag);
+/**
+ * Whether the ROCm build serves every AMD GPU on this host. All of them, not any: the
+ * build refuses to start on a card it ships no kernels for, so a host it only partly
+ * covers is better served by the default build, which runs all of them over Vulkan.
+ */
+async function rocmServesHost(data: GitHubRelease, gfxTargets: string[]): Promise<boolean> {
+    const manifestName = `${getPlatformAssetName(SERVER_VARIANT.ROCM)}${GFX_MANIFEST_SUFFIX}`;
+    const shipped = await shippedGfxTargets(data.assets.find((a) => a.name === manifestName));
+    return shipped !== null && gfxTargets.every((target) => shipped.has(target));
+}
+
+/** A release that ships a build for this machine, with the build it falls back to. */
+interface InstallableRelease {
+    data: GitHubRelease;
+    /** The default build, carried from the check that found it, so no later step can miss it. */
+    fallback: GitHubAsset;
+}
+
+/** Choose the vendor asset the host can run and the release ships; otherwise the default build. */
+async function selectAsset(
+    release: InstallableRelease,
+    host: HostGpu,
+): Promise<{ variant: ServerVariant; asset: GitHubAsset }> {
+    const { data } = release;
+    if (host.cuda) {
+        const cudaAsset = data.assets.find((a) => a.name === getPlatformAssetName(host.cuda));
+        if (cudaAsset) return { variant: host.cuda, asset: cudaAsset };
+    }
+    if (host.amdGfxTargets.length > 0) {
+        const rocmAsset = data.assets.find((a) => a.name === getPlatformAssetName(SERVER_VARIANT.ROCM));
+        if (rocmAsset && (await rocmServesHost(data, host.amdGfxTargets))) {
+            return { variant: SERVER_VARIANT.ROCM, asset: rocmAsset };
+        }
+    }
+    return { variant: SERVER_VARIANT.DEFAULT, asset: release.fallback };
+}
+
+async function toReleaseInfo(release: InstallableRelease, host: HostGpu): Promise<ReleaseInfo> {
+    const { variant, asset } = await selectAsset(release, host);
+    const { data } = release;
     return {
         tag: data.tag_name,
         assetUrl: asset.browser_download_url,
@@ -179,6 +300,18 @@ export function isDevBuild(tag: string): boolean {
     return /\.dev\d*$/i.test(tag);
 }
 
+/** The default build for this machine, the asset every install falls back to, or null when
+ *  the release ships none — including on a platform lilbee publishes no build for at all. */
+function platformFallbackAsset(data: GitHubRelease): GitHubAsset | null {
+    let defaultName: string;
+    try {
+        defaultName = getPlatformAssetName(null);
+    } catch {
+        return null; // unsupported platform: no release is installable here
+    }
+    return data.assets.find((a) => a.name === defaultName) ?? null;
+}
+
 /**
  * Published releases that ship a build for this machine, newest first: up to *limit* stable
  * releases, plus up to *limit* dev builds when includeDev is set. The quotas are per kind so a
@@ -186,9 +319,8 @@ export function isDevBuild(tag: string): boolean {
  * and releases without a matching asset are left out. Pages through the releases API until
  * both quotas are filled, a short (final) page arrives, or the page budget is exhausted.
  */
-async function fetchInstallableReleases(limit: number, includeDev: boolean): Promise<ReleaseInfo[]> {
-    const cudaTag = await detectCudaTag();
-    const releases: ReleaseInfo[] = [];
+async function collectInstallableReleases(limit: number, includeDev: boolean): Promise<InstallableRelease[]> {
+    const releases: InstallableRelease[] = [];
     let stableCount = 0;
     let devCount = 0;
     for (let page = 1; page <= RELEASE_PAGE_BUDGET; page++) {
@@ -204,12 +336,9 @@ async function fetchInstallableReleases(limit: number, includeDev: boolean): Pro
             const dev = isDevBuild(data.tag_name);
             if (dev && !includeDev) continue;
             if (dev ? devCount >= limit : stableCount >= limit) continue;
-            try {
-                releases.push(toReleaseInfo(data, cudaTag));
-            } catch {
-                // Release ships no build for this platform; it isn't installable here.
-                continue;
-            }
+            const fallback = platformFallbackAsset(data);
+            if (!fallback) continue;
+            releases.push({ data, fallback });
             if (dev) devCount++;
             else stableCount++;
             if (stableCount >= limit && (!includeDev || devCount >= limit)) return releases;
@@ -217,6 +346,17 @@ async function fetchInstallableReleases(limit: number, includeDev: boolean): Pro
         if (pageData.length < RELEASE_PAGE_SIZE) break; // last page
     }
     return releases;
+}
+
+/**
+ * Installable releases with the build this host should run resolved for each. The releases
+ * resolve together rather than one after another: picking the ROCm build reads a manifest
+ * per release, and a version list would otherwise pay that round trip ten times over.
+ */
+async function fetchInstallableReleases(limit: number, includeDev: boolean): Promise<ReleaseInfo[]> {
+    const host = await detectHostGpu();
+    const candidates = await collectInstallableReleases(limit, includeDev);
+    return Promise.all(candidates.map((release) => toReleaseInfo(release, host)));
 }
 
 /**

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,4 +1,4 @@
-import { AGENT_CLIENT, MODEL_TASK, type WorkerRole } from "../types";
+import { AGENT_CLIENT, MODEL_TASK, SERVER_VARIANT, type ServerVariant, type WorkerRole } from "../types";
 
 // Natural-language noun for each worker role, so tooltips read "embedding
 // worker" rather than the internal "embed".
@@ -391,6 +391,14 @@ export const MESSAGES = {
     DESC_SERVER_VERSION_DOWNGRADE: (installed: string) =>
         `${installed} installed. Downgrading replaces it with an older build and turns off automatic server updates.`,
     DESC_SERVER_VERSION_LOADING: "Reading the release list from GitHub...",
+    /** How a server build is named wherever the user sees one. macOS ships Metal in the
+     *  default build and Linux and Windows ship Vulkan, so the default is named for neither. */
+    LABEL_SERVER_BUILD: (variant: ServerVariant): string => {
+        if (variant === SERVER_VARIANT.ROCM) return "ROCm";
+        if (variant === SERVER_VARIANT.DEFAULT) return "default";
+        return `CUDA ${variant.slice(2, 4)}.${variant.slice(4)}`;
+    },
+    DESC_SERVER_BUILD: (build: string) => ` Running the ${build} build.`,
     DESC_SERVER_VERSION_OFFLINE: (tag: string, reason: string) =>
         `${tag} installed. The release list could not be read from GitHub: ${reason}`,
     DESC_DEV_BUILD_AVAILABLE: (tag: string) =>
@@ -647,6 +655,8 @@ export const MESSAGES = {
     ERROR_FAILED_UPDATE: "lilbee: update failed",
     NOTICE_SERVER_AUTO_UPDATING: (version: string) => `lilbee: updating server to ${version}...`,
     NOTICE_SERVER_AUTO_UPDATED: (version: string) => `lilbee server updated to ${version}`,
+    NOTICE_SERVER_SWITCHING_BUILD: (build: string) => `lilbee: switching to the ${build} build for your GPU...`,
+    NOTICE_SERVER_SWITCHED_BUILD: (build: string) => `lilbee server now runs the ${build} build`,
     NOTICE_SERVER_AUTO_UPDATE_FAILED: "lilbee: automatic server update failed. You can retry from settings.",
     NOTICE_EXTERNAL_SERVER_OUTDATED: (current: string, latest: string): string =>
         `Your lilbee server (${current}) is behind the latest release (${latest}). Update it to get the newest features and fixes.`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1015,10 +1015,22 @@ export default class LilbeePlugin extends Plugin {
         registry.saveConfig({ ...config, lastUpdateCheckPluginVersion: this.manifest.version });
         if (!result.available || !result.release) return;
         const release = result.release;
-        const notice = new Notice(MESSAGES.NOTICE_SERVER_AUTO_UPDATING(release.tag), NOTICE_PERMANENT);
+        // A build switch keeps the version it already has, so naming the version would
+        // report an update to the version the user is on. Name the build instead.
+        const installedVariant = this.getSharedLilbeeVariant();
+        const build =
+            installedVariant !== "" && installedVariant !== release.variant
+                ? MESSAGES.LABEL_SERVER_BUILD(release.variant)
+                : null;
+        const notice = new Notice(
+            build ? MESSAGES.NOTICE_SERVER_SWITCHING_BUILD(build) : MESSAGES.NOTICE_SERVER_AUTO_UPDATING(release.tag),
+            NOTICE_PERMANENT,
+        );
         try {
             await this.updateServer(release);
-            new Notice(MESSAGES.NOTICE_SERVER_AUTO_UPDATED(release.tag));
+            new Notice(
+                build ? MESSAGES.NOTICE_SERVER_SWITCHED_BUILD(build) : MESSAGES.NOTICE_SERVER_AUTO_UPDATED(release.tag),
+            );
         } catch {
             new Notice(MESSAGES.NOTICE_SERVER_AUTO_UPDATE_FAILED, NOTICE_ERROR_DURATION_MS);
         } finally {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -544,6 +544,11 @@ export class LilbeeSettingTab extends PluginSettingTab {
             const tags = releases.map((r) => r.tag);
             const action = versionActionFor(tags, installed, selectedTag);
             let desc = versionDescription(action, installed, selectedTag, tags[0] === installed);
+            // Which build is installed answers why the download was the size it was.
+            const installedBuild = this.plugin.getSharedLilbeeVariant();
+            if (installed && installedBuild) {
+                desc += MESSAGES.DESC_SERVER_BUILD(MESSAGES.LABEL_SERVER_BUILD(installedBuild));
+            }
             if (newerDevTag) desc += ` ${MESSAGES.DESC_DEV_BUILD_AVAILABLE(newerDevTag)}`;
             setting.setDesc(desc);
             actionBtn.setButtonText(versionButtonLabel(action, selectedTag));

--- a/src/types.ts
+++ b/src/types.ts
@@ -1309,13 +1309,18 @@ export const ARCH = {
 
 /** The CUDA build tags lilbee ships, newest first. */
 export type CudaTag = "cu121" | "cu124" | "cu125";
-/** Which lilbee server build is installed: the default (Vulkan/CPU) build or a CUDA build. */
-export type ServerVariant = "default" | CudaTag;
+/** The ROCm build tag lilbee ships. Linux x86_64 only. */
+export type RocmTag = "rocm";
+/** A vendor build tag, as it appears in the release asset name. */
+export type GpuTag = CudaTag | RocmTag;
+/** Which lilbee server build is installed: the default (Vulkan/CPU) build or a vendor build. */
+export type ServerVariant = "default" | GpuTag;
 export const SERVER_VARIANT = {
     DEFAULT: "default",
     CU121: "cu121",
     CU124: "cu124",
     CU125: "cu125",
+    ROCM: "rocm",
 } as const satisfies Record<string, ServerVariant>;
 
 /** Source of the lilbee server binary; surfaced wherever the unsigned download is explained. */

--- a/src/views/managed-consent-modal.ts
+++ b/src/views/managed-consent-modal.ts
@@ -1,11 +1,11 @@
 import { App, Modal, setIcon } from "obsidian";
 import { MESSAGES } from "../locales/en";
-import { MANAGED_CONSENT_RESULT, type ManagedConsentResult } from "../types";
+import { MANAGED_CONSENT_RESULT, type ManagedConsentResult, type ServerVariant } from "../types";
 import {
     GITHUB_REPO,
     LILBEE_GITHUB_REPO_URL,
     getLatestRelease,
-    getPlatformAssetName,
+    assetNameForVariant,
     type ReleaseInfo,
 } from "../binary-manager";
 
@@ -112,7 +112,7 @@ export class ManagedConsentModal extends Modal {
         const asset = this.provBody.createDiv({ cls: "lilbee-managed-consent-prov-asset" });
         asset.createSpan({
             cls: "lilbee-managed-consent-prov-asset-name",
-            text: safeAssetName(),
+            text: safeAssetName(release.variant),
         });
         asset.createSpan({
             cls: "lilbee-managed-consent-prov-asset-size",
@@ -186,9 +186,10 @@ export class ManagedConsentModal extends Modal {
     }
 }
 
-function safeAssetName(): string {
+/** The file this install downloads. Named from the resolved build, so the name matches the size. */
+function safeAssetName(variant: ServerVariant): string {
     try {
-        return getPlatformAssetName(null);
+        return assetNameForVariant(variant);
     } catch {
         return "lilbee";
     }

--- a/tests/binary-manager.test.ts
+++ b/tests/binary-manager.test.ts
@@ -11,6 +11,7 @@ import {
     isDevBuild,
     checkForUpdate,
     detectCudaTag,
+    detectAmdGfxTargets,
     BinaryManager,
 } from "../src/binary-manager";
 
@@ -80,6 +81,24 @@ function stubEnoughSpace() {
 /** Mock nvidia-smi as absent (no NVIDIA driver). */
 function stubNoNvidia() {
     return vi.spyOn(node, "execFile").mockRejectedValue(new Error("nvidia-smi not found"));
+}
+
+/** Mock the amdgpu KFD topology: one node per gfx_target_version, plus a CPU node reporting 0. */
+function stubKfdTopology(versions: number[]) {
+    vi.spyOn(node, "existsSync").mockImplementation((path: string) => path === "/dev/kfd");
+    vi.spyOn(node, "readdirSync").mockReturnValue(
+        versions.map((_v, i) => String(i + 1)).concat("0") as unknown as ReturnType<typeof node.readdirSync>,
+    );
+    vi.spyOn(node, "readFileSync").mockImplementation((path: string) => {
+        const index = Number(String(path).split("/").at(-2));
+        const version = index === 0 ? 0 : versions[index - 1];
+        return `cpu_cores_count 8\ngfx_target_version ${version}\nsimd_count 0\n`;
+    });
+}
+
+/** Mock a host with no AMD compute device (no /dev/kfd). */
+function stubNoAmd() {
+    return vi.spyOn(node, "existsSync").mockReturnValue(false);
 }
 
 /* ------------------------------------------------------------------ */
@@ -181,6 +200,80 @@ describe("detectCudaTag", () => {
         restore = stubPlatform("win32", "x64");
         vi.spyOn(node, "execFile").mockResolvedValue({ stdout: "CUDA Version: 11.8", stderr: "" });
         expect(await detectCudaTag()).toBeNull();
+    });
+});
+
+/* ------------------------------------------------------------------ */
+/*  detectAmdGfxTargets                                               */
+/* ------------------------------------------------------------------ */
+
+describe("detectAmdGfxTargets", () => {
+    let restore: () => void;
+    afterEach(() => restore?.());
+
+    it("returns nothing on macOS without touching the filesystem", () => {
+        restore = stubPlatform("darwin", "arm64");
+        const exists = vi.spyOn(node, "existsSync");
+        expect(detectAmdGfxTargets()).toEqual([]);
+        expect(exists).not.toHaveBeenCalled();
+    });
+
+    it("returns nothing when the host exposes no compute device", () => {
+        restore = stubPlatform("linux", "x64");
+        stubNoAmd();
+        expect(detectAmdGfxTargets()).toEqual([]);
+    });
+
+    it("names the gfx target the driver reports", () => {
+        restore = stubPlatform("linux", "x64");
+        stubKfdTopology([110000]);
+        expect(detectAmdGfxTargets()).toEqual(["gfx1100"]);
+    });
+
+    it.each([
+        [90010, "gfx90a"],
+        [90402, "gfx942"],
+        [90006, "gfx906"],
+        [100103, "gfx1013"],
+        [120001, "gfx1201"],
+    ])("prints target version %i as %s", (version, name) => {
+        restore = stubPlatform("linux", "x64");
+        stubKfdTopology([version]);
+        expect(detectAmdGfxTargets()).toEqual([name]);
+    });
+
+    it("reports every card on a multi-GPU host, without duplicates", () => {
+        restore = stubPlatform("linux", "x64");
+        stubKfdTopology([110000, 90006, 110000]);
+        expect(detectAmdGfxTargets()).toEqual(["gfx1100", "gfx906"]);
+    });
+
+    it("ignores CPU nodes, which report no target", () => {
+        restore = stubPlatform("linux", "x64");
+        stubKfdTopology([]);
+        expect(detectAmdGfxTargets()).toEqual([]);
+    });
+
+    it("skips a node whose properties cannot be read", () => {
+        restore = stubPlatform("linux", "x64");
+        stubKfdTopology([110000, 90006]);
+        const readFileSync = node.readFileSync as unknown as ReturnType<typeof vi.fn>;
+        const readable = readFileSync.getMockImplementation()!;
+        readFileSync.mockImplementation((path: string) => {
+            if (String(path).includes("/2/")) throw new Error("EACCES");
+            return readable(path);
+        });
+
+        expect(detectAmdGfxTargets()).toEqual(["gfx1100"]);
+    });
+
+    it("returns nothing when the topology cannot be read", () => {
+        restore = stubPlatform("linux", "x64");
+        vi.spyOn(node, "existsSync").mockReturnValue(true);
+        vi.spyOn(node, "readdirSync").mockImplementation(() => {
+            throw new Error("EACCES");
+        });
+        expect(detectAmdGfxTargets()).toEqual([]);
     });
 });
 
@@ -298,6 +391,150 @@ describe("getLatestRelease", () => {
         });
         // listReleases suppresses the per-release CUDA-fallback warning.
         expect(warn).not.toHaveBeenCalled();
+    });
+
+    /** A release carrying the default build, the ROCm build, and the kernel manifest. */
+    function rocmRelease(tag: string, shipped: string[] | null) {
+        const assets = [
+            {
+                name: "lilbee-linux-x86_64",
+                browser_download_url: "https://e/default",
+                size: 10,
+                digest: "sha256:default",
+            },
+            {
+                name: "lilbee-linux-x86_64-rocm",
+                browser_download_url: "https://e/rocm",
+                size: 20,
+                digest: "sha256:rocm",
+            },
+        ];
+        if (shipped !== null) {
+            assets.push({
+                name: "lilbee-linux-x86_64-rocm.gfx.txt",
+                browser_download_url: "https://e/rocm.gfx.txt",
+                size: 30,
+                digest: "sha256:manifest",
+            });
+        }
+        return { tag_name: tag, assets };
+    }
+
+    /** Answer the release list with *releases*, and the manifest URL with *manifest* text. */
+    function stubReleasesAndManifest(releases: unknown[], manifest: string | null) {
+        vi.spyOn(node, "requestUrl").mockImplementation((async (req: { url: string }) => {
+            if (!req.url.endsWith(".gfx.txt")) return releaseResponse(releases);
+            if (manifest === null) throw new Error("404");
+            return { status: 200, text: manifest, arrayBuffer: new ArrayBuffer(0), headers: {} };
+        }) as unknown as typeof node.requestUrl);
+    }
+
+    it("prefers the ROCm build when the manifest covers the host's card", async () => {
+        restore = stubPlatform("linux", "x64");
+        stubNoNvidia();
+        stubKfdTopology([110000]);
+        stubReleasesAndManifest([rocmRelease("v1.0.0", [])], "gfx908\ngfx90a\ngfx1100\ngfx1201\n");
+
+        expect(await getLatestRelease(false)).toEqual({
+            tag: "v1.0.0",
+            assetUrl: "https://e/rocm",
+            variant: "rocm",
+            sizeBytes: 20,
+            digest: "sha256:rocm",
+        });
+    });
+
+    it("keeps the default build when the ROCm build ships no kernels for the card", async () => {
+        restore = stubPlatform("linux", "x64");
+        stubNoNvidia();
+        stubKfdTopology([90006]);
+        stubReleasesAndManifest([rocmRelease("v1.0.0", [])], "gfx908\ngfx90a\ngfx1100\n");
+
+        const release = await getLatestRelease(false);
+        expect(release.variant).toBe("default");
+        expect(release.assetUrl).toBe("https://e/default");
+    });
+
+    it("keeps the default build when only one of two cards is covered", async () => {
+        restore = stubPlatform("linux", "x64");
+        stubNoNvidia();
+        stubKfdTopology([110000, 90006]);
+        stubReleasesAndManifest([rocmRelease("v1.0.0", [])], "gfx1100\n");
+
+        expect((await getLatestRelease(false)).variant).toBe("default");
+    });
+
+    it("keeps the default build when the release publishes no manifest", async () => {
+        restore = stubPlatform("linux", "x64");
+        stubNoNvidia();
+        stubKfdTopology([110000]);
+        stubReleasesAndManifest([rocmRelease("v1.0.0", null)], null);
+
+        expect((await getLatestRelease(false)).variant).toBe("default");
+    });
+
+    it("keeps the default build when the manifest cannot be fetched", async () => {
+        restore = stubPlatform("linux", "x64");
+        stubNoNvidia();
+        stubKfdTopology([110000]);
+        stubReleasesAndManifest([rocmRelease("v1.0.0", [])], null);
+
+        expect((await getLatestRelease(false)).variant).toBe("default");
+    });
+
+    it("keeps the default build when the manifest read answers an error status", async () => {
+        restore = stubPlatform("linux", "x64");
+        stubNoNvidia();
+        stubKfdTopology([110000]);
+        vi.spyOn(node, "requestUrl").mockImplementation((async (req: { url: string }) => {
+            if (!req.url.endsWith(".gfx.txt")) return releaseResponse([rocmRelease("v1.0.0", [])]);
+            return { status: 404, text: "Not Found", arrayBuffer: new ArrayBuffer(0), headers: {} };
+        }) as unknown as typeof node.requestUrl);
+
+        expect((await getLatestRelease(false)).variant).toBe("default");
+    });
+
+    it("keeps the default build when the manifest is empty", async () => {
+        restore = stubPlatform("linux", "x64");
+        stubNoNvidia();
+        stubKfdTopology([110000]);
+        stubReleasesAndManifest([rocmRelease("v1.0.0", [])], "\n \n");
+
+        expect((await getLatestRelease(false)).variant).toBe("default");
+    });
+
+    it("prefers CUDA over ROCm on a host with both vendors", async () => {
+        restore = stubPlatform("linux", "x64");
+        vi.spyOn(node, "execFile").mockResolvedValue({ stdout: "CUDA Version: 12.5", stderr: "" });
+        stubKfdTopology([110000]);
+        const release = rocmRelease("v1.0.0", []);
+        release.assets.push({
+            name: "lilbee-linux-x86_64-cu125",
+            browser_download_url: "https://e/cu125",
+            size: 40,
+            digest: "sha256:cu125",
+        });
+        stubReleasesAndManifest([release], "gfx1100\n");
+
+        expect((await getLatestRelease(false)).variant).toBe("cu125");
+    });
+
+    it("does not read the ROCm manifest on a host with no AMD card", async () => {
+        restore = stubPlatform("linux", "x64");
+        stubNoNvidia();
+        stubNoAmd();
+        const requestUrl = vi.spyOn(node, "requestUrl").mockResolvedValue(releaseResponse([rocmRelease("v1.0.0", [])]));
+
+        expect((await getLatestRelease(false)).variant).toBe("default");
+        expect(requestUrl.mock.calls.some(([req]) => (req as { url: string }).url.endsWith(".gfx.txt"))).toBe(false);
+    });
+
+    it("finds nothing installable on a platform lilbee ships no build for", async () => {
+        restore = stubPlatform("freebsd", "arm");
+        stubNoNvidia();
+        vi.spyOn(node, "requestUrl").mockResolvedValue(releaseResponse([linuxRelease("v1.0.0")]));
+
+        await expect(getLatestRelease(false)).rejects.toThrow("No installable lilbee release was found.");
     });
 
     it("returns the latest stable build, skipping a newer dev build, by default", async () => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -6390,6 +6390,34 @@ describe("LilbeePlugin", () => {
             expect(Notice.instances.map((n) => n.message)).toContain(MESSAGES.NOTICE_SERVER_AUTO_UPDATED(RELEASE.tag));
         });
 
+        it("names the build, not the version, when the update is a build switch", async () => {
+            const rocm = { ...RELEASE, tag: "v0.1.0", variant: "rocm" as const };
+            const plugin = await createPlugin({ serverMode: "managed" });
+            vi.spyOn(plugin, "checkForUpdate").mockResolvedValue({ available: true, release: rocm });
+            vi.spyOn(plugin, "updateServer").mockResolvedValue(undefined);
+            vi.spyOn(plugin as any, "getSharedLilbeeVariant").mockReturnValue("default");
+            seedSharedConfig("");
+            await plugin.onload();
+            await flush();
+
+            const messages = Notice.instances.map((n) => n.message);
+            expect(messages).toContain(MESSAGES.NOTICE_SERVER_SWITCHING_BUILD("ROCm"));
+            expect(messages).toContain(MESSAGES.NOTICE_SERVER_SWITCHED_BUILD("ROCm"));
+            expect(messages).not.toContain(MESSAGES.NOTICE_SERVER_AUTO_UPDATED(rocm.tag));
+        });
+
+        it("names the version when the build is unchanged", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            vi.spyOn(plugin, "checkForUpdate").mockResolvedValue({ available: true, release: RELEASE });
+            vi.spyOn(plugin, "updateServer").mockResolvedValue(undefined);
+            vi.spyOn(plugin as any, "getSharedLilbeeVariant").mockReturnValue("default");
+            seedSharedConfig("");
+            await plugin.onload();
+            await flush();
+
+            expect(Notice.instances.map((n) => n.message)).toContain(MESSAGES.NOTICE_SERVER_AUTO_UPDATED(RELEASE.tag));
+        });
+
         it("skips the check when this plugin version already checked", async () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             const check = vi.spyOn(plugin, "checkForUpdate");

--- a/tests/managed-consent-modal.test.ts
+++ b/tests/managed-consent-modal.test.ts
@@ -7,7 +7,7 @@ vi.mock("../src/binary-manager", async (importOriginal) => {
     return {
         ...actual,
         getLatestRelease: vi.fn(),
-        getPlatformAssetName: vi.fn(actual.getPlatformAssetName),
+        assetNameForVariant: vi.fn(actual.assetNameForVariant),
     };
 });
 
@@ -160,7 +160,7 @@ describe("ManagedConsentModal", () => {
     });
 
     it("falls back to 'lilbee' when the platform has no asset name", async () => {
-        const mockedAssetFn = binMgr.getPlatformAssetName as unknown as MockedReleaseFn;
+        const mockedAssetFn = binMgr.assetNameForVariant as unknown as MockedReleaseFn;
         mockedAssetFn.mockImplementationOnce(() => {
             throw new Error("Unsupported platform");
         });
@@ -173,6 +173,22 @@ describe("ManagedConsentModal", () => {
         const { root } = openModal();
         await flush();
         expect(root.find("lilbee-managed-consent-prov-asset-name")?.textContent).toBe("lilbee");
+    });
+
+    it("names the ROCm asset when the release resolves to the ROCm build", async () => {
+        const mockedAssetFn = binMgr.assetNameForVariant as unknown as MockedReleaseFn;
+        mockedGetLatestRelease.mockResolvedValue({
+            tag: "v0",
+            assetUrl: "",
+            variant: "rocm",
+            sizeBytes: 897_000_000,
+        });
+        const { root } = openModal();
+        await flush();
+
+        // The name and the size both come from the resolved build, so they agree.
+        expect(mockedAssetFn).toHaveBeenCalledWith("rocm");
+        expect(root.find("lilbee-managed-consent-prov-asset-size")?.textContent).toContain("~855 MB");
     });
 
     it("renders '?' when the release reports a negative or missing size", async () => {

--- a/tests/settings-version-picker.test.ts
+++ b/tests/settings-version-picker.test.ts
@@ -3,7 +3,7 @@ import { App, Setting } from "obsidian";
 import { MockElement } from "./__mocks__/obsidian";
 import { LilbeeSettingTab } from "../src/settings";
 import { node } from "../src/binary-manager";
-import { DEFAULT_SETTINGS, SERVER_MODE } from "../src/types";
+import { DEFAULT_SETTINGS, SERVER_MODE, SERVER_VARIANT } from "../src/types";
 import { MESSAGES } from "../src/locales/en";
 import type LilbeePlugin from "../src/main";
 
@@ -127,6 +127,7 @@ describe("server version picker with the real release list", () => {
         const plugin = {
             settings: { ...DEFAULT_SETTINGS, serverMode: SERVER_MODE.MANAGED, includeDevBuilds },
             getSharedLilbeeVersion: () => STABLE_RUN[0],
+            getSharedLilbeeVariant: () => SERVER_VARIANT.DEFAULT,
         } as unknown as LilbeePlugin;
         return new LilbeeSettingTab(new App(), plugin);
     }
@@ -145,6 +146,32 @@ describe("server version picker with the real release list", () => {
         expect(dd.value).toBe(STABLE_RUN[0]);
         expect(dd.disabledStates).toContain(false);
         expect(descs[descs.length - 1]).not.toBe(MESSAGES.DESC_SERVER_VERSION_LOADING);
+    });
+
+    it("says which build is installed, so the download size is accounted for", async () => {
+        const plugin = {
+            settings: { ...DEFAULT_SETTINGS, serverMode: SERVER_MODE.MANAGED, includeDevBuilds: false },
+            getSharedLilbeeVersion: () => STABLE_RUN[0],
+            getSharedLilbeeVariant: () => SERVER_VARIANT.ROCM,
+        } as unknown as LilbeePlugin;
+        const tab = new LilbeeSettingTab(new App(), plugin);
+        (tab as any).renderVersionSetting(new MockElement() as unknown as HTMLElement);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(descs[descs.length - 1]).toContain("Running the ROCm build.");
+    });
+
+    it("says nothing about the build when the install predates build tracking", async () => {
+        const plugin = {
+            settings: { ...DEFAULT_SETTINGS, serverMode: SERVER_MODE.MANAGED, includeDevBuilds: false },
+            getSharedLilbeeVersion: () => STABLE_RUN[0],
+            getSharedLilbeeVariant: () => "",
+        } as unknown as LilbeePlugin;
+        const tab = new LilbeeSettingTab(new App(), plugin);
+        (tab as any).renderVersionSetting(new MockElement() as unknown as HTMLElement);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(descs[descs.length - 1]).not.toContain("build.");
     });
 
     it("offers dev and stable builds when dev builds are included", async () => {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -3,7 +3,7 @@ import { App, Notice, Setting } from "obsidian";
 import { MockElement } from "./__mocks__/obsidian";
 import { LilbeeSettingTab, SEPARATOR_KEY } from "../src/settings";
 import type { CatalogEntry, CatalogResponse, InstalledModel, LilbeeSettings } from "../src/types";
-import { DEFAULT_SETTINGS, MEMORY_CONFIG_KEY, MODEL_TASK, SSE_EVENT, TABLE_MODEL } from "../src/types";
+import { DEFAULT_SETTINGS, MEMORY_CONFIG_KEY, MODEL_TASK, SERVER_VARIANT, SSE_EVENT, TABLE_MODEL } from "../src/types";
 import { MESSAGES } from "../src/locales/en";
 import { ServerStartingError } from "../src/api";
 import { ok, err } from "../src/result";
@@ -177,6 +177,7 @@ function makePlugin(
         wikiSync: null,
         taskQueue: new TaskQueue(),
         getSharedLilbeeVersion: () => sharedVersion,
+        getSharedLilbeeVariant: () => SERVER_VARIANT.DEFAULT,
         setSharedLilbeeVersion: (v: string) => {
             sharedVersion = v;
         },


### PR DESCRIPTION
## Problem

The plugin picks a CUDA build from `nvidia-smi` but has no AMD path, so every AMD machine gets the default Vulkan build. lilbee ships a faster ROCm build for Linux, and nothing here ever asked for it.

Picking it wrong is expensive. The ROCm build is 897 MB against 524 MB, carries no Vulkan fallback, and the server refuses to start on a card it ships no kernels for. A wrong guess costs the download and then either fails to start or serves on CPU, which is worse than today.

## Solution

**Detection.** Gfx targets come from the amdgpu driver's KFD topology, not from `rocm-smi` or `amd-smi`. Those ship with ROCm, and the ROCm build bundles its own, so the host needs only the amdgpu driver.

**Which cards count.** The release publishes the gfx targets its ROCm build carries kernels for (tobocop2/lilbee#716). The ROCm build is taken when every card on the host is in that list. All of them, not any: a card the build cannot serve stops the server, so a partly covered host is better off on the default build, which runs every card over Vulkan.

**Falling back.** No manifest, an unreadable one, an uncovered card, a non-Linux host: the default build, exactly as now. NVIDIA still resolves first.

**Cost of the check.** Releases resolve together rather than one after another, so a version list pays one manifest round trip instead of ten.

**What the user sees.** The consent modal names the file it is actually downloading; it printed the default asset name next to the resolved build's size, which already misreported on CUDA machines. A build switch says so instead of naming a version the user is already on. Settings shows the installed build, which is what answers why a download was the size it was.

Detection, selection, and fallbacks are covered by unit tests. Behaviour on real AMD silicon is not yet verified: RunPod had no MI300X capacity in any region at the time of writing.