### PR TITLE
Stop the chat view polling after close, and count hosted models

### DIFF
--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -230,6 +230,8 @@ export class ChatView extends ItemView {
     private static readonly OFFLINE_THRESHOLD = 3;
     private retryTimer: number | null = null;
     private retryCount = 0;
+    /** Set by onClose; in-flight fetches must not re-arm the retry after it. */
+    private closed = false;
     private emptyStateEl: HTMLElement | null = null;
 
     constructor(leaf: WorkspaceLeaf, plugin: LilbeePlugin) {
@@ -250,6 +252,7 @@ export class ChatView extends ItemView {
     }
 
     async onOpen(): Promise<void> {
+        this.closed = false;
         const container = this.containerEl.children[1] as HTMLElement;
         container.empty();
         container.addClass("lilbee-chat-container");
@@ -260,6 +263,7 @@ export class ChatView extends ItemView {
     }
 
     async onClose(): Promise<void> {
+        this.closed = true;
         this.streamController?.abort();
         this.pullController?.abort();
         if (this.retryTimer) {
@@ -432,6 +436,7 @@ export class ChatView extends ItemView {
             this.plugin.api.catalog({ task: MODEL_TASK.RERANK }).catch(() => null),
         ])
             .then(([chatCatalogResult, chatInstalled, embeddingResult, serverConfig, visionCatalog, rerankCatalog]) => {
+                if (this.closed) return;
                 if (this.retryTimer) {
                     window.clearTimeout(this.retryTimer);
                     this.retryTimer = null;
@@ -450,7 +455,11 @@ export class ChatView extends ItemView {
                 );
                 this.renderChatModeToggle(serverConfig);
 
-                if (this.chatInstalled.length === 0) {
+                // Count what the rail can actually offer, not the installed
+                // registry: hosted rows are selectable without being installed,
+                // so a frontier-only user was told to install a model they were
+                // already running, and the retry below never stopped.
+                if (this.chatOptionGroups().flat().length === 0) {
                     this.showEmptyState();
                     this.retryTimer = window.setTimeout(() => this.fetchAndFillSelectors(), RETRY_INTERVAL_MS);
                 } else {
@@ -458,6 +467,7 @@ export class ChatView extends ItemView {
                 }
             })
             .catch(() => {
+                if (this.closed) return;
                 this.retryCount++;
                 const connecting = this.retryCount < ChatView.OFFLINE_THRESHOLD;
                 const label = connecting ? MESSAGES.LABEL_CONNECTING : MESSAGES.LABEL_OFFLINE;

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -3056,6 +3056,87 @@ describe("ChatView — save to vault", () => {
     });
 });
 
+describe("ChatView empty state", () => {
+    it("a hosted-only user is not told to install a model", async () => {
+        const plugin = makePlugin();
+        // Nothing in the installed registry, but a usable frontier row exists:
+        // the server marks hosted models installed=true in the catalog.
+        plugin.api.installedModels = vi.fn().mockResolvedValue({ models: [] });
+        plugin.api.catalog = vi.fn().mockResolvedValue(
+            ok({
+                models: [
+                    {
+                        hf_repo: "gemini-2.0-flash",
+                        display_name: "Gemini 2.0 Flash",
+                        source: "frontier",
+                        provider: "gemini",
+                        task: "chat",
+                        installed: true,
+                        key_status: "ready",
+                        size_gb: 0,
+                        featured: true,
+                    },
+                ],
+                total: 1,
+                limit: 20,
+                offset: 0,
+                has_more: false,
+            }),
+        );
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        expect(container.textContent ?? "").not.toContain("No models installed");
+        expect((view as any).retryTimer).toBeNull();
+    });
+});
+
+describe("ChatView lifecycle after close", () => {
+    it("a selector fetch that lands after close does not re-arm the retry", async () => {
+        vi.useFakeTimers();
+        try {
+            const plugin = makePlugin();
+            // Server unreachable: the catch arm is the one that re-arms.
+            plugin.api.catalog = vi.fn().mockRejectedValue(new Error("offline"));
+            const view = new ChatView(makeLeaf(), plugin);
+            await view.onOpen();
+            await view.onClose();
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect((view as any).retryTimer).toBeNull();
+            const before = (plugin.api.catalog as ReturnType<typeof vi.fn>).mock.calls.length;
+            await vi.advanceTimersByTimeAsync(120_000);
+            expect((plugin.api.catalog as ReturnType<typeof vi.fn>).mock.calls.length).toBe(before);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("an empty installed list after close does not re-arm the retry", async () => {
+        vi.useFakeTimers();
+        try {
+            const plugin = makePlugin();
+            plugin.api.installedModels = vi.fn().mockResolvedValue({ models: [] });
+            const view = new ChatView(makeLeaf(), plugin);
+            await view.onOpen();
+            await view.onClose();
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect((view as any).retryTimer).toBeNull();
+            const before = (plugin.api.catalog as ReturnType<typeof vi.fn>).mock.calls.length;
+            await vi.advanceTimersByTimeAsync(120_000);
+            expect((plugin.api.catalog as ReturnType<typeof vi.fn>).mock.calls.length).toBe(before);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});
+
 describe("ChatView.onClose — aborts both controllers", () => {
     it("aborts streamController when active", async () => {
         Notice.clear();


### PR DESCRIPTION
## Problem

The chat view polls after it closes. `onClose` clears the retry timer. A selector fetch that is already in flight settles later, and both continuation arms re-arm the timer. Neither arm checks whether the view is gone.

Open the chat panel while the server is down, then close it. Six requests fire every retry interval for the rest of the session. Each round paints an empty state into a detached container.

The empty state ignores hosted models. It counts `chatInstalled`, which comes from the installed registry. The rail also lists hosted rows, which are selectable without being installed.

A user whose only chat model is frontier or ollama sees "No models installed" under a rail that lists and runs that model. The same branch arms the timer, so the view also enters the poll above.

## Solution

`onClose` sets a closed flag, and both continuation arms return when it is set. `onOpen` clears the flag.

The empty state counts what the rail can offer. It reads `chatOptionGroups().flat()` instead of the installed registry.
