### PR TITLE
Stop the wizard advancing after a failed download or catalog load

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -109,6 +109,7 @@ export const MESSAGES = {
     BUTTON_INSTALL_SERVER: "Install server",
     BUTTON_REINSTALL: "Reinstall",
     BUTTON_RETRY: "Retry",
+    WIZARD_NO_MODELS_OFFERED: "The server offered no models for this step.",
     BUTTON_UNINSTALL_SERVER: "Uninstall server",
     BUTTON_UNINSTALL: "Uninstall",
     BUTTON_DOWNLOADING: "Downloading...",

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -27,6 +27,7 @@ import { renderModelCard } from "../components/model-card";
 import {
     bindEscapeToClose,
     closeSettings,
+    errorMessage,
     extractSseErrorMessage,
     getSystemMemoryGB,
     percentFromSse,
@@ -211,6 +212,8 @@ export class SetupWizard extends Modal {
     private plugin: LilbeePlugin;
     private step = 0;
     private selectedModel: FeaturedModel | null = null;
+    /** The step's primary action; disabled while nothing is selectable. */
+    private primaryBtn: HTMLButtonElement | null = null;
     private featuredModels: FeaturedModel[] = [];
     private pullController: AbortController | null = null;
     private syncController: AbortController | null = null;
@@ -698,6 +701,7 @@ export class SetupWizard extends Modal {
         });
 
         const downloadBtn = actions.createEl("button", { text: MESSAGES.BUTTON_DOWNLOAD_CONTINUE, cls: "mod-cta" });
+        this.primaryBtn = downloadBtn;
         downloadBtn.addEventListener("click", () => {
             if (!this.selectedModel) {
                 statusEl.setText(MESSAGES.WIZARD_SELECT_MODEL);
@@ -731,17 +735,28 @@ export class SetupWizard extends Modal {
             });
             if (result.isErr()) {
                 this.featuredModels = [];
+                this.renderCatalogFailure(container, statusEl, result.error.message, () => {
+                    void this.loadFeaturedModels(container, memGB, statusEl);
+                });
                 return;
             }
             this.featuredModels = pickNativeChatModels(result.value.models);
-        } catch {
+        } catch (e) {
             this.featuredModels = [];
-            statusEl.setText(MESSAGES.ERROR_LOAD_MODELS);
+            this.renderCatalogFailure(container, statusEl, errorMessage(e, MESSAGES.ERROR_LOAD_MODELS), () => {
+                void this.loadFeaturedModels(container, memGB, statusEl);
+            });
+            return;
+        }
+        if (this.featuredModels.length === 0) {
+            this.renderCatalogFailure(container, statusEl, MESSAGES.WIZARD_NO_MODELS_OFFERED, () => {
+                void this.loadFeaturedModels(container, memGB, statusEl);
+            });
             return;
         }
 
         const recommended = recommendedIndex(this.featuredModels, memGB);
-        this.selectedModel = this.featuredModels[recommended] ?? null;
+        this.selectedModel = this.featuredModels[recommended];
 
         this.renderSectionHeading(container, MESSAGES.LABEL_OUR_PICKS);
         const grid = container.createDiv({ cls: "lilbee-catalog-grid" });
@@ -753,6 +768,31 @@ export class SetupWizard extends Modal {
                 onClick: () => this.selectModel(grid, entry),
             });
         }
+    }
+
+    /** Say why the model grid is empty and let the user try again without
+     *  restarting the wizard. A silent empty step has nothing to select, so the
+     *  primary action can only answer "select a model". */
+    /** Reflect whether the step has something to act on. */
+    private syncPrimaryEnabled(): void {
+        if (!this.primaryBtn) return;
+        this.primaryBtn.disabled = this.selectedModel === null && this.selectedEmbedding === null;
+    }
+
+    private renderCatalogFailure(
+        container: HTMLElement,
+        statusEl: HTMLElement,
+        reason: string,
+        retry: () => void,
+    ): void {
+        container.empty();
+        statusEl.setText(reason);
+        const retryBtn = container.createEl("button", { text: MESSAGES.BUTTON_RETRY });
+        retryBtn.addEventListener("click", () => {
+            statusEl.setText("");
+            retry();
+        });
+        this.syncPrimaryEnabled();
     }
 
     private selectModel(grid: HTMLElement, model: FeaturedModel): void {
@@ -797,11 +837,16 @@ export class SetupWizard extends Modal {
                         );
                     }
                 } else if (event.event === SSE_EVENT.ERROR) {
+                    // A model that failed to download must not be set as active:
+                    // the set is a ref write, so the server accepts it and the
+                    // wizard would advance claiming a model it never fetched.
                     const d = event.data as { message?: string } | string;
                     const msg = extractSseErrorMessage(d, MESSAGES.ERROR_UNKNOWN);
                     new Notice(MESSAGES.ERROR_DOWNLOAD_FAILED);
                     statusEl.setText(msg);
-                    break;
+                    progressEl.hide();
+                    (downloadBtn as HTMLButtonElement).disabled = false;
+                    return;
                 }
             }
 
