### PR TITLE
Open the archive behind a status row that names one of its members

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -855,6 +855,8 @@ export const MESSAGES = {
     LABEL_STATUS_HELD_OUT_RETRY: `Run "${RETRY_SKIPPED_COMMAND}" to index them again.`,
     LABEL_STATUS_DOCUMENTS_FAILED: "Could not load the document list. Scroll to try again.",
     NOTICE_DOCUMENT_NOT_IN_VAULT: (name: string): string => `${name} is not in this vault.`,
+    NOTICE_DOCUMENT_IN_ARCHIVE: (name: string, archive: string): string =>
+        `${name} is inside ${archive}. Opening the archive.`,
     LABEL_STATUS_CHAT_MODEL: "Chat model",
     LABEL_STATUS_OCR: "OCR",
     STATUS_VALUE_OCR_AUTO: "Auto",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -856,7 +856,7 @@ export const MESSAGES = {
     LABEL_STATUS_DOCUMENTS_FAILED: "Could not load the document list. Scroll to try again.",
     NOTICE_DOCUMENT_NOT_IN_VAULT: (name: string): string => `${name} is not in this vault.`,
     NOTICE_DOCUMENT_IN_ARCHIVE: (name: string, archive: string): string =>
-        `${name} is inside ${archive}. Opening the archive.`,
+        `${name} is inside ${archive}. Showing the archive in the file explorer.`,
     LABEL_STATUS_CHAT_MODEL: "Chat model",
     LABEL_STATUS_OCR: "OCR",
     STATUS_VALUE_OCR_AUTO: "Auto",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { Notice, type App, type Modal } from "obsidian";
+import { Notice, type App, type Modal, type TFile } from "obsidian";
 import { ServerStartingError, SessionTokenError } from "./api";
 import { MESSAGES } from "./locales/en";
 import { SERVER_MODE } from "./types";
@@ -469,4 +469,17 @@ export function noticeServerUnreachableIfApplicable(err: unknown): boolean {
 export function configString(cfg: Record<string, unknown>, key: string): string {
     const v = cfg[key];
     return typeof v === "string" ? v : "";
+}
+
+/**
+ * Select *file* in Obsidian's file explorer. The explorer view's `revealInFolder`
+ * is undocumented, so it is shape-checked; false means the explorer is not open.
+ */
+export function revealInFileExplorer(app: App, file: TFile): boolean {
+    const leaf = app.workspace.getLeavesOfType("file-explorer")[0];
+    const view = leaf?.view as unknown as { revealInFolder?: (file: TFile) => void } | undefined;
+    if (!leaf || typeof view?.revealInFolder !== "function") return false;
+    void app.workspace.revealLeaf(leaf);
+    view.revealInFolder(file);
+    return true;
 }

--- a/src/views/status-modal.ts
+++ b/src/views/status-modal.ts
@@ -3,7 +3,7 @@ import type LilbeePlugin from "../main";
 import { MANAGED_DOCS_PREFIX, type ModelShowResponse, type StatusResponse } from "../types";
 import { DocumentList } from "../components/document-list";
 import { MESSAGES } from "../locales/en";
-import { bindEscapeToClose, noticeForResultError } from "../utils";
+import { bindEscapeToClose, noticeForResultError, revealInFileExplorer } from "../utils";
 
 export class StatusModal extends Modal {
     private plugin: LilbeePlugin;
@@ -74,6 +74,7 @@ export class StatusModal extends Modal {
             return;
         }
         // A member of an archive is named archive/member; the archive is the vault file.
+        // Opening it would hand the archive to the OS, so select it in the explorer instead.
         const archive = this.enclosingArchive(filename);
         if (!archive) {
             new Notice(MESSAGES.NOTICE_DOCUMENT_NOT_IN_VAULT(filename));
@@ -81,7 +82,7 @@ export class StatusModal extends Modal {
         }
         new Notice(MESSAGES.NOTICE_DOCUMENT_IN_ARCHIVE(filename, archive.file.name));
         this.close();
-        void workspace.getLeaf(false).openFile(archive.file);
+        revealInFileExplorer(this.app, archive.file);
     }
 
     private vaultFile(sourceName: string): TFile | null {

--- a/src/views/status-modal.ts
+++ b/src/views/status-modal.ts
@@ -66,16 +66,40 @@ export class StatusModal extends Modal {
 
     /** Opens the note behind an indexed document, which lives under the managed folder when content is stored in the vault. */
     private openDocument(filename: string): void {
-        const { vault, workspace } = this.app;
-        const file = [`${MANAGED_DOCS_PREFIX}${filename}`, filename]
-            .map((path) => vault.getAbstractFileByPath(path))
-            .find((entry): entry is TFile => entry instanceof TFile);
-        if (!file) {
+        const { workspace } = this.app;
+        const file = this.vaultFile(filename);
+        if (file) {
+            this.close();
+            void workspace.getLeaf(false).openFile(file);
+            return;
+        }
+        // A member of an archive is named archive/member; the archive is the vault file.
+        const archive = this.enclosingArchive(filename);
+        if (!archive) {
             new Notice(MESSAGES.NOTICE_DOCUMENT_NOT_IN_VAULT(filename));
             return;
         }
+        new Notice(MESSAGES.NOTICE_DOCUMENT_IN_ARCHIVE(filename, archive.file.name));
         this.close();
-        void workspace.getLeaf(false).openFile(file);
+        void workspace.getLeaf(false).openFile(archive.file);
+    }
+
+    private vaultFile(sourceName: string): TFile | null {
+        const { vault } = this.app;
+        return (
+            [`${MANAGED_DOCS_PREFIX}${sourceName}`, sourceName]
+                .map((path) => vault.getAbstractFileByPath(path))
+                .find((entry): entry is TFile => entry instanceof TFile) ?? null
+        );
+    }
+
+    private enclosingArchive(sourceName: string): { file: TFile } | null {
+        const segments = sourceName.split("/");
+        for (let end = segments.length - 1; end > 0; end -= 1) {
+            const file = this.vaultFile(segments.slice(0, end).join("/"));
+            if (file) return { file };
+        }
+        return null;
     }
 
     private renderHeldOut(container: HTMLElement, status: StatusResponse): void {

--- a/tests/views/status-modal.test.ts
+++ b/tests/views/status-modal.test.ts
@@ -499,6 +499,39 @@ describe("StatusModal document list", () => {
         );
         const openFile = vi.fn();
         asMock(app.workspace.getLeaf).mockReturnValue({ openFile });
+        const revealInFolder = vi.fn();
+        const explorer = { view: { revealInFolder } };
+        app.workspace.getLeavesOfType = vi.fn().mockReturnValue([explorer]);
+        app.workspace.revealLeaf = vi.fn();
+        const modal = new StatusModal(app, plugin);
+        const closeSpy = vi.spyOn(modal, "close");
+        modal.open();
+        const content = (modal as any).contentEl as MockElement;
+        await vi.waitFor(() => {
+            expect(content.find("lilbee-documents-row-link")).toBeTruthy();
+        });
+        content.find("lilbee-documents-row-link")!.trigger("click");
+        expect(openFile).not.toHaveBeenCalled();
+        expect(revealInFolder).toHaveBeenCalledWith(archive);
+        expect(app.workspace.revealLeaf).toHaveBeenCalledWith(explorer);
+        expect(closeSpy).toHaveBeenCalledTimes(1);
+        expect(Notice.instances.map((n: any) => n.message)).toContain(
+            MESSAGES.NOTICE_DOCUMENT_IN_ARCHIVE(member, "docs.zip"),
+        );
+    });
+
+    it("still names the archive when the file explorer is closed", async () => {
+        const plugin = makePlugin();
+        asMock(plugin.api.status).mockResolvedValue(ok(makeStatus()));
+        asMock(plugin.api.showModel).mockResolvedValue({});
+        asMock(plugin.api.listDocuments).mockResolvedValue(makeDocsResponse([makeDoc({ filename: "docs.zip/a.pdf" })]));
+        const app = new App();
+        const archive = new TFile();
+        archive.name = "docs.zip";
+        asMock(app.vault.getAbstractFileByPath).mockImplementation((path: string) =>
+            path === "lilbee/docs.zip" ? archive : null,
+        );
+        app.workspace.getLeavesOfType = vi.fn().mockReturnValue([]);
         const modal = new StatusModal(app, plugin);
         modal.open();
         const content = (modal as any).contentEl as MockElement;
@@ -506,9 +539,8 @@ describe("StatusModal document list", () => {
             expect(content.find("lilbee-documents-row-link")).toBeTruthy();
         });
         content.find("lilbee-documents-row-link")!.trigger("click");
-        expect(openFile).toHaveBeenCalledWith(archive);
         expect(Notice.instances.map((n: any) => n.message)).toContain(
-            MESSAGES.NOTICE_DOCUMENT_IN_ARCHIVE(member, "docs.zip"),
+            MESSAGES.NOTICE_DOCUMENT_IN_ARCHIVE("docs.zip/a.pdf", "docs.zip"),
         );
     });
 

--- a/tests/views/status-modal.test.ts
+++ b/tests/views/status-modal.test.ts
@@ -483,6 +483,35 @@ describe("StatusModal document list", () => {
         expect(closeSpy).toHaveBeenCalledTimes(1);
     });
 
+    it.each([
+        ["docs.zip/report.pdf", "lilbee/docs.zip"],
+        ["docs.zip/inner.zip/notes.txt", "docs.zip"],
+    ])("opens the archive behind a member row %s and says which archive holds it", async (member, archivePath) => {
+        const plugin = makePlugin();
+        asMock(plugin.api.status).mockResolvedValue(ok(makeStatus()));
+        asMock(plugin.api.showModel).mockResolvedValue({});
+        asMock(plugin.api.listDocuments).mockResolvedValue(makeDocsResponse([makeDoc({ filename: member })]));
+        const app = new App();
+        const archive = new TFile();
+        archive.name = "docs.zip";
+        asMock(app.vault.getAbstractFileByPath).mockImplementation((path: string) =>
+            path === archivePath ? archive : null,
+        );
+        const openFile = vi.fn();
+        asMock(app.workspace.getLeaf).mockReturnValue({ openFile });
+        const modal = new StatusModal(app, plugin);
+        modal.open();
+        const content = (modal as any).contentEl as MockElement;
+        await vi.waitFor(() => {
+            expect(content.find("lilbee-documents-row-link")).toBeTruthy();
+        });
+        content.find("lilbee-documents-row-link")!.trigger("click");
+        expect(openFile).toHaveBeenCalledWith(archive);
+        expect(Notice.instances.map((n: any) => n.message)).toContain(
+            MESSAGES.NOTICE_DOCUMENT_IN_ARCHIVE(member, "docs.zip"),
+        );
+    });
+
     it("says when a document is not in this vault", async () => {
         const plugin = makePlugin();
         asMock(plugin.api.listDocuments).mockResolvedValue(makeDocsResponse([makeDoc({ filename: "outside.pdf" })]));


### PR DESCRIPTION
## Problem

The server now indexes the files inside an archive as their own documents, named `docs.zip/report.pdf`. The status list links each row to a vault file of the same name. A member has no vault file, so the click showed "docs.zip/report.pdf is not in this vault."

## Solution

When the row's name has no vault file, the modal walks the name back one path segment at a time to the first ancestor that is a vault file, which is the archive. It selects that archive in Obsidian's file explorer and shows a notice that names it. A nested member such as `docs.zip/inner.zip/notes.txt` selects `docs.zip`. A name with no archive behind it still shows the "not in this vault" notice.

## Why select, not open

Obsidian has no view for an archive, so opening it hands the file to the operating system. On macOS that runs Archive Utility, which extracts the archive into the vault next to itself, and the next sync indexes the extracted copies. Selecting the archive in the explorer shows the user where it is without that side effect.


## Validation

| Check | Method | Result |
|---|---|---|
| A sync on the released 0.6.90b433 server indexes a seeded zip as `e2e-archive.zip` plus two member sources | CDP harness against the live demo vault, managed server on the released binary | Passed |
| The status list reaches the member row after scrolling through 1,300 documents | Same harness | Passed |
| Clicking the member row closes the modal and shows the notice that names the archive | Same harness | Passed |
| The archive is selected in the file explorer and is in view | Same harness, `has-focus` on the explorer row | Passed |
| Nothing is extracted into the vault | Same harness, vault checked for an `e2e-archive` folder | Passed |
| Full gate: lint, format, typecheck, tests with 100% coverage | `npm` gate on the branch | Passed, 3458 tests |

The first version of this change opened the archive, and Obsidian handed the zip to Archive Utility, which extracted it into the vault. That is the reason for the select-not-open design and for the extraction check above.
