### PR TITLE
Make the four inert settings controls read and write the server

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,7 +2,7 @@
 
 Everything the lilbee plugin can do inside Obsidian: the setup wizard, the chat and search surfaces, models, the wiki, crawling, and every setting. For installation see the [README quick start](../README.md#quick-start); for the engine itself (how it indexes and retrieves) see [lilbee](https://lilbee.sh/).
 
-The plugin talks to a local **lilbee** server over HTTP. In the default *managed* mode it downloads and runs that server for you — there's nothing else to install, and no Ollama. Everything stays on your computer unless you choose a cloud model.
+The plugin talks to a local **lilbee** server over HTTP. In the default _managed_ mode it downloads and runs that server for you — there's nothing else to install, and no Ollama. Everything stays on your computer unless you choose a cloud model.
 
 - [First launch: the setup wizard](#first-launch-the-setup-wizard)
 - [The status bar and ribbon](#the-status-bar-and-ribbon)
@@ -29,7 +29,7 @@ The plugin talks to a local **lilbee** server over HTTP. In the default *managed
 The first time you enable the plugin, a setup wizard opens and walks you through getting running. You can re-run it any time from the command palette (**Run setup wizard**) or Settings → **Run setup wizard**.
 
 1. **Welcome.** A short intro. Choose **Get Started** or **Skip Setup**.
-2. **Server.** Pick **Managed (Recommended)** to let the plugin download and run the server, or **External** to point at a lilbee server you run yourself (enter its URL and, for a remote machine, a session token). On managed, the wizard downloads the right binary for your platform, starts it, and shows progress as *Downloading → Starting → Ready*. It will not advance until the server is ready.
+2. **Server.** Pick **Managed (Recommended)** to let the plugin download and run the server, or **External** to point at a lilbee server you run yourself (enter its URL and, for a remote machine, a session token). On managed, the wizard downloads the right binary for your platform, starts it, and shows progress as _Downloading → Starting → Ready_. It will not advance until the server is ready.
 3. **Chat model.** Pick a chat model from a featured grid. If your system RAM is known, the wizard shows it and pre-selects a model that fits. The download streams in; you can open the Task Center to watch it, or browse the full catalog.
 4. **Embedding model.** Pick the model that turns your documents into something searchable. Indexing needs this.
 5. **Sync.** Optionally index your vault now. Progress shows file by file.
@@ -44,16 +44,16 @@ Finishing setup opens the chat sidebar once, so you don't land on an empty edito
 
 **Status bar** (bottom of the window) shows the server and task state with a colored dot:
 
-| Shows | Means |
-|-------|-------|
-| `lilbee: ready` | Managed server up and serving this vault |
-| `lilbee: ready [external]` | Connected to a server you run yourself |
-| `lilbee: downloading...` / `starting...` | Bringing the managed server up |
-| `lilbee: stopped` | Server not running |
-| `lilbee: error` | Server failed to start or isn't reachable |
-| `lilbee: auth error` | Missing or invalid session token (usually external mode) |
-| `lilbee: serving "Other Vault"` | Another open vault currently holds the shared server (see [multiple vaults](#server-modes-and-multiple-vaults)) |
-| `lilbee: 2 tasks running · …` | Background jobs in progress, with the active job and percentage |
+| Shows                                    | Means                                                                                                           |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `lilbee: ready`                          | Managed server up and serving this vault                                                                        |
+| `lilbee: ready [external]`               | Connected to a server you run yourself                                                                          |
+| `lilbee: downloading...` / `starting...` | Bringing the managed server up                                                                                  |
+| `lilbee: stopped`                        | Server not running                                                                                              |
+| `lilbee: error`                          | Server failed to start or isn't reachable                                                                       |
+| `lilbee: auth error`                     | Missing or invalid session token (usually external mode)                                                        |
+| `lilbee: serving "Other Vault"`          | Another open vault currently holds the shared server (see [multiple vaults](#server-modes-and-multiple-vaults)) |
+| `lilbee: 2 tasks running · …`            | Background jobs in progress, with the active job and percentage                                                 |
 
 Click the status bar to jump to settings. A separate pill with a refresh icon and a count appears when files have changed and a sync is pending.
 
@@ -69,29 +69,29 @@ To lay everything out at once, run **Arrange views** — it tiles chat, the Task
 
 Open the command palette (`Cmd/Ctrl + P`) and type `lilbee`. Commands that need the server are unavailable until it's ready.
 
-| Command | What it does |
-|---------|-------------|
-| **Open chat** | Open the chat sidebar |
-| **Search knowledge base** | Open the search modal for semantic search with live results |
-| **Sync vault** | Index new and changed files, drop deleted ones |
-| **Retry skipped documents** | Re-attempt files that produced no content on an earlier sync |
-| **Rebuild index** | Drop the whole index and re-embed everything (asks first) |
-| **Add current file to lilbee** | Index just the active file |
-| **Add current folder to lilbee** | Index every file in the active folder |
-| **Browse documents** | Open the documents browser |
-| **Browse model catalog** | Open the model catalog |
-| **Pick chat model** / **Pick embedding model** | Quick picker to switch the active model for a role |
-| **Show info for active chat model** / **…embedding model** | Show the active model's details |
-| **Crawl web page** | Fetch a web page (or a site) into your vault |
-| **Show task center** | Open the Task Center |
-| **Arrange views** | Tile the plugin's views (chat, Task Center, and any open wiki or memories panes) into even splits |
-| **Show status** | Document and chunk counts, model and wiki status |
-| **Run setup wizard** | Re-run the first-launch wizard |
-| **Browse wiki** | Open the wiki view *(when wiki is enabled)* |
-| **Generate wiki for current file** | Write a wiki page from the active file *(wiki enabled)* |
-| **Review wiki drafts** | Open the drafts review queue *(wiki enabled)* |
-| **Run wiki lint** | Check wiki pages for stale or broken citations *(wiki enabled)* |
-| **Take over the managed lilbee server** | Reclaim the shared server for this vault *(managed mode, when another vault holds it)* |
+| Command                                                    | What it does                                                                                      |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| **Open chat**                                              | Open the chat sidebar                                                                             |
+| **Search knowledge base**                                  | Open the search modal for semantic search with live results                                       |
+| **Sync vault**                                             | Index new and changed files, drop deleted ones                                                    |
+| **Retry skipped documents**                                | Re-attempt files that produced no content on an earlier sync                                      |
+| **Rebuild index**                                          | Drop the whole index and re-embed everything (asks first)                                         |
+| **Add current file to lilbee**                             | Index just the active file                                                                        |
+| **Add current folder to lilbee**                           | Index every file in the active folder                                                             |
+| **Browse documents**                                       | Open the documents browser                                                                        |
+| **Browse model catalog**                                   | Open the model catalog                                                                            |
+| **Pick chat model** / **Pick embedding model**             | Quick picker to switch the active model for a role                                                |
+| **Show info for active chat model** / **…embedding model** | Show the active model's details                                                                   |
+| **Crawl web page**                                         | Fetch a web page (or a site) into your vault                                                      |
+| **Show task center**                                       | Open the Task Center                                                                              |
+| **Arrange views**                                          | Tile the plugin's views (chat, Task Center, and any open wiki or memories panes) into even splits |
+| **Show status**                                            | Document and chunk counts, model and wiki status                                                  |
+| **Run setup wizard**                                       | Re-run the first-launch wizard                                                                    |
+| **Browse wiki**                                            | Open the wiki view _(when wiki is enabled)_                                                       |
+| **Generate wiki for current file**                         | Write a wiki page from the active file _(wiki enabled)_                                           |
+| **Review wiki drafts**                                     | Open the drafts review queue _(wiki enabled)_                                                     |
+| **Run wiki lint**                                          | Check wiki pages for stale or broken citations _(wiki enabled)_                                   |
+| **Take over the managed lilbee server**                    | Reclaim the shared server for this vault _(managed mode, when another vault holds it)_            |
 
 You can also right-click any file or folder in the file explorer and choose **Add to lilbee**.
 
@@ -101,7 +101,7 @@ You can also right-click any file or folder in the file explorer and choose **Ad
 
 The chat sidebar (**Open chat**, or the ribbon icon) is the main way to use lilbee.
 
-- **Two modes.** Toggle between **Search** and **Chat**. *Search* runs your question through your documents and answers with citations. *Chat* is a plain assistant with no retrieval. Search needs an embedding model; the toggle is disabled until one is set.
+- **Two modes.** Toggle between **Search** and **Chat**. _Search_ runs your question through your documents and answers with citations. _Chat_ is a plain assistant with no retrieval. Search needs an embedding model; the toggle is disabled until one is set.
 - **Search scope.** When the wiki is on, scope buttons let you search **All**, just the **Wiki** summaries, or just the **Raw** document chunks.
 - **Streaming answers** render token by token, with full markdown. Capable models show a collapsible **Reasoning** section.
 - **Citations.** Each answer has a **Sources** block of clickable chips. Click one to open the [Source Preview](#source-preview-and-citations) at the exact spot.
@@ -109,7 +109,7 @@ The chat sidebar (**Open chat**, or the ribbon icon) is the main way to use lilb
 - **Switch models from the toolbar.** Change the chat model inline; if it isn't installed yet, you'll get a confirmation showing its size and RAM, then a progress bar. Changing the embedding model warns you that a re-index is needed.
 - **Stop** a streaming answer mid-flight (the send button becomes a stop button).
 - **Save** the conversation to your vault as a dated markdown file under `lilbee/`, or **Clear Chat** to start over.
-- **Inline progress.** Sync and indexing progress shows right in the chat, with a cancel option. If the server isn't reachable the input shows *Connecting…* and then *Offline*.
+- **Inline progress.** Sync and indexing progress shows right in the chat, with a cancel option. If the server isn't reachable the input shows _Connecting…_ and then _Offline_.
 
 ---
 
@@ -161,12 +161,12 @@ All of this runs as background jobs in the [Task Center](#the-task-center), so y
 
 lilbee uses four model **roles**, each independently chosen:
 
-| Role | What it's for | Default |
-|------|---------------|---------|
-| **Chat** | Writes the answers | Picked in the wizard |
+| Role          | What it's for                                                                    | Default              |
+| ------------- | -------------------------------------------------------------------------------- | -------------------- |
+| **Chat**      | Writes the answers                                                               | Picked in the wizard |
 | **Embedding** | Turns documents into something searchable; required for indexing and Search mode | Picked in the wizard |
-| **Vision** | Reads scanned PDFs and image-only pages when OCR isn't enough | Disabled |
-| **Reranker** | Reorders results for better relevance | Disabled |
+| **Vision**    | Reads scanned PDFs and image-only pages when OCR isn't enough                    | Disabled             |
+| **Reranker**  | Reorders results for better relevance                                            | Disabled             |
 
 Pick or switch any role from Settings → **Models** (each has a dropdown plus a **Browse more…** button), from the chat toolbar, or with the **Pick chat model** / **Pick embedding model** commands.
 
@@ -237,18 +237,18 @@ You can mix and match — for example a cloud vision model for OCR while chat an
 
 Settings → Community plugins → **lilbee**. A filter box at the top searches setting names. Settings are grouped top to bottom:
 
-| Section | Covers |
-|---------|--------|
-| **Connection** | Server mode (managed/external), re-run setup wizard. Managed: status, start/stop/restart, shared directory, adopt an existing data dir, disk usage, version & updates. External: server URL + test, session token, reset to managed. |
-| **Models** | Active chat, embedding, vision, and reranker models; refresh; open the catalog. |
-| **Search & Retrieval** | **Results count** (1–20, default 12), **Search strictness** (how close a match must be), **Adaptive threshold** (auto-broaden when too few results). Strictness and the adaptive threshold are server settings: they apply to every client that talks to this server, and they carry a per-row reset. |
-| **Generation** *(advanced)* | System prompts for answering with and without documents, **Chat mode**, **Creativity** (temperature), **Top P**, **Top K**, **Repetition penalty**, **Seed**, and caps like max tokens, reasoning length, keep-alive, and GPU memory fraction. Blank means "use the model's default." |
-| **Retrieval (advanced)** | Candidate-pool multiplier, minimum relevance score, max sources per answer, max chunks per source, and the MMR relevance/diversity balance. |
-| **Ingest** | Chunk size and overlap (changing these invalidates the index), and OCR timeouts. |
-| **Worker pool** | Timeouts and idle behavior for the background model workers; whether to start them eagerly. |
-| **Crawling** | Depth, page limit, timeouts, request pacing, rate-limit retry/backoff, and URL exclude patterns. |
-| **Wiki (beta)** | Enable the wiki, summary accuracy, default search mode, sync-to-vault and its folder, plus health-check and clean-up buttons. |
-| **Advanced** | Store content in vault, rerank candidate count, **AI backend** (auto / local / external), API keys (OpenAI, Anthropic, Gemini, Hugging Face), the external endpoint, and **Reset all** server-backed settings. |
+| Section                     | Covers                                                                                                                                                                                                                                                                                  |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Connection**              | Server mode (managed/external), re-run setup wizard. Managed: status, start/stop/restart, shared directory, adopt an existing data dir, disk usage, version & updates. External: server URL + test, session token, reset to managed.                                                    |
+| **Models**                  | Active chat, embedding, vision, and reranker models; refresh; open the catalog.                                                                                                                                                                                                         |
+| **Search & Retrieval**      | **Results count** (1–20, default 12), **Search strictness** (how close a match must be), **Adaptive threshold** (auto-broaden when too few results). Search strictness and Adaptive threshold are server settings. They apply to every client of this server, and each row has a reset. |
+| **Generation** _(advanced)_ | System prompts for answering with and without documents, **Chat mode**, **Creativity** (temperature), **Top P**, **Top K**, **Repetition penalty**, **Seed**, and caps like max tokens, reasoning length, keep-alive, and GPU memory fraction. Blank means "use the model's default."   |
+| **Retrieval (advanced)**    | Candidate-pool multiplier, minimum relevance score, max sources per answer, max chunks per source, and the MMR relevance/diversity balance.                                                                                                                                             |
+| **Ingest**                  | Chunk size and overlap (changing these invalidates the index), and OCR timeouts.                                                                                                                                                                                                        |
+| **Worker pool**             | Timeouts and idle behavior for the background model workers; whether to start them eagerly.                                                                                                                                                                                             |
+| **Crawling**                | Depth, page limit, timeouts, request pacing, rate-limit retry/backoff, and URL exclude patterns.                                                                                                                                                                                        |
+| **Wiki (beta)**             | Enable the wiki, summary accuracy, default search mode, sync-to-vault and its folder, plus health-check and clean-up buttons.                                                                                                                                                           |
+| **Advanced**                | Store content in vault, rerank candidate count, **AI backend** (auto / local / external), API keys (OpenAI, Anthropic, Gemini, Hugging Face), the external endpoint, and **Reset all** server-backed settings.                                                                          |
 
 Most knobs in Search & Retrieval, Generation, Retrieval, Ingest, Worker pool, and Wiki are revealed only when the server reports them, so an older server shows fewer. Server-backed settings have a per-row reset; **Reset all** restores them to defaults while leaving your API keys and local preferences untouched.
 
@@ -258,15 +258,15 @@ Most knobs in Search & Retrieval, Generation, Retrieval, Ingest, Worker pool, an
 
 Text extraction is handled by [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg), code chunking by [tree-sitter](https://tree-sitter.github.io/tree-sitter/). The list below isn't exhaustive.
 
-| Format | Extensions |
-|--------|-----------|
-| PDF | `.pdf` (embedded text, with OCR fallback for scanned pages) |
-| Office | `.docx`, `.xlsx`, `.pptx` |
-| eBook | `.epub` |
-| Images | `.png`, `.jpg`, `.jpeg`, `.tiff`, `.bmp`, `.webp` (read with OCR or a vision model) |
-| Data | `.csv`, `.tsv`, `.xml`, `.json`, `.jsonl`, `.yaml`, `.yml` |
-| Text | `.md`, `.txt`, `.html`, `.rst` |
-| Code | `.py`, `.js`, `.ts`, `.go`, `.rs`, `.java`, and [150+ more](https://github.com/Goldziher/tree-sitter-language-pack) |
+| Format | Extensions                                                                                                          |
+| ------ | ------------------------------------------------------------------------------------------------------------------- |
+| PDF    | `.pdf` (embedded text, with OCR fallback for scanned pages)                                                         |
+| Office | `.docx`, `.xlsx`, `.pptx`                                                                                           |
+| eBook  | `.epub`                                                                                                             |
+| Images | `.png`, `.jpg`, `.jpeg`, `.tiff`, `.bmp`, `.webp` (read with OCR or a vision model)                                 |
+| Data   | `.csv`, `.tsv`, `.xml`, `.json`, `.jsonl`, `.yaml`, `.yml`                                                          |
+| Text   | `.md`, `.txt`, `.html`, `.rst`                                                                                      |
+| Code   | `.py`, `.js`, `.ts`, `.go`, `.rs`, `.java`, and [150+ more](https://github.com/Goldziher/tree-sitter-language-pack) |
 
 Scanned PDFs and image-only pages are read with OCR (Tesseract), or with a local or cloud **vision model** for higher quality on tables and layout. Set one under Settings → Models, or toggle OCR from the chat toolbar.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,7 +2,7 @@
 
 Everything the lilbee plugin can do inside Obsidian: the setup wizard, the chat and search surfaces, models, the wiki, crawling, and every setting. For installation see the [README quick start](../README.md#quick-start); for the engine itself (how it indexes and retrieves) see [lilbee](https://lilbee.sh/).
 
-The plugin talks to a local **lilbee** server over HTTP. In the default _managed_ mode it downloads and runs that server for you — there's nothing else to install, and no Ollama. Everything stays on your computer unless you choose a cloud model.
+The plugin talks to a local **lilbee** server over HTTP. In the default _managed_ mode it downloads and runs that server for you. There is nothing else to install, and no Ollama. Everything stays on your computer unless you choose a cloud model.
 
 - [First launch: the setup wizard](#first-launch-the-setup-wizard)
 - [The status bar and ribbon](#the-status-bar-and-ribbon)
@@ -244,7 +244,7 @@ Settings → Community plugins → **lilbee**. A filter box at the top searches 
 | **Search & Retrieval**      | **Results count** (1–20, default 12), **Search strictness** (how close a match must be), **Adaptive threshold** (auto-broaden when too few results). Search strictness and Adaptive threshold are server settings. They apply to every client of this server, and each row has a reset. |
 | **Generation** _(advanced)_ | System prompts for answering with and without documents, **Chat mode**, **Creativity** (temperature), **Top P**, **Top K**, **Repetition penalty**, **Seed**, and caps like max tokens, reasoning length, keep-alive, and GPU memory fraction. Blank means "use the model's default."   |
 | **Retrieval (advanced)**    | Candidate-pool multiplier, minimum relevance score, max sources per answer, max chunks per source, and the MMR relevance/diversity balance.                                                                                                                                             |
-| **Ingest**                  | Chunk size and overlap (changing these invalidates the index), and OCR timeouts.                                                                                                                                                                                                        |
+| **Ingest**                  | Chunk size and overlap (changing these invalidates the index), **Max chunks per file** (a file over the limit is skipped and reported; 0 means no limit), and OCR timeouts.                                                                                                              |
 | **Worker pool**             | Timeouts and idle behavior for the background model workers; whether to start them eagerly.                                                                                                                                                                                             |
 | **Crawling**                | Depth, page limit, timeouts, request pacing, rate-limit retry/backoff, and URL exclude patterns.                                                                                                                                                                                        |
 | **Wiki (beta)**             | Enable the wiki, summary accuracy, default search mode, sync-to-vault and its folder, plus health-check and clean-up buttons.                                                                                                                                                           |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -241,7 +241,7 @@ Settings → Community plugins → **lilbee**. A filter box at the top searches 
 |---------|--------|
 | **Connection** | Server mode (managed/external), re-run setup wizard. Managed: status, start/stop/restart, shared directory, adopt an existing data dir, disk usage, version & updates. External: server URL + test, session token, reset to managed. |
 | **Models** | Active chat, embedding, vision, and reranker models; refresh; open the catalog. |
-| **Search & Retrieval** | **Results count** (1–20, default 5), **Search strictness** (how close a match must be), **Adaptive threshold** (auto-broaden when too few results). |
+| **Search & Retrieval** | **Results count** (1–20, default 12), **Search strictness** (how close a match must be), **Adaptive threshold** (auto-broaden when too few results). Strictness and the adaptive threshold are server settings: they apply to every client that talks to this server, and they carry a per-row reset. |
 | **Generation** *(advanced)* | System prompts for answering with and without documents, **Chat mode**, **Creativity** (temperature), **Top P**, **Top K**, **Repetition penalty**, **Seed**, and caps like max tokens, reasoning length, keep-alive, and GPU memory fraction. Blank means "use the model's default." |
 | **Retrieval (advanced)** | Candidate-pool multiplier, minimum relevance score, max sources per answer, max chunks per source, and the MMR relevance/diversity balance. |
 | **Ingest** | Chunk size and overlap (changing these invalidates the index), and OCR timeouts. |
@@ -250,7 +250,7 @@ Settings → Community plugins → **lilbee**. A filter box at the top searches 
 | **Wiki (beta)** | Enable the wiki, summary accuracy, default search mode, sync-to-vault and its folder, plus health-check and clean-up buttons. |
 | **Advanced** | Store content in vault, rerank candidate count, **AI backend** (auto / local / external), API keys (OpenAI, Anthropic, Gemini, Hugging Face), the external endpoint, and **Reset all** server-backed settings. |
 
-Most knobs in Generation, Retrieval, Ingest, and Worker pool are revealed only when the server reports them, so an older server shows fewer. Server-backed settings have a per-row reset; **Reset all** restores them to defaults while leaving your API keys and local preferences untouched.
+Most knobs in Search & Retrieval, Generation, Retrieval, Ingest, Worker pool, and Wiki are revealed only when the server reports them, so an older server shows fewer. Server-backed settings have a per-row reset; **Reset all** restores them to defaults while leaving your API keys and local preferences untouched.
 
 ---
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -187,6 +187,7 @@ export const MESSAGES = {
     LABEL_INGEST_HELP: "How documents are split, OCR'd and prepared before they enter the index.",
     LABEL_CHUNK_SIZE: "Chunk size (tokens)",
     LABEL_CHUNK_OVERLAP: "Chunk overlap (tokens)",
+    LABEL_MAX_CHUNKS_PER_FILE: "Max chunks per file",
     LABEL_TESSERACT_TIMEOUT: "Tesseract per-page timeout (s)",
     LABEL_VISION_LOAD_BUDGET: "Vision OCR pool budget (s)",
     LABEL_RETRIEVAL_ADVANCED: "Retrieval (advanced)",
@@ -507,6 +508,8 @@ export const MESSAGES = {
     DESC_CRAWL_RETRY_MAX_ATTEMPTS: "Retry count per URL before giving up.",
     DESC_CHUNK_SIZE: "Document chunk size in tokens (changes invalidate the index)",
     DESC_CHUNK_OVERLAP: "Tokens of overlap between adjacent chunks (preserves context across boundaries)",
+    DESC_MAX_CHUNKS_PER_FILE:
+        "Most chunks one file can add to the index. A file over the limit is skipped and reported. 0 means no limit. Raise it for a long document at a small chunk size.",
     DESC_EMBEDDING_MODEL: "The AI model used to understand your documents. Changing requires re-indexing.",
     DESC_LLM_PROVIDER: "Auto picks the best available. Use External to connect to OpenAI, Claude, or other services.",
     DESC_LLM_PROVIDER_AUTO: "Auto (recommended)",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -125,7 +125,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
     private serverConfigHideableEls: Map<string, HTMLElement> = new Map();
     private configDefaults: Record<string, unknown> = {};
     // Guards programmatic toggle.setValue() and slider.setValue() calls from echoing back to the server.
-    private suppressToggleChanges = false;
+    private suppressChangeEvents = false;
     private chatModeSettingEl: HTMLElement | null = null;
     private chatModeDropdown: { setValue: (v: string) => unknown } | null = null;
     private chatModeSelectEl: HTMLSelectElement | null = null;
@@ -1006,7 +1006,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             .setDesc(MESSAGES.DESC_SHOW_REASONING)
             .addToggle((toggle) => {
                 toggle.onChange(async (value) => {
-                    if (this.suppressToggleChanges) return;
+                    if (this.suppressChangeEvents) return;
                     try {
                         await this.plugin.api.updateConfig({ [CONFIG_KEY.SHOW_REASONING]: value });
                         new Notice(MESSAGES.NOTICE_FIELD_UPDATED(MESSAGES.LABEL_SHOW_REASONING));
@@ -1024,7 +1024,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             .setDesc(MESSAGES.DESC_CHAT_COMPACTION)
             .addToggle((toggle) => {
                 toggle.onChange(async (value) => {
-                    if (this.suppressToggleChanges) return;
+                    if (this.suppressChangeEvents) return;
                     try {
                         await this.plugin.api.updateConfig({ [CONFIG_KEY.CHAT_COMPACTION]: value });
                         new Notice(MESSAGES.NOTICE_FIELD_UPDATED(MESSAGES.LABEL_CHAT_COMPACTION));
@@ -1088,25 +1088,11 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 }
                 for (const [key, toggle] of this.serverConfigToggles) {
                     const v = cfg[key];
-                    if (typeof v === "boolean") {
-                        this.suppressToggleChanges = true;
-                        try {
-                            toggle.setValue(v);
-                        } finally {
-                            this.suppressToggleChanges = false;
-                        }
-                    }
+                    if (typeof v === "boolean") this.setValueSilently(() => toggle.setValue(v));
                 }
                 for (const [key, slider] of this.serverConfigSliders) {
                     const v = cfg[key];
-                    if (typeof v === "number") {
-                        this.suppressToggleChanges = true;
-                        try {
-                            slider.setValue(v);
-                        } finally {
-                            this.suppressToggleChanges = false;
-                        }
-                    }
+                    if (typeof v === "number") this.setValueSilently(() => slider.setValue(v));
                 }
                 for (const [key, textArea] of this.serverConfigTextAreas) {
                     const v = cfg[key];
@@ -1138,6 +1124,16 @@ export class LilbeeSettingTab extends PluginSettingTab {
             .catch(() => {
                 // Connection status is shown via the Test button — no duplicate warning needed
             });
+    }
+
+    /** Runs a programmatic setValue with the control's onChange muted, so nothing echoes to the server. */
+    private setValueSilently(apply: () => unknown): void {
+        this.suppressChangeEvents = true;
+        try {
+            apply();
+        } finally {
+            this.suppressChangeEvents = false;
+        }
     }
 
     private applyHideableConfigFields(cfg: ConfigResponse): void {
@@ -1411,7 +1407,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             .setDesc(MESSAGES.DESC_WORKER_POOL_EAGER_START)
             .addToggle((toggle) => {
                 toggle.onChange(async (value) => {
-                    if (this.suppressToggleChanges) return;
+                    if (this.suppressChangeEvents) return;
                     try {
                         await this.plugin.api.updateConfig({ worker_pool_eager_start: value });
                         new Notice(MESSAGES.NOTICE_FIELD_UPDATED(MESSAGES.LABEL_WORKER_POOL_EAGER_START));
@@ -1476,7 +1472,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             .setDesc(MESSAGES.DESC_FLASH_ATTENTION)
             .addToggle((toggle) => {
                 toggle.onChange(async (value) => {
-                    if (this.suppressToggleChanges) return;
+                    if (this.suppressChangeEvents) return;
                     try {
                         await this.plugin.api.updateConfig({ flash_attention: value });
                         new Notice(MESSAGES.NOTICE_FIELD_UPDATED(MESSAGES.LABEL_FLASH_ATTENTION));
@@ -1847,14 +1843,14 @@ export class LilbeeSettingTab extends PluginSettingTab {
         this.appendResetAffordance(mmrSetting, "mmr_lambda", MESSAGES.LABEL_MMR_LAMBDA);
     }
 
-    /** A server-config boolean, registered so loadServerDefaults can fill it. */
+    /** A server-config boolean on a toggle, hidden until loadServerDefaults sees the key. */
     private renderConfigToggle(container: HTMLElement, key: string, name: string, desc: string): void {
         const setting = new Setting(container)
             .setName(name)
             .setDesc(desc)
             .addToggle((toggle) => {
                 toggle.onChange(async (value) => {
-                    if (this.suppressToggleChanges) return;
+                    if (this.suppressChangeEvents) return;
                     try {
                         await this.plugin.api.updateConfig({ [key]: value });
                         new Notice(MESSAGES.NOTICE_FIELD_UPDATED(name));
@@ -1864,6 +1860,8 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 });
                 this.serverConfigToggles.set(key, toggle);
             });
+        setting.settingEl.hide();
+        this.serverConfigHideableEls.set(key, setting.settingEl);
         this.appendResetAffordance(setting, key, name);
     }
 
@@ -1880,7 +1878,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             .setDesc(desc)
             .addSlider((slider) => {
                 slider.setLimits(opts.min, opts.max, opts.step).onChange(async (value) => {
-                    if (this.suppressToggleChanges) return;
+                    if (this.suppressChangeEvents) return;
                     try {
                         await this.plugin.api.updateConfig({ [key]: value });
                         new Notice(MESSAGES.NOTICE_FIELD_UPDATED(name));
@@ -2481,7 +2479,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
                     .setDesc(field.desc)
                     .addToggle((toggle) => {
                         toggle.onChange(async (value) => {
-                            if (this.suppressToggleChanges) return;
+                            if (this.suppressChangeEvents) return;
                             try {
                                 await this.plugin.api.updateConfig({ [field.key]: value });
                                 new Notice(MESSAGES.NOTICE_FIELD_UPDATED(field.name));

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1630,6 +1630,15 @@ export class LilbeeSettingTab extends PluginSettingTab {
         );
         this.appendResetAffordance(chunkOverlapSetting, "chunk_overlap", MESSAGES.LABEL_CHUNK_OVERLAP);
 
+        const maxChunksSetting = this.renderHideableNumberField(
+            details,
+            "max_chunks_per_file",
+            MESSAGES.LABEL_MAX_CHUNKS_PER_FILE,
+            MESSAGES.DESC_MAX_CHUNKS_PER_FILE,
+            { integer: true, min: 0 },
+        );
+        this.appendResetAffordance(maxChunksSetting, "max_chunks_per_file", MESSAGES.LABEL_MAX_CHUNKS_PER_FILE);
+
         const tesseractSetting = this.renderHideableNumberField(
             details,
             "tesseract_timeout",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -120,10 +120,11 @@ export class LilbeeSettingTab extends PluginSettingTab {
     private memoryToggles: Map<string, { setValue: (v: boolean) => unknown }> = new Map();
     private serverConfigTextAreas: Map<string, HTMLTextAreaElement> = new Map();
     private serverConfigDropdowns: Map<string, { setValue: (v: string) => unknown }> = new Map();
+    private serverConfigSliders: Map<string, { setValue: (v: number) => unknown }> = new Map();
     // Rows hidden until loadServerDefaults sees a defined value for the matching cfg key.
     private serverConfigHideableEls: Map<string, HTMLElement> = new Map();
     private configDefaults: Record<string, unknown> = {};
-    // Guards programmatic toggle.setValue() calls from echoing back to the server.
+    // Guards programmatic toggle.setValue() and slider.setValue() calls from echoing back to the server.
     private suppressToggleChanges = false;
     private chatModeSettingEl: HTMLElement | null = null;
     private chatModeDropdown: { setValue: (v: string) => unknown } | null = null;
@@ -1054,30 +1055,18 @@ export class LilbeeSettingTab extends PluginSettingTab {
             );
         this.appendLocalResetAffordance(topKSetting, "topK", MESSAGES.LABEL_RESULTS_COUNT);
 
-        const maxDistanceSetting = new Setting(containerEl)
-            .setName(MESSAGES.LABEL_MAX_DISTANCE)
-            .setDesc(MESSAGES.DESC_MAX_DISTANCE)
-            .addSlider((slider) =>
-                slider
-                    .setLimits(0.1, 1.0, 0.1)
-                    .setValue(this.plugin.settings.maxDistance ?? 0.9)
-                    .onChange(async (value) => {
-                        this.plugin.settings.maxDistance = value;
-                        await this.plugin.saveSettings();
-                    }),
-            );
-        this.appendLocalResetAffordance(maxDistanceSetting, "maxDistance", MESSAGES.LABEL_MAX_DISTANCE);
+        this.renderConfigSlider(containerEl, "max_distance", MESSAGES.LABEL_MAX_DISTANCE, MESSAGES.DESC_MAX_DISTANCE, {
+            min: 0.05,
+            max: 1.0,
+            step: 0.05,
+        });
 
-        const adaptiveSetting = new Setting(containerEl)
-            .setName(MESSAGES.LABEL_ADAPTIVE_THRESHOLD)
-            .setDesc(MESSAGES.DESC_ADAPTIVE_THRESHOLD)
-            .addToggle((toggle) =>
-                toggle.setValue(this.plugin.settings.adaptiveThreshold ?? false).onChange(async (value) => {
-                    this.plugin.settings.adaptiveThreshold = value;
-                    await this.plugin.saveSettings();
-                }),
-            );
-        this.appendLocalResetAffordance(adaptiveSetting, "adaptiveThreshold", MESSAGES.LABEL_ADAPTIVE_THRESHOLD);
+        this.renderConfigToggle(
+            containerEl,
+            "adaptive_threshold",
+            MESSAGES.LABEL_ADAPTIVE_THRESHOLD,
+            MESSAGES.DESC_ADAPTIVE_THRESHOLD,
+        );
     }
 
     private loadServerDefaults(): void {
@@ -1103,6 +1092,17 @@ export class LilbeeSettingTab extends PluginSettingTab {
                         this.suppressToggleChanges = true;
                         try {
                             toggle.setValue(v);
+                        } finally {
+                            this.suppressToggleChanges = false;
+                        }
+                    }
+                }
+                for (const [key, slider] of this.serverConfigSliders) {
+                    const v = cfg[key];
+                    if (typeof v === "number") {
+                        this.suppressToggleChanges = true;
+                        try {
+                            slider.setValue(v);
                         } finally {
                             this.suppressToggleChanges = false;
                         }
@@ -1215,37 +1215,6 @@ export class LilbeeSettingTab extends PluginSettingTab {
                     await this.plugin.saveSettings();
                     new Notice(MESSAGES.NOTICE_FIELD_RESET(label));
                     this.render();
-                }),
-        );
-    }
-
-    /**
-     * Reset affordance for fields that dual-write: PATCH the server default AND mirror it back
-     * into `plugin.settings[localKey]`. Prevents the re-render from picking up a stale local value
-     * via `toggle.setValue(this.plugin.settings[localKey])`.
-     */
-    private appendDualResetAffordance<K extends keyof LilbeeSettings>(
-        setting: Setting,
-        serverKey: string,
-        localKey: K,
-        label: string,
-    ): Setting {
-        return setting.addExtraButton((btn) =>
-            btn
-                .setIcon(ICON_RESET)
-                .setTooltip(MESSAGES.LABEL_RESET_TO_DEFAULT)
-                .onClick(async () => {
-                    if (!(serverKey in this.configDefaults)) return;
-                    const def = this.configDefaults[serverKey];
-                    try {
-                        await this.plugin.api.updateConfig({ [serverKey]: def });
-                        this.plugin.settings[localKey] = def as LilbeeSettings[K];
-                        await this.plugin.saveSettings();
-                        new Notice(MESSAGES.NOTICE_FIELD_RESET(label));
-                        this.render();
-                    } catch {
-                        new Notice(MESSAGES.NOTICE_FAILED_RESET(label));
-                    }
                 }),
         );
     }
@@ -1895,6 +1864,34 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 });
                 this.serverConfigToggles.set(key, toggle);
             });
+        this.appendResetAffordance(setting, key, name);
+    }
+
+    /** A server-config number on a slider, hidden until loadServerDefaults sees the key. */
+    private renderConfigSlider(
+        container: HTMLElement,
+        key: string,
+        name: string,
+        desc: string,
+        opts: { min: number; max: number; step: number },
+    ): void {
+        const setting = new Setting(container)
+            .setName(name)
+            .setDesc(desc)
+            .addSlider((slider) => {
+                slider.setLimits(opts.min, opts.max, opts.step).onChange(async (value) => {
+                    if (this.suppressToggleChanges) return;
+                    try {
+                        await this.plugin.api.updateConfig({ [key]: value });
+                        new Notice(MESSAGES.NOTICE_FIELD_UPDATED(name));
+                    } catch {
+                        new Notice(MESSAGES.NOTICE_FAILED_UPDATE(name));
+                    }
+                });
+                this.serverConfigSliders.set(key, slider);
+            });
+        setting.settingEl.hide();
+        this.serverConfigHideableEls.set(key, setting.settingEl);
         this.appendResetAffordance(setting, key, name);
     }
 
@@ -2607,48 +2604,20 @@ export class LilbeeSettingTab extends PluginSettingTab {
         new Setting(subSettingsContainer).setName(MESSAGES.LABEL_WIKI_STATUS).setDesc(statusDesc).setDisabled(true);
 
         // Prune raw chunks
-        const pruneSetting = new Setting(subSettingsContainer)
-            .setName(MESSAGES.LABEL_WIKI_PRUNE_RAW)
-            .setDesc(MESSAGES.DESC_WIKI_PRUNE_RAW)
-            .addToggle((toggle) => {
-                toggle.setValue(this.plugin.settings.wikiPruneRaw);
-                toggle.onChange(async (value) => {
-                    this.plugin.settings.wikiPruneRaw = value;
-                    await this.plugin.saveSettings();
-                    try {
-                        await this.plugin.api.updateConfig({ wiki_prune_raw: value });
-                        new Notice(MESSAGES.NOTICE_FIELD_UPDATED(MESSAGES.LABEL_WIKI_PRUNE_RAW));
-                    } catch {
-                        new Notice(MESSAGES.NOTICE_FAILED_UPDATE(MESSAGES.LABEL_WIKI_PRUNE_RAW));
-                    }
-                });
-            });
-        this.appendDualResetAffordance(pruneSetting, "wiki_prune_raw", "wikiPruneRaw", MESSAGES.LABEL_WIKI_PRUNE_RAW);
+        this.renderConfigToggle(
+            subSettingsContainer,
+            "wiki_prune_raw",
+            MESSAGES.LABEL_WIKI_PRUNE_RAW,
+            MESSAGES.DESC_WIKI_PRUNE_RAW,
+        );
 
         // Faithfulness threshold
-        const faithSetting = new Setting(subSettingsContainer)
-            .setName(MESSAGES.LABEL_WIKI_FAITHFULNESS)
-            .setDesc(MESSAGES.DESC_WIKI_FAITHFULNESS)
-            .addSlider((slider) => {
-                slider
-                    .setLimits(0, 1, 0.05)
-                    .setValue(this.plugin.settings.wikiFaithfulnessThreshold)
-                    .onChange(async (value) => {
-                        this.plugin.settings.wikiFaithfulnessThreshold = value;
-                        await this.plugin.saveSettings();
-                        try {
-                            await this.plugin.api.updateConfig({ wiki_embedding_faithfulness_threshold: value });
-                            new Notice(MESSAGES.NOTICE_FIELD_UPDATED(MESSAGES.LABEL_WIKI_FAITHFULNESS));
-                        } catch {
-                            new Notice(MESSAGES.NOTICE_FAILED_UPDATE(MESSAGES.LABEL_WIKI_FAITHFULNESS));
-                        }
-                    });
-            });
-        this.appendDualResetAffordance(
-            faithSetting,
+        this.renderConfigSlider(
+            subSettingsContainer,
             "wiki_embedding_faithfulness_threshold",
-            "wikiFaithfulnessThreshold",
             MESSAGES.LABEL_WIKI_FAITHFULNESS,
+            MESSAGES.DESC_WIKI_FAITHFULNESS,
+            { min: 0, max: 1, step: 0.05 },
         );
 
         // Default search mode

--- a/src/types.ts
+++ b/src/types.ts
@@ -567,15 +567,11 @@ export const AGENT_MIN_CONTEXT_TOKENS = 20_000;
 export interface LilbeeSettings {
     serverUrl: string;
     topK: number;
-    maxDistance: number;
-    adaptiveThreshold: boolean;
     serverMode: ServerMode;
     ragSystemPrompt: string;
     generalSystemPrompt: string;
     setupCompleted: boolean;
     wikiEnabled: boolean;
-    wikiPruneRaw: boolean;
-    wikiFaithfulnessThreshold: number;
     searchChunkType: SearchChunkType;
     wikiSyncToVault: boolean;
     wikiVaultFolder: string;
@@ -611,15 +607,11 @@ export const DEFAULT_SETTINGS: LilbeeSettings = {
     // Match the server's default retrieval depth (core config top_k = 12) so the
     // plugin and a bare `lilbee serve` behave identically out of the box.
     topK: 12,
-    maxDistance: 0.9,
-    adaptiveThreshold: false,
     serverMode: "managed",
     ragSystemPrompt: "",
     generalSystemPrompt: "",
     setupCompleted: false,
     wikiEnabled: false,
-    wikiPruneRaw: false,
-    wikiFaithfulnessThreshold: 0.7,
     searchChunkType: "raw",
     // On, but only reached once the wiki itself is enabled (which is opt-in).
     // A wiki you cannot open in the vault is most of the point missing: these

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,7 @@ export interface ConfigResponse {
     vision_load_budget_s?: number;
     chunk_size?: number;
     chunk_overlap?: number;
+    max_chunks_per_file?: number;
     tesseract_timeout?: number;
     max_tokens?: number;
     show_reasoning?: boolean;

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -4589,6 +4589,33 @@ describe("LilbeePlugin", () => {
             expect(plugin.settings.reasoningDefaulted).toBe(true);
         });
 
+        it("loads a settings file holding the retired local keys and patches nothing from them", async () => {
+            // Search strictness and the adaptive threshold live on the server now. A data.json
+            // written by an older plugin still carries the local copies: nothing reads them and
+            // nothing sends them, so the server keeps the values it already has.
+            const { DEFAULT_SETTINGS } = await import("../src/types");
+            const plugin = await createPlugin({
+                serverMode: "external",
+                maxDistance: 0.5,
+                adaptiveThreshold: true,
+                wikiPruneRaw: true,
+                wikiFaithfulnessThreshold: 0.85,
+            });
+            await plugin.onload();
+            const updateConfig = vi.fn();
+            plugin.api.updateConfig = updateConfig;
+            plugin.api.config = vi.fn().mockResolvedValue({});
+            plugin.api.listModels = vi.fn().mockResolvedValue({
+                chat: { active: "x", installed: [], catalog: [] },
+            });
+
+            await plugin.fetchActiveModel();
+
+            expect(updateConfig).not.toHaveBeenCalled();
+            expect(plugin.settings.topK).toBe(DEFAULT_SETTINGS.topK);
+            expect(plugin.settings.serverMode).toBe("external");
+        });
+
         it("status bar shows task name during sync and flashes done after", async () => {
             const plugin = await createPlugin();
             await plugin.onload();

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -4589,7 +4589,7 @@ describe("LilbeePlugin", () => {
             expect(plugin.settings.reasoningDefaulted).toBe(true);
         });
 
-        it("loads a settings file holding the retired local keys and patches nothing from them", async () => {
+        it("loads a settings file holding the retired local keys without error", async () => {
             // Search strictness and the adaptive threshold live on the server now. A data.json
             // written by an older plugin still carries the local copies: nothing reads them and
             // nothing sends them, so the server keeps the values it already has.

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -449,7 +449,7 @@ function captureSettingCallbacks(fn: () => void): Captured {
     (Setting.prototype as any).addToggle = function (cb: (toggle: any) => void) {
         // Mirrors real Obsidian ToggleComponent: setValue(v) programmatically flips the underlying
         // checkbox which triggers onChange. Required so tests exercise the echo-patch path the
-        // suppressToggleChanges flag guards against (bb-t6yg).
+        // suppressChangeEvents flag guards against (bb-t6yg).
         let ownOnChange: ToggleOnChange | null = null;
         const fakeToggle = {
             setValue: (v: boolean) => {
@@ -698,9 +698,9 @@ describe("LilbeeSettingTab", () => {
             const { sliderByName } = captureSettingCallbacks(() => tab.display());
 
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockClear();
-            (tab as any).suppressToggleChanges = true;
+            (tab as any).suppressChangeEvents = true;
             await sliderByName.get(MESSAGES.LABEL_MAX_DISTANCE)!(0.75);
-            (tab as any).suppressToggleChanges = false;
+            (tab as any).suppressChangeEvents = false;
             expect(plugin.api.updateConfig).not.toHaveBeenCalled();
         });
 
@@ -765,6 +765,31 @@ describe("LilbeeSettingTab", () => {
 
             await toggleByName.get(MESSAGES.LABEL_ADAPTIVE_THRESHOLD)!(true);
             expect(plugin.api.updateConfig).toHaveBeenCalledWith({ adaptive_threshold: true });
+        });
+
+        it("stays hidden while the server does not report adaptive_threshold", async () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({});
+            const tab = makeTab(plugin);
+            captureSettingCallbacks(() => tab.display());
+            await new Promise((r) => setTimeout(r, 0));
+
+            const row = (tab as any).serverConfigHideableEls.get("adaptive_threshold");
+            expect(row.style.display).toBe("none");
+        });
+
+        it("reveals the row showing the server's value once it reports adaptive_threshold", async () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({ adaptive_threshold: true });
+            const tab = makeTab(plugin);
+            captureSettingCallbacks(() => tab.display());
+            await new Promise((r) => setTimeout(r, 0));
+
+            const row = (tab as any).serverConfigHideableEls.get("adaptive_threshold");
+            expect(row.style.display).toBe("");
+            expect(plugin.api.updateConfig).not.toHaveBeenCalled();
         });
     });
 
@@ -3594,23 +3619,23 @@ describe("managed mode settings", () => {
             // Invoke the crawl_retry_on_rate_limit onChange without the flag — proves the guard is
             // load-bearing (if the flag failed to set, updateConfig WOULD be called).
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockClear();
-            (tab as any).suppressToggleChanges = false;
+            (tab as any).suppressChangeEvents = false;
             // toggleOnChanges[6] is crawl_retry_on_rate_limit; [0]=auto-update, [1]=includeDevBuilds,
             // [2]=show_reasoning, [3]=chat_compaction, [4]=adaptive_threshold, [5]=worker_pool_eager_start.
             await toggleByName.get(MESSAGES.LABEL_CRAWL_RETRY_ON_RATE_LIMIT)!(true);
             expect(plugin.api.updateConfig).toHaveBeenCalledWith({ crawl_retry_on_rate_limit: true });
         });
 
-        it("suppressToggleChanges === true short-circuits the crawl-retry toggle onChange", async () => {
+        it("suppressChangeEvents === true short-circuits the crawl-retry toggle onChange", async () => {
             const plugin = makePlugin();
             mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { toggleByName } = captureSettingCallbacks(() => tab.display());
             await new Promise((r) => setTimeout(r, 0));
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockClear();
-            (tab as any).suppressToggleChanges = true;
+            (tab as any).suppressChangeEvents = true;
             await toggleByName.get(MESSAGES.LABEL_CRAWL_RETRY_ON_RATE_LIMIT)!(true);
-            (tab as any).suppressToggleChanges = false;
+            (tab as any).suppressChangeEvents = false;
             expect(plugin.api.updateConfig).not.toHaveBeenCalled();
         });
 
@@ -4772,9 +4797,9 @@ describe("managed mode settings", () => {
             const tab = makeTab(plugin);
             const { toggleByName } = captureSettingCallbacks(() => tab.display());
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockClear();
-            (tab as any).suppressToggleChanges = true;
+            (tab as any).suppressChangeEvents = true;
             await toggleByName.get(MESSAGES.LABEL_FLASH_ATTENTION)!(true);
-            (tab as any).suppressToggleChanges = false;
+            (tab as any).suppressChangeEvents = false;
             expect(plugin.api.updateConfig).not.toHaveBeenCalled();
         });
 
@@ -6888,9 +6913,9 @@ describe("managed mode settings", () => {
             const tab = makeTab(plugin);
             const { toggleByName } = captureSettingCallbacks(() => tab.display());
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockClear();
-            (tab as any).suppressToggleChanges = true;
+            (tab as any).suppressChangeEvents = true;
             await toggleByName.get(MESSAGES.LABEL_WORKER_POOL_EAGER_START)!(true);
-            (tab as any).suppressToggleChanges = false;
+            (tab as any).suppressChangeEvents = false;
             expect(plugin.api.updateConfig).not.toHaveBeenCalled();
         });
     });
@@ -6926,9 +6951,9 @@ describe("managed mode settings", () => {
             const tab = makeTab(plugin);
             const { toggleByName } = captureSettingCallbacks(() => tab.display());
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockClear();
-            (tab as any).suppressToggleChanges = true;
+            (tab as any).suppressChangeEvents = true;
             await toggleByName.get(MESSAGES.LABEL_SHOW_REASONING)!(true);
-            (tab as any).suppressToggleChanges = false;
+            (tab as any).suppressChangeEvents = false;
             expect(plugin.api.updateConfig).not.toHaveBeenCalled();
         });
     });
@@ -6964,9 +6989,9 @@ describe("managed mode settings", () => {
             const tab = makeTab(plugin);
             const { toggleByName } = captureSettingCallbacks(() => tab.display());
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockClear();
-            (tab as any).suppressToggleChanges = true;
+            (tab as any).suppressChangeEvents = true;
             await toggleByName.get(MESSAGES.LABEL_CHAT_COMPACTION)!(true);
-            (tab as any).suppressToggleChanges = false;
+            (tab as any).suppressChangeEvents = false;
             expect(plugin.api.updateConfig).not.toHaveBeenCalled();
         });
     });
@@ -7849,7 +7874,7 @@ describe("new server config fields", () => {
         const tab = makeTab(plugin);
         const { toggleByName } = captureSettingCallbacks(() => tab.display());
 
-        (tab as any).suppressToggleChanges = true;
+        (tab as any).suppressChangeEvents = true;
         await toggleByName.get(MESSAGES.LABEL_TITLE_SEARCH)!(true);
         expect(plugin.api.updateConfig).not.toHaveBeenCalled();
     });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -619,10 +619,10 @@ describe("LilbeeSettingTab", () => {
             mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { textOnChanges } = captureSettingCallbacks(() => tab.display());
-            // sharedRoot + 9 generation + 5 retrieval-advanced + 4 ingest + 2 worker-pool
+            // sharedRoot + 9 generation + 5 retrieval-advanced + 5 ingest + 2 worker-pool
             // + 10 crawling + wikiVaultFolder + rerank_candidates + hfToken
-            // + ollama URL + lm_studio URL + 4 fleet (n_gpu_layers, embed/vision replicas, gpu_devices) = 40
-            expect(textOnChanges.length).toBe(50);
+            // + ollama URL + lm_studio URL + 4 fleet (n_gpu_layers, embed/vision replicas, gpu_devices)
+            expect(textOnChanges.length).toBe(51);
         });
     });
 
@@ -2888,6 +2888,18 @@ describe("managed mode settings", () => {
 
             await textByName.get(MESSAGES.LABEL_CHUNK_OVERLAP)!("64");
             expect(plugin.api.updateConfig).toHaveBeenCalledWith({ chunk_overlap: 64 });
+        });
+
+        it("max_chunks_per_file calls updateConfig without a reindex confirm", async () => {
+            mockGenericConfirmResult = false;
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const { textByName } = captureSettingCallbacks(() => tab.display());
+
+            await textByName.get(MESSAGES.LABEL_MAX_CHUNKS_PER_FILE)!("0");
+            expect(plugin.api.updateConfig).toHaveBeenCalledWith({ max_chunks_per_file: 0 });
+            mockGenericConfirmResult = true;
         });
 
         it("skips empty value", async () => {
@@ -6997,6 +7009,14 @@ describe("managed mode settings", () => {
     });
 
     describe("ingest settings", () => {
+        const INGEST_HIDEABLE_KEYS = [
+            "chunk_size",
+            "chunk_overlap",
+            "max_chunks_per_file",
+            "tesseract_timeout",
+            "vision_load_budget_s",
+        ];
+
         it("hides each ingest row when cfg keys are undefined", async () => {
             const plugin = makePlugin();
             (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({});
@@ -7005,7 +7025,7 @@ describe("managed mode settings", () => {
             tab.display();
             await new Promise((r) => setTimeout(r, 0));
             const hideable = (tab as any).serverConfigHideableEls as Map<string, { style: { display: string } }>;
-            for (const key of ["chunk_size", "chunk_overlap", "tesseract_timeout", "vision_load_budget_s"]) {
+            for (const key of INGEST_HIDEABLE_KEYS) {
                 expect(hideable.get(key)?.style.display).toBe("none");
             }
         });
@@ -7015,6 +7035,7 @@ describe("managed mode settings", () => {
             (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
                 chunk_size: 512,
                 chunk_overlap: 64,
+                max_chunks_per_file: 3000,
                 tesseract_timeout: 30,
                 vision_load_budget_s: 90,
             });
@@ -7023,9 +7044,31 @@ describe("managed mode settings", () => {
             tab.display();
             await new Promise((r) => setTimeout(r, 0));
             const hideable = (tab as any).serverConfigHideableEls as Map<string, { style: { display: string } }>;
-            for (const key of ["chunk_size", "chunk_overlap", "tesseract_timeout", "vision_load_budget_s"]) {
+            for (const key of INGEST_HIDEABLE_KEYS) {
                 expect(hideable.get(key)?.style.display).toBe("");
             }
+        });
+
+        it("fills max_chunks_per_file with the server value", async () => {
+            const plugin = makePlugin();
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({ max_chunks_per_file: 3000 });
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            tab.display();
+            await new Promise((r) => setTimeout(r, 0));
+            const inputs = (tab as any).serverConfigInputs as Map<string, { value: string }>;
+            expect(inputs.get("max_chunks_per_file")?.value).toBe("3000");
+        });
+
+        it("resets max_chunks_per_file by PATCHing the server default", async () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            (plugin.api.configDefaults as ReturnType<typeof vi.fn>).mockResolvedValue({ max_chunks_per_file: 3000 });
+            const tab = makeTab(plugin);
+            const { extraButtonOnClicks } = captureSettingCallbacks(() => tab.display());
+            await new Promise((r) => setTimeout(r, 0));
+            for (const click of extraButtonOnClicks) await click();
+            expect(plugin.api.updateConfig).toHaveBeenCalledWith({ max_chunks_per_file: 3000 });
         });
 
         it("PATCHes tesseract_timeout with a parsed float", async () => {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -283,6 +283,9 @@ interface Captured {
     toggleByName: Map<string, ToggleOnChange>;
     dropdownByName: Map<string, DropdownOnChange>;
     textAreaByName: Map<string, TextOnChange>;
+    sliderByName: Map<string, SliderOnChange>;
+    /** Every value pushed into a row's slider via setValue, in call order. */
+    sliderSetValuesByName: Map<string, number[]>;
     textOnChanges: TextOnChange[];
     textAreaOnChanges: TextOnChange[];
     blurHandlers: BlurCapture[];
@@ -324,6 +327,8 @@ function captureSettingCallbacks(fn: () => void): Captured {
     const toggleByName = new Map<string, ToggleOnChange>();
     const dropdownByName = new Map<string, DropdownOnChange>();
     const textAreaByName = new Map<string, TextOnChange>();
+    const sliderByName = new Map<string, SliderOnChange>();
+    const sliderSetValuesByName = new Map<string, number[]>();
     let currentName = "";
     const origSetName = Setting.prototype.setName;
     Setting.prototype.setName = function (name: string) {
@@ -392,16 +397,23 @@ function captureSettingCallbacks(fn: () => void): Captured {
     };
 
     Setting.prototype.addSlider = function (cb: (slider: any) => void) {
+        const name = currentName;
+        const setValues: number[] = [];
         const fakeSlider = {
             setLimits: () => fakeSlider,
-            setValue: () => fakeSlider,
+            setValue: (v: number) => {
+                setValues.push(v);
+                return fakeSlider;
+            },
             setDynamicTooltip: () => fakeSlider,
             onChange: (handler: SliderOnChange) => {
                 sliderOnChanges.push(handler);
+                if (name) sliderByName.set(name, handler);
                 return fakeSlider;
             },
         };
         cb(fakeSlider);
+        if (name) sliderSetValuesByName.set(name, setValues);
         return this;
     };
 
@@ -511,6 +523,8 @@ function captureSettingCallbacks(fn: () => void): Captured {
         toggleByName,
         dropdownByName,
         textAreaByName,
+        sliderByName,
+        sliderSetValuesByName,
         textOnChanges,
         textAreaOnChanges,
         blurHandlers,
@@ -652,50 +666,105 @@ describe("LilbeeSettingTab", () => {
         });
     });
 
-    describe("maxDistance slider onChange", () => {
-        it("updates maxDistance and calls saveSettings", async () => {
+    describe("search strictness slider (server-backed max_distance)", () => {
+        it("PATCHes max_distance on change", async () => {
+            Notice.clear();
             const plugin = makePlugin();
             mockChatPicker(plugin);
             const tab = makeTab(plugin);
-            const { sliderOnChanges } = captureSettingCallbacks(() => tab.display());
+            const { sliderByName } = captureSettingCallbacks(() => tab.display());
 
-            await sliderOnChanges[1](0.8);
-            expect(plugin.settings.maxDistance).toBe(0.8);
-            expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
+            await sliderByName.get(MESSAGES.LABEL_MAX_DISTANCE)!(0.75);
+            expect(plugin.api.updateConfig).toHaveBeenCalledWith({ max_distance: 0.75 });
+            expect(Notice.instances.some((n) => n.message.includes(MESSAGES.LABEL_MAX_DISTANCE))).toBe(true);
         });
 
-        it("uses default value when maxDistance is undefined", async () => {
-            const plugin = makePlugin({ maxDistance: undefined });
+        it("surfaces a notice when the PATCH fails", async () => {
+            Notice.clear();
+            const plugin = makePlugin();
+            (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("boom"));
             mockChatPicker(plugin);
             const tab = makeTab(plugin);
-            captureSettingCallbacks(() => tab.display());
+            const { sliderByName } = captureSettingCallbacks(() => tab.display());
 
-            // When maxDistance is undefined, setValue should use ?? 0.9 fallback
-            // Just call display to render - this exercises the ?? operator
-            expect(() => tab.display()).not.toThrow();
+            await sliderByName.get(MESSAGES.LABEL_MAX_DISTANCE)!(0.75);
+            expect(Notice.instances.some((n) => n.message.includes("failed to update"))).toBe(true);
+        });
+
+        it("does not echo a programmatic setValue back to the server", async () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const { sliderByName } = captureSettingCallbacks(() => tab.display());
+
+            (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockClear();
+            (tab as any).suppressToggleChanges = true;
+            await sliderByName.get(MESSAGES.LABEL_MAX_DISTANCE)!(0.75);
+            (tab as any).suppressToggleChanges = false;
+            expect(plugin.api.updateConfig).not.toHaveBeenCalled();
+        });
+
+        it("shows the server's current value once config loads", async () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({ max_distance: 0.62 });
+            const tab = makeTab(plugin);
+            const { sliderSetValuesByName } = captureSettingCallbacks(() => tab.display());
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(sliderSetValuesByName.get(MESSAGES.LABEL_MAX_DISTANCE)).toEqual([0.62]);
+        });
+
+        it("ignores a stale local value left behind in the settings file", async () => {
+            const plugin = makePlugin({
+                maxDistance: 0.5,
+                adaptiveThreshold: true,
+            } as unknown as Partial<LilbeeSettings>);
+            mockChatPicker(plugin);
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({ max_distance: 0.75 });
+            const tab = makeTab(plugin);
+            const { sliderSetValuesByName } = captureSettingCallbacks(() => tab.display());
+            await new Promise((r) => setTimeout(r, 0));
+
+            // The row shows what the server has, and rendering sends nothing back.
+            expect(sliderSetValuesByName.get(MESSAGES.LABEL_MAX_DISTANCE)).toEqual([0.75]);
+            expect(plugin.api.updateConfig).not.toHaveBeenCalled();
+        });
+
+        it("stays hidden while the server does not report max_distance", async () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({});
+            const tab = makeTab(plugin);
+            captureSettingCallbacks(() => tab.display());
+            await new Promise((r) => setTimeout(r, 0));
+
+            const row = (tab as any).serverConfigHideableEls.get("max_distance");
+            expect(row.style.display).toBe("none");
+        });
+
+        it("reveals the row once the server reports max_distance", async () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({ max_distance: 0.75 });
+            const tab = makeTab(plugin);
+            captureSettingCallbacks(() => tab.display());
+            await new Promise((r) => setTimeout(r, 0));
+
+            const row = (tab as any).serverConfigHideableEls.get("max_distance");
+            expect(row.style.display).toBe("");
         });
     });
 
-    describe("adaptiveThreshold toggle onChange", () => {
-        it("updates adaptiveThreshold and calls saveSettings", async () => {
+    describe("adaptive threshold toggle (server-backed adaptive_threshold)", () => {
+        it("PATCHes adaptive_threshold on change", async () => {
             const plugin = makePlugin();
             mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { toggleByName } = captureSettingCallbacks(() => tab.display());
 
-            // [0] auto-update, [1] includeDevBuilds (managed server section), [2] show_reasoning, [3] chat_compaction (Chat), [4] adaptiveThreshold.
             await toggleByName.get(MESSAGES.LABEL_ADAPTIVE_THRESHOLD)!(true);
-            expect(plugin.settings.adaptiveThreshold).toBe(true);
-            expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
-        });
-
-        it("uses default value when adaptiveThreshold is undefined", async () => {
-            const plugin = makePlugin({ adaptiveThreshold: undefined });
-            mockChatPicker(plugin);
-            const tab = makeTab(plugin);
-
-            // When adaptiveThreshold is undefined, setValue should use ?? false fallback
-            expect(() => tab.display()).not.toThrow();
+            expect(plugin.api.updateConfig).toHaveBeenCalledWith({ adaptive_threshold: true });
         });
     });
 
@@ -3356,7 +3425,7 @@ describe("managed mode settings", () => {
             const { toggleByName } = captureSettingCallbacks(() => tab.display());
 
             // Toggle order: [0] auto-update, [1] includeDevBuilds (managed server), [2] show_reasoning,
-            // [3] chat_compaction (Chat), [4] adaptiveThreshold (search/retrieval), [5] worker_pool_eager_start
+            // [3] chat_compaction (Chat), [4] adaptive_threshold (search/retrieval), [5] worker_pool_eager_start
             // (worker-pool), [6] crawl_retry_on_rate_limit (crawling), [7+] wiki toggles.
             await toggleByName.get(MESSAGES.LABEL_CRAWL_RETRY_ON_RATE_LIMIT)!(false);
             expect(plugin.api.updateConfig).toHaveBeenCalledWith({ crawl_retry_on_rate_limit: false });
@@ -3527,7 +3596,7 @@ describe("managed mode settings", () => {
             (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockClear();
             (tab as any).suppressToggleChanges = false;
             // toggleOnChanges[6] is crawl_retry_on_rate_limit; [0]=auto-update, [1]=includeDevBuilds,
-            // [2]=show_reasoning, [3]=chat_compaction, [4]=adaptiveThreshold, [5]=worker_pool_eager_start.
+            // [2]=show_reasoning, [3]=chat_compaction, [4]=adaptive_threshold, [5]=worker_pool_eager_start.
             await toggleByName.get(MESSAGES.LABEL_CRAWL_RETRY_ON_RATE_LIMIT)!(true);
             expect(plugin.api.updateConfig).toHaveBeenCalledWith({ crawl_retry_on_rate_limit: true });
         });
@@ -3690,7 +3759,7 @@ describe("managed mode settings", () => {
 
     describe("per-row reset-to-default affordance", () => {
         // Reset button order:
-        // 0=serverMode(local) 1=topK 2=maxDistance 3=adaptiveThreshold
+        // 0=serverMode(local) 1=topK 2=max_distance 3=adaptive_threshold
         // 4=ragSystemPrompt(local) 5=generalSystemPrompt(local) 6=temperature 7=top_p
         // 8=top_k_sampling 9=repeat_penalty 10=num_ctx 11=seed ...
         const TEMPERATURE_RESET = 6;
@@ -3744,10 +3813,10 @@ describe("managed mode settings", () => {
         });
     });
 
-    describe("appendDualResetAffordance (server PATCH + plugin.settings mirror)", () => {
-        it("resets wiki_prune_raw by PATCHing the default AND mirroring back to wikiPruneRaw", async () => {
+    describe("wiki row reset affordances", () => {
+        it("resets wiki_prune_raw by PATCHing the server default", async () => {
             Notice.clear();
-            const plugin = makePlugin({ wikiEnabled: true, wikiPruneRaw: true });
+            const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
             mockChatPicker(plugin);
             // configDefaults is re-fetched on each display(); keep it resolving to our seed.
@@ -3755,19 +3824,13 @@ describe("managed mode settings", () => {
             const tab = makeTab(plugin);
             const { extraButtonOnClicks } = captureSettingCallbacks(() => tab.display());
             await new Promise((r) => setTimeout(r, 0));
-            (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockClear();
-            // Search for the reset button whose click PATCHes wiki_prune_raw.
             for (let i = 0; i < extraButtonOnClicks.length; i++) {
                 (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mockClear();
                 await extraButtonOnClicks[i]();
                 const call = (plugin.api.updateConfig as ReturnType<typeof vi.fn>).mock.calls[0];
-                if (call && JSON.stringify(call[0]) === JSON.stringify({ wiki_prune_raw: false })) {
-                    expect(plugin.settings.wikiPruneRaw).toBe(false);
-                    expect(plugin.saveSettings).toHaveBeenCalled();
-                    return;
-                }
+                if (call && JSON.stringify(call[0]) === JSON.stringify({ wiki_prune_raw: false })) return;
             }
-            throw new Error("wiki_prune_raw dual-reset button not found");
+            throw new Error("wiki_prune_raw reset button not found");
         });
 
         it("no-ops silently when the key is absent from configDefaults", async () => {
@@ -4326,7 +4389,7 @@ describe("managed mode settings", () => {
             const tab = makeTab(plugin);
             const { toggleOnChanges, buttonOnClicks } = captureSettingCallbacks(() => tab.display());
             // Wiki section adds: 1 toggle (enable) + 1 toggle (prune raw) + 1 slider (faithfulness) + 1 dropdown (search mode) + 2 buttons (lint, prune)
-            // toggleOnChanges: adaptiveThreshold + wikiEnable + wikiPruneRaw + wikiSyncToVault
+            // toggleOnChanges: adaptive_threshold + wikiEnabled + wiki_prune_raw + wikiSyncToVault
             expect(toggleOnChanges.length).toBeGreaterThanOrEqual(3);
             expect(buttonOnClicks.length).toBeGreaterThanOrEqual(2);
         });
@@ -4408,35 +4471,42 @@ describe("managed mode settings", () => {
             expect((subContainer as any).style.display).toBe("");
         });
 
-        it("prune raw toggle calls updateConfig", async () => {
+        it("prune raw toggle PATCHes wiki_prune_raw", async () => {
             const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
             mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const { toggleByName } = captureSettingCallbacks(() => tab.display());
 
-            // wiki prune toggle is before the sync-to-vault toggle
             await toggleByName.get(MESSAGES.LABEL_WIKI_PRUNE_RAW)!(true);
-            expect(plugin.settings.wikiPruneRaw).toBe(true);
-            expect(plugin.saveSettings).toHaveBeenCalled();
             expect(plugin.api.updateConfig).toHaveBeenCalledWith({ wiki_prune_raw: true });
         });
 
-        it("faithfulness slider calls updateConfig", async () => {
+        it("faithfulness slider PATCHes wiki_embedding_faithfulness_threshold", async () => {
             const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
             mockChatPicker(plugin);
             const tab = makeTab(plugin);
-            const { sliderOnChanges } = captureSettingCallbacks(() => tab.display());
+            const { sliderByName } = captureSettingCallbacks(() => tab.display());
 
-            // wiki faithfulness slider is the last slider
-            const faithfulnessIdx = sliderOnChanges.length - 1;
-            await sliderOnChanges[faithfulnessIdx](0.85);
-            expect(plugin.settings.wikiFaithfulnessThreshold).toBe(0.85);
-            expect(plugin.saveSettings).toHaveBeenCalled();
+            await sliderByName.get(MESSAGES.LABEL_WIKI_FAITHFULNESS)!(0.85);
             expect(plugin.api.updateConfig).toHaveBeenCalledWith({
                 wiki_embedding_faithfulness_threshold: 0.85,
             });
+        });
+
+        it("faithfulness slider shows the server's current value", async () => {
+            const plugin = makePlugin({ wikiEnabled: true });
+            (plugin as any).wikiEnabled = true;
+            mockChatPicker(plugin);
+            (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
+                wiki_embedding_faithfulness_threshold: 0.5,
+            });
+            const tab = makeTab(plugin);
+            const { sliderSetValuesByName } = captureSettingCallbacks(() => tab.display());
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect(sliderSetValuesByName.get(MESSAGES.LABEL_WIKI_FAITHFULNESS)).toEqual([0.5]);
         });
 
         it("search mode dropdown updates settings", async () => {
@@ -6738,7 +6808,7 @@ describe("managed mode settings", () => {
     describe("worker pool settings", () => {
         // Manual mode worker-pool text inputs: [19] worker_pool_call_timeout_s,
         // [20] worker_pool_max_idle_s. Toggle [1] is worker_pool_eager_start
-        // ([0]=adaptiveThreshold).
+        // ([0]=adaptive_threshold).
 
         it("hides each worker-pool row when cfg keys are undefined", async () => {
             const plugin = makePlugin();

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -72,12 +72,10 @@ describe("DEFAULT_SETTINGS", () => {
     it("is a plain object with exactly the expected keys", () => {
         const keys = Object.keys(DEFAULT_SETTINGS).sort();
         const expected = [
-            "adaptiveThreshold",
             "agentIntegration",
             "includeDevBuilds",
             "reasoningDefaulted",
             "manualToken",
-            "maxDistance",
             "searchChunkType",
             "serverMode",
             "serverUrl",
@@ -89,8 +87,6 @@ describe("DEFAULT_SETTINGS", () => {
             "ragSystemPrompt",
             "topK",
             "wikiEnabled",
-            "wikiFaithfulnessThreshold",
-            "wikiPruneRaw",
             "wikiSyncToVault",
             "wikiVaultFolder",
         ].sort();
@@ -99,6 +95,13 @@ describe("DEFAULT_SETTINGS", () => {
 
     it("sharedRoot defaults to empty (use platform default)", () => {
         expect(DEFAULT_SETTINGS.sharedRoot).toBe("");
+    });
+
+    it("no longer carries the settings the server owns", () => {
+        const retired = ["maxDistance", "adaptiveThreshold", "wikiPruneRaw", "wikiFaithfulnessThreshold"];
+        for (const key of retired) {
+            expect(key in DEFAULT_SETTINGS).toBe(false);
+        }
     });
 });
 
@@ -288,8 +291,6 @@ describe("LilbeeSettings interface", () => {
     it("accepts a fully-specified settings object", () => {
         const s: LilbeeSettings = {
             serverUrl: "http://localhost:7433",
-            maxDistance: 0.9,
-            adaptiveThreshold: false,
             topK: 3,
             serverMode: "managed",
             ragSystemPrompt: "",


### PR DESCRIPTION
## Problem

Four controls in the settings tab wrote a value that nothing read. **Search strictness** and **Adaptive threshold** persisted locally and never reached the server. A user who adjusted them because his answers were wrong changed nothing. The server kept its own defaults (0.75 and off). The two wiki controls did PATCH the server. But they displayed a stale local mirror, with a default of 0.7 against the server's 0.5.

## Solution

**The server is the only source of truth.** All four render through the server-config pattern the tab already uses. Each row shows the server's current value, patches on change, hides until the server reports the key, and offers the standard reset. The toggle rows the tab already had now hide the same way, so a server that is down never shows a stale "off". The change deletes the four local keys. Load ignores a stale key in an existing settings file. Nothing replays a stored value to the server: a value that never took effect must not start taking effect silently.

**The Ingest section gains Max chunks per file.** The row follows the same server-backed pattern. It hides until the server reports the key, so an older server shows nothing.

**Docs match.** The Results count default reads 12. The Search & Retrieval row says which settings the server owns. The Ingest row names the new control.

This branch and the GPU-detection branch both touch `src/settings.ts`. Whichever merges second rebases.
