### PR TITLE
Fix the crash budget and report a refused restart

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -697,6 +697,15 @@ export default class LilbeePlugin extends Plugin {
                 const notice = new Notice(`${MESSAGES.ERROR_SERVER_CRASHED}${detail}`, NOTICE_PERMANENT);
                 this.attachExportLink(notice);
             },
+            onScopeHeld: () => {
+                // Another vault took the root while this server was down. The
+                // restart path has no take-over of its own, so route it into the
+                // same negotiation a first start uses instead of dying silently.
+                const registry = this.vaultRegistry;
+                if (!registry) return;
+                this.serverManager = null;
+                void this.negotiateTakeOver(registry);
+            },
             onShutdownFailure: (err: Error) => {
                 new Notice(`${MESSAGES.ERROR_SERVER_SHUTDOWN_FAILED}: ${err.message}`);
             },

--- a/src/server-manager.ts
+++ b/src/server-manager.ts
@@ -23,6 +23,9 @@ const SERVER_MANAGER_CONFIG = {
     KILL_GRACE_MS: 5000,
     CRASH_RESTART_DELAY_MS: 3000,
     MAX_CRASH_RESTARTS: 3,
+    // A run that served this long counts as healthy, so its failure starts a
+    // fresh budget. Shorter runs are a flap and keep spending the old one.
+    STABLE_UPTIME_MS: 60_000,
     PORT_FILE_POLL_INTERVAL_MS: 500,
     PORT_FILE_MAX_ATTEMPTS: 240,
     SPAWN_CRASH_LOG_MAX_BYTES: 262_144,
@@ -190,6 +193,8 @@ export interface ServerManagerOptions {
     installedVersion: string;
     onStateChange?: (state: ServerState) => void;
     onRestartsExhausted?: (output: string) => void;
+    /** Another vault took the shared root while this server was down. */
+    onScopeHeld?: (error: ScopeHeldError) => void;
     onShutdownFailure?: (error: Error) => void;
     /** Receives one line per lifecycle decision (spawn, adopt, stop, crash-restart). */
     onJournal?: (message: string) => void;
@@ -222,6 +227,8 @@ export class ServerManager {
     private adoptedWatch: number | null = null;
     private _state: ServerState = SERVER_STATE.STOPPED;
     private crashCount = 0;
+    /** When the current run reached READY; null while it is not up. */
+    private readyAt: number | null = null;
     private restartTimer: number | null = null;
     private _actualPort: number | null = null;
     private _spawnedVersion = "";
@@ -407,6 +414,12 @@ export class ServerManager {
     }
 
     private scheduleCrashRestart(): void {
+        // Reaching READY is not evidence the server works; staying there is.
+        // Resetting on the start itself let an adopt-fail-adopt cycle spend
+        // attempt 1 forever, so the budget never ran out and nothing was said.
+        const uptime = this.readyAt === null ? 0 : Date.now() - this.readyAt;
+        if (uptime >= SERVER_MANAGER_CONFIG.STABLE_UPTIME_MS) this.crashCount = 0;
+        this.readyAt = null;
         if (this.crashCount < SERVER_MANAGER_CONFIG.MAX_CRASH_RESTARTS) {
             this.crashCount++;
             this.journal(
@@ -429,12 +442,14 @@ export class ServerManager {
         this.opts.onRestartsExhausted?.(this.lastOutput);
     }
 
-    /** Crash-loop restart: failures already surface via state + onRestartsExhausted, so don't rethrow. */
+    /** Crash-loop restart: failures surface via state + onRestartsExhausted, so
+     *  don't rethrow. A lock refusal is not a crash and has its own recovery,
+     *  so it is handed to the caller instead of being dropped here. */
     private async startForRestart(): Promise<void> {
         try {
             await this.start();
-        } catch {
-            // already reported
+        } catch (err) {
+            if (err instanceof ScopeHeldError) this.opts.onScopeHeld?.(err);
         }
     }
 
@@ -481,7 +496,7 @@ export class ServerManager {
         // running a different version than the installed binary is asked to
         // exit, so a binary update takes effect on the next reload.
         if (await this.tryAdopt()) {
-            this.crashCount = 0;
+            this.readyAt = Date.now();
             this.setState(SERVER_STATE.READY);
             return;
         }
@@ -497,7 +512,7 @@ export class ServerManager {
         try {
             await this.waitForPortFile(generation);
             await this.waitForReady(generation);
-            this.crashCount = 0;
+            this.readyAt = Date.now();
             this.setState(SERVER_STATE.READY);
         } catch (err) {
             // A crash-restart superseded this attempt; the newer start owns the state.

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -5396,6 +5396,38 @@ describe("LilbeePlugin", () => {
             await flush();
         });
 
+        it("onScopeHeld routes a restart refusal into the take-over negotiation", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const onScopeHeld = mockServerOpts?.onScopeHeld;
+            expect(onScopeHeld).toBeDefined();
+            const negotiate = vi.spyOn(plugin as any, "negotiateTakeOver").mockResolvedValue(undefined);
+
+            onScopeHeld(new Error("another server owns the shared root"));
+            await flush();
+
+            expect(negotiate).toHaveBeenCalled();
+            // The refused manager is released so the negotiation starts clean.
+            expect((plugin as any).serverManager).toBeNull();
+        });
+
+        it("onScopeHeld does nothing without a vault registry", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const onScopeHeld = mockServerOpts?.onScopeHeld;
+            const negotiate = vi.spyOn(plugin as any, "negotiateTakeOver").mockResolvedValue(undefined);
+            (plugin as any).vaultRegistry = null;
+
+            onScopeHeld(new Error("another server owns the shared root"));
+            await flush();
+
+            expect(negotiate).not.toHaveBeenCalled();
+        });
+
         it("onRestartsExhausted shows persistent error Notice with stderr", async () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();

--- a/tests/server-manager.test.ts
+++ b/tests/server-manager.test.ts
@@ -871,15 +871,47 @@ describe("ServerManager", () => {
             expect(spawnSpy).toHaveBeenCalledTimes(4); // no further restarts
         });
 
-        it("a ready start resets the crash budget", async () => {
+        it("a run that stayed up resets the crash budget", async () => {
             const mgr = await startFresh();
             for (let round = 0; round < 5; round++) {
+                // Up long enough to count as healthy before the next crash.
+                await vi.advanceTimersByTimeAsync(120_000);
                 child()._emit("exit", 1, null);
                 await vi.advanceTimersByTimeAsync(3000); // restart -> ready again
             }
-            // Five crash/recover rounds and it is still willing to restart:
             expect(mgr.state).toBe("ready");
             expect(spawnSpy).toHaveBeenCalledTimes(6);
+        });
+
+        it("a server that keeps dying right after ready gives up instead of looping", async () => {
+            let exhausted = "";
+            const mgr = await startFresh({ onRestartsExhausted: (out) => (exhausted = out) });
+            // Each round reaches ready and dies immediately: a flap, not a recovery.
+            for (let round = 0; round < 5; round++) {
+                child()._emit("exit", 1, null);
+                await vi.advanceTimersByTimeAsync(3000);
+            }
+            expect(exhausted).toContain("server exited (exit code 1)");
+            expect(mgr.state).toBe("error");
+            await vi.advanceTimersByTimeAsync(30_000);
+            // Four spawns: the original plus MAX_CRASH_RESTARTS.
+            expect(spawnSpy).toHaveBeenCalledTimes(4);
+        });
+
+        it("a lock refusal during a crash restart is reported, not swallowed", async () => {
+            let held = 0;
+            const mgr = await startFresh({ onScopeHeld: () => (held += 1) });
+            // The respawn is refused: another vault took the shared root while
+            // this server was down.
+            vi.spyOn(node, "existsSync").mockReturnValue(false);
+            child()._emit("exit", 1, null);
+            await vi.advanceTimersByTimeAsync(3000);
+            (await spawnedChild())._emit("exit", LOCK_REFUSAL_EXIT_CODE, null);
+            // The refusal is raised by the port-file poll, not the exit itself.
+            await vi.advanceTimersByTimeAsync(2000);
+
+            expect(held).toBe(1);
+            expect(mgr.state).toBe("error");
         });
 
         it("stop() cancels a pending crash-restart", async () => {


### PR DESCRIPTION
## Problem

The crash budget never runs out. `start()` resets `crashCount` on every success, including a successful adopt. `checkAdopted` schedules a restart after one failed probe.

An adopt-fail-adopt cycle therefore spends attempt 1 of 3 forever. `MAX_CRASH_RESTARTS` is unreachable, `onRestartsExhausted` never fires, and the user never learns the server is failing. Each lap passes through READY, so a ready notice appears every few seconds.

A user's log shows the counter pinned:

```
17:05:53  adopted server became unreachable
17:05:53  restarting in 3000ms (attempt 1/3)
17:06:36  server pid 1859 exited (exit code 0)
17:06:36  restarting in 3000ms (attempt 1/3)
```

A lock refusal during a restart is discarded. `startForRestart` catches every error and drops it. `ScopeHeldError` reaches the take-over negotiation only from the first start. A server refused on respawn shows a red pill and no prompt. The plugin already has a working dialog for this case.

## Solution

The budget resets when a run stays up for `STABLE_UPTIME_MS`. Reaching READY is not evidence the server works. Staying there is.

The restart path reports a refusal through the new `onScopeHeld` callback. The plugin routes it to the same negotiation the first start uses.

## Notes

One test asserted that five crash-and-recover rounds keep restarting. Those rounds die at once after READY, which is the flap this change catches. The test now advances the clock to model a server that stays up.
