### PR TITLE
Open the Task Center when a model pull starts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2555,6 +2555,13 @@ export default class LilbeePlugin extends Plugin {
         for (const p of paths) this.failedAddPaths.add(p);
     }
 
+    /** Enqueue a model pull and open the Task Center so the download is visible. */
+    enqueuePull(name: string): string | null {
+        const taskId = this.taskQueue.enqueue(name, TASK_TYPE.PULL);
+        if (taskId !== null) void this.activateTaskView();
+        return taskId;
+    }
+
     async activateTaskView(): Promise<void> {
         const existing = this.app.workspace.getLeavesOfType(VIEW_TYPE_TASKS);
         if (existing.length > 0) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2182,7 +2182,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
     }
 
     private async pullAndSetReranker(entry: CatalogEntry): Promise<void> {
-        const taskId = this.plugin.taskQueue.enqueue(`Pull ${entry.display_name}`, TASK_TYPE.PULL);
+        const taskId = this.plugin.enqueuePull(`Pull ${entry.display_name}`);
         if (taskId === null) {
             new Notice(MESSAGES.NOTICE_QUEUE_FULL);
             return;
@@ -2333,7 +2333,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
     }
 
     private async pullAndSetVision(entry: CatalogEntry): Promise<void> {
-        const taskId = this.plugin.taskQueue.enqueue(`Pull ${entry.display_name}`, TASK_TYPE.PULL);
+        const taskId = this.plugin.enqueuePull(`Pull ${entry.display_name}`);
         if (taskId === null) {
             new Notice(MESSAGES.NOTICE_QUEUE_FULL);
             return;
@@ -3136,7 +3136,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
     }
 
     private async streamChatPull(entry: CatalogEntry): Promise<boolean> {
-        const taskId = this.plugin.taskQueue.enqueue(`Pull ${entry.display_name}`, TASK_TYPE.PULL);
+        const taskId = this.plugin.enqueuePull(`Pull ${entry.display_name}`);
         if (taskId === null) {
             new Notice(MESSAGES.NOTICE_QUEUE_FULL);
             return false;

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -899,7 +899,7 @@ export class CatalogModal extends Modal {
     }
 
     private async executePull(entry: CatalogEntry): Promise<void> {
-        const taskId = this.plugin.taskQueue.enqueue(`Pull ${entry.hf_repo}`, TASK_TYPE.PULL);
+        const taskId = this.plugin.enqueuePull(`Pull ${entry.hf_repo}`);
         if (taskId === null) {
             new Notice(MESSAGES.NOTICE_QUEUE_FULL);
             return;

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -19,7 +19,6 @@ import {
     SEARCH_CHUNK_TYPE,
     SESSION_ROLE,
     SSE_EVENT,
-    TASK_TYPE,
     ERROR_NAME,
 } from "../types";
 import type {
@@ -820,7 +819,7 @@ export class ChatView extends ItemView {
     }
 
     private async autoPullAndSet(entry: CatalogEntry): Promise<void> {
-        const taskId = this.plugin.taskQueue.enqueue(`Pull ${entry.display_name}`, TASK_TYPE.PULL);
+        const taskId = this.plugin.enqueuePull(`Pull ${entry.display_name}`);
         if (taskId === null) {
             new Notice(MESSAGES.NOTICE_QUEUE_FULL);
             return;

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1438,6 +1438,31 @@ describe("LilbeePlugin", () => {
         });
     });
 
+    describe("enqueuePull()", () => {
+        it("enqueues a pull task and opens the Task Center", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const activateSpy = vi.spyOn(plugin as any, "activateTaskView").mockResolvedValue(undefined);
+
+            const taskId = plugin.enqueuePull("Pull org/model");
+
+            expect(taskId).not.toBeNull();
+            expect(plugin.taskQueue.active?.name).toBe("Pull org/model");
+            expect(plugin.taskQueue.active?.type).toBe("pull");
+            expect(activateSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it("returns null and leaves the Task Center alone when the pull queue is full", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            const activateSpy = vi.spyOn(plugin as any, "activateTaskView").mockResolvedValue(undefined);
+            plugin.taskQueue.enqueue = vi.fn(() => null) as any;
+
+            expect(plugin.enqueuePull("Pull org/model")).toBeNull();
+            expect(activateSpy).not.toHaveBeenCalled();
+        });
+    });
+
     describe("triggerSync()", () => {
         it("updates status bar during sync and flashes done on completion", async () => {
             const plugin = await createPlugin();

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -3,7 +3,15 @@ import { App, Notice, Setting } from "obsidian";
 import { MockElement } from "./__mocks__/obsidian";
 import { LilbeeSettingTab, SEPARATOR_KEY } from "../src/settings";
 import type { CatalogEntry, CatalogResponse, InstalledModel, LilbeeSettings } from "../src/types";
-import { DEFAULT_SETTINGS, MEMORY_CONFIG_KEY, MODEL_TASK, SERVER_VARIANT, SSE_EVENT, TABLE_MODEL } from "../src/types";
+import {
+    DEFAULT_SETTINGS,
+    MEMORY_CONFIG_KEY,
+    MODEL_TASK,
+    SERVER_VARIANT,
+    SSE_EVENT,
+    TABLE_MODEL,
+    TASK_TYPE,
+} from "../src/types";
 import { MESSAGES } from "../src/locales/en";
 import { ServerStartingError } from "../src/api";
 import { ok, err } from "../src/result";
@@ -131,6 +139,7 @@ function makePlugin(
     let sharedVersion = ver ?? "";
     let sharedHfToken = hf ?? "";
     const sessionToken = tok ?? null;
+    const taskQueue = new TaskQueue();
     const api = {
         listModels: vi.fn(),
         setChatModel: vi.fn(),
@@ -179,7 +188,8 @@ function makePlugin(
         activeModel: "",
         wikiEnabled: overrides.wikiEnabled !== undefined ? settings.wikiEnabled : true,
         wikiSync: null,
-        taskQueue: new TaskQueue(),
+        taskQueue,
+        enqueuePull: vi.fn((name: string) => taskQueue.enqueue(name, TASK_TYPE.PULL)),
         getSharedLilbeeVersion: () => sharedVersion,
         getSharedLilbeeVariant: () => SERVER_VARIANT.DEFAULT,
         isUnloaded: () => false,
@@ -2372,9 +2382,9 @@ describe("LilbeeSettingTab", () => {
             return { tab, captured };
         }
 
-        it("pullAndSetChat surfaces NOTICE_QUEUE_FULL when enqueue returns null", async () => {
+        it("pullAndSetChat surfaces NOTICE_QUEUE_FULL when enqueuePull returns null", async () => {
             const plugin = makePlugin();
-            plugin.taskQueue.enqueue = vi.fn(() => null) as any;
+            plugin.enqueuePull = vi.fn(() => null) as any;
             const { captured } = pickerSetup(plugin);
             Notice.clear();
             await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
@@ -5479,9 +5489,9 @@ describe("managed mode settings", () => {
             expect(Object.keys(options[0])).toEqual([""]);
         });
 
-        it("pull flow surfaces queue-full notice when enqueue fails", async () => {
+        it("pull flow surfaces queue-full notice when enqueuePull fails", async () => {
             const plugin = makePlugin();
-            plugin.taskQueue.enqueue = vi.fn(() => null) as any;
+            plugin.enqueuePull = vi.fn(() => null) as any;
             (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({
                 reranker_model: "",
                 rerank_candidates: 20,
@@ -6333,9 +6343,9 @@ describe("managed mode settings", () => {
             expect(Object.keys(options[0])).toEqual([""]);
         });
 
-        it("pull flow surfaces queue-full notice when enqueue fails", async () => {
+        it("pull flow surfaces queue-full notice when enqueuePull fails", async () => {
             const plugin = makePlugin();
-            plugin.taskQueue.enqueue = vi.fn(() => null) as any;
+            plugin.enqueuePull = vi.fn(() => null) as any;
             (plugin.api.config as ReturnType<typeof vi.fn>).mockResolvedValue({ vision_model: "" });
             (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
                 ok({

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -3,7 +3,7 @@ import { windowStub } from "../window-stub";
 import { App, Notice } from "obsidian";
 import { MockElement } from "../__mocks__/obsidian";
 import { CatalogModal } from "../../src/views/catalog-modal";
-import { CATALOG_TAB, SSE_EVENT } from "../../src/types";
+import { CATALOG_TAB, SSE_EVENT, TASK_TYPE } from "../../src/types";
 import type { CatalogEntry, CatalogResponse, CatalogTab } from "../../src/types";
 import { TaskQueue } from "../../src/task-queue";
 import { ok, err } from "../../src/result";
@@ -62,6 +62,7 @@ function makeCatalogResponse(
 }
 
 function makePlugin(overrides: Record<string, unknown> = {}) {
+    const taskQueue = new TaskQueue();
     return {
         api: {
             catalog: vi.fn().mockResolvedValue(ok(makeCatalogResponse([]))),
@@ -78,7 +79,8 @@ function makePlugin(overrides: Record<string, unknown> = {}) {
         fetchActiveModel: vi.fn(),
         refreshSettingsTab: vi.fn(),
         refreshOpenChatRails: vi.fn(),
-        taskQueue: new TaskQueue(),
+        taskQueue,
+        enqueuePull: vi.fn((name: string) => taskQueue.enqueue(name, TASK_TYPE.PULL)),
         ...overrides,
     };
 }
@@ -1242,10 +1244,10 @@ describe("CatalogModal", () => {
             expect(plugin.taskQueue.completed.some((t: any) => t.status === "failed")).toBe(false);
         });
 
-        it("shows NOTICE_QUEUE_FULL when enqueue returns null (per-type cap)", async () => {
+        it("shows NOTICE_QUEUE_FULL when enqueuePull returns null (per-type cap)", async () => {
             const plugin = makePlugin();
             plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry()])));
-            plugin.taskQueue.enqueue = vi.fn(() => null) as any;
+            plugin.enqueuePull = vi.fn(() => null) as any;
             plugin.api.pullModel = vi.fn();
             const modal = await openModal(plugin);
             const content = contentEl(modal);

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -26,7 +26,7 @@ import { ChatView, VIEW_TYPE_CHAT, VaultFilePickerModal, compactionMarkerText } 
 import { electronDialog } from "../../src/utils/file-dialog";
 import { ok, err } from "../../src/result";
 import type LilbeePlugin from "../../src/main";
-import { SSE_EVENT } from "../../src/types";
+import { SSE_EVENT, TASK_TYPE } from "../../src/types";
 import { MESSAGES } from "../../src/locales/en";
 
 const mockChatViewConfirmResult = true;
@@ -147,6 +147,7 @@ function triggerText(container: MockElement, triggerCls: string): string {
 }
 
 function makePlugin(): LilbeePlugin {
+    const taskQueue = new TaskQueue();
     return {
         api: {
             chatStream: vi.fn(),
@@ -250,7 +251,8 @@ function makePlugin(): LilbeePlugin {
         assertFleetReady: vi.fn().mockReturnValue(true),
         serverSupportsSessions: vi.fn().mockReturnValue(true),
         refreshMemoryViews: vi.fn(),
-        taskQueue: new TaskQueue(),
+        taskQueue,
+        enqueuePull: vi.fn((name: string) => taskQueue.enqueue(name, TASK_TYPE.PULL)),
         app: {
             vault: {
                 getAbstractFileByPath: vi.fn().mockReturnValue(null),
@@ -4040,10 +4042,10 @@ describe("ChatView — embedding model selector", () => {
 });
 
 describe("ChatView — queue-full notice on auto-pull", () => {
-    it("shows NOTICE_QUEUE_FULL when enqueue returns null", async () => {
+    it("shows NOTICE_QUEUE_FULL when enqueuePull returns null", async () => {
         Notice.clear();
         const plugin = makePlugin();
-        plugin.taskQueue.enqueue = vi.fn(() => null) as any;
+        plugin.enqueuePull = vi.fn(() => null) as any;
         plugin.api.pullModel = vi.fn();
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();


### PR DESCRIPTION
## Problem

Pulling a model from the catalog, the settings tab, or the chat model picker only updates the status bar when the Task Center is closed. Nothing on screen says a download is running. The setup wizard shows its own progress panel, so a user who first met pulls there expects the same feedback from the catalog and gets none.

## Solution

**Every pull opens the Task Center.** The plugin gains one helper that enqueues the pull task and reveals the Task Center in the right sidebar. The five pull entry points (catalog modal, chat model picker, and the chat, reranker and vision pickers in settings) call it instead of the queue directly. A full queue still shows the queue-full notice and leaves the layout alone.

**Nothing else changes.** The wizard keeps its in-modal progress panel. The Task Center has a close button since #246, so the user can dismiss it once the pull is visible.

Verified end to end in the demo vault: with the Task Center closed, confirming a catalog pull opened it with the active pull row, and cancelling from that row stopped the pull.