### PR TITLE
Bundle lilbee 0.6.99 so NVIDIA hosts without a readable CUDA version get the Vulkan build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "fflate": "^0.8.3",
-        "lilbee": "^0.6.98",
+        "lilbee": "^0.6.99",
         "node-fetch": "^3.3.2"
       },
       "devDependencies": {
@@ -4979,9 +4979,9 @@
       }
     },
     "node_modules/lilbee": {
-      "version": "0.6.98",
-      "resolved": "https://registry.npmjs.org/lilbee/-/lilbee-0.6.98.tgz",
-      "integrity": "sha512-Frt6pcyz4nD3i63mR0GVJ+CdazhZqkdu4N9NvDPqySgjFJeXBnaBntZM1BGtdLSPDSX/22yLmKbKRMFqZMuO1w==",
+      "version": "0.6.99",
+      "resolved": "https://registry.npmjs.org/lilbee/-/lilbee-0.6.99.tgz",
+      "integrity": "sha512-MyNx0GFt1RjXrT0Pi/5g/u6qo04PfxXjGigKKhxqrsgKuL8/sm7pChgQWKh9T5GZ7YYQurFiC0L6vZxXZHJFXw==",
       "license": "MIT",
       "bin": {
         "lilbee": "bin/lilbee.mjs",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "dependencies": {
     "fflate": "^0.8.3",
-    "lilbee": "^0.6.98",
+    "lilbee": "^0.6.99",
     "node-fetch": "^3.3.2"
   },
   "overrides": {


### PR DESCRIPTION
## Problem

The bundled launcher, lilbee 0.6.98, gives a Linux host with an NVIDIA device but no readable CUDA version the cu121 build, which runs an old llama.cpp and falls back to the CPU when the CUDA runtime cannot initialise.

## Solution

Depend on lilbee 0.6.99 (tobocop2/lilbee#787). On those hosts the plugin now installs the default build, whose Vulkan engine drives the card. Nothing else in the plugin changes.