@@ -857,6 +902,7 @@ export class SetupWizard extends Modal {
         });
 
         const downloadBtn = actions.createEl("button", { text: MESSAGES.BUTTON_DOWNLOAD_CONTINUE, cls: "mod-cta" });
+        this.primaryBtn = downloadBtn;
         downloadBtn.addEventListener("click", () => {
             if (!this.selectedEmbedding) {
                 this.step = WIZARD_STEP.SYNC;
@@ -895,21 +941,32 @@ export class SetupWizard extends Modal {
             });
             if (result.isErr()) {
                 this.embeddingModels = [];
+                this.renderCatalogFailure(container, statusEl, result.error.message, () => {
+                    void this.loadEmbeddingModels(container, statusEl);
+                });
                 return;
             }
             // Trust the server's featured list — don't filter by source.
             // Mis-configured builds can stamp every featured embedding as
             // source="litellm", which would leave the picker empty.
             this.embeddingModels = result.value.models.slice(0, MAX_FEATURED_PICKS);
-        } catch {
+        } catch (e) {
             this.embeddingModels = [];
-            statusEl.setText(MESSAGES.ERROR_LOAD_MODELS);
+            this.renderCatalogFailure(container, statusEl, errorMessage(e, MESSAGES.ERROR_LOAD_MODELS), () => {
+                void this.loadEmbeddingModels(container, statusEl);
+            });
+            return;
+        }
+        if (this.embeddingModels.length === 0) {
+            this.renderCatalogFailure(container, statusEl, MESSAGES.WIZARD_NO_MODELS_OFFERED, () => {
+                void this.loadEmbeddingModels(container, statusEl);
+            });
             return;
         }
 
         const recommended = this.embeddingModels.findIndex((m) => m.hf_repo.toLowerCase().includes("nomic-embed-text"));
         const defaultIdx = recommended >= 0 ? recommended : 0;
-        this.selectedEmbedding = this.embeddingModels[defaultIdx] ?? null;
+        this.selectedEmbedding = this.embeddingModels[defaultIdx];
 
         this.renderSectionHeading(container, MESSAGES.WIZARD_EMBEDDING_RECOMMENDED);
         const grid = container.createDiv({ cls: "lilbee-catalog-grid" });
@@ -965,11 +1022,16 @@ export class SetupWizard extends Modal {
                         );
                     }
                 } else if (event.event === SSE_EVENT.ERROR) {
+                    // A model that failed to download must not be set as active:
+                    // the set is a ref write, so the server accepts it and the
+                    // wizard would advance claiming a model it never fetched.
                     const d = event.data as { message?: string } | string;
                     const msg = extractSseErrorMessage(d, MESSAGES.ERROR_UNKNOWN);
                     new Notice(MESSAGES.ERROR_DOWNLOAD_FAILED);
                     statusEl.setText(msg);
-                    break;
+                    progressEl.hide();
+                    (downloadBtn as HTMLButtonElement).disabled = false;
+                    return;
                 }
             }
 

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -735,6 +735,7 @@ export class SetupWizard extends Modal {
             });
             if (result.isErr()) {
                 this.featuredModels = [];
+                this.selectedModel = null;
                 this.renderCatalogFailure(container, statusEl, result.error.message, () => {
                     void this.loadFeaturedModels(container, memGB, statusEl);
                 });
@@ -743,12 +744,14 @@ export class SetupWizard extends Modal {
             this.featuredModels = pickNativeChatModels(result.value.models);
         } catch (e) {
             this.featuredModels = [];
+            this.selectedModel = null;
             this.renderCatalogFailure(container, statusEl, errorMessage(e, MESSAGES.ERROR_LOAD_MODELS), () => {
                 void this.loadFeaturedModels(container, memGB, statusEl);
             });
             return;
         }
         if (this.featuredModels.length === 0) {
+            this.selectedModel = null;
             this.renderCatalogFailure(container, statusEl, MESSAGES.WIZARD_NO_MODELS_OFFERED, () => {
                 void this.loadFeaturedModels(container, memGB, statusEl);
             });
@@ -770,15 +773,9 @@ export class SetupWizard extends Modal {
         }
     }
 
-    /** Say why the model grid is empty and let the user try again without
-     *  restarting the wizard. A silent empty step has nothing to select, so the
-     *  primary action can only answer "select a model". */
-    /** Reflect whether the step has something to act on. */
-    private syncPrimaryEnabled(): void {
-        if (!this.primaryBtn) return;
-        this.primaryBtn.disabled = this.selectedModel === null && this.selectedEmbedding === null;
-    }
-
+    /** Say why the grid is empty and let the user try again without restarting
+     *  the wizard. The step has nothing to select, so it also clears the stale
+     *  selection and disables the primary action. */
     private renderCatalogFailure(
         container: HTMLElement,
         statusEl: HTMLElement,
@@ -792,7 +789,7 @@ export class SetupWizard extends Modal {
             statusEl.setText("");
             retry();
         });
-        this.syncPrimaryEnabled();
+        if (this.primaryBtn) this.primaryBtn.disabled = true;
     }
 
     private selectModel(grid: HTMLElement, model: FeaturedModel): void {
@@ -941,6 +938,7 @@ export class SetupWizard extends Modal {
             });
             if (result.isErr()) {
                 this.embeddingModels = [];
+                this.selectedEmbedding = null;
                 this.renderCatalogFailure(container, statusEl, result.error.message, () => {
                     void this.loadEmbeddingModels(container, statusEl);
                 });
@@ -952,12 +950,14 @@ export class SetupWizard extends Modal {
             this.embeddingModels = result.value.models.slice(0, MAX_FEATURED_PICKS);
         } catch (e) {
             this.embeddingModels = [];
+            this.selectedEmbedding = null;
             this.renderCatalogFailure(container, statusEl, errorMessage(e, MESSAGES.ERROR_LOAD_MODELS), () => {
                 void this.loadEmbeddingModels(container, statusEl);
             });
             return;
         }
         if (this.embeddingModels.length === 0) {
+            this.selectedEmbedding = null;
             this.renderCatalogFailure(container, statusEl, MESSAGES.WIZARD_NO_MODELS_OFFERED, () => {
                 void this.loadEmbeddingModels(container, statusEl);
             });

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -1029,6 +1029,45 @@ describe("SetupWizard", () => {
             expect((wizard.contentEl as unknown as MockElement).textContent ?? "").toContain("Qwen3");
         });
 
+        it("a failed catalog load drops a selection made before it", async () => {
+            const entries = [makeEntry({ hf_repo: "Qwen/Qwen3-0.6B-GGUF" })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+            expect((wizard as any).selectedModel).not.toBeNull();
+
+            // Re-entering the step against a server that now fails must not keep
+            // the earlier pick: the grid is empty and the model is unreachable.
+            plugin.api.catalog = vi.fn().mockResolvedValue(err(new Error("connection refused")));
+            (wizard as any).renderStep();
+            await tick();
+            await tick();
+
+            expect((wizard as any).selectedModel).toBeNull();
+            const el = wizard.contentEl as unknown as MockElement;
+            const btn = findButtons(el).find((b) => b.textContent === "Download & continue");
+            expect((btn as unknown as { disabled: boolean }).disabled).toBe(true);
+        });
+
+        it("disables the model step's action even when an embedding is selected", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(err(new Error("offline")));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            // A later step's selection must not enable this one's action.
+            (wizard as any).selectedEmbedding = { hf_repo: "nomic", display_name: "nomic" };
+            wizard.next();
+            await tick();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const btn = findButtons(el).find((b) => b.textContent === "Download & continue");
+            expect((btn as unknown as { disabled: boolean }).disabled).toBe(true);
+        });
+
         it("a failed catalog load says so and offers a retry", async () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             plugin.api.catalog = vi.fn().mockResolvedValue(err(new Error("connection refused")));

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -900,7 +900,9 @@ describe("SetupWizard", () => {
 
             const el = wizard.contentEl as unknown as MockElement;
             const texts = collectTexts(el);
-            expect(texts.some((t) => t.includes("Could not load models"))).toBe(true);
+            // The server's own reason, not a generic string, plus a way out.
+            expect(texts.some((t) => t.includes("fail"))).toBe(true);
+            expect(findButtons(el).some((b) => b.textContent === "Retry")).toBe(true);
         });
 
         it("sets empty featured models when catalog returns error result", async () => {
@@ -982,6 +984,150 @@ describe("SetupWizard", () => {
             await tick();
 
             expect(plugin.api.pullModel).toHaveBeenCalled();
+        });
+
+        it("an empty featured list says so instead of rendering nothing", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            expect(el.textContent ?? "").toContain("offered no models");
+
+            plugin.api.catalog = vi
+                .fn()
+                .mockResolvedValue(ok(makeCatalogResponse([makeEntry({ hf_repo: "Qwen/Qwen3-0.6B-GGUF" })])));
+            findButtons(el)
+                .find((b) => b.textContent === "Retry")!
+                .trigger("click");
+            await tick();
+            await tick();
+            expect((wizard.contentEl as unknown as MockElement).textContent ?? "").toContain("Qwen3");
+        });
+
+        it("a thrown catalog error reports its reason and retries", async () => {
+            const entries = [makeEntry({ hf_repo: "Qwen/Qwen3-0.6B-GGUF" })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockRejectedValue(new Error("socket hang up"));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            expect(el.textContent ?? "").toContain("socket hang up");
+
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
+            findButtons(el)
+                .find((b) => b.textContent === "Retry")!
+                .trigger("click");
+            await tick();
+            await tick();
+            expect((wizard.contentEl as unknown as MockElement).textContent ?? "").toContain("Qwen3");
+        });
+
+        it("a failed catalog load says so and offers a retry", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(err(new Error("connection refused")));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            expect(el.textContent ?? "").toContain("connection refused");
+            expect(findButtons(el).some((b) => b.textContent === "Retry")).toBe(true);
+        });
+
+        it("retrying a failed catalog load renders the models", async () => {
+            const entries = [makeEntry({ hf_repo: "Qwen/Qwen3-0.6B-GGUF" })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(err(new Error("connection refused")));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
+            const el = wizard.contentEl as unknown as MockElement;
+            findButtons(el)
+                .find((b) => b.textContent === "Retry")!
+                .trigger("click");
+            await tick();
+            await tick();
+
+            const after = wizard.contentEl as unknown as MockElement;
+            expect(after.textContent ?? "").toContain("Qwen3");
+        });
+
+        it("the download button is disabled while no model can be selected", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(err(new Error("offline")));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const btn = findButtons(el).find((b) => b.textContent === "Download & continue");
+            expect((btn as unknown as { disabled: boolean }).disabled).toBe(true);
+        });
+
+        it("a failed download does not set the model or advance the step", async () => {
+            const entries = [makeEntry({ hf_repo: "Qwen/Qwen3-0.6B-GGUF" })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
+            plugin.api.pullModel = vi.fn().mockReturnValue(
+                (async function* () {
+                    yield { event: SSE_EVENT.PROGRESS, data: { current: 10, total: 100 } };
+                    yield { event: SSE_EVENT.ERROR, data: { message: "no space left on device" } };
+                })(),
+            );
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            findButtons(el)
+                .find((b) => b.textContent === "Download & continue")!
+                .trigger("click");
+            await tick();
+            await tick();
+
+            expect(plugin.api.setChatModel).not.toHaveBeenCalled();
+            // Still on the model step, with the server's reason on screen.
+            expect((wizard as any).step).toBe(WIZARD_STEP.MODEL_PICKER);
+            const text = (wizard.contentEl as unknown as MockElement).textContent ?? "";
+            expect(text).toContain("no space left on device");
+        });
+
+        it("a failed embedding download does not set the model or advance the step", async () => {
+            const entries = [makeEntry({ hf_repo: "nomic-ai/nomic-embed-text-v1.5-GGUF" })];
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
+            plugin.api.pullModel = vi.fn().mockReturnValue(
+                (async function* () {
+                    yield { event: SSE_EVENT.ERROR, data: { message: "checksum mismatch" } };
+                })(),
+            );
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = WIZARD_STEP.EMBEDDING_PICKER;
+            (wizard as any).renderStep();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const btn = findButtons(el).find((b) => b.textContent === "Download & continue");
+            btn!.trigger("click");
+            await tick();
+            await tick();
+
+            expect(plugin.api.setEmbeddingModel).not.toHaveBeenCalled();
+            expect((wizard as any).step).toBe(WIZARD_STEP.EMBEDDING_PICKER);
         });
 
         it("pull progress with current/total computes percentage", async () => {
@@ -2874,6 +3020,46 @@ describe("SetupWizard", () => {
             expect(other.classList.contains("is-selected")).toBe(false);
         });
 
+        it("loadEmbeddingModels reports an empty list and retries", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const statusEl = new MockElement("div") as unknown as HTMLElement;
+            await (wizard as any).loadEmbeddingModels(container, statusEl);
+            expect((statusEl as unknown as MockElement).textContent).toContain("offered no models");
+
+            const entries = [makeEntry({ hf_repo: "nomic-ai/nomic-embed-text-v1.5-GGUF" })];
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
+            findButtons(container as unknown as MockElement)
+                .find((b) => b.textContent === "Retry")!
+                .trigger("click");
+            await tick();
+            await tick();
+            expect((wizard as any).embeddingModels.length).toBe(1);
+        });
+
+        it("loadEmbeddingModels retries after an isErr result", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(err(new Error("gateway timeout")));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const statusEl = new MockElement("div") as unknown as HTMLElement;
+            await (wizard as any).loadEmbeddingModels(container, statusEl);
+            expect((statusEl as unknown as MockElement).textContent).toContain("gateway timeout");
+
+            const entries = [makeEntry({ hf_repo: "nomic-ai/nomic-embed-text-v1.5-GGUF" })];
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
+            findButtons(container as unknown as MockElement)
+                .find((b) => b.textContent === "Retry")!
+                .trigger("click");
+            await tick();
+            await tick();
+            expect((wizard as any).embeddingModels.length).toBe(1);
+        });
+
         it("loadEmbeddingModels handles catalog error", async () => {
             const plugin = makePlugin({ settings: { serverMode: "external" } });
             plugin.api.catalog = vi.fn().mockRejectedValue(new Error("fail"));
@@ -2883,7 +3069,17 @@ describe("SetupWizard", () => {
             const statusEl = new MockElement("div") as unknown as HTMLElement;
             await (wizard as any).loadEmbeddingModels(container, statusEl);
             expect((wizard as any).embeddingModels).toEqual([]);
-            expect((statusEl as unknown as MockElement).textContent).toContain("Could not load models");
+            // The server's own reason reaches the step, not a generic string.
+            expect((statusEl as unknown as MockElement).textContent).toContain("fail");
+
+            const entries = [makeEntry({ hf_repo: "nomic-ai/nomic-embed-text-v1.5-GGUF" })];
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
+            findButtons(container as unknown as MockElement)
+                .find((b) => b.textContent === "Retry")!
+                .trigger("click");
+            await tick();
+            await tick();
+            expect((wizard as any).embeddingModels.length).toBe(1);
         });
 
         it("loadEmbeddingModels handles catalog isErr result", async () => {


### PR DESCRIPTION
## Problem

A failed download advances the wizard. The SSE error arm leaves the loop, and the code falls through to `setChatModel`. That call writes a reference. It does not check the file. The server accepts it, the wizard moves to the next step, and `renderStep` clears the error.

The Done screen then reports the model as downloaded. The active model points at weights the wizard never fetched. The embedding path has the same defect.

A failed catalog call renders nothing. The `Result` error arm returns before the message and before the grid. The step shows its title and no models. "Download & continue" stays enabled and answers "select a model" for a list that does not exist.

The `catch` arm reports the error. The `Result` arm does not, and it is the normal failure mode.

## Solution

Both download paths report the error and stay on the step.

Both catalog paths show the server's reason and a Retry button. An empty list says so. The primary action is disabled while nothing is selectable.

## Notes

Two tests asserted the generic error string. They now assert the server's reason and the retry.

With the empty-list guard in place, `featuredModels[recommended]` is always defined. The `?? null` fallback on each list is removed.

## Reproduced

On a fresh vault the model step rendered empty. The same request returned 200 with eight models by hand. Back and forward populated the step.
