### PR TITLE
Add a close button and a toggle command to the Task Center

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -294,6 +294,7 @@ export const MESSAGES = {
         "These settings affect how your documents are processed. Only change if you know what you're doing.",
     LABEL_CLOSE_GLYPH: "\u00D7",
     LABEL_TASK_CENTER: "Task Center",
+    LABEL_CLOSE_TASK_CENTER: "Close task center",
     LABEL_TASK_CAP_PILL: "{active}/{cap} running",
     LABEL_TASK_COUNTERS: "{active} running · {queued} queued · {done} done",
     LABEL_ACTIVE_TASKS: "ACTIVE",
@@ -776,6 +777,7 @@ export const MESSAGES = {
     COMMAND_DOCUMENTS: "Browse documents",
     COMMAND_SETUP: "Run setup wizard",
     COMMAND_TASKS: "Show task center",
+    COMMAND_TOGGLE_TASKS: "Toggle task center",
     COMMAND_STATUS: "Show status",
 
     // Status modal

--- a/src/main.ts
+++ b/src/main.ts
@@ -1493,7 +1493,7 @@ export default class LilbeePlugin extends Plugin {
         });
 
         this.addCommand({
-            id: "toggle-task-center",
+            id: "tasks-toggle",
             name: MESSAGES.COMMAND_TOGGLE_TASKS,
             callback: () => this.toggleTaskView(),
         });
@@ -2458,13 +2458,19 @@ export default class LilbeePlugin extends Plugin {
         }
     }
 
