### PR TITLE
Clean up dead and deprecated CSS on the marketing site

### DIFF
--- a/site/style.css
+++ b/site/style.css
@@ -47,7 +47,6 @@ body {
   min-height: 100vh;
   padding: 2.5rem var(--gutter) 4rem;
   position: relative;
-  overflow-x: hidden;
   /* clip, not hidden: hidden makes body a scroll container on mobile browsers,
      which breaks the sticky nav. clip never creates one. */
   overflow-x: clip;
@@ -83,7 +82,7 @@ pre { font: inherit; white-space: pre; }
 
 h1.sr {
   position: absolute; width: 1px; height: 1px;
-  overflow: hidden; clip: rect(0, 0, 0, 0);
+  overflow: hidden; clip-path: inset(50%);
 }
 
 /* page-load: one quiet staggered settle, top to bottom ---------------- */
@@ -429,43 +428,8 @@ section[id] { scroll-margin-top: 4.2rem; }
 
 .tutorialpane[hidden] { display: none; }
 
-.tutorial-frame {
-  background: var(--bg-sunken);
-  border: 1px solid var(--rule-2);
-  border-radius: 6px;
-  overflow: hidden;
-  box-shadow: 0 22px 60px -26px rgba(0, 0, 0, 0.85);
-  /* hold the box at the recording's shape (1200x749) while the GIF streams
-     in, so a click never lands on an empty void */
-  aspect-ratio: 1200 / 749;
-  position: relative;
-}
-.tutorial-frame::before {
-  content: "loading recording.";
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-family: var(--mono);
-  font-size: 12px;
-  letter-spacing: 0.18em;
-  color: var(--ink-3);
-  text-transform: uppercase;
-  background:
-    repeating-linear-gradient(135deg, transparent 0 8px, rgba(255, 255, 255, 0.014) 8px 16px),
-    var(--bg-sunken);
-}
-.tutorial-frame img {
-  position: relative;
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-  z-index: 1;
-}
-/* Video clip (crisp, full-resolution webm) — same box as .tutorial-frame but
-   without the loading overlay, so the video isn't hidden behind it. */
+/* Video clip (crisp, full-resolution webm), held at the recording's shape
+   (1200x749) so the box never resizes as the video streams in. */
 .tutorial-clip {
   background: #000;
   border: 1px solid var(--rule-2);
@@ -541,7 +505,7 @@ section[id] { scroll-margin-top: 4.2rem; }
   padding: 0.7rem 0.4rem;
   color: var(--ink);
   font-weight: 500;
-  word-break: break-word;
+  overflow-wrap: break-word;
 }
 .install a.cmd { color: var(--accent); }
 .install a.cmd:hover { color: var(--accent-hot); }

--- a/site/tutorial/index.html
+++ b/site/tutorial/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8" />
@@ -78,7 +78,7 @@
     <h1 class="tutorial-h1">Tutorial reel</h1>
     <p class="tutorial-intro">Every lilbee for Obsidian demo as a video, each with a longer note than the homepage carries. The clips loop and are silent; watch at your own pace.</p>
 
-    <nav class="tutorial-toc">
+    <nav class="tutorial-toc" aria-label="Contents">
       <div class="toc-label">contents</div>
       <ol id="tutorial-toc"></ol>
     </nav>


### PR DESCRIPTION
## Problem

The Obsidian plugin report flagged a duplicate `overflow-x` in `site/style.css`. Nothing under `site/` is linted: `npm run lint` covers `src/` and `tests/` only, so the page had collected a few more defects of the same kind.

## Solution

**The duplicate.** `overflow-x: hidden` sat above `overflow-x: clip` since the sticky-nav fix. The `hidden` line takes effect only in browsers that do not understand `clip`, which are exactly the browsers with the sticky-nav bug it was meant to fix. Removed.

**Deprecated CSS.** The visually hidden `h1.sr` used `clip: rect(0, 0, 0, 0)` and now uses `clip-path: inset(50%)`. The install command line used `word-break: break-word` and now uses `overflow-wrap: break-word`.

**Dead rules.** `.tutorial-frame`, its loading overlay, and its `img` rule are from the GIF era. No page has referenced them since the demos became `<video>`, so they are gone.

**Tutorial page.** The doctype is uppercase to match the other two pages, and the contents `<nav>` gets an accessible name so it no longer collides with the site nav.

**Left alone.** The 18 demo clips still autoplay muted and looping, which is the whole point of replacing the GIFs.
