### PR TITLE
Key nested uploads by path and report a sync already running

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The pattern works for any vault you've curated:
 
 Whatever it holds becomes searchable, and you can talk to it.
 
-Add a single file from the right-click menu or the command palette. Run **Sync vault** to index everything at once. Background jobs run in a **Task Center**: sync, crawl, wiki build, and model downloads. You keep asking questions while they work.
+Add a single file from the right-click menu or the command palette. Run **Sync vault** to index everything at once. Background jobs run in a **Task Center**: sync, crawl, wiki build, and model downloads. **Chat and search keep working while they run.** The Task Center runs two jobs at a time, so anything you start beyond that waits in the queue for a free slot.
 
 <!-- demo: add | tutorial/#ask | add a PDF and a README from the palette, watch the Task Center index them, then ask a cited question -->
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -137,7 +137,7 @@ There are several ways to get documents into your library:
 - **Rebuild index** drops the entire index and re-embeds from scratch — use it after changing the embedding model or chunking. It asks for confirmation first.
 - **Retry skipped documents** re-attempts files that yielded no content last time (for example a scan that needed OCR you've since enabled).
 
-All of this runs as background jobs in the [Task Center](#the-task-center), so you can keep asking questions while indexing proceeds.
+All of this runs as background jobs in the [Task Center](#the-task-center). Chat and search keep working while indexing proceeds. Other jobs you start take a slot or wait in the queue, so check the [Task Center](#the-task-center) before you start a big sync.
 
 ---
 
@@ -189,7 +189,11 @@ Downloads run through the [Task Center](#the-task-center), so you can keep worki
 - Jobs are grouped into **active**, **queued**, and **completed**, with a header count.
 - Each row shows a type badge, name, elapsed time, a progress bar (with bytes and rate for downloads), and any detail or error.
 - Active jobs can be **Cancelled**; failed ones can be **Retried**.
-- Jobs of the same type queue behind a concurrency cap so a big sync doesn't starve everything else. **Clear Tasks** tidies the completed list.
+- Two jobs run at a time, and only one of each type. A crawl started during a sync runs alongside it. A third job waits in **queued** until a slot opens.
+- Chat and search aren't jobs. They keep working while a sync, a crawl, or a model download runs.
+- The sync commands (**Sync vault**, **Rebuild index**, **Retry skipped documents**) don't start a second sync while one is active or queued. They tell you a sync is already running, so wait for it or cancel it first. This keeps repeated clicks from stacking up several passes over your vault.
+- Each type holds five queued jobs. Past that, lilbee asks you to wait for some to finish.
+- **Clear Tasks** tidies the completed list.
 
 ---
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -707,6 +707,8 @@ export const MESSAGES = {
     NOTICE_SESSION_TOKEN_INVALID_MANAGED:
         "lilbee: managed server rejected its own token — restart the server from Settings → Switch to managed server, or open Status for logs",
     NOTICE_QUEUE_FULL: "lilbee: too many tasks queued — wait for some to finish",
+    NOTICE_SYNC_IN_PROGRESS:
+        "lilbee: a sync is already running or queued. Wait for it to finish, or cancel it in the Task Center.",
     LABEL_DATASET_FILTER: "lilbee dataset",
     LABEL_DATASET_IMPORT_TASK: "Importing dataset",
     STATUS_DATASET_IMPORTING: "Re-embedding pages…",

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,6 +46,7 @@ import {
     SERVER_STATE,
     SETUP_OUTCOME,
     SSE_EVENT,
+    SYNC_TRIGGER,
     TASK_STATUS,
     TASK_TYPE,
     type AgentClient,
@@ -68,6 +69,7 @@ import {
     type SyncDone,
     type SSEEvent,
     type SyncOptions,
+    type SyncTrigger,
     type TaskEntry,
     type WikiBuildResult,
     type WikiPagePayload,
@@ -2116,21 +2118,22 @@ export default class LilbeePlugin extends Plugin {
     }
 
     /** Read every file under each path (recursing directories) off disk as
-     *  upload payloads — for external mode, where the server can't read paths. */
+     *  upload payloads — for external mode, where the server can't read paths.
+     *  Name is the path under the picked entry so nested same-named files keep distinct source keys. */
     private readUploadsFromDisk(paths: string[]): UploadPayload[] {
         const out: UploadPayload[] = [];
-        const walk = (p: string): void => {
+        const walk = (p: string, relative: string): void => {
             if (node.statSync(p).isDirectory()) {
-                for (const child of node.readdirSync(p)) walk(node.join(p, child));
+                for (const child of node.readdirSync(p)) walk(node.join(p, child), `${relative}/${child}`);
             } else {
                 const buf = node.readFileSync(p);
                 out.push({
-                    name: node.basename(p),
+                    name: relative,
                     data: buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength),
                 });
             }
         };
-        for (const p of paths) walk(p);
+        for (const p of paths) walk(p, node.basename(p));
         return out;
     }
 
@@ -2239,10 +2242,11 @@ export default class LilbeePlugin extends Plugin {
         }
     }
 
-    /** Read every file under *file* (recursing folders) as upload payloads. */
-    private async collectVaultUploads(file: TAbstractFile): Promise<{ name: string; data: ArrayBuffer }[]> {
+    /** Read every file under *file* (recursing folders) as upload payloads.
+     *  Name is the vault-relative path so nested same-named notes keep distinct source keys. */
+    private async collectVaultUploads(file: TAbstractFile): Promise<UploadPayload[]> {
         const tfiles = file instanceof TFolder ? this.filesInFolder(file) : file instanceof TFile ? [file] : [];
-        return Promise.all(tfiles.map(async (f) => ({ name: f.name, data: await this.app.vault.readBinary(f) })));
+        return Promise.all(tfiles.map(async (f) => ({ name: f.path, data: await this.app.vault.readBinary(f) })));
     }
 
     private filesInFolder(folder: TFolder): TFile[] {
@@ -2865,7 +2869,7 @@ export default class LilbeePlugin extends Plugin {
                         const d = event.data as { pages_crawled?: number };
                         this.taskQueue.complete(taskId);
                         new Notice(MESSAGES.NOTICE_CRAWL_DONE(d.pages_crawled ?? pageCount));
-                        void this.triggerSync();
+                        void this.triggerSync(undefined, SYNC_TRIGGER.AUTOMATIC);
                         return;
                     }
                     case SSE_EVENT.CRAWL_ERROR:
@@ -2893,13 +2897,17 @@ export default class LilbeePlugin extends Plugin {
         }
     }
 
-    async triggerSync(options?: SyncOptions): Promise<void> {
+    async triggerSync(options?: SyncOptions, trigger: SyncTrigger = SYNC_TRIGGER.USER): Promise<void> {
         if (!this.statusBarEl) return;
         // Re-entry guard: if a sync is already active or queued, this trigger
-        // is a no-op. Without it, repeated clicks (sync hint, command palette,
-        // crawler-finished auto-trigger) stack up — and cancelling the active
-        // task just promotes the next queued sync, making cancel feel broken.
-        if (this.taskQueue.hasPending(TASK_TYPE.SYNC)) return;
+        // only reports it. Without it, repeated clicks (sync hint, command
+        // palette, crawler-finished auto-trigger) stack up — and cancelling the
+        // active task just promotes the next queued sync, making cancel feel broken.
+        // An automatic trigger stays silent: the notice answers a click the user didn't make.
+        if (this.taskQueue.hasPending(TASK_TYPE.SYNC)) {
+            if (trigger === SYNC_TRIGGER.USER) new Notice(MESSAGES.NOTICE_SYNC_IN_PROGRESS);
+            return;
+        }
         const taskId = this.taskQueue.enqueue(syncTaskLabel(options), TASK_TYPE.SYNC);
         if (taskId === null) {
             new Notice(MESSAGES.NOTICE_QUEUE_FULL);

--- a/src/main.ts
+++ b/src/main.ts
@@ -160,6 +160,11 @@ function summarizeSyncResult(done: SyncDone): string {
     return parts.join(", ");
 }
 
+/** Forward-slash form of a path with no trailing separator. */
+function posixPath(p: string): string {
+    return p.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
 /** Task-center label for a sync, distinguishing the recovery variants. */
 function syncTaskLabel(options?: SyncOptions): string {
     if (options?.forceRebuild) return MESSAGES.COMMAND_SYNC_REBUILD;
@@ -2117,10 +2122,9 @@ export default class LilbeePlugin extends Plugin {
         }
     }
 
-    /** Read every file under each path (recursing directories) off disk as
-     *  upload payloads — for external mode, where the server can't read paths.
-     *  Name is the path under the picked entry so nested same-named files keep distinct source keys. */
+    /** Upload payloads for every file under each path, keyed by vault-relative path like collectVaultUploads. */
     private readUploadsFromDisk(paths: string[]): UploadPayload[] {
+        const vaultBase = this.getVaultBasePath();
         const out: UploadPayload[] = [];
         const walk = (p: string, relative: string): void => {
             if (node.statSync(p).isDirectory()) {
@@ -2133,26 +2137,17 @@ export default class LilbeePlugin extends Plugin {
                 });
             }
         };
-        for (const p of paths) walk(p, node.basename(p));
+        for (const p of paths) walk(p, this.uploadRootName(p, vaultBase));
         return out;
     }
 
-    /**
-     * Copy each external path into ``<vault>/lilbee/imports/`` and return the
-     * new absolute paths for indexing. Paths already under the vault root
-     * are returned unchanged. On copy failure the offending file is dropped
-     * with a user-visible Notice so the rest of the batch still proceeds.
-     *
-     * Directory sources are copied recursively with ``node.cpSync`` — the
-     * native file picker's "openDirectory" mode returns folder paths, and
-     * ``copyFileSync`` on a directory throws EISDIR. Without the stat-first
-     * branch every picked folder would fall into the catch and get silently
-     * dropped, regressing folder ingestion.
-     *
-     * All path joins go through ``node.path`` so Windows ``\\`` separators
-     * round-trip correctly — a naïve string ``startsWith(vaultBase + "/")``
-     * check would miss every file on Windows and mis-copy them into imports.
-     */
+    /** Vault-relative path of a picked entry; its own name when the entry sits outside the vault. */
+    private uploadRootName(p: string, vaultBase: string): string {
+        if (!this.isUnderVault(p, vaultBase)) return node.basename(p);
+        return posixPath(p).slice(posixPath(vaultBase).length + 1);
+    }
+
+    /** Absolute vault paths for each entry: copied into ``<vault>/lilbee/imports/`` unless already under the vault. */
     private copyExternalFilesToVault(paths: string[]): string[] {
         const vaultBase = this.getVaultBasePath();
         const importsDir = node.join(vaultBase, "lilbee", "imports");
@@ -2187,15 +2182,9 @@ export default class LilbeePlugin extends Plugin {
         return results;
     }
 
-    /**
-     * True if ``source`` sits under ``vaultBase``. Normalises separators so
-     * ``C:\\vault\\foo.pdf`` correctly matches a vault base of ``C:\\vault``
-     * regardless of which slash flavour either side uses.
-     */
+    /** True if ``source`` sits under ``vaultBase``, whichever separator either side uses. */
     private isUnderVault(source: string, vaultBase: string): boolean {
-        const norm = (p: string) => p.replace(/\\/g, "/");
-        const prefix = norm(vaultBase).replace(/\/+$/, "");
-        return norm(source).startsWith(`${prefix}/`);
+        return posixPath(source).startsWith(`${posixPath(vaultBase)}/`);
     }
 
     /** Append a ``-N`` suffix until ``<dir>/<name>`` doesn't exist on disk. */
@@ -2221,14 +2210,16 @@ export default class LilbeePlugin extends Plugin {
         const name = file.name || file.path || MESSAGES.LABEL_VAULT_ROOT;
 
         const isRetry = this.failedAddPaths.has(absolutePath);
-        if (!isRetry && !(await this.confirmReindexIfNeeded(name))) return;
+        // A note is keyed by its vault path, so the check searches for that, not the basename.
+        const indexKey = file instanceof TFile && file.path ? file.path : name;
+        if (!isRetry && !(await this.confirmReindexIfNeeded(indexKey))) return;
 
         new Notice(MESSAGES.STATUS_ADDING.replace("{label}", name));
         if (this.settings.serverMode === SERVER_MODE.EXTERNAL) {
             // A remote server can't read this machine's paths, so send the file
             // bytes straight from the vault instead of a server-side path. The
             // read runs before runAdd's guard, so surface a failure here too.
-            let uploads: { name: string; data: ArrayBuffer }[];
+            let uploads: UploadPayload[];
             try {
                 uploads = await this.collectVaultUploads(file);
             } catch (err) {
@@ -2242,8 +2233,7 @@ export default class LilbeePlugin extends Plugin {
         }
     }
 
-    /** Read every file under *file* (recursing folders) as upload payloads.
-     *  Name is the vault-relative path so nested same-named notes keep distinct source keys. */
+    /** Upload payloads for every file under *file*, keyed by vault-relative path. */
     private async collectVaultUploads(file: TAbstractFile): Promise<UploadPayload[]> {
         const tfiles = file instanceof TFolder ? this.filesInFolder(file) : file instanceof TFile ? [file] : [];
         return Promise.all(tfiles.map(async (f) => ({ name: f.path, data: await this.app.vault.readBinary(f) })));
@@ -2260,7 +2250,7 @@ export default class LilbeePlugin extends Plugin {
 
     /** Ingest by uploading file content (external mode); reuses runAdd's stream loop. */
     private async runUpload(
-        files: { name: string; data: ArrayBuffer }[],
+        files: UploadPayload[],
         retryKeys: string[],
         retry?: () => void | Promise<void>,
     ): Promise<void> {
@@ -2675,10 +2665,7 @@ export default class LilbeePlugin extends Plugin {
             .filter((f) => f.path.startsWith(MANAGED_DOCS_PREFIX) && !this.wikiSync?.isWikiPath(f.path));
         const known = new Set<string>();
         try {
-            // Page through the documents endpoint so we count every known
-            // source, not just the first page. Match on basename: crawled
-            // sources keep a relative path (_web/.../index.md) while added
-            // files use a basename, so the basename is the common key.
+            // Sources are relative paths; the basename is the key shared with vault files.
             let offset = 0;
             const limit = 100;
             while (true) {
@@ -2899,11 +2886,7 @@ export default class LilbeePlugin extends Plugin {
 
     async triggerSync(options?: SyncOptions, trigger: SyncTrigger = SYNC_TRIGGER.USER): Promise<void> {
         if (!this.statusBarEl) return;
-        // Re-entry guard: if a sync is already active or queued, this trigger
-        // only reports it. Without it, repeated clicks (sync hint, command
-        // palette, crawler-finished auto-trigger) stack up — and cancelling the
-        // active task just promotes the next queued sync, making cancel feel broken.
-        // An automatic trigger stays silent: the notice answers a click the user didn't make.
+        // One sync at a time; only a user trigger reports a pending one.
         if (this.taskQueue.hasPending(TASK_TYPE.SYNC)) {
             if (trigger === SYNC_TRIGGER.USER) new Notice(MESSAGES.NOTICE_SYNC_IN_PROGRESS);
             return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -274,6 +274,14 @@ export interface SyncOptions {
     retrySkipped?: boolean;
 }
 
+/** Who asked for a sync. Only a user-initiated one reports that a sync is already pending. */
+export type SyncTrigger = "user" | "automatic";
+
+export const SYNC_TRIGGER = {
+    USER: "user",
+    AUTOMATIC: "automatic",
+} as const satisfies Record<string, SyncTrigger>;
+
 export interface GenerationOptions {
     temperature?: number;
     top_p?: number;

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -2,7 +2,7 @@ import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { windowStub } from "./window-stub";
 import { Notice, TFile, TFolder } from "obsidian";
 import { App, MockElement, WorkspaceLeaf } from "./__mocks__/obsidian";
-import { DEFAULT_SHARED_CONFIG, INDETERMINATE_PROGRESS, SETUP_OUTCOME, SSE_EVENT } from "../src/types";
+import { DEFAULT_SHARED_CONFIG, INDETERMINATE_PROGRESS, SETUP_OUTCOME, SSE_EVENT, SYNC_TRIGGER } from "../src/types";
 import { VaultRegistry } from "../src/vault-registry";
 import { FileProgressTracker } from "../src/main";
 import { MESSAGES } from "../src/locales/en";
@@ -735,11 +735,13 @@ describe("LilbeePlugin", () => {
             expect(events.some((e) => e.event === SSE_EVENT.ERROR)).toBe(true);
         });
 
-        it("collectVaultUploads reads a single file", async () => {
+        it("collectVaultUploads keys a single file by its vault path", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             plugin.app.vault.readBinary = vi.fn().mockResolvedValue(new ArrayBuffer(2));
-            const uploads = await (plugin as any).collectVaultUploads(Object.assign(new TFile(), { name: "one.py" }));
-            expect((uploads as any[])[0].name).toBe("one.py");
+            const uploads = await (plugin as any).collectVaultUploads(
+                Object.assign(new TFile(), { name: "one.py", path: "src/one.py" }),
+            );
+            expect((uploads as any[])[0].name).toBe("src/one.py");
         });
 
         it("collectVaultUploads yields nothing for an abstract entry that is neither file nor folder", async () => {
@@ -791,15 +793,43 @@ describe("LilbeePlugin", () => {
                 .mockImplementation(async (f: any) => new TextEncoder().encode(f.name).buffer);
             const sub = Object.assign(new TFolder(), {
                 name: "sub",
-                children: [Object.assign(new TFile(), { name: "b.py" })],
+                path: "src/sub",
+                children: [Object.assign(new TFile(), { name: "b.py", path: "src/sub/b.py" })],
             });
             const root = Object.assign(new TFolder(), {
                 name: "src",
+                path: "src",
                 // A child that is neither a TFile nor a TFolder is skipped.
-                children: [Object.assign(new TFile(), { name: "a.py" }), sub, { name: "ignored" } as unknown as TFile],
+                children: [
+                    Object.assign(new TFile(), { name: "a.py", path: "src/a.py" }),
+                    sub,
+                    { name: "ignored", path: "src/ignored" } as unknown as TFile,
+                ],
             });
             const uploads = await (plugin as any).collectVaultUploads(root);
-            expect((uploads as any[]).map((u) => u.name).sort()).toEqual(["a.py", "b.py"]);
+            expect((uploads as any[]).map((u) => u.name).sort()).toEqual(["src/a.py", "src/sub/b.py"]);
+        });
+
+        it("collectVaultUploads gives same-named notes in different folders distinct keys", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            plugin.app.vault.readBinary = vi
+                .fn()
+                .mockImplementation(async (f: any) => new TextEncoder().encode(f.path).buffer);
+            const alpha = Object.assign(new TFolder(), {
+                name: "alpha",
+                path: "notes/alpha",
+                children: [Object.assign(new TFile(), { name: "index.md", path: "notes/alpha/index.md" })],
+            });
+            const beta = Object.assign(new TFolder(), {
+                name: "beta",
+                path: "notes/beta",
+                children: [Object.assign(new TFile(), { name: "index.md", path: "notes/beta/index.md" })],
+            });
+            const root = Object.assign(new TFolder(), { name: "notes", path: "notes", children: [alpha, beta] });
+            const uploads = await (plugin as any).collectVaultUploads(root);
+            const names = (uploads as any[]).map((u) => u.name).sort();
+            expect(names).toEqual(["notes/alpha/index.md", "notes/beta/index.md"]);
+            expect(new Set(names).size).toBe(2);
         });
 
         it("runUpload with no files notices and skips runAdd", async () => {
@@ -1434,6 +1464,37 @@ describe("LilbeePlugin", () => {
             await new Promise((r) => setTimeout(r, 0));
             expect(plugin.api.syncStream).toHaveBeenCalledTimes(1);
             await plugin.triggerSync();
+            expect(plugin.api.syncStream).toHaveBeenCalledTimes(1);
+        });
+
+        it("tells the user why a second sync did nothing", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            async function* hangs() {
+                await new Promise<void>(() => {});
+            }
+            plugin.api.syncStream = vi.fn().mockImplementation(() => hangs());
+            void plugin.triggerSync();
+            await new Promise((r) => setTimeout(r, 0));
+            Notice.clear();
+            // Rebuild and retry-skipped route through the same guard, so the
+            // message has to be true for every sync command.
+            await plugin.triggerSync({ forceRebuild: true });
+            expect(Notice.instances.map((n) => n.message)).toContain(MESSAGES.NOTICE_SYNC_IN_PROGRESS);
+        });
+
+        it("stays silent when an automatic trigger finds a sync already pending", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            async function* hangs() {
+                await new Promise<void>(() => {});
+            }
+            plugin.api.syncStream = vi.fn().mockImplementation(() => hangs());
+            void plugin.triggerSync();
+            await new Promise((r) => setTimeout(r, 0));
+            Notice.clear();
+            await plugin.triggerSync(undefined, SYNC_TRIGGER.AUTOMATIC);
+            expect(Notice.instances.map((n) => n.message)).not.toContain(MESSAGES.NOTICE_SYNC_IN_PROGRESS);
             expect(plugin.api.syncStream).toHaveBeenCalledTimes(1);
         });
 
@@ -2660,7 +2721,7 @@ describe("LilbeePlugin", () => {
             expect(Notice.instances.some((n) => n.message.includes("EACCES"))).toBe(true);
         });
 
-        it("readUploadsFromDisk recurses picked directories", async () => {
+        it("readUploadsFromDisk recurses picked directories and keys files by their path under the pick", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             const { node } = await import("../src/binary-manager");
             const statSync = node.statSync as ReturnType<typeof vi.fn>;
@@ -2670,9 +2731,32 @@ describe("LilbeePlugin", () => {
             readFileSync.mockReturnValue(Buffer.from("x"));
             try {
                 const uploads = (plugin as any).readUploadsFromDisk(["/root/pkg"]) as { name: string }[];
-                expect(uploads.map((u) => u.name).sort()).toEqual(["a.py", "b.py"]);
+                expect(uploads.map((u) => u.name).sort()).toEqual(["pkg/a.py", "pkg/b.py"]);
             } finally {
                 statSync.mockImplementation(() => ({ isDirectory: () => false, dev: 1, size: 0 }));
+                readFileSync.mockReset();
+            }
+        });
+
+        it("readUploadsFromDisk gives same-named files in nested directories distinct keys", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            const { node } = await import("../src/binary-manager");
+            const statSync = node.statSync as ReturnType<typeof vi.fn>;
+            const readFileSync = node.readFileSync as ReturnType<typeof vi.fn>;
+            const tree: Record<string, string[]> = {
+                "/root/pkg": ["alpha", "beta"],
+                "/root/pkg/alpha": ["index.md"],
+                "/root/pkg/beta": ["index.md"],
+            };
+            statSync.mockImplementation((p: string) => ({ isDirectory: () => p in tree, dev: 1, size: 1 }));
+            (node.readdirSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => tree[p]);
+            readFileSync.mockReturnValue(Buffer.from("x"));
+            try {
+                const uploads = (plugin as any).readUploadsFromDisk(["/root/pkg"]) as { name: string }[];
+                expect(uploads.map((u) => u.name).sort()).toEqual(["pkg/alpha/index.md", "pkg/beta/index.md"]);
+            } finally {
+                statSync.mockImplementation(() => ({ isDirectory: () => false, dev: 1, size: 0 }));
+                (node.readdirSync as ReturnType<typeof vi.fn>).mockReset();
                 readFileSync.mockReset();
             }
         });

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -2700,7 +2700,8 @@ describe("LilbeePlugin", () => {
 
             expect(runUploadSpy).toHaveBeenCalled();
             const uploads = runUploadSpy.mock.calls[0][0] as { name: string; data: ArrayBuffer }[];
-            expect(uploads[0].name).toBe("foo.py");
+            // The copy lands in the vault, so its upload key is the vault path.
+            expect(uploads[0].name).toBe("lilbee/imports/foo.py");
             expect(uploads[0].data.byteLength).toBeGreaterThan(0);
             expect(plugin.api.addFiles).not.toHaveBeenCalled();
         });
@@ -2757,6 +2758,47 @@ describe("LilbeePlugin", () => {
             } finally {
                 statSync.mockImplementation(() => ({ isDirectory: () => false, dev: 1, size: 0 }));
                 (node.readdirSync as ReturnType<typeof vi.fn>).mockReset();
+                readFileSync.mockReset();
+            }
+        });
+
+        it("readUploadsFromDisk keys a picked vault folder the same way collectVaultUploads does", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            const { node } = await import("../src/binary-manager");
+            const statSync = node.statSync as ReturnType<typeof vi.fn>;
+            const readFileSync = node.readFileSync as ReturnType<typeof vi.fn>;
+            const tree: Record<string, string[]> = { "/test/vault/notes/sub": ["a.md"] };
+            statSync.mockImplementation((p: string) => ({ isDirectory: () => p in tree, dev: 1, size: 1 }));
+            (node.readdirSync as ReturnType<typeof vi.fn>).mockImplementation((p: string) => tree[p]);
+            readFileSync.mockReturnValue(Buffer.from("x"));
+            try {
+                const uploads = (plugin as any).readUploadsFromDisk(["/test/vault/notes/sub"]) as { name: string }[];
+                expect(uploads.map((u) => u.name)).toEqual(["notes/sub/a.md"]);
+            } finally {
+                statSync.mockImplementation(() => ({ isDirectory: () => false, dev: 1, size: 0 }));
+                (node.readdirSync as ReturnType<typeof vi.fn>).mockReset();
+                readFileSync.mockReset();
+            }
+        });
+
+        it("readUploadsFromDisk keys a Windows vault path with forward slashes and no drive prefix", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            (plugin.app.vault.adapter.getBasePath as ReturnType<typeof vi.fn>).mockReturnValue(
+                "C:\\Users\\me\\vault\\",
+            );
+            const { node } = await import("../src/binary-manager");
+            const statSync = node.statSync as ReturnType<typeof vi.fn>;
+            const readFileSync = node.readFileSync as ReturnType<typeof vi.fn>;
+            statSync.mockImplementation(() => ({ isDirectory: () => false, dev: 1, size: 1 }));
+            readFileSync.mockReturnValue(Buffer.from("x"));
+            try {
+                const uploads = (plugin as any).readUploadsFromDisk([
+                    "C:\\Users\\me\\vault\\notes\\a.md",
+                    "C:/Users/me/vault2/b.md",
+                ]) as { name: string }[];
+                expect(uploads.map((u) => u.name)).toEqual(["notes/a.md", "b.md"]);
+            } finally {
+                statSync.mockImplementation(() => ({ isDirectory: () => false, dev: 1, size: 0 }));
                 readFileSync.mockReset();
             }
         });


### PR DESCRIPTION
## Problem

Uploading a folder in external mode named every file by its basename. Two notes called `index.md` in different folders landed under one source key on the server and overwrote each other. The upload reported success, and the count looked right. The index held fewer documents. The disk-picker path had the same defect.

Starting a sync while one was active or queued returned silently. Every sync command routes through that guard. So during a long sync, **Rebuild index** and **Retry skipped documents** did nothing and gave no feedback. One user reported that as fragile multitasking.

## Solution

**Upload names carry their path.** Vault uploads send the vault-relative path. Disk uploads send the same key once the copy lands in the vault. Nested files keep distinct keys. The server already preserves relative upload names and creates the parent directories. The "already indexed" check now searches for the vault path, so two notes with one basename do not prompt for each other.

**Documents uploaded before this change keep their old key.** An external-mode note uploaded earlier under its basename stays indexed under that key. The next upload of the same note lands under its path, so the index holds both until you remove the old entry in Browse documents. The durable fix is a server-side content match, tracked as a follow-up.

**A second sync says so.** The re-entry guard stays. It now shows a notice that a sync is running or queued. The notice names the Task Center as the place to wait for it or cancel it. The crawl-finished auto-trigger stays silent, because the user did not click anything.

**Docs match the code.** README and usage now state the same rule. Chat and search keep working during background jobs. Two jobs run at a time. The sync commands report rather than stack while a sync is pending.