+    /** Opens the Task Center, reveals it when its sidebar is collapsed, and closes it otherwise. */
     async toggleTaskView(): Promise<void> {
         const existing = this.app.workspace.getLeavesOfType(VIEW_TYPE_TASKS);
-        if (existing.length > 0) {
-            for (const leaf of existing) leaf.detach();
+        if (existing.length === 0) {
+            await this.activateTaskView();
             return;
         }
-        await this.activateTaskView();
+        const sidebar = this.app.workspace.rightSplit;
+        if (existing[0].getRoot() === sidebar && sidebar.collapsed) {
+            void this.app.workspace.revealLeaf(existing[0]);
+            return;
+        }
+        for (const leaf of existing) leaf.detach();
     }
 
     refreshOpenWikiViews(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1493,6 +1493,12 @@ export default class LilbeePlugin extends Plugin {
         });
 
         this.addCommand({
+            id: "toggle-task-center",
+            name: MESSAGES.COMMAND_TOGGLE_TASKS,
+            callback: () => this.toggleTaskView(),
+        });
+
+        this.addCommand({
             id: "arrange-views",
             name: "Arrange views",
             callback: () => this.arrangeViews(),
@@ -2450,6 +2456,15 @@ export default class LilbeePlugin extends Plugin {
             await leaf.setViewState({ type: VIEW_TYPE_TASKS, active: true });
             void this.app.workspace.revealLeaf(leaf);
         }
+    }
+
+    async toggleTaskView(): Promise<void> {
+        const existing = this.app.workspace.getLeavesOfType(VIEW_TYPE_TASKS);
+        if (existing.length > 0) {
+            for (const leaf of existing) leaf.detach();
+            return;
+        }
+        await this.activateTaskView();
     }
 
     refreshOpenWikiViews(): void {

--- a/src/views/task-center.ts
+++ b/src/views/task-center.ts
@@ -1,4 +1,4 @@
-import { ItemView, WorkspaceLeaf } from "obsidian";
+import { ItemView, setIcon, WorkspaceLeaf } from "obsidian";
 import type LilbeePlugin from "../main";
 import {
     BACKGROUND_TASK_TYPES,
@@ -65,6 +65,13 @@ export class TaskCenterView extends ItemView {
             this.plugin.taskQueue.clearHistory();
             this.render();
         });
+
+        const closeBtn = header.createEl("button", {
+            cls: "lilbee-tasks-close",
+            attr: { "aria-label": MESSAGES.LABEL_CLOSE_TASK_CENTER },
+        });
+        setIcon(closeBtn, "x");
+        closeBtn.addEventListener("click", () => this.leaf.detach());
 
         this.activeSection = contentEl.createDiv({ cls: "lilbee-tasks-section" });
         this.activeSection.createDiv({ cls: "lilbee-tasks-section-header" }).setText(MESSAGES.LABEL_ACTIVE_TASKS);

--- a/src/views/task-center.ts
+++ b/src/views/task-center.ts
@@ -1,4 +1,4 @@
-import { ItemView, setIcon, WorkspaceLeaf } from "obsidian";
+import { ItemView, WorkspaceLeaf } from "obsidian";
 import type LilbeePlugin from "../main";
 import {
     BACKGROUND_TASK_TYPES,
@@ -66,12 +66,7 @@ export class TaskCenterView extends ItemView {
             this.render();
         });
 
-        const closeBtn = header.createEl("button", {
-            cls: "lilbee-tasks-close",
-            attr: { "aria-label": MESSAGES.LABEL_CLOSE_TASK_CENTER },
-        });
-        setIcon(closeBtn, "x");
-        closeBtn.addEventListener("click", () => this.leaf.detach());
+        this.addAction("x", MESSAGES.LABEL_CLOSE_TASK_CENTER, () => this.leaf.detach());
 
         this.activeSection = contentEl.createDiv({ cls: "lilbee-tasks-section" });
         this.activeSection.createDiv({ cls: "lilbee-tasks-section-header" }).setText(MESSAGES.LABEL_ACTIVE_TASKS);

--- a/styles.css
+++ b/styles.css
@@ -2415,24 +2415,6 @@
     color: var(--text-normal);
 }
 
-.lilbee-tasks-close {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: none;
-    border: none;
-    box-shadow: none;
-    cursor: pointer;
-    color: var(--text-muted);
-    padding: 4px;
-    margin-left: var(--size-4-2, 8px);
-    border-radius: 6px;
-}
-
-.lilbee-tasks-close:hover {
-    background-color: var(--background-modifier-hover);
-    color: var(--text-normal);
-}
 
 .lilbee-tasks-section {
     margin-bottom: var(--size-4-3, 12px);

--- a/styles.css
+++ b/styles.css
@@ -2415,6 +2415,25 @@
     color: var(--text-normal);
 }
 
+.lilbee-tasks-close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    box-shadow: none;
+    cursor: pointer;
+    color: var(--text-muted);
+    padding: 4px;
+    margin-left: var(--size-4-2, 8px);
+    border-radius: 6px;
+}
+
+.lilbee-tasks-close:hover {
+    background-color: var(--background-modifier-hover);
+    color: var(--text-normal);
+}
+
 .lilbee-tasks-section {
     margin-bottom: var(--size-4-3, 12px);
 }

--- a/styles.css
+++ b/styles.css
@@ -2415,7 +2415,6 @@
     color: var(--text-normal);
 }
 
-
 .lilbee-tasks-section {
     margin-bottom: var(--size-4-3, 12px);
 }

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -591,6 +591,18 @@ export class ItemView {
         this.contentEl = new MockElement("div");
     }
 
