### PR TITLE
Record why the plugin chose its server build and show it

### DIFF
--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -22,7 +22,17 @@ import {
 import { basename, join, resolve, dirname } from "path";
 import { createHash } from "crypto";
 import { promisify } from "util";
-import { ARCH, PLATFORM, SERVER_VARIANT, type CudaTag, type GpuTag, type ServerVariant } from "./types";
+import {
+    ARCH,
+    NVIDIA_PROBE_STATUS,
+    PLATFORM,
+    SERVER_VARIANT,
+    type CudaTag,
+    type GpuDetection,
+    type GpuTag,
+    type NvidiaProbe,
+    type ServerVariant,
+} from "./types";
 import { formatDiskSize } from "./utils";
 
 const execFileAsync = promisify(execFile);
@@ -79,14 +89,36 @@ const RATE_LIMIT_STATUSES = new Set([403, 429]);
 
 const GITHUB_RATE_LIMITED = "GitHub's rate limit was reached; release checks reset within the hour.";
 
-/** Run `nvidia-smi` and return its stdout, or null if it is absent or fails. */
-async function runNvidiaSmi(): Promise<string | null> {
-    try {
-        const { stdout } = await node.execFile("nvidia-smi", []);
-        return stdout;
-    } catch {
-        return null;
+/** Windows installers put `nvidia-smi` here but leave it off PATH: DCH drivers use System32,
+ *  older layouts use the NVSMI directory. */
+function windowsNvidiaSmiPaths(): string[] {
+    const systemRoot = process.env.SystemRoot ?? "C:\\Windows";
+    const programFiles = process.env.ProgramFiles ?? "C:\\Program Files";
+    return [
+        node.join(systemRoot, "System32", "nvidia-smi.exe"),
+        node.join(programFiles, "NVIDIA Corporation", "NVSMI", "nvidia-smi.exe"),
+    ];
+}
+
+/** Where to look for `nvidia-smi`: PATH first, then the Windows install locations. */
+function nvidiaSmiCandidates(): string[] {
+    const candidates = ["nvidia-smi"];
+    if (process.platform === PLATFORM.WIN32) candidates.push(...windowsNvidiaSmiPaths());
+    return candidates;
+}
+
+/** Run `nvidia-smi` and return its stdout, or the error the PATH lookup failed with. */
+async function runNvidiaSmi(): Promise<{ stdout: string; error: null } | { stdout: null; error: string }> {
+    let firstError = "";
+    for (const command of nvidiaSmiCandidates()) {
+        try {
+            const { stdout } = await node.execFile(command, []);
+            return { stdout, error: null };
+        } catch (e) {
+            if (!firstError) firstError = e instanceof Error ? e.message : String(e);
+        }
     }
+    return { stdout: null, error: firstError };
 }
 
 /** Parse the driver's max CUDA version from `nvidia-smi` output as major*100+minor (12.5 -> 1205). */
@@ -104,17 +136,27 @@ function pickCudaTag(ceiling: number): CudaTag | null {
     return null;
 }
 
+/** Probe the NVIDIA driver, recording why the probe ended where it did. */
+async function probeNvidia(): Promise<NvidiaProbe> {
+    if (process.platform === PLATFORM.DARWIN) return { status: NVIDIA_PROBE_STATUS.SKIPPED };
+    const { stdout, error } = await runNvidiaSmi();
+    if (stdout === null) return { status: NVIDIA_PROBE_STATUS.MISSING, error };
+    const ceiling = parseCudaCeiling(stdout);
+    if (ceiling === null) return { status: NVIDIA_PROBE_STATUS.UNREADABLE };
+    return { status: NVIDIA_PROBE_STATUS.DETECTED, cudaCeiling: ceiling };
+}
+
+/** The CUDA build a probe result calls for, or null when it calls for none. */
+function cudaTagFor(probe: NvidiaProbe): CudaTag | null {
+    return probe.status === NVIDIA_PROBE_STATUS.DETECTED ? pickCudaTag(probe.cudaCeiling) : null;
+}
+
 /**
  * Detect the best CUDA build for this machine, or null to use the default build.
  * Returns null on macOS, when no NVIDIA driver is present, or on any detection failure.
  */
 export async function detectCudaTag(): Promise<CudaTag | null> {
-    if (process.platform === PLATFORM.DARWIN) return null;
-    const stdout = await runNvidiaSmi();
-    if (stdout === null) return null;
-    const ceiling = parseCudaCeiling(stdout);
-    if (ceiling === null) return null;
-    return pickCudaTag(ceiling);
+    return cudaTagFor(await probeNvidia());
 }
 
 /** The amdgpu compute device. Without it ROCm cannot run, whatever else sysfs says. */
@@ -175,12 +217,21 @@ export function detectAmdGfxTargets(): string[] {
 interface HostGpu {
     /** The newest CUDA build the NVIDIA driver supports, or null. */
     cuda: CudaTag | null;
-    /** The gfx targets of the host's AMD GPUs; empty when there are none. */
-    amdGfxTargets: string[];
+    /** Why the probe ended where it did, carried into the journal and the diagnostics bundle. */
+    detection: GpuDetection;
 }
 
-async function detectHostGpu(): Promise<HostGpu> {
-    return { cuda: await detectCudaTag(), amdGfxTargets: detectAmdGfxTargets() };
+/** Probe both vendors and keep the reasoning, so a build choice can be explained after the fact. */
+export async function detectHostGpu(): Promise<HostGpu> {
+    const nvidia = await probeNvidia();
+    return {
+        cuda: cudaTagFor(nvidia),
+        detection: {
+            nvidia,
+            amdGfxTargets: detectAmdGfxTargets(),
+            detectedAt: new Date().toISOString(),
+        },
+    };
 }
 
 export function getPlatformAssetName(gpuTag?: GpuTag | null): string {
@@ -217,6 +268,8 @@ export interface ReleaseInfo {
     tag: string;
     assetUrl: string;
     variant: ServerVariant;
+    /** The GPU probe that chose *variant*. */
+    detection: GpuDetection;
     sizeBytes: number;
     /** GitHub-reported "sha256:<hex>" of the asset, verified against the download bytes. */
     digest: string | null;
@@ -274,9 +327,10 @@ async function selectAsset(
         const cudaAsset = data.assets.find((a) => a.name === getPlatformAssetName(host.cuda));
         if (cudaAsset) return { variant: host.cuda, asset: cudaAsset };
     }
-    if (host.amdGfxTargets.length > 0) {
+    const { amdGfxTargets } = host.detection;
+    if (amdGfxTargets.length > 0) {
         const rocmAsset = data.assets.find((a) => a.name === getPlatformAssetName(SERVER_VARIANT.ROCM));
-        if (rocmAsset && (await rocmServesHost(data, host.amdGfxTargets))) {
+        if (rocmAsset && (await rocmServesHost(data, amdGfxTargets))) {
             return { variant: SERVER_VARIANT.ROCM, asset: rocmAsset };
         }
     }
@@ -290,6 +344,7 @@ async function toReleaseInfo(release: InstallableRelease, host: HostGpu): Promis
         tag: data.tag_name,
         assetUrl: asset.browser_download_url,
         variant,
+        detection: host.detection,
         sizeBytes: asset.size,
         digest: asset.digest,
     };

--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -19,6 +19,7 @@ import {
     readdirSync,
     rmSync,
 } from "fs";
+import { homedir } from "os";
 import { basename, join, resolve, dirname } from "path";
 import { createHash } from "crypto";
 import { promisify } from "util";
@@ -42,6 +43,7 @@ const statfsAsync = promisify(statfs);
 /** Exported for test mocking. */
 export const node = {
     spawn,
+    homedir,
     execFile: execFileAsync,
     appendFileSync,
     existsSync,
@@ -92,6 +94,8 @@ const GITHUB_RATE_LIMITED = "GitHub's rate limit was reached; release checks res
 
 /** `nvidia-smi` hangs on a wedged GPU; past this the probe records a timeout instead of waiting. */
 const NVIDIA_SMI_TIMEOUT_MS = 10_000;
+/** Present when the NVIDIA kernel module is loaded, whatever a sandbox hides from PATH. */
+const NVIDIA_DRIVER_VERSION_PATH = "/proc/driver/nvidia/version";
 const NVIDIA_SMI_TIMED_OUT = `nvidia-smi did not answer within ${NVIDIA_SMI_TIMEOUT_MS / 1000} s`;
 
 /** Windows installers put `nvidia-smi` here but leave it off PATH: DCH drivers use System32,
@@ -119,18 +123,30 @@ function probeFailureText(e: unknown): string {
     return text.replace(/\s+/g, " ").trim();
 }
 
-/** Run `nvidia-smi` and return its stdout, or the error the PATH lookup failed with. */
-async function runNvidiaSmi(): Promise<{ stdout: string; error: null } | { stdout: null; error: string }> {
+type NvidiaSmiRun =
+    | { stdout: string; error: null; notFound: false }
+    /** `notFound` is true when no candidate existed at all, as opposed to one that ran and failed. */
+    | { stdout: null; error: string; notFound: boolean };
+
+/** Run `nvidia-smi` and return its stdout, or the error the first lookup failed with. */
+async function runNvidiaSmi(): Promise<NvidiaSmiRun> {
     let firstError = "";
+    let notFound = true;
     for (const command of nvidiaSmiCandidates()) {
         try {
             const { stdout } = await node.execFile(command, [], { timeout: NVIDIA_SMI_TIMEOUT_MS });
-            return { stdout, error: null };
+            return { stdout, error: null, notFound: false };
         } catch (e) {
             if (!firstError) firstError = probeFailureText(e);
+            if ((e as NodeJS.ErrnoException).code !== "ENOENT") notFound = false;
         }
     }
-    return { stdout: null, error: firstError };
+    return { stdout: null, error: firstError, notFound };
+}
+
+/** Linux only: a loaded kernel module without a reachable `nvidia-smi` means a sandbox, not a missing driver. */
+function driverPresentWithoutSmi(): boolean {
+    return process.platform === PLATFORM.LINUX && node.existsSync(NVIDIA_DRIVER_VERSION_PATH);
 }
 
 /** Parse the driver's max CUDA version from `nvidia-smi` output as major*100+minor (12.5 -> 1205). */
@@ -151,8 +167,11 @@ function pickCudaTag(ceiling: number): CudaTag | null {
 /** Probe the NVIDIA driver, recording why the probe ended where it did. */
 async function probeNvidia(): Promise<NvidiaProbe> {
     if (process.platform === PLATFORM.DARWIN) return { status: NVIDIA_PROBE_STATUS.SKIPPED };
-    const { stdout, error } = await runNvidiaSmi();
-    if (stdout === null) return { status: NVIDIA_PROBE_STATUS.MISSING, error };
+    const { stdout, error, notFound } = await runNvidiaSmi();
+    if (stdout === null) {
+        if (notFound && driverPresentWithoutSmi()) return { status: NVIDIA_PROBE_STATUS.SANDBOXED };
+        return { status: NVIDIA_PROBE_STATUS.MISSING, error };
+    }
     const ceiling = parseCudaCeiling(stdout);
     if (ceiling === null) return { status: NVIDIA_PROBE_STATUS.UNREADABLE };
     return { status: NVIDIA_PROBE_STATUS.DETECTED, cudaCeiling: ceiling };

--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -1,5 +1,5 @@
 import { requestUrl } from "obsidian";
-import { execFile, spawn } from "child_process";
+import { execFile, spawn, type ExecFileException } from "child_process";
 import { get as httpsGet } from "https";
 import type { ClientRequest, IncomingMessage } from "http";
 import {
@@ -26,6 +26,7 @@ import {
     ARCH,
     NVIDIA_PROBE_STATUS,
     PLATFORM,
+    CUDA_MIN_CEILING,
     SERVER_VARIANT,
     type CudaTag,
     type GpuDetection,
@@ -89,6 +90,10 @@ const RATE_LIMIT_STATUSES = new Set([403, 429]);
 
 const GITHUB_RATE_LIMITED = "GitHub's rate limit was reached; release checks reset within the hour.";
 
+/** `nvidia-smi` hangs on a wedged GPU; past this the probe records a timeout instead of waiting. */
+const NVIDIA_SMI_TIMEOUT_MS = 10_000;
+const NVIDIA_SMI_TIMED_OUT = `nvidia-smi did not answer within ${NVIDIA_SMI_TIMEOUT_MS / 1000} s`;
+
 /** Windows installers put `nvidia-smi` here but leave it off PATH: DCH drivers use System32,
  *  older layouts use the NVSMI directory. */
 function windowsNvidiaSmiPaths(): string[] {
@@ -107,15 +112,22 @@ function nvidiaSmiCandidates(): string[] {
     return candidates;
 }
 
+/** One line for the journal: execFile's message carries the command's stderr on later lines. */
+function probeFailureText(e: unknown): string {
+    if (e instanceof Error && (e as ExecFileException).killed) return NVIDIA_SMI_TIMED_OUT;
+    const text = e instanceof Error ? e.message : String(e);
+    return text.replace(/\s+/g, " ").trim();
+}
+
 /** Run `nvidia-smi` and return its stdout, or the error the PATH lookup failed with. */
 async function runNvidiaSmi(): Promise<{ stdout: string; error: null } | { stdout: null; error: string }> {
     let firstError = "";
     for (const command of nvidiaSmiCandidates()) {
         try {
-            const { stdout } = await node.execFile(command, []);
+            const { stdout } = await node.execFile(command, [], { timeout: NVIDIA_SMI_TIMEOUT_MS });
             return { stdout, error: null };
         } catch (e) {
-            if (!firstError) firstError = e instanceof Error ? e.message : String(e);
+            if (!firstError) firstError = probeFailureText(e);
         }
     }
     return { stdout: null, error: firstError };
@@ -132,7 +144,7 @@ function parseCudaCeiling(stdout: string): number | null {
 function pickCudaTag(ceiling: number): CudaTag | null {
     if (ceiling >= 1205) return SERVER_VARIANT.CU125;
     if (ceiling >= 1204) return SERVER_VARIANT.CU124;
-    if (ceiling >= 1201) return SERVER_VARIANT.CU121;
+    if (ceiling >= CUDA_MIN_CEILING) return SERVER_VARIANT.CU121;
     return null;
 }
 
@@ -149,14 +161,6 @@ async function probeNvidia(): Promise<NvidiaProbe> {
 /** The CUDA build a probe result calls for, or null when it calls for none. */
 function cudaTagFor(probe: NvidiaProbe): CudaTag | null {
     return probe.status === NVIDIA_PROBE_STATUS.DETECTED ? pickCudaTag(probe.cudaCeiling) : null;
-}
-
-/**
- * Detect the best CUDA build for this machine, or null to use the default build.
- * Returns null on macOS, when no NVIDIA driver is present, or on any detection failure.
- */
-export async function detectCudaTag(): Promise<CudaTag | null> {
-    return cudaTagFor(await probeNvidia());
 }
 
 /** The amdgpu compute device. Without it ROCm cannot run, whatever else sysfs says. */
@@ -221,7 +225,7 @@ interface HostGpu {
     detection: GpuDetection;
 }
 
-/** Probe both vendors and keep the reasoning, so a build choice can be explained after the fact. */
+/** Probe both vendors and keep the reasoning. */
 export async function detectHostGpu(): Promise<HostGpu> {
     const nvidia = await probeNvidia();
     return {

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -2,8 +2,8 @@ import { zipSync } from "fflate";
 import { node } from "./binary-manager";
 import { formatJournalEntry } from "./error-journal";
 import { MESSAGES } from "./locales/en";
-import { redactSecrets, redactSettings } from "./redact";
-import { LOG_FILE, LOGS_DIR } from "./types";
+import { redactConfigKeys, redactSecrets, redactSettings } from "./redact";
+import { LOG_FILE, LOGS_DIR, SHARED_PATH } from "./types";
 import type { CollectedFile, DiagnosticsBundle, DiagnosticsContext } from "./types";
 
 export const LOG_TAIL_MAX_BYTES = 1_048_576;
@@ -28,6 +28,19 @@ function collectFile(zipName: string, path: string): CollectedFile {
         return { name: zipName, data: textEncoder.encode(redactSecrets(text)), note };
     } catch (e) {
         return { name: zipName, data: null, note: e instanceof Error ? e.message : String(e) };
+    }
+}
+
+/** Collects the shared root's config.json, blanking its credential fields by key. */
+function collectSharedConfig(sharedRoot: string): CollectedFile {
+    const path = node.join(sharedRoot, SHARED_PATH.CONFIG);
+    try {
+        if (!node.existsSync(path)) return { name: SHARED_PATH.CONFIG, data: null, note: NOTE_NOT_FOUND };
+        const parsed = JSON.parse(node.readFileSync(path, "utf-8")) as Record<string, unknown>;
+        const json = JSON.stringify(redactConfigKeys(parsed), null, 2);
+        return { name: SHARED_PATH.CONFIG, data: textEncoder.encode(json), note: null };
+    } catch (e) {
+        return { name: SHARED_PATH.CONFIG, data: null, note: e instanceof Error ? e.message : String(e) };
     }
 }
 
@@ -74,6 +87,8 @@ export function renderSummary(ctx: DiagnosticsContext, files: CollectedFile[]): 
         "## Environment",
         `- Plugin version: ${ctx.pluginVersion}`,
         `- Server version: ${ctx.serverVersion || "(unknown)"}`,
+        `- Server build: ${ctx.serverVariant ? MESSAGES.LABEL_SERVER_BUILD(ctx.serverVariant) : "(unknown)"}`,
+        `- GPU detection: ${ctx.gpuDetection ? MESSAGES.DESC_GPU_DETECTION(ctx.gpuDetection) : MESSAGES.DESC_GPU_DETECTION_NONE}`,
         `- Platform: ${process.platform} ${process.arch}`,
         `- Server state: ${ctx.serverState}`,
         `- Server URL: ${ctx.serverUrl || "(none)"}`,
@@ -101,6 +116,9 @@ export function collectDiagnostics(ctx: DiagnosticsContext): DiagnosticsBundle {
     const files: CollectedFile[] = collectLogFiles(ctx.dataDir);
     if (ctx.dataDir !== null) {
         files.push(collectFile("config.toml", node.join(ctx.dataDir, "config.toml")));
+    }
+    if (ctx.sharedRoot !== null) {
+        files.push(collectSharedConfig(ctx.sharedRoot));
     }
     files.push({
         name: "settings.json",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,5 +1,6 @@
 import {
     AGENT_CLIENT,
+    CUDA_MIN_CEILING,
     MODEL_TASK,
     NVIDIA_PROBE_STATUS,
     SERVER_VARIANT,
@@ -409,7 +410,7 @@ export const MESSAGES = {
         return `CUDA ${variant.slice(2, 4)}.${variant.slice(4)}`;
     },
     DESC_SERVER_BUILD: (build: string) => ` Running the ${build} build.`,
-    /** Why that build was chosen, so a machine on the wrong build shows its own reason. */
+    /** Why the GPU probe chose the build it did. */
     DESC_GPU_DETECTION: (detection: GpuDetection): string => {
         const { nvidia, amdGfxTargets } = detection;
         if (nvidia.status === NVIDIA_PROBE_STATUS.SKIPPED) return "lilbee ships one macOS build, so nothing is probed.";
@@ -417,7 +418,11 @@ export const MESSAGES = {
         if (nvidia.status === NVIDIA_PROBE_STATUS.MISSING) return `nvidia-smi did not run: ${nvidia.error}. ${amd}`;
         if (nvidia.status === NVIDIA_PROBE_STATUS.UNREADABLE)
             return `nvidia-smi ran but reported no CUDA version. ${amd}`;
-        return `The NVIDIA driver reports CUDA ${cudaVersionLabel(nvidia.cudaCeiling)}. ${amd}`;
+        const floor =
+            nvidia.cudaCeiling < CUDA_MIN_CEILING
+                ? ` lilbee ships CUDA builds for ${cudaVersionLabel(CUDA_MIN_CEILING)} and newer, so the default build runs.`
+                : "";
+        return `The NVIDIA driver reports CUDA ${cudaVersionLabel(nvidia.cudaCeiling)}.${floor} ${amd}`;
     },
     DESC_GPU_DETECTION_NONE: "(none recorded)",
     DESC_SERVER_VERSION_OFFLINE: (tag: string, reason: string) =>

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,4 +1,12 @@
-import { AGENT_CLIENT, MODEL_TASK, SERVER_VARIANT, type ServerVariant, type WorkerRole } from "../types";
+import {
+    AGENT_CLIENT,
+    MODEL_TASK,
+    NVIDIA_PROBE_STATUS,
+    SERVER_VARIANT,
+    type GpuDetection,
+    type ServerVariant,
+    type WorkerRole,
+} from "../types";
 
 // Natural-language noun for each worker role, so tooltips read "embedding
 // worker" rather than the internal "embed".
@@ -9,6 +17,8 @@ const ROLE_NOUN: Record<WorkerRole, string> = {
     rerank: "reranking",
 };
 const roleNoun = (role: WorkerRole): string => ROLE_NOUN[role];
+/** A CUDA ceiling as the driver prints it: 1204 -> "12.4". */
+const cudaVersionLabel = (ceiling: number): string => `${Math.floor(ceiling / 100)}.${ceiling % 100}`;
 const indefinite = (word: string): string => (/^[aeiou]/i.test(word) ? "an" : "a");
 
 export const MESSAGES = {
@@ -399,6 +409,17 @@ export const MESSAGES = {
         return `CUDA ${variant.slice(2, 4)}.${variant.slice(4)}`;
     },
     DESC_SERVER_BUILD: (build: string) => ` Running the ${build} build.`,
+    /** Why that build was chosen, so a machine on the wrong build shows its own reason. */
+    DESC_GPU_DETECTION: (detection: GpuDetection): string => {
+        const { nvidia, amdGfxTargets } = detection;
+        if (nvidia.status === NVIDIA_PROBE_STATUS.SKIPPED) return "lilbee ships one macOS build, so nothing is probed.";
+        const amd = amdGfxTargets.length > 0 ? `AMD targets: ${amdGfxTargets.join(", ")}.` : "No AMD compute device.";
+        if (nvidia.status === NVIDIA_PROBE_STATUS.MISSING) return `nvidia-smi did not run: ${nvidia.error}. ${amd}`;
+        if (nvidia.status === NVIDIA_PROBE_STATUS.UNREADABLE)
+            return `nvidia-smi ran but reported no CUDA version. ${amd}`;
+        return `The NVIDIA driver reports CUDA ${cudaVersionLabel(nvidia.cudaCeiling)}. ${amd}`;
+    },
+    DESC_GPU_DETECTION_NONE: "(none recorded)",
     DESC_SERVER_VERSION_OFFLINE: (tag: string, reason: string) =>
         `${tag} installed. The release list could not be read from GitHub: ${reason}`,
     DESC_DEV_BUILD_AVAILABLE: (tag: string) =>

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -416,6 +416,8 @@ export const MESSAGES = {
         if (nvidia.status === NVIDIA_PROBE_STATUS.SKIPPED) return "lilbee ships one macOS build, so nothing is probed.";
         const amd = amdGfxTargets.length > 0 ? `AMD targets: ${amdGfxTargets.join(", ")}.` : "No AMD compute device.";
         if (nvidia.status === NVIDIA_PROBE_STATUS.MISSING) return `nvidia-smi did not run: ${nvidia.error}. ${amd}`;
+        if (nvidia.status === NVIDIA_PROBE_STATUS.SANDBOXED)
+            return `An NVIDIA driver is present, but this Obsidian cannot reach nvidia-smi, so its CUDA version is unknown. Flatpak and Snap sandboxes hide it. ${amd}`;
         if (nvidia.status === NVIDIA_PROBE_STATUS.UNREADABLE)
             return `nvidia-smi ran but reported no CUDA version. ${amd}`;
         const floor =
@@ -464,6 +466,7 @@ export const MESSAGES = {
     LABEL_UNINSTALL_BINARY: "Server executable",
     LABEL_UNINSTALL_MODELS: "Downloaded models",
     LABEL_UNINSTALL_INDEX: "Search index for this vault",
+    LABEL_UNINSTALL_CACHE: "Unpacked server files",
     LABEL_UNINSTALL_KEEP: "Your notes and attachments",
     LABEL_UNINSTALL_KEEP_VALUE: "untouched",
     LABEL_UNINSTALL_DELETE_TAG: "Delete",

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,6 +53,7 @@ import {
     type CrawlRenderMode,
     type DiagnosticsContext,
     type DotState,
+    type GpuDetection,
     type HealthResponse,
     type LilbeeSettings,
     type ManagedServerProgressHandler,
@@ -756,7 +757,8 @@ export default class LilbeePlugin extends Plugin {
         try {
             const release = await getLatestRelease(this.settings.includeDevBuilds);
             this.setSharedLilbeeVersion(release.tag);
-            this.setSharedLilbeeVariant(release.variant);
+            this.setSharedLilbeeVariant(release.variant, release.detection);
+            this.journalGpuDetection("gpu detection at install", release);
         } catch {
             /* version tracking is best-effort */
         }
@@ -960,6 +962,7 @@ export default class LilbeePlugin extends Plugin {
             ...registry.loadConfig(),
             lilbeeVersion: "",
             lilbeeVariant: "",
+            lilbeeDetection: null,
             serverAutoUpdate: true,
             serverUninstalled: true,
         });
@@ -981,8 +984,17 @@ export default class LilbeePlugin extends Plugin {
         this.setStatusClass(null);
     }
 
+    /** Journal which build the GPU probe chose and why, so a wrong choice can be explained later. */
+    private journalGpuDetection(context: string, release: ReleaseInfo): void {
+        this.journal.lifecycle(
+            `${context}: ${MESSAGES.LABEL_SERVER_BUILD(release.variant)} build. ` +
+                MESSAGES.DESC_GPU_DETECTION(release.detection),
+        );
+    }
+
     async checkForUpdate(): Promise<{ available: boolean; release?: ReleaseInfo }> {
         const release = await getLatestRelease(this.settings.includeDevBuilds);
+        this.journalGpuDetection("gpu detection at update check", release);
         const versionChanged = checkForUpdate(this.getSharedLilbeeVersion(), release.tag);
         // A known installed variant that differs from the detected one means the
         // hardware-appropriate build changed (e.g. an NVIDIA driver was added).
@@ -1096,7 +1108,8 @@ export default class LilbeePlugin extends Plugin {
 
         // Save the new version and the build variant we just installed
         this.setSharedLilbeeVersion(release.tag);
-        this.setSharedLilbeeVariant(release.variant);
+        this.setSharedLilbeeVariant(release.variant, release.detection);
+        this.journalGpuDetection("gpu detection at install", release);
         this.journal.lifecycle(`server binary updated to ${release.tag}`);
 
         // Restart if in managed mode
@@ -1136,6 +1149,8 @@ export default class LilbeePlugin extends Plugin {
             journalEntries: this.journal.entries,
             pluginVersion: this.manifest.version,
             serverVersion: this.getSharedLilbeeVersion(),
+            serverVariant: this.getSharedLilbeeVariant(),
+            gpuDetection: this.getSharedGpuDetection(),
             serverState: this.serverManager?.state ?? SERVER_STATE.STOPPED,
             serverUrl: this.serverManager?.serverUrl ?? this.settings.serverUrl,
             lastOutput: this.serverManager?.lastOutput ?? "",
@@ -1653,10 +1668,15 @@ export default class LilbeePlugin extends Plugin {
         return this.vaultRegistry?.loadConfig().lilbeeVariant ?? "";
     }
 
-    setSharedLilbeeVariant(variant: ServerVariant): void {
+    /** The GPU probe that chose the installed build, or null when none is recorded. */
+    getSharedGpuDetection(): GpuDetection | null {
+        return this.vaultRegistry?.loadConfig().lilbeeDetection ?? null;
+    }
+
+    setSharedLilbeeVariant(variant: ServerVariant, detection: GpuDetection): void {
         const reg = this.vaultRegistry;
         if (!reg) return;
-        reg.saveConfig({ ...reg.loadConfig(), lilbeeVariant: variant });
+        reg.saveConfig({ ...reg.loadConfig(), lilbeeVariant: variant, lilbeeDetection: detection });
     }
 
     isServerAutoUpdateEnabled(): boolean {

--- a/src/main.ts
+++ b/src/main.ts
@@ -984,7 +984,7 @@ export default class LilbeePlugin extends Plugin {
         this.setStatusClass(null);
     }
 
-    /** Journal which build the GPU probe chose and why, so a wrong choice can be explained later. */
+    /** Journal which build the GPU probe chose and why. */
     private journalGpuDetection(context: string, release: ReleaseInfo): void {
         this.journal.lifecycle(
             `${context}: ${MESSAGES.LABEL_SERVER_BUILD(release.variant)} build. ` +

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -17,17 +17,14 @@ export function redactSecrets(text: string): string {
     return out;
 }
 
-const SECRET_SETTING_KEYS = ["manualToken", "hfToken"] as const;
+/** A top-level key that names a credential (manualToken, hfToken, and any later apiKey or secret). */
+const SECRET_KEY_PATTERN = /(token|api[_-]?key|apikey|secret|password)$/i;
 
-/**
- * Returns a copy of a settings or config object with credential fields blanked.
- * These keys carry no word boundary before "token", so redactSecrets does not
- * reach them; JSON files holding them must go through this instead.
- */
+/** Returns a copy of a settings or config object with credential fields blanked by key name. */
 export function redactConfigKeys(config: Record<string, unknown>): Record<string, unknown> {
     const copy: Record<string, unknown> = { ...config };
-    for (const key of SECRET_SETTING_KEYS) {
-        if (typeof copy[key] === "string" && copy[key].length > 0) {
+    for (const [key, value] of Object.entries(copy)) {
+        if (SECRET_KEY_PATTERN.test(key) && typeof value === "string" && value.length > 0) {
             copy[key] = REDACTED;
         }
     }

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -19,13 +19,22 @@ export function redactSecrets(text: string): string {
 
 const SECRET_SETTING_KEYS = ["manualToken", "hfToken"] as const;
 
-/** Returns a copy of the settings with credential fields blanked. */
-export function redactSettings(settings: LilbeeSettings & Partial<SharedConfig>): Record<string, unknown> {
-    const copy: Record<string, unknown> = { ...settings };
+/**
+ * Returns a copy of a settings or config object with credential fields blanked.
+ * These keys carry no word boundary before "token", so redactSecrets does not
+ * reach them; JSON files holding them must go through this instead.
+ */
+export function redactConfigKeys(config: Record<string, unknown>): Record<string, unknown> {
+    const copy: Record<string, unknown> = { ...config };
     for (const key of SECRET_SETTING_KEYS) {
         if (typeof copy[key] === "string" && copy[key].length > 0) {
             copy[key] = REDACTED;
         }
     }
     return copy;
+}
+
+/** Returns a copy of the settings with credential fields blanked. */
+export function redactSettings(settings: LilbeeSettings & Partial<SharedConfig>): Record<string, unknown> {
+    return redactConfigKeys({ ...settings });
 }

--- a/src/server-uninstall.ts
+++ b/src/server-uninstall.ts
@@ -5,10 +5,33 @@
 import { node } from "./binary-manager";
 import { dirSizeBytes } from "./storage-stats";
 import { sharedBinDir, sharedModelsDir } from "./vault-registry";
-import { UNINSTALL_TARGET, type UninstallPlan, type UninstallTarget, type UninstallTargetKind } from "./types";
+import {
+    PLATFORM,
+    UNINSTALL_TARGET,
+    type UninstallPlan,
+    type UninstallTarget,
+    type UninstallTargetKind,
+} from "./types";
+
+/** Written by the server into every directory it unpacks itself into. */
+const BOOTSTRAP_MANIFEST = ".lilbee-bootstrap-manifest";
 
 function target(kind: UninstallTargetKind, path: string): UninstallTarget {
     return { kind, path, bytes: dirSizeBytes(path) };
+}
+
+/** Where the server unpacks itself. On Windows that is the shared root, so its payload directories are listed by their manifest. */
+function unpackCachePaths(sharedRoot: string): string[] {
+    if (process.platform === PLATFORM.WIN32) {
+        if (!node.existsSync(sharedRoot)) return [];
+        return node
+            .readdirSync(sharedRoot)
+            .map((name) => node.join(sharedRoot, name))
+            .filter((path) => node.existsSync(node.join(path, BOOTSTRAP_MANIFEST)));
+    }
+    const home = node.homedir();
+    if (process.platform === PLATFORM.DARWIN) return [node.join(home, "Library", "Caches", "lilbee")];
+    return [node.join(home, ".cache", "lilbee")];
 }
 
 /** Size every removable path so the confirmation can name what it deletes. */
@@ -17,6 +40,7 @@ export function planUninstall(sharedRoot: string, vaultDataDir: string): Uninsta
         target(UNINSTALL_TARGET.BINARY, sharedBinDir(sharedRoot)),
         target(UNINSTALL_TARGET.MODELS, sharedModelsDir(sharedRoot)),
         target(UNINSTALL_TARGET.INDEX, vaultDataDir),
+        ...unpackCachePaths(sharedRoot).map((path) => target(UNINSTALL_TARGET.CACHE, path)),
     ];
     return { targets, totalBytes: targets.reduce((sum, t) => sum + t.bytes, 0) };
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -548,6 +548,9 @@ export class LilbeeSettingTab extends PluginSettingTab {
             const installedBuild = this.plugin.getSharedLilbeeVariant();
             if (installed && installedBuild) {
                 desc += MESSAGES.DESC_SERVER_BUILD(MESSAGES.LABEL_SERVER_BUILD(installedBuild));
+                // Why that build, so an NVIDIA machine left on the default build names its own reason.
+                const detection = this.plugin.getSharedGpuDetection();
+                if (detection) desc += ` ${MESSAGES.DESC_GPU_DETECTION(detection)}`;
             }
             if (newerDevTag) desc += ` ${MESSAGES.DESC_DEV_BUILD_AVAILABLE(newerDevTag)}`;
             setting.setDesc(desc);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -548,7 +548,6 @@ export class LilbeeSettingTab extends PluginSettingTab {
             const installedBuild = this.plugin.getSharedLilbeeVariant();
             if (installed && installedBuild) {
                 desc += MESSAGES.DESC_SERVER_BUILD(MESSAGES.LABEL_SERVER_BUILD(installedBuild));
-                // Why that build, so an NVIDIA machine left on the default build names its own reason.
                 const detection = this.plugin.getSharedGpuDetection();
                 if (detection) desc += ` ${MESSAGES.DESC_GPU_DETECTION(detection)}`;
             }

--- a/src/types.ts
+++ b/src/types.ts
@@ -645,6 +645,8 @@ export interface SharedConfig {
     lilbeeVersion: string;
     /** Which server build is installed. Empty when unknown (e.g. installed before variant tracking). */
     lilbeeVariant: ServerVariant | "";
+    /** The GPU probe that chose `lilbeeVariant`. Null when the install predates detection tracking. */
+    lilbeeDetection: GpuDetection | null;
     hfToken: string;
     /** Plugin version that last ran the automatic server-update check. */
     lastUpdateCheckPluginVersion: string;
@@ -657,6 +659,7 @@ export interface SharedConfig {
 export const DEFAULT_SHARED_CONFIG: SharedConfig = {
     lilbeeVersion: "",
     lilbeeVariant: "",
+    lilbeeDetection: null,
     hfToken: "",
     lastUpdateCheckPluginVersion: "",
     serverAutoUpdate: true,
@@ -755,6 +758,10 @@ export interface DiagnosticsContext {
     journalEntries: readonly JournalEntry[];
     pluginVersion: string;
     serverVersion: string;
+    /** Which server build is installed. Empty when nothing has recorded one. */
+    serverVariant: ServerVariant | "";
+    /** The GPU probe that chose the installed build, or null when none was recorded. */
+    gpuDetection: GpuDetection | null;
     serverState: ServerState;
     serverUrl: string;
     lastOutput: string;
@@ -1322,6 +1329,36 @@ export const SERVER_VARIANT = {
     CU125: "cu125",
     ROCM: "rocm",
 } as const satisfies Record<string, ServerVariant>;
+
+/** How the `nvidia-smi` probe ended. */
+export type NvidiaProbeStatus = "skipped" | "missing" | "unreadable" | "detected";
+export const NVIDIA_PROBE_STATUS = {
+    /** macOS: lilbee ships one build there, so nothing is probed. */
+    SKIPPED: "skipped",
+    /** `nvidia-smi` is absent or exited non-zero at every location tried. */
+    MISSING: "missing",
+    /** `nvidia-smi` ran but its output names no CUDA version. */
+    UNREADABLE: "unreadable",
+    /** The driver named the newest CUDA version it supports. */
+    DETECTED: "detected",
+} as const satisfies Record<string, NvidiaProbeStatus>;
+
+/** What the `nvidia-smi` probe found, and why it ended there. */
+export type NvidiaProbe =
+    | { status: "skipped" }
+    | { status: "missing"; error: string }
+    | { status: "unreadable" }
+    /** The driver's maximum CUDA version as major*100+minor (12.4 -> 1204). */
+    | { status: "detected"; cudaCeiling: number };
+
+/** Why the plugin picked the server build it did. Recorded at every install and update check. */
+export interface GpuDetection {
+    nvidia: NvidiaProbe;
+    /** The gfx targets of the host's AMD GPUs; empty when there are none. */
+    amdGfxTargets: string[];
+    /** When the probe ran, ISO 8601. */
+    detectedAt: string;
+}
 
 /** Source of the lilbee server binary; surfaced wherever the unsigned download is explained. */
 export const LILBEE_REPO_URL = "https://github.com/tobocop2/lilbee";

--- a/src/types.ts
+++ b/src/types.ts
@@ -667,12 +667,13 @@ export const DEFAULT_SHARED_CONFIG: SharedConfig = {
 };
 
 /** What a managed-mode uninstall deletes. Documents in the vault are never a target. */
-export type UninstallTargetKind = "binary" | "models" | "index";
+export type UninstallTargetKind = "binary" | "models" | "index" | "cache";
 
 export const UNINSTALL_TARGET = {
     BINARY: "binary",
     MODELS: "models",
     INDEX: "index",
+    CACHE: "cache",
 } as const satisfies Record<string, UninstallTargetKind>;
 
 export interface UninstallTarget {
@@ -1334,12 +1335,14 @@ export const SERVER_VARIANT = {
 export const CUDA_MIN_CEILING = 1201;
 
 /** How the `nvidia-smi` probe ended. */
-export type NvidiaProbeStatus = "skipped" | "missing" | "unreadable" | "detected";
+export type NvidiaProbeStatus = "skipped" | "missing" | "sandboxed" | "unreadable" | "detected";
 export const NVIDIA_PROBE_STATUS = {
     /** macOS: lilbee ships one build there, so nothing is probed. */
     SKIPPED: "skipped",
     /** `nvidia-smi` is absent or exited non-zero at every location tried. */
     MISSING: "missing",
+    /** Linux: the kernel module is loaded but no `nvidia-smi` is reachable (Flatpak, Snap). */
+    SANDBOXED: "sandboxed",
     /** `nvidia-smi` ran but its output names no CUDA version. */
     UNREADABLE: "unreadable",
     /** The driver named the newest CUDA version it supports. */
@@ -1350,6 +1353,7 @@ export const NVIDIA_PROBE_STATUS = {
 export type NvidiaProbe =
     | { status: "skipped" }
     | { status: "missing"; error: string }
+    | { status: "sandboxed" }
     | { status: "unreadable" }
     /** The driver's maximum CUDA version as major*100+minor (12.4 -> 1204). */
     | { status: "detected"; cudaCeiling: number };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1330,6 +1330,9 @@ export const SERVER_VARIANT = {
     ROCM: "rocm",
 } as const satisfies Record<string, ServerVariant>;
 
+/** Lowest CUDA driver ceiling (major*100 + minor) that any lilbee CUDA build supports. */
+export const CUDA_MIN_CEILING = 1201;
+
 /** How the `nvidia-smi` probe ended. */
 export type NvidiaProbeStatus = "skipped" | "missing" | "unreadable" | "detected";
 export const NVIDIA_PROBE_STATUS = {

--- a/src/views/uninstall-modal.ts
+++ b/src/views/uninstall-modal.ts
@@ -7,6 +7,7 @@ const TARGET_LABELS: Record<UninstallTargetKind, string> = {
     [UNINSTALL_TARGET.BINARY]: MESSAGES.LABEL_UNINSTALL_BINARY,
     [UNINSTALL_TARGET.MODELS]: MESSAGES.LABEL_UNINSTALL_MODELS,
     [UNINSTALL_TARGET.INDEX]: MESSAGES.LABEL_UNINSTALL_INDEX,
+    [UNINSTALL_TARGET.CACHE]: MESSAGES.LABEL_UNINSTALL_CACHE,
 };
 
 /** Confirms a managed-server uninstall by naming and sizing everything it deletes. */

--- a/tests/binary-manager.test.ts
+++ b/tests/binary-manager.test.ts
@@ -12,6 +12,7 @@ import {
     checkForUpdate,
     detectCudaTag,
     detectAmdGfxTargets,
+    detectHostGpu,
     BinaryManager,
 } from "../src/binary-manager";
 
@@ -81,6 +82,20 @@ function stubEnoughSpace() {
 /** Mock nvidia-smi as absent (no NVIDIA driver). */
 function stubNoNvidia() {
     return vi.spyOn(node, "execFile").mockRejectedValue(new Error("nvidia-smi not found"));
+}
+
+/** The detection a host records when nvidia-smi is absent. */
+function noNvidiaDetection(amdGfxTargets: string[] = []) {
+    return {
+        nvidia: { status: "missing", error: "nvidia-smi not found" },
+        amdGfxTargets,
+        detectedAt: expect.any(String),
+    };
+}
+
+/** The detection a host records when the driver names a CUDA ceiling. */
+function cudaDetection(cudaCeiling: number) {
+    return { nvidia: { status: "detected", cudaCeiling }, amdGfxTargets: [], detectedAt: expect.any(String) };
 }
 
 /** Mock the amdgpu KFD topology: one node per gfx_target_version, plus a CPU node reporting 0. */
@@ -200,6 +215,132 @@ describe("detectCudaTag", () => {
         restore = stubPlatform("win32", "x64");
         vi.spyOn(node, "execFile").mockResolvedValue({ stdout: "CUDA Version: 11.8", stderr: "" });
         expect(await detectCudaTag()).toBeNull();
+    });
+});
+
+/* ------------------------------------------------------------------ */
+/*  nvidia-smi lookup on Windows                                      */
+/* ------------------------------------------------------------------ */
+
+describe("nvidia-smi lookup on Windows", () => {
+    let restore: () => void;
+    afterEach(() => {
+        restore?.();
+        vi.unstubAllEnvs();
+    });
+
+    // Built with node.join so the expectation matches the separator of whichever OS runs the suite.
+    const SYSTEM32 = node.join("C:\\Windows", "System32", "nvidia-smi.exe");
+    const NVSMI = node.join("C:\\Program Files", "NVIDIA Corporation", "NVSMI", "nvidia-smi.exe");
+
+    /** Fail every command but *found*, which answers with a driver line. */
+    function stubOnly(found: string) {
+        return vi.spyOn(node, "execFile").mockImplementation((async (command: string) => {
+            if (command !== found) throw new Error(`spawn ${command} ENOENT`);
+            return { stdout: "CUDA Version: 12.4", stderr: "" };
+        }) as unknown as typeof node.execFile);
+    }
+
+    it("finds the DCH driver under System32 when nvidia-smi is off PATH", async () => {
+        restore = stubPlatform("win32", "x64");
+        vi.stubEnv("SystemRoot", "C:\\Windows");
+        const exec = stubOnly(SYSTEM32);
+
+        expect(await detectCudaTag()).toBe("cu124");
+        expect(exec).toHaveBeenCalledWith("nvidia-smi", []);
+        expect(exec).toHaveBeenCalledWith(SYSTEM32, []);
+    });
+
+    it("falls back to the older NVSMI directory", async () => {
+        restore = stubPlatform("win32", "x64");
+        vi.stubEnv("SystemRoot", "C:\\Windows");
+        vi.stubEnv("ProgramFiles", "C:\\Program Files");
+        stubOnly(NVSMI);
+
+        expect(await detectCudaTag()).toBe("cu124");
+    });
+
+    it("uses the default Windows locations when the environment names none", async () => {
+        restore = stubPlatform("win32", "x64");
+        vi.stubEnv("SystemRoot", undefined);
+        vi.stubEnv("ProgramFiles", undefined);
+        const exec = stubOnly(SYSTEM32);
+
+        expect(await detectCudaTag()).toBe("cu124");
+        expect(exec).toHaveBeenCalledWith(SYSTEM32, []);
+    });
+
+    it("reports the PATH error once every location has failed", async () => {
+        restore = stubPlatform("win32", "x64");
+        const exec = stubOnly("never-matches");
+
+        const { detection } = await detectHostGpu();
+        expect(detection.nvidia).toEqual({ status: "missing", error: "spawn nvidia-smi ENOENT" });
+        expect(exec).toHaveBeenCalledTimes(3);
+    });
+
+    it("tries PATH only on Linux", async () => {
+        restore = stubPlatform("linux", "x64");
+        const exec = stubOnly("never-matches");
+
+        expect(await detectCudaTag()).toBeNull();
+        expect(exec).toHaveBeenCalledTimes(1);
+    });
+});
+
+/* ------------------------------------------------------------------ */
+/*  detectHostGpu                                                     */
+/* ------------------------------------------------------------------ */
+
+describe("detectHostGpu", () => {
+    let restore: () => void;
+    afterEach(() => restore?.());
+
+    it("records that macOS is never probed", async () => {
+        restore = stubPlatform("darwin", "arm64");
+        const { cuda, detection } = await detectHostGpu();
+        expect(cuda).toBeNull();
+        expect(detection.nvidia).toEqual({ status: "skipped" });
+        expect(detection.amdGfxTargets).toEqual([]);
+        expect(Date.parse(detection.detectedAt)).not.toBeNaN();
+    });
+
+    it("keeps the error text when nvidia-smi does not run", async () => {
+        restore = stubPlatform("linux", "x64");
+        stubNoNvidia();
+        const { detection } = await detectHostGpu();
+        expect(detection.nvidia).toEqual({ status: "missing", error: "nvidia-smi not found" });
+    });
+
+    it("keeps a non-Error rejection as its own text", async () => {
+        restore = stubPlatform("linux", "x64");
+        vi.spyOn(node, "execFile").mockRejectedValue("EACCES");
+        const { detection } = await detectHostGpu();
+        expect(detection.nvidia).toEqual({ status: "missing", error: "EACCES" });
+    });
+
+    it("records that nvidia-smi ran but named no CUDA version", async () => {
+        restore = stubPlatform("linux", "x64");
+        vi.spyOn(node, "execFile").mockResolvedValue({ stdout: "no version line here", stderr: "" });
+        const { cuda, detection } = await detectHostGpu();
+        expect(cuda).toBeNull();
+        expect(detection.nvidia).toEqual({ status: "unreadable" });
+    });
+
+    it("records the CUDA ceiling the driver reports, even below any shipped build", async () => {
+        restore = stubPlatform("linux", "x64");
+        vi.spyOn(node, "execFile").mockResolvedValue({ stdout: "CUDA Version: 11.8", stderr: "" });
+        const { cuda, detection } = await detectHostGpu();
+        expect(cuda).toBeNull();
+        expect(detection.nvidia).toEqual({ status: "detected", cudaCeiling: 1108 });
+    });
+
+    it("records the AMD gfx targets alongside the NVIDIA probe", async () => {
+        restore = stubPlatform("linux", "x64");
+        stubNoNvidia();
+        stubKfdTopology([110000, 90006]);
+        const { detection } = await detectHostGpu();
+        expect(detection.amdGfxTargets).toEqual(["gfx1100", "gfx906"]);
     });
 });
 
@@ -324,6 +465,7 @@ describe("getLatestRelease", () => {
             tag: "v1.0.0",
             assetUrl: "https://e/v1.0.0",
             variant: "default",
+            detection: noNvidiaDetection(),
             sizeBytes: 1234,
             digest: "sha256:aaa",
         });
@@ -359,6 +501,7 @@ describe("getLatestRelease", () => {
             tag: "v1.0.0",
             assetUrl: "https://e/cu125",
             variant: "cu125",
+            detection: cudaDetection(1205),
             sizeBytes: 20,
             digest: "sha256:cu125",
         });
@@ -389,6 +532,7 @@ describe("getLatestRelease", () => {
             tag: "v1.0.0",
             assetUrl: "https://e/cpu",
             variant: "default",
+            detection: cudaDetection(1205),
             sizeBytes: 10,
             digest: "sha256:cpu",
         });
@@ -442,6 +586,7 @@ describe("getLatestRelease", () => {
             tag: "v1.0.0",
             assetUrl: "https://e/rocm",
             variant: "rocm",
+            detection: noNvidiaDetection(["gfx1100"]),
             sizeBytes: 20,
             digest: "sha256:rocm",
         });
@@ -1365,6 +1510,7 @@ describe("listReleases", () => {
             tag: "v1.1.0",
             assetUrl: "https://e/v1.1.0",
             variant: "default",
+            detection: noNvidiaDetection(),
             sizeBytes: 10,
             digest: null,
         });

--- a/tests/binary-manager.test.ts
+++ b/tests/binary-manager.test.ts
@@ -342,6 +342,34 @@ describe("detectHostGpu", () => {
         expect(exec).toHaveBeenCalledWith("nvidia-smi", [], expect.objectContaining({ timeout: 10_000 }));
     });
 
+    it("records a sandboxed driver when nvidia-smi is off PATH but the kernel module is loaded", async () => {
+        restore = stubPlatform("linux", "x64");
+        const notFound = Object.assign(new Error("spawn nvidia-smi ENOENT"), { code: "ENOENT" });
+        vi.spyOn(node, "execFile").mockRejectedValue(notFound);
+        vi.spyOn(node, "existsSync").mockImplementation((path: string) => path === "/proc/driver/nvidia/version");
+        const { cuda, detection } = await detectHostGpu();
+        expect(cuda).toBeNull();
+        expect(detection.nvidia).toEqual({ status: "sandboxed" });
+    });
+
+    it("records a missing driver when nvidia-smi is off PATH and no kernel module is loaded", async () => {
+        restore = stubPlatform("linux", "x64");
+        const notFound = Object.assign(new Error("spawn nvidia-smi ENOENT"), { code: "ENOENT" });
+        vi.spyOn(node, "execFile").mockRejectedValue(notFound);
+        stubNoAmd();
+        const { detection } = await detectHostGpu();
+        expect(detection.nvidia).toEqual({ status: "missing", error: "spawn nvidia-smi ENOENT" });
+    });
+
+    it("keeps a driver error over the sandbox reason when nvidia-smi ran and failed", async () => {
+        restore = stubPlatform("linux", "x64");
+        vi.spyOn(node, "execFile").mockRejectedValue(new Error("Command failed: nvidia-smi"));
+        const exists = vi.spyOn(node, "existsSync").mockReturnValue(true);
+        const { detection } = await detectHostGpu();
+        expect(detection.nvidia).toEqual({ status: "missing", error: "Command failed: nvidia-smi" });
+        expect(exists).not.toHaveBeenCalledWith("/proc/driver/nvidia/version");
+    });
+
     it("records that nvidia-smi ran but named no CUDA version", async () => {
         restore = stubPlatform("linux", "x64");
         vi.spyOn(node, "execFile").mockResolvedValue({ stdout: "no version line here", stderr: "" });

--- a/tests/binary-manager.test.ts
+++ b/tests/binary-manager.test.ts
@@ -10,7 +10,6 @@ import {
     listReleases,
     isDevBuild,
     checkForUpdate,
-    detectCudaTag,
     detectAmdGfxTargets,
     detectHostGpu,
     BinaryManager,
@@ -174,30 +173,30 @@ describe("getPlatformAssetName", () => {
 });
 
 /* ------------------------------------------------------------------ */
-/*  detectCudaTag                                                     */
+/*  detectHostGpu: the CUDA build                                     */
 /* ------------------------------------------------------------------ */
 
-describe("detectCudaTag", () => {
+describe("detectHostGpu cuda", () => {
     let restore: () => void;
     afterEach(() => restore?.());
 
     it("returns null on macOS without probing for a GPU", async () => {
         restore = stubPlatform("darwin", "arm64");
         const exec = vi.spyOn(node, "execFile");
-        expect(await detectCudaTag()).toBeNull();
+        expect((await detectHostGpu()).cuda).toBeNull();
         expect(exec).not.toHaveBeenCalled();
     });
 
     it("returns null when nvidia-smi is absent", async () => {
         restore = stubPlatform("linux", "x64");
         stubNoNvidia();
-        expect(await detectCudaTag()).toBeNull();
+        expect((await detectHostGpu()).cuda).toBeNull();
     });
 
     it("returns null when the CUDA version can't be parsed", async () => {
         restore = stubPlatform("linux", "x64");
         vi.spyOn(node, "execFile").mockResolvedValue({ stdout: "no version line here", stderr: "" });
-        expect(await detectCudaTag()).toBeNull();
+        expect((await detectHostGpu()).cuda).toBeNull();
     });
 
     it.each([
@@ -208,13 +207,13 @@ describe("detectCudaTag", () => {
     ])("maps driver line %s to %s", async (line, tag) => {
         restore = stubPlatform("linux", "x64");
         vi.spyOn(node, "execFile").mockResolvedValue({ stdout: `header | ${line} | rest`, stderr: "" });
-        expect(await detectCudaTag()).toBe(tag);
+        expect((await detectHostGpu()).cuda).toBe(tag);
     });
 
     it("returns null when the driver is too old for any shipped CUDA build", async () => {
         restore = stubPlatform("win32", "x64");
         vi.spyOn(node, "execFile").mockResolvedValue({ stdout: "CUDA Version: 11.8", stderr: "" });
-        expect(await detectCudaTag()).toBeNull();
+        expect((await detectHostGpu()).cuda).toBeNull();
     });
 });
 
@@ -232,6 +231,7 @@ describe("nvidia-smi lookup on Windows", () => {
     // Built with node.join so the expectation matches the separator of whichever OS runs the suite.
     const SYSTEM32 = node.join("C:\\Windows", "System32", "nvidia-smi.exe");
     const NVSMI = node.join("C:\\Program Files", "NVIDIA Corporation", "NVSMI", "nvidia-smi.exe");
+    const EXEC_OPTS = expect.objectContaining({ timeout: expect.any(Number) });
 
     /** Fail every command but *found*, which answers with a driver line. */
     function stubOnly(found: string) {
@@ -246,9 +246,9 @@ describe("nvidia-smi lookup on Windows", () => {
         vi.stubEnv("SystemRoot", "C:\\Windows");
         const exec = stubOnly(SYSTEM32);
 
-        expect(await detectCudaTag()).toBe("cu124");
-        expect(exec).toHaveBeenCalledWith("nvidia-smi", []);
-        expect(exec).toHaveBeenCalledWith(SYSTEM32, []);
+        expect((await detectHostGpu()).cuda).toBe("cu124");
+        expect(exec).toHaveBeenCalledWith("nvidia-smi", [], EXEC_OPTS);
+        expect(exec).toHaveBeenCalledWith(SYSTEM32, [], EXEC_OPTS);
     });
 
     it("falls back to the older NVSMI directory", async () => {
@@ -257,7 +257,7 @@ describe("nvidia-smi lookup on Windows", () => {
         vi.stubEnv("ProgramFiles", "C:\\Program Files");
         stubOnly(NVSMI);
 
-        expect(await detectCudaTag()).toBe("cu124");
+        expect((await detectHostGpu()).cuda).toBe("cu124");
     });
 
     it("uses the default Windows locations when the environment names none", async () => {
@@ -266,8 +266,8 @@ describe("nvidia-smi lookup on Windows", () => {
         vi.stubEnv("ProgramFiles", undefined);
         const exec = stubOnly(SYSTEM32);
 
-        expect(await detectCudaTag()).toBe("cu124");
-        expect(exec).toHaveBeenCalledWith(SYSTEM32, []);
+        expect((await detectHostGpu()).cuda).toBe("cu124");
+        expect(exec).toHaveBeenCalledWith(SYSTEM32, [], EXEC_OPTS);
     });
 
     it("reports the PATH error once every location has failed", async () => {
@@ -283,7 +283,7 @@ describe("nvidia-smi lookup on Windows", () => {
         restore = stubPlatform("linux", "x64");
         const exec = stubOnly("never-matches");
 
-        expect(await detectCudaTag()).toBeNull();
+        expect((await detectHostGpu()).cuda).toBeNull();
         expect(exec).toHaveBeenCalledTimes(1);
     });
 });
@@ -317,6 +317,29 @@ describe("detectHostGpu", () => {
         vi.spyOn(node, "execFile").mockRejectedValue("EACCES");
         const { detection } = await detectHostGpu();
         expect(detection.nvidia).toEqual({ status: "missing", error: "EACCES" });
+    });
+
+    it("folds a multi-line driver error onto one line", async () => {
+        restore = stubPlatform("linux", "x64");
+        const mismatch = new Error(
+            "Command failed: nvidia-smi\nFailed to initialize NVML: Driver/library version mismatch\n",
+        );
+        vi.spyOn(node, "execFile").mockRejectedValue(mismatch);
+        const { detection } = await detectHostGpu();
+        expect(detection.nvidia).toEqual({
+            status: "missing",
+            error: "Command failed: nvidia-smi Failed to initialize NVML: Driver/library version mismatch",
+        });
+    });
+
+    it("records a timeout when nvidia-smi hangs past the deadline", async () => {
+        restore = stubPlatform("linux", "x64");
+        const timedOut = Object.assign(new Error("Command failed: nvidia-smi"), { killed: true, signal: "SIGTERM" });
+        const exec = vi.spyOn(node, "execFile").mockRejectedValue(timedOut);
+        const { cuda, detection } = await detectHostGpu();
+        expect(cuda).toBeNull();
+        expect(detection.nvidia).toEqual({ status: "missing", error: "nvidia-smi did not answer within 10 s" });
+        expect(exec).toHaveBeenCalledWith("nvidia-smi", [], expect.objectContaining({ timeout: 10_000 }));
     });
 
     it("records that nvidia-smi ran but named no CUDA version", async () => {

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -3,8 +3,15 @@ import { strFromU8, unzipSync } from "fflate";
 import { buildZip, collectDiagnostics, LOG_TAIL_MAX_BYTES, renderSummary, resolveOutputDir } from "../src/diagnostics";
 import { node } from "../src/binary-manager";
 import { MESSAGES } from "../src/locales/en";
-import { DEFAULT_SETTINGS, SERVER_STATE } from "../src/types";
-import type { DiagnosticsContext } from "../src/types";
+import { REDACTED } from "../src/redact";
+import { DEFAULT_SETTINGS, NVIDIA_PROBE_STATUS, SERVER_STATE, SERVER_VARIANT, SHARED_PATH } from "../src/types";
+import type { DiagnosticsContext, GpuDetection } from "../src/types";
+
+const DETECTION: GpuDetection = {
+    nvidia: { status: NVIDIA_PROBE_STATUS.DETECTED, cudaCeiling: 1204 },
+    amdGfxTargets: [],
+    detectedAt: "2026-01-01T00:00:00.000Z",
+};
 
 vi.mock("../src/binary-manager", async (importOriginal) => {
     const actual = await importOriginal<typeof import("../src/binary-manager")>();
@@ -29,6 +36,8 @@ function makeContext(overrides: Partial<DiagnosticsContext> = {}): DiagnosticsCo
         journalEntries: [],
         pluginVersion: "1.2.3",
         serverVersion: "v0.4.0",
+        serverVariant: SERVER_VARIANT.CU124,
+        gpuDetection: DETECTION,
         serverState: SERVER_STATE.ERROR,
         serverUrl: "http://127.0.0.1:1234",
         lastOutput: "Traceback: boom",
@@ -166,6 +175,48 @@ describe("collectDiagnostics", () => {
     it("marks a noteless miss as missing in the summary", () => {
         const summary = renderSummary(makeContext(), [{ name: "logs/server.log", data: null, note: null }]);
         expect(summary).toContain("- logs/server.log: missing");
+    });
+
+    it("names the installed build and why it was chosen", () => {
+        const bundle = collectDiagnostics(makeContext());
+        expect(bundle.summaryMarkdown).toContain("- Server build: CUDA 12.4");
+        expect(bundle.summaryMarkdown).toContain("- GPU detection: The NVIDIA driver reports CUDA 12.4.");
+    });
+
+    it("says so when no build and no detection were ever recorded", () => {
+        const bundle = collectDiagnostics(makeContext({ serverVariant: "", gpuDetection: null }));
+        expect(bundle.summaryMarkdown).toContain("- Server build: (unknown)");
+        expect(bundle.summaryMarkdown).toContain(`- GPU detection: ${MESSAGES.DESC_GPU_DETECTION_NONE}`);
+    });
+
+    it("collects the shared root config.json with its HuggingFace token blanked", () => {
+        vi.mocked(node.existsSync).mockImplementation((path: string) => path === `/shared/${SHARED_PATH.CONFIG}`);
+        vi.mocked(node.readFileSync).mockReturnValue(
+            JSON.stringify({ lilbeeVariant: "cu124", hfToken: "hf_secret", lilbeeVersion: "v0.4.0" }),
+        );
+
+        const text = fileText(makeContext(), SHARED_PATH.CONFIG);
+        expect(text).not.toContain("hf_secret");
+        expect(JSON.parse(text)).toEqual({
+            lilbeeVariant: "cu124",
+            hfToken: REDACTED,
+            lilbeeVersion: "v0.4.0",
+        });
+    });
+
+    it("notes a missing or unreadable shared config instead of failing", () => {
+        const missing = collectDiagnostics(makeContext());
+        expect(missing.files.find((f) => f.name === SHARED_PATH.CONFIG)?.note).toBe("not found");
+
+        vi.mocked(node.existsSync).mockReturnValue(true);
+        vi.mocked(node.readFileSync).mockReturnValue("{not json");
+        const corrupt = collectDiagnostics(makeContext());
+        expect(corrupt.files.find((f) => f.name === SHARED_PATH.CONFIG)?.data).toBeNull();
+    });
+
+    it("skips the shared config when the server is not local", () => {
+        const bundle = collectDiagnostics(makeContext({ sharedRoot: null }));
+        expect(bundle.files.some((f) => f.name === SHARED_PATH.CONFIG)).toBe(false);
     });
 
     it("ignores non-log files and readdir failures", () => {

--- a/tests/locales/en.test.ts
+++ b/tests/locales/en.test.ts
@@ -456,6 +456,13 @@ describe("types", () => {
             );
         });
 
+        it("names the sandbox when the driver is present but nvidia-smi is out of reach", () => {
+            expect(MESSAGES.DESC_GPU_DETECTION(detection({ status: NVIDIA_PROBE_STATUS.SANDBOXED }))).toBe(
+                "An NVIDIA driver is present, but this Obsidian cannot reach nvidia-smi, so its CUDA version is unknown. " +
+                    "Flatpak and Snap sandboxes hide it. No AMD compute device.",
+            );
+        });
+
         it("separates a driver that did not answer from one that is absent", () => {
             expect(MESSAGES.DESC_GPU_DETECTION(detection({ status: NVIDIA_PROBE_STATUS.UNREADABLE }))).toBe(
                 "nvidia-smi ran but reported no CUDA version. No AMD compute device.",

--- a/tests/locales/en.test.ts
+++ b/tests/locales/en.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { MESSAGES, FILTERS, TASK_LABELS } from "../../src/locales/en";
-import { MODEL_TASK } from "../../src/types";
+import { MODEL_TASK, NVIDIA_PROBE_STATUS, SERVER_VARIANT } from "../../src/types";
+import type { GpuDetection, NvidiaProbe } from "../../src/types";
 
 describe("MESSAGES", () => {
     describe("BUTTON_ constants", () => {
@@ -434,6 +435,54 @@ describe("types", () => {
         expect(sorts).toContain(FILTERS.SORT.NAME);
         expect(sorts).toContain(FILTERS.SORT.SIZE_ASC);
         expect(sorts).toContain(FILTERS.SORT.SIZE_DESC);
+    });
+
+    describe("DESC_GPU_DETECTION", () => {
+        /** A detection with the given NVIDIA probe and AMD targets. */
+        function detection(nvidia: NvidiaProbe, amdGfxTargets: string[] = []): GpuDetection {
+            return { nvidia, amdGfxTargets, detectedAt: "2026-01-01T00:00:00.000Z" };
+        }
+
+        it("says nothing was probed on macOS", () => {
+            expect(MESSAGES.DESC_GPU_DETECTION(detection({ status: NVIDIA_PROBE_STATUS.SKIPPED }))).toBe(
+                "lilbee ships one macOS build, so nothing is probed.",
+            );
+        });
+
+        it("carries the error nvidia-smi failed with", () => {
+            const probe = { status: NVIDIA_PROBE_STATUS.MISSING, error: "spawn nvidia-smi ENOENT" } as const;
+            expect(MESSAGES.DESC_GPU_DETECTION(detection(probe))).toBe(
+                "nvidia-smi did not run: spawn nvidia-smi ENOENT. No AMD compute device.",
+            );
+        });
+
+        it("separates a driver that did not answer from one that is absent", () => {
+            expect(MESSAGES.DESC_GPU_DETECTION(detection({ status: NVIDIA_PROBE_STATUS.UNREADABLE }))).toBe(
+                "nvidia-smi ran but reported no CUDA version. No AMD compute device.",
+            );
+        });
+
+        it("prints the CUDA ceiling the way the driver does", () => {
+            const probe = { status: NVIDIA_PROBE_STATUS.DETECTED, cudaCeiling: 1204 } as const;
+            expect(MESSAGES.DESC_GPU_DETECTION(detection(probe))).toBe(
+                "The NVIDIA driver reports CUDA 12.4. No AMD compute device.",
+            );
+        });
+
+        it("names every AMD target the host reports", () => {
+            const probe = { status: NVIDIA_PROBE_STATUS.MISSING, error: "ENOENT" } as const;
+            expect(MESSAGES.DESC_GPU_DETECTION(detection(probe, ["gfx1100", "gfx906"]))).toBe(
+                "nvidia-smi did not run: ENOENT. AMD targets: gfx1100, gfx906.",
+            );
+        });
+    });
+
+    describe("LABEL_SERVER_BUILD", () => {
+        it("names each build the way a user would", () => {
+            expect(MESSAGES.LABEL_SERVER_BUILD(SERVER_VARIANT.DEFAULT)).toBe("default");
+            expect(MESSAGES.LABEL_SERVER_BUILD(SERVER_VARIANT.ROCM)).toBe("ROCm");
+            expect(MESSAGES.LABEL_SERVER_BUILD(SERVER_VARIANT.CU124)).toBe("CUDA 12.4");
+        });
     });
 
     describe("PLACEMENT_ tooltip functions", () => {

--- a/tests/locales/en.test.ts
+++ b/tests/locales/en.test.ts
@@ -469,6 +469,13 @@ describe("types", () => {
             );
         });
 
+        it("names the floor when the driver is too old for any CUDA build", () => {
+            const probe = { status: NVIDIA_PROBE_STATUS.DETECTED, cudaCeiling: 1108 } as const;
+            expect(MESSAGES.DESC_GPU_DETECTION(detection(probe))).toBe(
+                "The NVIDIA driver reports CUDA 11.8. lilbee ships CUDA builds for 12.1 and newer, so the default build runs. No AMD compute device.",
+            );
+        });
+
         it("names every AMD target the host reports", () => {
             const probe = { status: NVIDIA_PROBE_STATUS.MISSING, error: "ENOENT" } as const;
             expect(MESSAGES.DESC_GPU_DETECTION(detection(probe, ["gfx1100", "gfx906"]))).toBe(

--- a/tests/main-shared.test.ts
+++ b/tests/main-shared.test.ts
@@ -134,7 +134,15 @@ vi.mock("../src/server-manager", () => {
 
 import LilbeePlugin from "../src/main";
 import { App, Notice } from "obsidian";
-import { SHARED_PATH } from "../src/types";
+import { NVIDIA_PROBE_STATUS, SHARED_PATH } from "../src/types";
+import type { GpuDetection } from "../src/types";
+
+/** A probe result, as every install now records one. */
+const DETECTION: GpuDetection = {
+    nvidia: { status: NVIDIA_PROBE_STATUS.MISSING, error: "spawn nvidia-smi ENOENT" },
+    amdGfxTargets: [],
+    detectedAt: "2026-01-01T00:00:00.000Z",
+};
 
 async function createPlugin() {
     const app = new App() as any;
@@ -183,23 +191,30 @@ describe("Shared lilbee version round-trip", () => {
         expect(plugin.getSharedLilbeeVariant()).toBe("");
     });
 
-    it("setSharedLilbeeVariant persists and getSharedLilbeeVariant reads it back", async () => {
+    it("setSharedLilbeeVariant persists the build and the probe that chose it", async () => {
         const plugin = await createPlugin();
-        plugin.setSharedLilbeeVariant("cu125");
+        plugin.setSharedLilbeeVariant("cu125", DETECTION);
         expect(plugin.getSharedLilbeeVariant()).toBe("cu125");
+        expect(plugin.getSharedGpuDetection()).toEqual(DETECTION);
+    });
+
+    it("getSharedGpuDetection returns null before any install records one", async () => {
+        const plugin = await createPlugin();
+        expect(plugin.getSharedGpuDetection()).toBeNull();
     });
 
     it("setSharedLilbeeVariant is a no-op when registry is not initialised", async () => {
         const plugin = await createPlugin();
         (plugin as any).vaultRegistry = null;
-        plugin.setSharedLilbeeVariant("cu125");
+        plugin.setSharedLilbeeVariant("cu125", DETECTION);
         expect(plugin.getSharedLilbeeVariant()).toBe("");
+        expect(plugin.getSharedGpuDetection()).toBeNull();
     });
 
     it("preserves version and variant alongside each other", async () => {
         const plugin = await createPlugin();
         plugin.setSharedLilbeeVersion("v0.5.1");
-        plugin.setSharedLilbeeVariant("cu124");
+        plugin.setSharedLilbeeVariant("cu124", DETECTION);
         expect(plugin.getSharedLilbeeVersion()).toBe("v0.5.1");
         expect(plugin.getSharedLilbeeVariant()).toBe("cu124");
     });
@@ -783,6 +798,17 @@ describe("managed-server uninstall", () => {
         (plugin as any).vaultRegistry = null;
 
         expect(await plugin.uninstallServer(plan)).toBe(0);
+    });
+
+    it("forgets the build and the probe that chose it", async () => {
+        const plugin = await createPlugin();
+        seedInstall(plugin);
+        plugin.setSharedLilbeeVariant("cu125", DETECTION);
+
+        await plugin.uninstallServer(plugin.planServerUninstall()!);
+
+        expect(plugin.getSharedLilbeeVariant()).toBe("");
+        expect(plugin.getSharedGpuDetection()).toBeNull();
     });
 
     it("never starts the managed server once uninstalled", async () => {

--- a/tests/main-shared.test.ts
+++ b/tests/main-shared.test.ts
@@ -60,6 +60,7 @@ vi.mock("../src/binary-manager", () => {
         cpSync: vi.fn(),
         statSync: vi.fn(() => ({ isDirectory: () => false, dev: 1, size: 0 })),
         readdirSync: vi.fn(() => [] as string[]),
+        homedir: () => "/home/u",
         rmSync: vi.fn((p: string) => {
             fsState.files.delete(p);
             fsState.dirs.delete(p);
@@ -134,7 +135,7 @@ vi.mock("../src/server-manager", () => {
 
 import LilbeePlugin from "../src/main";
 import { App, Notice } from "obsidian";
-import { NVIDIA_PROBE_STATUS, SHARED_PATH } from "../src/types";
+import { NVIDIA_PROBE_STATUS, SHARED_PATH, UNINSTALL_TARGET } from "../src/types";
 import type { GpuDetection } from "../src/types";
 
 /** A probe result, as every install now records one. */
@@ -750,11 +751,13 @@ describe("managed-server uninstall", () => {
 
         const plan = plugin.planServerUninstall()!;
 
-        expect(plan.targets.map((t) => t.path)).toEqual([
+        expect(plan.targets.slice(0, 3).map((t) => t.path)).toEqual([
             `${root}/bin`,
             `${root}/models`,
             `${root}/vaults/${plugin.vaultId}`,
         ]);
+        // The server's unpack cache follows; its path depends on the host platform.
+        expect(plan.targets.slice(3).map((t) => t.kind)).toEqual([UNINSTALL_TARGET.CACHE]);
     });
 
     it("has no plan without a vault registry", async () => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -294,6 +294,13 @@ vi.mock("../src/server-manager", () => ({
 /** Flush the microtask queue so fire-and-forget promises settle. */
 const flush = () => new Promise((r) => setTimeout(r, 0));
 
+/** The GPU probe every release now carries, as a host without an NVIDIA driver records it. */
+const GPU_DETECTION = {
+    nvidia: { status: "missing", error: "nvidia-smi not found" },
+    amdGfxTargets: [],
+    detectedAt: "2026-01-01T00:00:00.000Z",
+};
+
 async function createPlugin(overrideData?: Record<string, unknown>) {
     const { default: LilbeePlugin } = await import("../src/main");
     const app = new App();
@@ -5825,6 +5832,7 @@ describe("LilbeePlugin", () => {
                 tag: "v0.5.1",
                 assetUrl: "https://example.com",
                 variant: "cu124",
+                detection: GPU_DETECTION,
                 sizeBytes: 100,
             });
 
@@ -5836,7 +5844,11 @@ describe("LilbeePlugin", () => {
             await flush();
 
             expect(setSpy).toHaveBeenCalledWith("v0.5.1");
-            expect(variantSpy).toHaveBeenCalledWith("cu124");
+            expect(variantSpy).toHaveBeenCalledWith("cu124", GPU_DETECTION);
+            expect(plugin.journal.entries.map((e) => e.message)).toContain(
+                "gpu detection at install: CUDA 12.4 build. nvidia-smi did not run: nvidia-smi not found. " +
+                    "No AMD compute device.",
+            );
         });
 
         it("does not overwrite existing shared lilbeeVersion on fresh download", async () => {
@@ -6220,6 +6232,8 @@ describe("LilbeePlugin", () => {
             (getLatestRelease as ReturnType<typeof vi.fn>).mockResolvedValue({
                 tag: "v0.2.0",
                 assetUrl: "https://example.com",
+                variant: "default",
+                detection: GPU_DETECTION,
             });
             (checkForUpdate as ReturnType<typeof vi.fn>).mockReturnValue(true);
 
@@ -6238,6 +6252,8 @@ describe("LilbeePlugin", () => {
             (getLatestRelease as ReturnType<typeof vi.fn>).mockResolvedValue({
                 tag: "v0.1.0",
                 assetUrl: "https://example.com",
+                variant: "default",
+                detection: GPU_DETECTION,
             });
             (checkForUpdate as ReturnType<typeof vi.fn>).mockReturnValue(false);
 
@@ -6256,6 +6272,7 @@ describe("LilbeePlugin", () => {
                 tag: "v0.1.0",
                 assetUrl: "https://example.com",
                 variant: "cu125",
+                detection: GPU_DETECTION,
                 sizeBytes: 100,
             });
             (checkForUpdate as ReturnType<typeof vi.fn>).mockReturnValue(false); // same version
@@ -6271,12 +6288,35 @@ describe("LilbeePlugin", () => {
             expect(result.release?.variant).toBe("cu125");
         });
 
+        it("journals which build the probe chose and why, at every update check", async () => {
+            const { getLatestRelease, checkForUpdate } = await import("../src/binary-manager");
+            (getLatestRelease as ReturnType<typeof vi.fn>).mockResolvedValue({
+                tag: "v0.1.0",
+                assetUrl: "https://example.com",
+                variant: "default",
+                detection: GPU_DETECTION,
+                sizeBytes: 100,
+            });
+            (checkForUpdate as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+            await plugin.checkForUpdate();
+
+            expect(plugin.journal.entries.map((e) => e.message)).toContain(
+                "gpu detection at update check: default build. nvidia-smi did not run: nvidia-smi not found. " +
+                    "No AMD compute device.",
+            );
+        });
+
         it("returns available: false when version and known variant both match", async () => {
             const { getLatestRelease, checkForUpdate } = await import("../src/binary-manager");
             (getLatestRelease as ReturnType<typeof vi.fn>).mockResolvedValue({
                 tag: "v0.1.0",
                 assetUrl: "https://example.com",
                 variant: "cu125",
+                detection: GPU_DETECTION,
                 sizeBytes: 100,
             });
             (checkForUpdate as ReturnType<typeof vi.fn>).mockReturnValue(false);
@@ -7242,6 +7282,7 @@ describe("LilbeePlugin", () => {
                     tag: "v0.3.0",
                     assetUrl: "https://example.com/v0.3.0",
                     variant: "cu125",
+                    detection: GPU_DETECTION,
                     sizeBytes: 256,
                     digest: "sha256:test",
                 },
@@ -7258,7 +7299,7 @@ describe("LilbeePlugin", () => {
                 expect.any(AbortSignal),
             );
             expect(setSpy).toHaveBeenCalledWith("v0.3.0");
-            expect(variantSpy).toHaveBeenCalledWith("cu125");
+            expect(variantSpy).toHaveBeenCalledWith("cu125", GPU_DETECTION);
             expect(progress).toContain("Stopping server...");
             expect(progress).toContain("Downloading...");
             expect(progress).toContain("Starting server...");
@@ -7266,6 +7307,10 @@ describe("LilbeePlugin", () => {
             const journal = plugin.journal.entries.map((e) => e.message);
             expect(journal).toContain("updating server binary: v0.2.9 -> v0.3.0");
             expect(journal).toContain("server binary updated to v0.3.0");
+            expect(journal).toContain(
+                "gpu detection at install: CUDA 12.5 build. nvidia-smi did not run: nvidia-smi not found. " +
+                    "No AMD compute device.",
+            );
         });
 
         it("turns download bytes into a percentage and a human line", async () => {
@@ -7283,7 +7328,14 @@ describe("LilbeePlugin", () => {
 
             const seen: Array<[string, number | undefined]> = [];
             await plugin.updateServer(
-                { tag: "v1", assetUrl: "https://e/dl", variant: "default", sizeBytes: 1, digest: null } as any,
+                {
+                    tag: "v1",
+                    assetUrl: "https://e/dl",
+                    variant: "default",
+                    detection: GPU_DETECTION,
+                    sizeBytes: 1,
+                    digest: null,
+                } as any,
                 (msg, percent) => seen.push([msg, percent]),
             );
 
@@ -7302,7 +7354,14 @@ describe("LilbeePlugin", () => {
 
             const seen: Array<[string, number | undefined]> = [];
             await plugin.updateServer(
-                { tag: "v1", assetUrl: "https://e/dl", variant: "default", sizeBytes: 1, digest: null } as any,
+                {
+                    tag: "v1",
+                    assetUrl: "https://e/dl",
+                    variant: "default",
+                    detection: GPU_DETECTION,
+                    sizeBytes: 1,
+                    digest: null,
+                } as any,
                 (msg, percent) => seen.push([msg, percent]),
             );
 
@@ -7339,6 +7398,7 @@ describe("LilbeePlugin", () => {
                 tag: "v0.3.0",
                 assetUrl: "https://example.com/v0.3.0",
                 variant: "default",
+                detection: GPU_DETECTION,
                 sizeBytes: 100,
                 digest: "sha256:test",
             });
@@ -7357,6 +7417,7 @@ describe("LilbeePlugin", () => {
                 tag: "v0.3.0",
                 assetUrl: "https://example.com",
                 variant: "default",
+                detection: GPU_DETECTION,
                 sizeBytes: 100,
             });
 
@@ -7375,6 +7436,7 @@ describe("LilbeePlugin", () => {
                 tag: "v0.3.0",
                 assetUrl: "https://example.com",
                 variant: "default",
+                detection: GPU_DETECTION,
                 sizeBytes: 100,
             });
 

--- a/tests/redact.test.ts
+++ b/tests/redact.test.ts
@@ -71,4 +71,23 @@ describe("redactConfigKeys", () => {
         expect(out.hfToken).toBe("[redacted]");
         expect(out.lilbeeVariant).toBe("cu124");
     });
+
+    it("blanks any key that names a credential, so a new one cannot ship unredacted", () => {
+        const out = redactConfigKeys({
+            openaiApiKey: "sk-1",
+            proxy_password: "pw",
+            clientSecret: "cs",
+            manualToken: "tok",
+            topK: 12,
+            tokenizer: "bert",
+        });
+        expect(out).toEqual({
+            openaiApiKey: "[redacted]",
+            proxy_password: "[redacted]",
+            clientSecret: "[redacted]",
+            manualToken: "[redacted]",
+            topK: 12,
+            tokenizer: "bert",
+        });
+    });
 });

--- a/tests/redact.test.ts
+++ b/tests/redact.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { redactSecrets, redactSettings } from "../src/redact";
+import { redactConfigKeys, redactSecrets, redactSettings } from "../src/redact";
 import { DEFAULT_SETTINGS, DEFAULT_SHARED_CONFIG } from "../src/types";
 
 describe("redactSecrets", () => {
@@ -58,5 +58,17 @@ describe("redactSettings", () => {
     it("ignores secret fields that are absent", () => {
         const out = redactSettings({ ...DEFAULT_SETTINGS });
         expect(out.hfToken).toBeUndefined();
+    });
+});
+
+describe("redactConfigKeys", () => {
+    it("blanks the shared config's HuggingFace token, which text redaction cannot reach", () => {
+        const raw = JSON.stringify({ hfToken: "hf_secret", lilbeeVariant: "cu124" });
+        // No word boundary before "Token", so the line-based pass leaves it in place.
+        expect(redactSecrets(raw)).toContain("hf_secret");
+
+        const out = redactConfigKeys(JSON.parse(raw) as Record<string, unknown>);
+        expect(out.hfToken).toBe("[redacted]");
+        expect(out.lilbeeVariant).toBe("cu124");
     });
 });

--- a/tests/server-uninstall.test.ts
+++ b/tests/server-uninstall.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 
 const { rmSync, existsSync, readdirSync, statSync } = vi.hoisted(() => ({
     rmSync: vi.fn(),
@@ -14,6 +14,7 @@ vi.mock("../src/binary-manager", () => ({
         readdirSync,
         statSync,
         join: (...parts: string[]) => parts.join("/"),
+        homedir: () => "/home/u",
     },
 }));
 
@@ -41,8 +42,21 @@ function mountFiles(files: Record<string, number>): void {
     }));
 }
 
+function stubPlatform(platform: string): () => void {
+    const original = Object.getOwnPropertyDescriptor(process, "platform")!;
+    Object.defineProperty(process, "platform", { value: platform, configurable: true });
+    return () => Object.defineProperty(process, "platform", original);
+}
+
+let restorePlatform: () => void = () => {};
+
 beforeEach(() => {
     vi.clearAllMocks();
+    restorePlatform = stubPlatform("linux");
+});
+
+afterEach(() => {
+    restorePlatform();
 });
 
 describe("planUninstall", () => {
@@ -60,8 +74,48 @@ describe("planUninstall", () => {
             { kind: UNINSTALL_TARGET.BINARY, path: "/root/bin", bytes: 400 },
             { kind: UNINSTALL_TARGET.MODELS, path: "/root/models", bytes: 1024 },
             { kind: UNINSTALL_TARGET.INDEX, path: "/root/vaults/abc", bytes: 76 },
+            { kind: UNINSTALL_TARGET.CACHE, path: "/home/u/.cache/lilbee", bytes: 0 },
         ]);
         expect(plan.totalBytes).toBe(1500);
+    });
+
+    it.each([
+        ["linux", "/home/u/.cache/lilbee"],
+        ["darwin", "/home/u/Library/Caches/lilbee"],
+    ])("targets the server's unpack cache on %s", (platform, cachePath) => {
+        restorePlatform();
+        restorePlatform = stubPlatform(platform);
+        mountFiles({ [`${cachePath}/0.6.90/lilbee.bin`]: 300 });
+
+        const plan = planUninstall("/root", "/root/vaults/abc");
+
+        expect(plan.targets).toContainEqual({ kind: UNINSTALL_TARGET.CACHE, path: cachePath, bytes: 300 });
+    });
+
+    it("targets only the unpack directories beside bin and models on Windows", () => {
+        restorePlatform();
+        restorePlatform = stubPlatform("win32");
+        mountFiles({
+            "/root/bin/lilbee.exe": 400,
+            "/root/0.6.90.432-windows-x86_64/.lilbee-bootstrap-manifest": 1,
+            "/root/0.6.90.432-windows-x86_64/lilbee.dll": 500,
+            "/root/models/a.gguf": 10,
+        });
+
+        const plan = planUninstall("/root", "/root/vaults/abc");
+
+        const cache = plan.targets.filter((t) => t.kind === UNINSTALL_TARGET.CACHE);
+        expect(cache).toEqual([{ kind: UNINSTALL_TARGET.CACHE, path: "/root/0.6.90.432-windows-x86_64", bytes: 501 }]);
+    });
+
+    it("plans no unpack directory when the shared root is missing on Windows", () => {
+        restorePlatform();
+        restorePlatform = stubPlatform("win32");
+        mountFiles({});
+
+        expect(planUninstall("/root", "/root/vaults/abc").targets.map((t) => t.kind)).not.toContain(
+            UNINSTALL_TARGET.CACHE,
+        );
     });
 
     it("sizes a missing path as zero rather than failing", () => {
@@ -92,6 +146,7 @@ describe("executeUninstall", () => {
             ["/root/bin", { recursive: true, force: true }],
             ["/root/models", { recursive: true, force: true }],
             ["/root/vaults/abc", { recursive: true, force: true }],
+            ["/home/u/.cache/lilbee", { recursive: true, force: true }],
         ]);
     });
 });

--- a/tests/settings-version-picker.test.ts
+++ b/tests/settings-version-picker.test.ts
@@ -3,7 +3,8 @@ import { App, Setting } from "obsidian";
 import { MockElement } from "./__mocks__/obsidian";
 import { LilbeeSettingTab } from "../src/settings";
 import { node } from "../src/binary-manager";
-import { DEFAULT_SETTINGS, SERVER_MODE, SERVER_VARIANT } from "../src/types";
+import { DEFAULT_SETTINGS, NVIDIA_PROBE_STATUS, SERVER_MODE, SERVER_VARIANT } from "../src/types";
+import type { GpuDetection } from "../src/types";
 import { MESSAGES } from "../src/locales/en";
 import type LilbeePlugin from "../src/main";
 
@@ -128,6 +129,7 @@ describe("server version picker with the real release list", () => {
             settings: { ...DEFAULT_SETTINGS, serverMode: SERVER_MODE.MANAGED, includeDevBuilds },
             getSharedLilbeeVersion: () => STABLE_RUN[0],
             getSharedLilbeeVariant: () => SERVER_VARIANT.DEFAULT,
+            getSharedGpuDetection: () => null,
         } as unknown as LilbeePlugin;
         return new LilbeeSettingTab(new App(), plugin);
     }
@@ -153,6 +155,7 @@ describe("server version picker with the real release list", () => {
             settings: { ...DEFAULT_SETTINGS, serverMode: SERVER_MODE.MANAGED, includeDevBuilds: false },
             getSharedLilbeeVersion: () => STABLE_RUN[0],
             getSharedLilbeeVariant: () => SERVER_VARIANT.ROCM,
+            getSharedGpuDetection: () => null,
         } as unknown as LilbeePlugin;
         const tab = new LilbeeSettingTab(new App(), plugin);
         (tab as any).renderVersionSetting(new MockElement() as unknown as HTMLElement);
@@ -161,11 +164,31 @@ describe("server version picker with the real release list", () => {
         expect(descs[descs.length - 1]).toContain("Running the ROCm build.");
     });
 
+    it("says why that build was chosen, so a default build on an NVIDIA box explains itself", async () => {
+        const plugin = {
+            settings: { ...DEFAULT_SETTINGS, serverMode: SERVER_MODE.MANAGED, includeDevBuilds: false },
+            getSharedLilbeeVersion: () => STABLE_RUN[0],
+            getSharedLilbeeVariant: () => SERVER_VARIANT.DEFAULT,
+            getSharedGpuDetection: (): GpuDetection => ({
+                nvidia: { status: NVIDIA_PROBE_STATUS.MISSING, error: "spawn nvidia-smi ENOENT" },
+                amdGfxTargets: [],
+                detectedAt: "2026-01-01T00:00:00.000Z",
+            }),
+        } as unknown as LilbeePlugin;
+        const tab = new LilbeeSettingTab(new App(), plugin);
+        (tab as any).renderVersionSetting(new MockElement() as unknown as HTMLElement);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(descs[descs.length - 1]).toContain("Running the default build.");
+        expect(descs[descs.length - 1]).toContain("nvidia-smi did not run: spawn nvidia-smi ENOENT.");
+    });
+
     it("says nothing about the build when the install predates build tracking", async () => {
         const plugin = {
             settings: { ...DEFAULT_SETTINGS, serverMode: SERVER_MODE.MANAGED, includeDevBuilds: false },
             getSharedLilbeeVersion: () => STABLE_RUN[0],
             getSharedLilbeeVariant: () => "",
+            getSharedGpuDetection: () => null,
         } as unknown as LilbeePlugin;
         const tab = new LilbeeSettingTab(new App(), plugin);
         (tab as any).renderVersionSetting(new MockElement() as unknown as HTMLElement);

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -178,6 +178,7 @@ function makePlugin(
         taskQueue: new TaskQueue(),
         getSharedLilbeeVersion: () => sharedVersion,
         getSharedLilbeeVariant: () => SERVER_VARIANT.DEFAULT,
+        getSharedGpuDetection: () => null,
         setSharedLilbeeVersion: (v: string) => {
             sharedVersion = v;
         },

--- a/tests/vault-registry.test.ts
+++ b/tests/vault-registry.test.ts
@@ -146,6 +146,7 @@ describe("VaultRegistry.loadConfig", () => {
         expect(reg.loadConfig()).toEqual({
             lilbeeVersion: "",
             lilbeeVariant: "",
+            lilbeeDetection: null,
             hfToken: "",
             lastUpdateCheckPluginVersion: "",
             serverAutoUpdate: true,
@@ -160,6 +161,7 @@ describe("VaultRegistry.loadConfig", () => {
         expect(new VaultRegistry("/r").loadConfig()).toEqual({
             lilbeeVersion: "v0.5.0",
             lilbeeVariant: "",
+            lilbeeDetection: null,
             hfToken: "",
             lastUpdateCheckPluginVersion: "",
             serverAutoUpdate: true,
@@ -174,6 +176,7 @@ describe("VaultRegistry.loadConfig", () => {
         expect(new VaultRegistry("/r").loadConfig()).toEqual({
             lilbeeVersion: "",
             lilbeeVariant: "",
+            lilbeeDetection: null,
             hfToken: "",
             lastUpdateCheckPluginVersion: "",
             serverAutoUpdate: true,
@@ -212,6 +215,7 @@ describe("VaultRegistry.saveConfig", () => {
         new VaultRegistry("/r").saveConfig({
             lilbeeVersion: "",
             lilbeeVariant: "",
+            lilbeeDetection: null,
             hfToken: "",
             lastUpdateCheckPluginVersion: "",
             serverAutoUpdate: true,


### PR DESCRIPTION
## Problem

CUDA detection ran `nvidia-smi` and returned null on any failure. Nothing recorded which build the plugin chose or why. A user with an RTX 4080 Super ran the Vulkan engine all day. His logs name the device `Vulkan0`. The plugin had installed the default build with no trace of the decision. Once made, the choice was sticky: a later check re-fetches only when a stored variant differs from a new detection.

The diagnostics bundle printed the server version but not the build. It did not include the shared root's `config.json`, which records the build.

## Solution

**Detection records its reason.** The probe reports whether it found `nvidia-smi`, with the error when not. It reports the CUDA ceiling it parsed, the AMD targets, and the variant chosen. A driver below CUDA 12.1 names that floor as the reason for the default build. The probe gives `nvidia-smi` ten seconds, so a wedged GPU records a timeout instead of stalling the install. The journal records that result at install and at update check. Settings stores it beside the installed variant and shows it under the version row.

**A sandbox on Linux is named as such.** When no `nvidia-smi` exists on PATH but the kernel module is loaded, the probe records `sandboxed` and the settings row says a Flatpak or Snap hides the tool. The build choice does not change, because the CUDA version is still unknown.

**A second chance on Windows.** When `nvidia-smi` is not on PATH, the probe tries the System32 and NVSMI locations before it concludes there is no NVIDIA driver.

**Uninstall removes the unpacked server files.** The plan lists the server's cache root on Linux and macOS. On Windows it lists only the unpack directories beside `bin/` and `models/`, found by their bootstrap manifest.

**Diagnostics carry it.** The summary prints the installed build and the detection reason. The zip includes `config.json`, redacted by key. Redaction blanks every top-level key that names a token, key, secret or password, so a credential added later cannot ship in a bundle.

This branch and the dead-settings branch both touch `src/settings.ts`. Whichever merges second rebases.
