### PR TITLE
Show an update-available icon and reminder when automatic server updates are off

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -115,6 +115,7 @@ export const MESSAGES = {
     LABEL_SERVER_VERSION: "Server version",
     LABEL_INCLUDE_DEV_BUILDS: "Include dev builds",
     LABEL_SERVER_AUTO_UPDATE: "Automatically update the server",
+    LABEL_SERVER_UPDATE_REMINDER: "Remind me about server updates",
     LABEL_UNINSTALL: "Uninstall",
     LABEL_UNINSTALL_SERVER: "Uninstall server",
     LABEL_INSTALL_SERVER: "Install server",
@@ -331,6 +332,8 @@ export const MESSAGES = {
     LABEL_CHAT_VIEW: "lilbee Chat",
     LABEL_TASKS_VIEW: "lilbee Tasks",
     LABEL_RIBBON_OPEN_CHAT: "Open lilbee chat",
+    LABEL_RIBBON_UPDATE_AVAILABLE: (version: string) =>
+        `lilbee server ${version} is available. Open the update settings.`,
     LABEL_STATUSBAR_OPEN_SETTINGS: "Open lilbee settings",
     ERROR_STREAM_IDLE: "server stopped sending events — check that lilbee is running",
     LABEL_OUR_PICKS: "Our picks",
@@ -405,6 +408,8 @@ export const MESSAGES = {
         `A newer dev build (${tag}) is out. Turn on "Include dev builds" to try it.`,
     DESC_SERVER_AUTO_UPDATE:
         "Install the latest server release when the plugin updates. Turned off automatically when you install an older version, so an explicit downgrade sticks.",
+    DESC_SERVER_UPDATE_REMINDER:
+        "When automatic updates are off, show a reminder on launch while a newer server release is available. The ribbon shows an update icon either way.",
     DESC_INCLUDE_DEV_BUILDS:
         "Offer in-development builds in the version list and track them for updates. They ship the newest features " +
         "but get less testing than a stable release.",
@@ -658,6 +663,16 @@ export const MESSAGES = {
     NOTICE_SERVER_SWITCHING_BUILD: (build: string) => `lilbee: switching to the ${build} build for your GPU...`,
     NOTICE_SERVER_SWITCHED_BUILD: (build: string) => `lilbee server now runs the ${build} build`,
     NOTICE_SERVER_AUTO_UPDATE_FAILED: "lilbee: automatic server update failed. You can retry from settings.",
+    UPDATE_MODAL_TITLE: "A newer lilbee server is available",
+    UPDATE_MODAL_BODY: (version: string, build: string | null) =>
+        build
+            ? `${version} is available, and the ${build} build matches this machine better than the installed one. Automatic updates are off, so the server stays on its current version until you update it.`
+            : `${version} is available. Automatic updates are off, so the server stays on its current version until you update it.`,
+    UPDATE_MODAL_HOW_TO_DISABLE:
+        'To stop this reminder, turn off "Remind me about server updates" in the lilbee settings. To install updates without asking, turn on "Automatically update the server".',
+    BUTTON_OPEN_UPDATE_SETTINGS: "Open update settings",
+    BUTTON_NOT_NOW: "Not now",
+    BUTTON_STOP_REMINDING: "Stop reminding me",
     NOTICE_EXTERNAL_SERVER_OUTDATED: (current: string, latest: string): string =>
         `Your lilbee server (${current}) is behind the latest release (${latest}). Update it to get the newest features and fixes.`,
     ERROR_LOAD_CATALOG: "lilbee: failed to load catalog",

--- a/src/main.ts
+++ b/src/main.ts
@@ -113,6 +113,7 @@ import { RememberModal } from "./views/remember-modal";
 import { LintModal } from "./views/lint-modal";
 import { DraftModal } from "./views/draft-modal";
 import { ConfirmModal } from "./views/confirm-modal";
+import { UpdateAvailableModal } from "./views/update-available-modal";
 import { StatusModal } from "./views/status-modal";
 import { GatekeeperModal } from "./views/gatekeeper-modal";
 import { TaskQueue, FLASH_WINDOW_MS as TASK_FLASH_WINDOW_MS } from "./task-queue";
@@ -282,6 +283,8 @@ function downloadStatusBar(progress: DownloadProgress): string {
 
 export default class LilbeePlugin extends Plugin {
     settings: LilbeeSettings = { ...DEFAULT_SETTINGS };
+    private settingTab: LilbeeSettingTab | null = null;
+    private updateRibbonIconEl: HTMLElement | null = null;
     api: LilbeeClient = new LilbeeClient("");
     activeModel = "";
     statusBarEl: HTMLElement | null = null;
@@ -383,7 +386,8 @@ export default class LilbeePlugin extends Plugin {
         safeRegisterView(VIEW_TYPE_WIKI, (leaf) => new WikiView(leaf, this));
         safeRegisterView(VIEW_TYPE_MEMORIES, (leaf) => new MemoriesView(leaf, this));
         safeRegisterView(VIEW_TYPE_PLACEMENT, (leaf) => new PlacementView(leaf, this));
-        this.addSettingTab(new LilbeeSettingTab(this.app, this));
+        this.settingTab = new LilbeeSettingTab(this.app, this);
+        this.addSettingTab(this.settingTab);
         this.taskQueue.onChange(() => this.updateStatusBarFromQueue());
         this.taskQueue.onChange(() => this.schedulePersistHistory());
         // Add/sync/crawl tasks completing is when the server's set of known
@@ -1002,6 +1006,7 @@ export default class LilbeePlugin extends Plugin {
         const config = registry.loadConfig();
         if (!config.serverAutoUpdate) {
             this.journal.lifecycle("automatic server update skipped: turned off in settings");
+            await this.remindServerUpdate(config.serverUpdateReminder);
             return;
         }
         if (config.lastUpdateCheckPluginVersion === this.manifest.version) return;
@@ -1098,6 +1103,7 @@ export default class LilbeePlugin extends Plugin {
         this.setSharedLilbeeVersion(release.tag);
         this.setSharedLilbeeVariant(release.variant);
         this.journal.lifecycle(`server binary updated to ${release.tag}`);
+        this.clearUpdateIndicator();
 
         // Restart if in managed mode
         if (this.settings.serverMode === SERVER_MODE.MANAGED) {
@@ -1670,6 +1676,62 @@ export default class LilbeePlugin extends Plugin {
         if (config.serverAutoUpdate === enabled) return;
         reg.saveConfig({ ...config, serverAutoUpdate: enabled });
         this.journal.lifecycle(enabled ? "automatic server updates turned on" : "automatic server updates turned off");
+    }
+
+    isServerUpdateReminderEnabled(): boolean {
+        return this.vaultRegistry?.loadConfig().serverUpdateReminder ?? true;
+    }
+
+    setServerUpdateReminder(enabled: boolean): void {
+        const reg = this.vaultRegistry;
+        if (!reg) return;
+        const config = reg.loadConfig();
+        if (config.serverUpdateReminder === enabled) return;
+        reg.saveConfig({ ...config, serverUpdateReminder: enabled });
+        this.journal.lifecycle(enabled ? "server update reminder turned on" : "server update reminder turned off");
+    }
+
+    /** With automatic updates off, point at a newer release instead of installing it. */
+    private async remindServerUpdate(showModal: boolean): Promise<void> {
+        let result: { available: boolean; release?: ReleaseInfo };
+        try {
+            result = await this.checkForUpdate();
+        } catch {
+            return;
+        }
+        if (!result.available || !result.release) return;
+        const release = result.release;
+        this.showUpdateIndicator(release);
+        if (!showModal) return;
+        const installedVariant = this.getSharedLilbeeVariant();
+        const build =
+            installedVariant !== "" && installedVariant !== release.variant
+                ? MESSAGES.LABEL_SERVER_BUILD(release.variant)
+                : null;
+        new UpdateAvailableModal(this.app, release, build, {
+            openSettings: () => this.openServerUpdateSettings(),
+            stopReminding: () => this.setServerUpdateReminder(false),
+        }).open();
+    }
+
+    private showUpdateIndicator(release: ReleaseInfo): void {
+        const label = MESSAGES.LABEL_RIBBON_UPDATE_AVAILABLE(release.tag);
+        if (this.updateRibbonIconEl) {
+            this.updateRibbonIconEl.setAttribute("aria-label", label);
+            return;
+        }
+        this.updateRibbonIconEl = this.addRibbonIcon("arrow-up-circle", label, () => this.openServerUpdateSettings());
+        this.updateRibbonIconEl.addClass("lilbee-ribbon-icon", "lilbee-ribbon-update");
+    }
+
+    private clearUpdateIndicator(): void {
+        this.updateRibbonIconEl?.remove();
+        this.updateRibbonIconEl = null;
+    }
+
+    openServerUpdateSettings(): void {
+        this.openPluginSettings();
+        this.settingTab?.scrollToServerUpdate();
     }
 
     getSharedHfToken(): string {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -109,6 +109,7 @@ interface UpdateProgressEls {
 }
 
 export class LilbeeSettingTab extends PluginSettingTab {
+    private versionSettingEl: HTMLElement | null = null;
     plugin: LilbeePlugin;
     /** Total bytes of the shared install, set by the storage report each render. */
     private storageTotalBytes = 0;
@@ -504,6 +505,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         this.renderStorageReport(containerEl);
         this.renderVersionSetting(containerEl);
         this.renderAutoUpdateToggle(containerEl);
+        this.renderUpdateReminderToggle(containerEl);
         this.renderDevBuildsToggle(containerEl);
     }
 
@@ -518,6 +520,22 @@ export class LilbeeSettingTab extends PluginSettingTab {
             );
     }
 
+    private renderUpdateReminderToggle(containerEl: HTMLElement): void {
+        new Setting(containerEl)
+            .setName(MESSAGES.LABEL_SERVER_UPDATE_REMINDER)
+            .setDesc(MESSAGES.DESC_SERVER_UPDATE_REMINDER)
+            .addToggle((toggle) =>
+                toggle.setValue(this.plugin.isServerUpdateReminderEnabled()).onChange((value) => {
+                    this.plugin.setServerUpdateReminder(value);
+                }),
+            );
+    }
+
+    /** Bring the server version row into view; the update ribbon icon and reminder land here. */
+    scrollToServerUpdate(): void {
+        this.versionSettingEl?.scrollIntoView({ block: "start" });
+    }
+
     /**
      * One control for upgrade, downgrade, and reinstall. The dropdown lists
      * recent releases newest-first; the button names what the selection does.
@@ -530,6 +548,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         // aria-label only: Obsidian renders its styled tooltip from it, and a
         // title attribute would stack the native browser tooltip on top.
         setting.settingEl.setAttribute("aria-label", MESSAGES.TOOLTIP_SERVER_VERSION_SUPPORT);
+        this.versionSettingEl = setting.settingEl;
         const progress = this.renderUpdateProgress(containerEl);
 
         let releases: ReleaseInfo[] = [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -652,6 +652,8 @@ export interface SharedConfig {
     serverAutoUpdate: boolean;
     /** The user removed the managed server; never download it again until they ask. */
     serverUninstalled: boolean;
+    /** Show a reminder on launch while a newer server release exists and automatic updates are off. */
+    serverUpdateReminder: boolean;
 }
 
 export const DEFAULT_SHARED_CONFIG: SharedConfig = {
@@ -661,6 +663,7 @@ export const DEFAULT_SHARED_CONFIG: SharedConfig = {
     lastUpdateCheckPluginVersion: "",
     serverAutoUpdate: true,
     serverUninstalled: false,
+    serverUpdateReminder: true,
 };
 
 /** What a managed-mode uninstall deletes. Documents in the vault are never a target. */

--- a/src/views/confirm-modal.ts
+++ b/src/views/confirm-modal.ts
@@ -24,7 +24,7 @@ export class ConfirmModal extends Modal {
 
         contentEl.createEl("p", { text: this.message });
 
-        const actions = contentEl.createDiv({ cls: "lilbee-confirm-actions" });
+        const actions = contentEl.createDiv({ cls: "modal-button-container" });
         const continueBtn = actions.createEl("button", { text: MESSAGES.BUTTON_CONTINUE, cls: "mod-cta" });
         continueBtn.addEventListener("click", () => this.decide(true));
 

--- a/src/views/gatekeeper-modal.ts
+++ b/src/views/gatekeeper-modal.ts
@@ -29,7 +29,7 @@ export class GatekeeperModal extends Modal {
         const repoLink = source.createEl("a", { text: MESSAGES.LINK_LILBEE_REPO });
         repoLink.setAttribute("href", LILBEE_REPO_URL);
 
-        const actions = contentEl.createDiv({ cls: "lilbee-confirm-actions" });
+        const actions = contentEl.createDiv({ cls: "modal-button-container" });
         const gotItBtn = actions.createEl("button", { text: MESSAGES.BUTTON_GOT_IT, cls: "mod-cta" });
         gotItBtn.addEventListener("click", () => this.close());
     }

--- a/src/views/uninstall-modal.ts
+++ b/src/views/uninstall-modal.ts
@@ -49,7 +49,7 @@ export class UninstallModal extends Modal {
         );
         keep.addClass("is-keep");
 
-        const actions = contentEl.createDiv({ cls: "lilbee-confirm-actions" });
+        const actions = contentEl.createDiv({ cls: "modal-button-container" });
         const cancelBtn = actions.createEl("button", { text: MESSAGES.BUTTON_CANCEL });
         cancelBtn.addEventListener("click", () => this.decide(false));
 

--- a/src/views/update-available-modal.ts
+++ b/src/views/update-available-modal.ts
@@ -28,7 +28,7 @@ export class UpdateAvailableModal extends Modal {
         contentEl.createEl("p", { text: MESSAGES.UPDATE_MODAL_BODY(this.release.tag, this.build) });
         contentEl.createEl("p", { text: MESSAGES.UPDATE_MODAL_HOW_TO_DISABLE, cls: "lilbee-update-modal-hint" });
 
-        const actions = contentEl.createDiv({ cls: "lilbee-confirm-actions" });
+        const actions = contentEl.createDiv({ cls: "modal-button-container" });
         const open = actions.createEl("button", { text: MESSAGES.BUTTON_OPEN_UPDATE_SETTINGS, cls: "mod-cta" });
         open.addEventListener("click", () => {
             this.close();

--- a/src/views/update-available-modal.ts
+++ b/src/views/update-available-modal.ts
@@ -1,0 +1,49 @@
+import { App, Modal } from "obsidian";
+import type { ReleaseInfo } from "../binary-manager";
+import { MESSAGES } from "../locales/en";
+import { bindEscapeToClose } from "../utils";
+
+export interface UpdateReminderActions {
+    openSettings: () => void;
+    stopReminding: () => void;
+}
+
+/** Launch-time reminder that a newer server exists while automatic updates are off. */
+export class UpdateAvailableModal extends Modal {
+    constructor(
+        app: App,
+        private release: ReleaseInfo,
+        private build: string | null,
+        private actions: UpdateReminderActions,
+    ) {
+        super(app);
+        bindEscapeToClose(this);
+    }
+
+    onOpen(): void {
+        const { contentEl } = this;
+        contentEl.empty();
+        contentEl.addClass("lilbee-update-modal");
+        contentEl.createEl("h3", { text: MESSAGES.UPDATE_MODAL_TITLE });
+        contentEl.createEl("p", { text: MESSAGES.UPDATE_MODAL_BODY(this.release.tag, this.build) });
+        contentEl.createEl("p", { text: MESSAGES.UPDATE_MODAL_HOW_TO_DISABLE, cls: "lilbee-update-modal-hint" });
+
+        const actions = contentEl.createDiv({ cls: "lilbee-confirm-actions" });
+        const open = actions.createEl("button", { text: MESSAGES.BUTTON_OPEN_UPDATE_SETTINGS, cls: "mod-cta" });
+        open.addEventListener("click", () => {
+            this.close();
+            this.actions.openSettings();
+        });
+        const later = actions.createEl("button", { text: MESSAGES.BUTTON_NOT_NOW });
+        later.addEventListener("click", () => this.close());
+        const stop = actions.createEl("button", { text: MESSAGES.BUTTON_STOP_REMINDING });
+        stop.addEventListener("click", () => {
+            this.actions.stopReminding();
+            this.close();
+        });
+    }
+
+    onClose(): void {
+        this.contentEl.empty();
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -2756,6 +2756,28 @@
     transition: color 180ms ease;
 }
 
+/* Update-available ribbon icon: an accent dot the theme colours, on top of the icon. */
+.side-dock-ribbon-action.lilbee-ribbon-update {
+    position: relative;
+}
+
+.side-dock-ribbon-action.lilbee-ribbon-update::after {
+    content: "";
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    box-shadow: 0 0 0 2px var(--background-secondary);
+}
+
+.lilbee-update-modal-hint {
+    color: var(--text-muted);
+    font-size: var(--font-ui-smaller);
+}
+
 .lilbee-task-cancel {
     background: none;
     border: 1px solid transparent;

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -187,6 +187,14 @@ vi.mock("../src/views/confirm-modal", () => ({
 }));
 
 const mockEnsureBinary = vi.fn().mockResolvedValue("/fake/bin/lilbee");
+const mockUpdateModalOpen = vi.fn();
+const mockUpdateModal = vi.fn();
+vi.mock("../src/views/update-available-modal", () => ({
+    UpdateAvailableModal: function (this: { open: () => void }, ...args: unknown[]) {
+        mockUpdateModal(...args);
+        this.open = mockUpdateModalOpen;
+    },
+}));
 const mockBinaryExists = vi.fn().mockReturnValue(true);
 const mockDownload = vi.fn().mockResolvedValue(undefined);
 const mockGatekeeperOpen = vi.fn();
@@ -388,6 +396,7 @@ describe("LilbeePlugin", () => {
             const loadConfig = vi.spyOn(VaultRegistry.prototype, "loadConfig").mockReturnValue({
                 ...DEFAULT_SHARED_CONFIG,
                 serverUninstalled: true,
+                serverUpdateReminder: true,
             });
             const consent = vi.spyOn(plugin, "ensureManagedConsentThenStart");
 
@@ -6361,6 +6370,10 @@ describe("LilbeePlugin", () => {
     });
 
     describe("automatic server update on plugin update", () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
         const RELEASE = { tag: "v0.2.0", assetUrl: "u", variant: "default", sizeBytes: 1, digest: null };
 
         const seedSharedConfig = (lastChecked: string) => {
@@ -6491,25 +6504,165 @@ describe("LilbeePlugin", () => {
             expect(check).not.toHaveBeenCalled();
         });
 
-        it("skips the check when automatic server updates are turned off", async () => {
-            const plugin = await createPlugin({ serverMode: "managed" });
-            const check = vi.spyOn(plugin, "checkForUpdate");
-            const loadConfig = vi.spyOn(VaultRegistry.prototype, "loadConfig").mockReturnValue({
-                lilbeeVersion: "v0.1.0",
-                lilbeeVariant: "",
-                hfToken: "",
-                lastUpdateCheckPluginVersion: "",
-                serverAutoUpdate: false,
-                serverUninstalled: false,
-            });
-            await plugin.onload();
-            await flush();
+        const offConfig = (reminder: boolean) => ({
+            lilbeeVersion: "v0.1.0",
+            lilbeeVariant: "" as const,
+            hfToken: "",
+            lastUpdateCheckPluginVersion: "",
+            serverAutoUpdate: false,
+            serverUninstalled: false,
+            serverUpdateReminder: reminder,
+        });
+        const newer = {
+            tag: "v9.9.9",
+            variant: "default" as const,
+            assetUrl: "https://example.test/lilbee",
+            sizeBytes: 1,
+            digest: "",
+            detection: { nvidia: { status: "skipped" }, amd: { status: "skipped" }, detectedAt: "" },
+        };
+        const updateLabels = (plugin: { addRibbonIcon: unknown }) =>
+            (plugin.addRibbonIcon as ReturnType<typeof vi.fn>).mock.calls
+                .map((c) => c[1] as string)
+                .filter((label) => label.startsWith("lilbee server v"));
 
-            expect(check).not.toHaveBeenCalled();
+        it("with automatic updates off, a newer release shows the ribbon icon and the reminder", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            vi.spyOn(plugin, "checkForUpdate").mockResolvedValue({ available: true, release: newer as any });
+            const update = vi.spyOn(plugin, "updateServer").mockResolvedValue();
+            vi.spyOn(VaultRegistry.prototype, "loadConfig").mockReturnValue(offConfig(true));
+            mockUpdateModal.mockClear();
+            mockUpdateModalOpen.mockClear();
+
+            await (plugin as any).autoUpdateServerBinary();
+
+            expect(update).not.toHaveBeenCalled();
+            const ribbon = (plugin.addRibbonIcon as ReturnType<typeof vi.fn>).mock.calls.find(
+                (c) => c[1] === MESSAGES.LABEL_RIBBON_UPDATE_AVAILABLE("v9.9.9"),
+            );
+            expect(ribbon?.[0]).toBe("arrow-up-circle");
+            expect(mockUpdateModal).toHaveBeenCalledWith(plugin.app, newer, null, expect.any(Object));
+            expect(mockUpdateModalOpen).toHaveBeenCalledTimes(1);
             expect(plugin.journal.entries.map((e) => e.message)).toContain(
                 "automatic server update skipped: turned off in settings",
             );
+        });
+
+        it("names the build in the reminder when the detected build differs from the installed one", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            vi.spyOn(plugin, "checkForUpdate").mockResolvedValue({
+                available: true,
+                release: { ...newer, variant: "cu125" } as any,
+            });
+            vi.spyOn(VaultRegistry.prototype, "loadConfig").mockReturnValue({
+                ...offConfig(true),
+                lilbeeVariant: "default",
+            });
+            mockUpdateModal.mockClear();
+
+            await (plugin as any).autoUpdateServerBinary();
+
+            expect(mockUpdateModal.mock.calls[0][2]).toBe(MESSAGES.LABEL_SERVER_BUILD("cu125"));
+        });
+
+        it("keeps the ribbon icon but skips the modal when the reminder is turned off", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            vi.spyOn(plugin, "checkForUpdate").mockResolvedValue({ available: true, release: newer as any });
+            vi.spyOn(VaultRegistry.prototype, "loadConfig").mockReturnValue(offConfig(false));
+            mockUpdateModalOpen.mockClear();
+
+            await (plugin as any).autoUpdateServerBinary();
+
+            expect(updateLabels(plugin)).toEqual([MESSAGES.LABEL_RIBBON_UPDATE_AVAILABLE("v9.9.9")]);
+            expect(mockUpdateModalOpen).not.toHaveBeenCalled();
+        });
+
+        it("shows nothing when the server is current or the check fails", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            vi.spyOn(VaultRegistry.prototype, "loadConfig").mockReturnValue(offConfig(true));
+            mockUpdateModalOpen.mockClear();
+
+            vi.spyOn(plugin, "checkForUpdate").mockResolvedValueOnce({ available: false });
+            await (plugin as any).autoUpdateServerBinary();
+            vi.spyOn(plugin, "checkForUpdate").mockRejectedValueOnce(new Error("offline"));
+            await (plugin as any).autoUpdateServerBinary();
+
+            expect(updateLabels(plugin)).toEqual([]);
+            expect(mockUpdateModalOpen).not.toHaveBeenCalled();
+        });
+
+        it("a second newer release updates the icon label; an install removes the icon", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            vi.spyOn(VaultRegistry.prototype, "loadConfig").mockReturnValue(offConfig(false));
+            vi.spyOn(plugin, "checkForUpdate")
+                .mockResolvedValueOnce({ available: true, release: newer as any })
+                .mockResolvedValueOnce({ available: true, release: { ...newer, tag: "v9.9.10" } as any });
+
+            await (plugin as any).autoUpdateServerBinary();
+            await (plugin as any).autoUpdateServerBinary();
+
+            expect(updateLabels(plugin)).toEqual([MESSAGES.LABEL_RIBBON_UPDATE_AVAILABLE("v9.9.9")]);
+            const icon = (plugin as any).updateRibbonIconEl as MockElement;
+            expect(icon.getAttribute("aria-label")).toBe(MESSAGES.LABEL_RIBBON_UPDATE_AVAILABLE("v9.9.10"));
+            const remove = vi.spyOn(icon, "remove");
+            (plugin as any).clearUpdateIndicator();
+            expect(remove).toHaveBeenCalledTimes(1);
+            expect((plugin as any).updateRibbonIconEl).toBeNull();
+        });
+
+        it("the ribbon icon and the modal open the update settings", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            vi.spyOn(VaultRegistry.prototype, "loadConfig").mockReturnValue(offConfig(true));
+            vi.spyOn(plugin, "checkForUpdate").mockResolvedValue({ available: true, release: newer as any });
+            const open = vi.spyOn(plugin, "openPluginSettings").mockImplementation(() => {});
+            const scroll = vi.fn();
+            (plugin as any).settingTab = { scrollToServerUpdate: scroll };
+            const setReminder = vi.spyOn(plugin, "setServerUpdateReminder").mockImplementation(() => {});
+            mockUpdateModal.mockClear();
+
+            await (plugin as any).autoUpdateServerBinary();
+            ((plugin as any).updateRibbonIconEl as MockElement).trigger("click");
+            const actions = mockUpdateModal.mock.calls[0][3] as { openSettings: () => void; stopReminding: () => void };
+            actions.openSettings();
+            actions.stopReminding();
+
+            expect(open).toHaveBeenCalledTimes(2);
+            expect(scroll).toHaveBeenCalledTimes(2);
+            expect(setReminder).toHaveBeenCalledWith(false);
+        });
+    });
+
+    describe("server update reminder setting", () => {
+        it("defaults to on, persists a change, and journals it once", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            expect(plugin.isServerUpdateReminderEnabled()).toBe(true);
+            const save = vi.spyOn(VaultRegistry.prototype, "saveConfig").mockImplementation(() => {});
+            plugin.setServerUpdateReminder(false);
+            expect(save).toHaveBeenCalledWith(expect.objectContaining({ serverUpdateReminder: false }));
+            const messages = () => plugin.journal.entries.map((e) => e.message);
+            expect(messages()).toContain("server update reminder turned off");
+            const loadConfig = vi
+                .spyOn(VaultRegistry.prototype, "loadConfig")
+                .mockReturnValue({ ...DEFAULT_SHARED_CONFIG, serverUpdateReminder: false });
+            plugin.setServerUpdateReminder(true);
+            expect(messages()).toContain("server update reminder turned on");
             loadConfig.mockRestore();
+            plugin.setServerUpdateReminder(true);
+            expect(save).toHaveBeenCalledTimes(2);
+            (plugin as any).vaultRegistry = null;
+            expect(plugin.isServerUpdateReminderEnabled()).toBe(true);
+            plugin.setServerUpdateReminder(false);
+            expect(save).toHaveBeenCalledTimes(2);
+            plugin.setServerUpdateReminder(true);
+            expect(save).toHaveBeenCalledTimes(2);
+            save.mockRestore();
         });
     });
 
@@ -6542,6 +6695,7 @@ describe("LilbeePlugin", () => {
                 lastUpdateCheckPluginVersion: "",
                 serverAutoUpdate: false,
                 serverUninstalled: false,
+                serverUpdateReminder: true,
             });
             const save = vi.spyOn(VaultRegistry.prototype, "saveConfig").mockImplementation(() => {});
             plugin.setServerAutoUpdate(true);

--- a/tests/settings-vault-sections.test.ts
+++ b/tests/settings-vault-sections.test.ts
@@ -109,6 +109,8 @@ function makePlugin(settings: Partial<LilbeeSettings> = {}, registry: any = null
         setSharedLilbeeVersion: vi.fn(),
         isServerAutoUpdateEnabled: () => true,
         setServerAutoUpdate: vi.fn(),
+        isServerUpdateReminderEnabled: () => true,
+        setServerUpdateReminder: vi.fn(),
         isServerInstalled: () => true,
         isServerUninstalled: () => false,
         isDownloadingServer: () => false,

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -183,6 +183,8 @@ function makePlugin(
         },
         isServerAutoUpdateEnabled: () => true,
         setServerAutoUpdate: vi.fn(),
+        isServerUpdateReminderEnabled: () => true,
+        setServerUpdateReminder: vi.fn(),
         isServerInstalled: () => true,
         isServerUninstalled: () => false,
         isDownloadingServer: () => false,
@@ -2423,17 +2425,44 @@ describe("managed mode settings", () => {
         expect(Object.keys(dropdownOptions[1])).toEqual(["v0.4.0.dev9", "v0.3.0", "v0.2.0", "v0.1.0"]);
     });
 
+    it("the update reminder toggle writes the shared setting", async () => {
+        mockListReleases.mockResolvedValue(RELEASES);
+        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.3.0" });
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+
+        const { toggleByName } = captureSettingCallbacks(() => tab.display());
+        await toggleByName.get(MESSAGES.LABEL_SERVER_UPDATE_REMINDER)!(false);
+
+        expect(plugin.setServerUpdateReminder).toHaveBeenCalledWith(false);
+    });
+
+    it("scrollToServerUpdate brings the version row into view", () => {
+        mockListReleases.mockResolvedValue(RELEASES);
+        const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.3.0" });
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+        const scroll = vi.spyOn(MockElement.prototype, "scrollIntoView");
+
+        tab.scrollToServerUpdate();
+        expect(scroll).not.toHaveBeenCalled();
+        tab.display();
+        tab.scrollToServerUpdate();
+
+        expect(scroll).toHaveBeenCalledWith({ block: "start" });
+        scroll.mockRestore();
+    });
+
     it("the dev-builds toggle persists the setting and re-renders", async () => {
         mockListReleases.mockResolvedValue(RELEASES);
         const plugin = makePlugin({ serverMode: "managed", lilbeeVersion: "v0.3.0" });
         mockChatPicker(plugin);
         const tab = makeTab(plugin);
 
-        const { toggleOnChanges } = captureSettingCallbacks(() => tab.display());
+        const { toggleByName } = captureSettingCallbacks(() => tab.display());
         // Spy after the first render so the toggle's own re-render is what we assert.
         const renderSpy = vi.spyOn(tab, "render").mockImplementation(() => {});
-        // [0] auto-update, [1] includeDevBuilds (managed server section, before Chat).
-        await toggleOnChanges[1](true);
+        await toggleByName.get(MESSAGES.LABEL_INCLUDE_DEV_BUILDS)!(true);
 
         expect(plugin.settings.includeDevBuilds).toBe(true);
         expect(plugin.saveSettings).toHaveBeenCalled();

--- a/tests/vault-registry.test.ts
+++ b/tests/vault-registry.test.ts
@@ -150,6 +150,7 @@ describe("VaultRegistry.loadConfig", () => {
             lastUpdateCheckPluginVersion: "",
             serverAutoUpdate: true,
             serverUninstalled: false,
+            serverUpdateReminder: true,
         });
     });
 
@@ -164,6 +165,7 @@ describe("VaultRegistry.loadConfig", () => {
             lastUpdateCheckPluginVersion: "",
             serverAutoUpdate: true,
             serverUninstalled: false,
+            serverUpdateReminder: true,
         });
     });
 
@@ -178,6 +180,7 @@ describe("VaultRegistry.loadConfig", () => {
             lastUpdateCheckPluginVersion: "",
             serverAutoUpdate: true,
             serverUninstalled: false,
+            serverUpdateReminder: true,
         });
     });
 });
@@ -194,6 +197,7 @@ describe("VaultRegistry.saveConfig", () => {
             hfToken: "tok",
             lastUpdateCheckPluginVersion: "",
             serverUninstalled: false,
+            serverUpdateReminder: true,
         });
         expect(fs.exists("/r/config.json")).toBe(true);
         expect(fs.exists("/r/config.json.tmp")).toBe(false);
@@ -203,6 +207,7 @@ describe("VaultRegistry.saveConfig", () => {
             hfToken: "tok",
             lastUpdateCheckPluginVersion: "",
             serverUninstalled: false,
+            serverUpdateReminder: true,
         });
     });
 
@@ -216,6 +221,7 @@ describe("VaultRegistry.saveConfig", () => {
             lastUpdateCheckPluginVersion: "",
             serverAutoUpdate: true,
             serverUninstalled: false,
+            serverUpdateReminder: true,
         });
         expect(fs.dirs.has("/r")).toBe(true);
     });

--- a/tests/views/update-available-modal.test.ts
+++ b/tests/views/update-available-modal.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from "vitest";
+import { App } from "obsidian";
+import { MESSAGES } from "../../src/locales/en";
+import { UpdateAvailableModal } from "../../src/views/update-available-modal";
+import type { ReleaseInfo } from "../../src/binary-manager";
+import type { MockElement } from "../__mocks__/obsidian";
+
+const release = { tag: "v9.9.9", variant: "default" } as ReleaseInfo;
+
+function openModal(build: string | null = null) {
+    const actions = { openSettings: vi.fn(), stopReminding: vi.fn() };
+    const modal = new UpdateAvailableModal(new App(), release, build, actions);
+    const close = vi.spyOn(modal, "close");
+    modal.open();
+    const content = modal.contentEl as unknown as MockElement;
+    const buttons = content.querySelectorAll(".lilbee-confirm-actions")[0].children;
+    const button = (text: string) => buttons.find((b) => b.textContent === text)!;
+    return { modal, actions, close, content, button };
+}
+
+describe("UpdateAvailableModal", () => {
+    it("names the release, explains the setting that turns the reminder off, and lists three choices", () => {
+        const { content, button } = openModal();
+        const text = content.textContent;
+        expect(text).toContain(MESSAGES.UPDATE_MODAL_TITLE);
+        expect(text).toContain(MESSAGES.UPDATE_MODAL_BODY("v9.9.9", null));
+        expect(text).toContain(MESSAGES.LABEL_SERVER_UPDATE_REMINDER);
+        expect(text).toContain(MESSAGES.LABEL_SERVER_AUTO_UPDATE);
+        expect(button(MESSAGES.BUTTON_OPEN_UPDATE_SETTINGS)).toBeDefined();
+        expect(button(MESSAGES.BUTTON_NOT_NOW)).toBeDefined();
+        expect(button(MESSAGES.BUTTON_STOP_REMINDING)).toBeDefined();
+    });
+
+    it("names the build when the detected build differs from the installed one", () => {
+        const { content } = openModal("CUDA 12.5");
+        expect(content.textContent).toContain(MESSAGES.UPDATE_MODAL_BODY("v9.9.9", "CUDA 12.5"));
+    });
+
+    it.each([
+        [() => MESSAGES.BUTTON_OPEN_UPDATE_SETTINGS, "openSettings"],
+        [() => MESSAGES.BUTTON_STOP_REMINDING, "stopReminding"],
+    ] as const)("%s runs its action and closes", (label, action) => {
+        const { actions, close, button } = openModal();
+        button(label()).trigger("click");
+        expect(actions[action]).toHaveBeenCalledTimes(1);
+        expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    it("not now closes without any action", () => {
+        const { actions, close, button, content } = openModal();
+        button(MESSAGES.BUTTON_NOT_NOW).trigger("click");
+        expect(actions.openSettings).not.toHaveBeenCalled();
+        expect(actions.stopReminding).not.toHaveBeenCalled();
+        expect(close).toHaveBeenCalledTimes(1);
+        expect(content.children.length).toBe(0);
+    });
+});

--- a/tests/views/update-available-modal.test.ts
+++ b/tests/views/update-available-modal.test.ts
@@ -13,7 +13,7 @@ function openModal(build: string | null = null) {
     const close = vi.spyOn(modal, "close");
     modal.open();
     const content = modal.contentEl as unknown as MockElement;
-    const buttons = content.querySelectorAll(".lilbee-confirm-actions")[0].children;
+    const buttons = content.querySelectorAll(".modal-button-container")[0].children;
     const button = (text: string) => buttons.find((b) => b.textContent === text)!;
     return { modal, actions, close, content, button };
 }


### PR DESCRIPTION
## Problem

With automatic server updates turned off, the plugin never says that a newer server exists. The update check only runs on the automatic path, so a user who turned that off stays on an old server, or on the wrong build for their GPU, without a hint.

## Ribbon icon

When automatic updates are off and the launch check finds a newer release, or a build that matches the machine better, a second ribbon icon appears with an accent dot. Its tooltip names the release. Clicking it opens the lilbee settings tab and scrolls to the server version row. The icon goes away when the server updates.

## Reminder modal

The same check opens a modal the user dismisses. It names the release, and the build when the build changed. It says which setting turns the reminder off and which setting installs updates without asking. Three buttons: open the update settings, not now, stop reminding me.

## Setting

"Remind me about server updates" sits next to "Automatically update the server". It is on by default and lives in the shared config, so it applies to every vault. Existing installs get the default without a migration.

## Modal buttons

The shared `lilbee-confirm-actions` class had no CSS rule, so the buttons in this modal, and in the confirm, gatekeeper and uninstall modals, sat flush against each other. All four now use Obsidian's `modal-button-container`, which the theme spaces and aligns.

## Detection

The launch check reruns GPU detection and selection, so a user on the wrong build is offered the right one. Validated 2026-09-04 on an MI300X, which selects the ROCm build, and on an L4 under Windows Server 2025 with driver 580.88, which selects the CUDA 12.5 build.

## Validation

| Check | Method | Result |
|---|---|---|
| With automatic updates off and a wrong recorded build, the reminder modal opens and names the release and the build | CDP harness against the live demo vault | Passed |
| The modal names the setting that turns the reminder off | Same harness | Passed |
| The ribbon shows the update icon with the release in its label and an accent dot | Same harness, screenshot | Passed |
| Not now closes the modal without touching the setting | Same harness | Passed |
| Clicking the ribbon icon opens settings with the server version row in view | Same harness, on the separate settings window | Passed |
| Turning the reminder off in settings persists; the next launch shows only the icon | Same harness, plugin reloaded | Passed |
| Stop reminding me turns the setting off | Same harness | Passed |
| Full gate: lint, format, typecheck, tests with 100% coverage | `npm` gate on the branch | Passed, 3362 tests |
| The seven live steps, rerun after the button spacing fix | Same harness | Passed, 7 of 7 |

Seven of seven live steps passed. Screenshots are in the demos repo under `e2e-validate/out/248-*.png`.

## Screenshots

The ribbon icon with the accent dot, below the existing lilbee icons:

<img src="https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/pr/248/248-ribbon-icon.png?v=2" width="60" alt="Update-available ribbon icon">

The reminder, shown on launch while automatic updates are off:

<img src="https://raw.githubusercontent.com/tobocop2/obsidian-lilbee/gh-pages/pr/248/248-update-reminder.png?v=2" width="700" alt="Update reminder modal">