+    /** Header actions registered through addAction, in registration order. */
+    actions: MockElement[] = [];
+
+    addAction(icon: string, title: string, callback: () => void): MockElement {
+        const el = new MockElement("a");
+        el.attributes["data-icon"] = icon;
+        el.setAttribute("aria-label", title);
+        el.addEventListener("click", callback);
+        this.actions.push(el);
+        return el;
+    }
+
     getViewType(): string {
         return "";
     }

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -314,6 +314,7 @@ export class App {
         createLeafBySplit: vi.fn().mockReturnValue(null),
         getLeaf: vi.fn().mockReturnValue(null),
         revealLeaf: vi.fn(),
+        rightSplit: { collapsed: false },
         on: vi.fn().mockReturnValue({ id: "mock-event" }),
         getActiveFile: vi.fn().mockReturnValue(null),
         // Obsidian's real workspace fires this once layout is up. Tests run
@@ -625,6 +626,7 @@ export class WorkspaceLeaf {
     }
     setViewState = vi.fn();
     detach = vi.fn();
+    getRoot = vi.fn().mockReturnValue(null);
 }
 
 export class Plugin {

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -612,6 +612,7 @@ export class WorkspaceLeaf {
         this.app = app ?? new App();
     }
     setViewState = vi.fn();
+    detach = vi.fn();
 }
 
 export class Plugin {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -466,7 +466,7 @@ describe("LilbeePlugin", () => {
             expect(allIds).toContain("model-info-active-embedding");
             expect(allIds).toContain("take-over");
             expect(allIds).toContain("export-diagnostics");
-            expect(allIds).toContain("toggle-task-center");
+            expect(allIds).toContain("tasks-toggle");
             const ids = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.map((c: any[]) => c[0].id);
             expect(ids).toContain("search");
             expect(ids).toContain("chat");
@@ -1871,7 +1871,7 @@ describe("LilbeePlugin", () => {
             expect(activateSpy).toHaveBeenCalled();
         });
 
-        it("lilbee:toggle-task-center detaches the open task view", async () => {
+        it("lilbee:tasks-toggle detaches the open task view", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
 
@@ -1879,21 +1879,38 @@ describe("LilbeePlugin", () => {
             plugin.app.workspace.getLeavesOfType = vi.fn().mockReturnValue([leaf]);
             const activateSpy = vi.spyOn(plugin as any, "activateTaskView").mockResolvedValue(undefined);
 
-            const cb = await getCommandCallback(plugin, "toggle-task-center");
+            const cb = await getCommandCallback(plugin, "tasks-toggle");
             cb?.();
 
             expect(leaf.detach).toHaveBeenCalled();
             expect(activateSpy).not.toHaveBeenCalled();
         });
 
-        it("lilbee:toggle-task-center opens the task view when none is open", async () => {
+        it("lilbee:tasks-toggle reveals a task view hidden in a collapsed sidebar", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+
+            const leaf = new WorkspaceLeaf(plugin.app as any);
+            const sidebar = plugin.app.workspace.rightSplit;
+            sidebar.collapsed = true;
+            leaf.getRoot = vi.fn().mockReturnValue(sidebar);
+            plugin.app.workspace.getLeavesOfType = vi.fn().mockReturnValue([leaf]);
+
+            const cb = await getCommandCallback(plugin, "tasks-toggle");
+            cb?.();
+
+            expect(plugin.app.workspace.revealLeaf).toHaveBeenCalledWith(leaf);
+            expect(leaf.detach).not.toHaveBeenCalled();
+        });
+
+        it("lilbee:tasks-toggle opens the task view when none is open", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
 
             plugin.app.workspace.getLeavesOfType = vi.fn().mockReturnValue([]);
             const activateSpy = vi.spyOn(plugin as any, "activateTaskView").mockResolvedValue(undefined);
 
-            const cb = await getCommandCallback(plugin, "toggle-task-center");
+            const cb = await getCommandCallback(plugin, "tasks-toggle");
             cb?.();
 
             expect(activateSpy).toHaveBeenCalled();

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -454,11 +454,11 @@ describe("LilbeePlugin", () => {
             expect(startSpy).toHaveBeenCalled();
         });
 
-        it("adds all thirty commands", async () => {
+        it("adds all thirty-one commands", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
 
-            expect(plugin.addCommand).toHaveBeenCalledTimes(30);
+            expect(plugin.addCommand).toHaveBeenCalledTimes(31);
             const allIds = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.map((c: any[]) => c[0].id);
             expect(allIds).toContain("model-picker-chat");
             expect(allIds).toContain("model-picker-embedding");
@@ -466,6 +466,7 @@ describe("LilbeePlugin", () => {
             expect(allIds).toContain("model-info-active-embedding");
             expect(allIds).toContain("take-over");
             expect(allIds).toContain("export-diagnostics");
+            expect(allIds).toContain("toggle-task-center");
             const ids = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.map((c: any[]) => c[0].id);
             expect(ids).toContain("search");
             expect(ids).toContain("chat");
@@ -1865,6 +1866,34 @@ describe("LilbeePlugin", () => {
 
             const activateSpy = vi.spyOn(plugin as any, "activateTaskView").mockResolvedValue(undefined);
             const cb = await getCommandCallback(plugin, "tasks");
+            cb?.();
+
+            expect(activateSpy).toHaveBeenCalled();
+        });
+
+        it("lilbee:toggle-task-center detaches the open task view", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+
+            const leaf = new WorkspaceLeaf(plugin.app as any);
+            plugin.app.workspace.getLeavesOfType = vi.fn().mockReturnValue([leaf]);
+            const activateSpy = vi.spyOn(plugin as any, "activateTaskView").mockResolvedValue(undefined);
+
+            const cb = await getCommandCallback(plugin, "toggle-task-center");
+            cb?.();
+
+            expect(leaf.detach).toHaveBeenCalled();
+            expect(activateSpy).not.toHaveBeenCalled();
+        });
+
+        it("lilbee:toggle-task-center opens the task view when none is open", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+
+            plugin.app.workspace.getLeavesOfType = vi.fn().mockReturnValue([]);
+            const activateSpy = vi.spyOn(plugin as any, "activateTaskView").mockResolvedValue(undefined);
+
+            const cb = await getCommandCallback(plugin, "toggle-task-center");
             cb?.();
 
             expect(activateSpy).toHaveBeenCalled();

--- a/tests/views/task-center.test.ts
+++ b/tests/views/task-center.test.ts
@@ -99,6 +99,18 @@ describe("TaskCenterView.onOpen", () => {
         expect(clearBtn!.textContent).toBe("Clear");
     });
 
+    it("renders a close button that detaches the leaf", () => {
+        const closeBtn = contentEl.find("lilbee-tasks-close");
+        expect(closeBtn).not.toBeNull();
+        expect(closeBtn!.attributes["data-icon"]).toBe("x");
+        expect(closeBtn!.getAttribute("aria-label")).toBe("Close task center");
+
+        const leaf = (view as any).leaf as WorkspaceLeaf;
+        expect(leaf.detach).not.toHaveBeenCalled();
+        closeBtn!.trigger("click");
+        expect(leaf.detach).toHaveBeenCalledTimes(1);
+    });
+
     it("renders counters in header", () => {
         const counters = contentEl.find("lilbee-tasks-counters");
         expect(counters).not.toBeNull();

--- a/tests/views/task-center.test.ts
+++ b/tests/views/task-center.test.ts
@@ -99,10 +99,9 @@ describe("TaskCenterView.onOpen", () => {
         expect(clearBtn!.textContent).toBe("Clear");
     });
 
-    it("renders a close button that detaches the leaf", () => {
-        const closeBtn = contentEl.find("lilbee-tasks-close");
-        expect(closeBtn).not.toBeNull();
-        expect(closeBtn!.attributes["data-icon"]).toBe("x");
+    it("registers a header action that detaches the leaf", () => {
+        const closeBtn = (view as any).actions.find((el: MockElement) => el.attributes["data-icon"] === "x");
+        expect(closeBtn).toBeDefined();
         expect(closeBtn!.getAttribute("aria-label")).toBe("Close task center");
 
         const leaf = (view as any).leaf as WorkspaceLeaf;


### PR DESCRIPTION
## Problem

The Task Center opens as a right-sidebar tab. Obsidian closes a sidebar tab from its right-click menu, with a middle click, or by collapsing the sidebar. A new user on 1.13.7 opened it from the command palette and found no way to close it (#236).

## Solution

**A close action in the view header.** The view registers it through `ItemView.addAction`, Obsidian's own header-action API. The action sits in the nav header, which never scrolls, and needs no stylesheet rule.

**A toggle command.** `Toggle task center` opens the view when it is closed. It reveals the view when its sidebar is collapsed. It closes the view otherwise. It reuses the existing open path.

Chat, Wiki, Memories and Placement share the same sidebar pattern. This change does not touch them.

Closes #236.
