### PR TITLE
Drop redundant type assertions in the AMD GPU probe

### DIFF
--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -135,7 +135,7 @@ function gfxTargetName(version: number): string {
 function nodeGfxTarget(nodeName: string): string | null {
     let text: string;
     try {
-        text = node.readFileSync(node.join(KFD_TOPOLOGY_NODES, nodeName, "properties"), "utf-8") as string;
+        text = node.readFileSync(node.join(KFD_TOPOLOGY_NODES, nodeName, "properties"), "utf-8");
     } catch {
         return null;
     }
@@ -159,7 +159,7 @@ export function detectAmdGfxTargets(): string[] {
     if (!node.existsSync(KFD_DEVICE_PATH)) return [];
     let nodes: string[];
     try {
-        nodes = node.readdirSync(KFD_TOPOLOGY_NODES) as unknown as string[];
+        nodes = node.readdirSync(KFD_TOPOLOGY_NODES);
     } catch {
         return [];
     }

--- a/tests/binary-manager.test.ts
+++ b/tests/binary-manager.test.ts
@@ -220,6 +220,9 @@ describe("detectAmdGfxTargets", () => {
 
     it("returns nothing when the host exposes no compute device", () => {
         restore = stubPlatform("linux", "x64");
+        // A readable topology naming a real card, with /dev/kfd absent: an empty
+        // result can then only come from that gate, not from unreadable sysfs.
+        stubKfdTopology([110000]);
         stubNoAmd();
         expect(detectAmdGfxTargets()).toEqual([]);
     });
@@ -522,6 +525,9 @@ describe("getLatestRelease", () => {
     it("does not read the ROCm manifest on a host with no AMD card", async () => {
         restore = stubPlatform("linux", "x64");
         stubNoNvidia();
+        // Topology first, then hide /dev/kfd: the manifest stays unread because the
+        // host has no compute device, not because sysfs could not be read.
+        stubKfdTopology([110000]);
         stubNoAmd();
         const requestUrl = vi.spyOn(node, "requestUrl").mockResolvedValue(releaseResponse([rocmRelease("v1.0.0", [])]));
 


### PR DESCRIPTION
## Problem

The AMD detection added in #225 asserted types the calls already return: `readFileSync(path, "utf-8") as string` and `readdirSync(path) as unknown as string[]`. Both are unnecessary, and `npm run lint:store` — the lint the Obsidian community store applies — reports them as errors. That check had no binary-manager findings before #225.

The assertions also hide type errors rather than reveal them. `as unknown as string[]` would silently survive a change to `withFileTypes`, which returns `Dirent[]`, and the loop would then compare objects as filenames.

One test was weak in the same area. `returns nothing when the host exposes no compute device` stubbed away `/dev/kfd` but left the topology unreadable, so removing the `/dev/kfd` gate entirely still passed: the unmocked read threw and produced the same empty result. It now presents a readable topology naming a real card, so an empty result can only come from the gate.

## Solution

Remove both assertions and let the real return types stand. Give the two tests that hide `/dev/kfd` a readable topology first.

No behaviour change: type assertions are erased at compile time, and the built `main.js` is byte-identical before and after (sha256 `7f65498f`). Selection was re-checked on Linux against the live release — gfx942, gfx1100 and an 8-card host resolve to the ROCm build; gfx906, a mixed host, a host without `/dev/kfd`, and any host with an NVIDIA driver resolve as they did before.