### PR TITLE
Apply the storage toggle both ways, and send the system prompts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -917,12 +917,25 @@ export default class LilbeePlugin extends Plugin {
      * deep-link into the local editor. No-op when the toggle is off, the
      * server is external, or the current values already match.
      */
+    /** Where the managed server keeps content when it is not stored in the vault. */
+    private serverOwnedDocumentsDir(): string | null {
+        const registry = this.vaultRegistry;
+        if (!registry) return null;
+        return node.join(registry.resolveDataDir(this.vaultId), "documents");
+    }
+
     async configureManagedStorage(): Promise<void> {
         if (this.settings.serverMode !== SERVER_MODE.MANAGED) return;
-        if (!this.settings.storeContentInVault) return;
 
+        // Off is a real destination, not a no-op: leaving documents_dir inside
+        // the vault means content keeps landing there after the user opted out.
+        // The server refuses to reset this field (its default is a sentinel), so
+        // the way back is an explicit path to the server's own data dir.
+        const storeInVault = this.settings.storeContentInVault;
         const vaultBase = this.getVaultBasePath();
-        const desiredDocsDir = `${vaultBase}/lilbee`;
+        const desiredDocsDir = storeInVault ? `${vaultBase}/lilbee` : this.serverOwnedDocumentsDir();
+        const desiredVaultBase = storeInVault ? vaultBase : null;
+        if (desiredDocsDir === null) return;
 
         let current: Record<string, unknown>;
         try {
@@ -934,7 +947,7 @@ export default class LilbeePlugin extends Plugin {
 
         const currentDocs = typeof current.documents_dir === "string" ? current.documents_dir : "";
         const currentVault = typeof current.vault_base === "string" ? current.vault_base : null;
-        if (currentDocs === desiredDocsDir && currentVault === vaultBase) {
+        if (currentDocs === desiredDocsDir && currentVault === desiredVaultBase) {
             return;
         }
 
@@ -942,7 +955,7 @@ export default class LilbeePlugin extends Plugin {
         try {
             await this.api.updateConfig({
                 documents_dir: desiredDocsDir,
-                vault_base: vaultBase,
+                vault_base: desiredVaultBase,
             });
             notice.hide();
             new Notice(MESSAGES.NOTICE_STORAGE_REORGANIZED);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1175,6 +1175,17 @@ export class LilbeeSettingTab extends PluginSettingTab {
             });
     }
 
+    /** Send a system prompt to the server. An empty box means "use the default",
+     *  so it clears the override rather than setting an empty prompt. */
+    private async pushSystemPrompt(key: string, value: string, name: string): Promise<void> {
+        const trimmed = value.trim();
+        try {
+            await this.plugin.api.updateConfig({ [key]: trimmed === "" ? null : trimmed });
+        } catch {
+            new Notice(MESSAGES.NOTICE_FAILED_UPDATE(name));
+        }
+    }
+
     /** Runs a programmatic setValue with the control's onChange muted, so nothing echoes to the server. */
     private setValueSilently(apply: () => unknown): void {
         this.suppressChangeEvents = true;
@@ -1273,6 +1284,9 @@ export class LilbeeSettingTab extends PluginSettingTab {
             cls: "setting-item-description",
         });
 
+        // Both prompts reach the server through /api/config. They used to travel
+        // only in the spawn environment, which made them dead in external mode
+        // and stale until the next spawn in managed mode.
         const ragPromptSetting = new Setting(details)
             .setName(MESSAGES.LABEL_RAG_SYSTEM_PROMPT)
             .setDesc(MESSAGES.DESC_RAG_SYSTEM_PROMPT)
@@ -1282,6 +1296,11 @@ export class LilbeeSettingTab extends PluginSettingTab {
                     .onChange(async (value) => {
                         this.plugin.settings.ragSystemPrompt = value;
                         await this.plugin.saveSettings();
+                        await this.pushSystemPrompt(
+                            CONFIG_KEY.RAG_SYSTEM_PROMPT,
+                            value,
+                            MESSAGES.LABEL_RAG_SYSTEM_PROMPT,
+                        );
                     });
                 this.serverConfigInputs.set("rag_system_prompt", text.inputEl);
             });
@@ -1296,6 +1315,11 @@ export class LilbeeSettingTab extends PluginSettingTab {
                     .onChange(async (value) => {
                         this.plugin.settings.generalSystemPrompt = value;
                         await this.plugin.saveSettings();
+                        await this.pushSystemPrompt(
+                            CONFIG_KEY.GENERAL_SYSTEM_PROMPT,
+                            value,
+                            MESSAGES.LABEL_GENERAL_SYSTEM_PROMPT,
+                        );
                     });
                 this.serverConfigInputs.set("general_system_prompt", text.inputEl);
             });
@@ -2810,9 +2834,8 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 toggle.onChange(async (value) => {
                     this.plugin.settings.storeContentInVault = value;
                     await this.plugin.saveSettings();
-                    if (value) {
-                        void this.plugin.configureManagedStorage();
-                    }
+                    // Both directions move content; off is not a no-op.
+                    void this.plugin.configureManagedStorage();
                 });
             });
         if (this.plugin.settings.serverMode !== SERVER_MODE.MANAGED) {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -8242,12 +8242,43 @@ describe("LilbeePlugin", () => {
             expect(updateConfig).not.toHaveBeenCalled();
         });
 
-        it("no-ops when storeContentInVault is off", async () => {
+        it("moves content back out of the vault when the toggle is off", async () => {
+            const updateConfig = vi.fn().mockResolvedValue({ updated: ["documents_dir", "vault_base"] });
+            const plugin = await setupConfiguredPlugin(
+                { storeContentInVault: false },
+                {
+                    config: vi.fn().mockResolvedValue({
+                        documents_dir: "/test/vault/lilbee",
+                        vault_base: "/test/vault",
+                    }),
+                    updateConfig,
+                },
+            );
+            await plugin.configureManagedStorage();
+            expect(updateConfig).toHaveBeenCalledTimes(1);
+            const patch = updateConfig.mock.calls[0][0] as Record<string, unknown>;
+            expect(String(patch.documents_dir)).toContain("documents");
+            expect(String(patch.documents_dir)).not.toContain("/test/vault/lilbee");
+            expect(patch.vault_base).toBeNull();
+        });
+
+        it("does not re-PATCH when content already sits outside the vault", async () => {
+            const updateConfig = vi.fn();
+            const plugin = await setupConfiguredPlugin({ storeContentInVault: false });
+            const docsDir = (plugin as any).serverOwnedDocumentsDir() as string;
+            (plugin.api as any).config = vi.fn().mockResolvedValue({ documents_dir: docsDir, vault_base: null });
+            (plugin.api as any).updateConfig = updateConfig;
+            await plugin.configureManagedStorage();
+            expect(updateConfig).not.toHaveBeenCalled();
+        });
+
+        it("does nothing when the data dir cannot be resolved", async () => {
             const updateConfig = vi.fn();
             const plugin = await setupConfiguredPlugin(
                 { storeContentInVault: false },
                 { config: vi.fn().mockResolvedValue({}), updateConfig },
             );
+            (plugin as any).vaultRegistry = null;
             await plugin.configureManagedStorage();
             expect(updateConfig).not.toHaveBeenCalled();
         });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -824,7 +824,7 @@ describe("LilbeeSettingTab", () => {
             expect((plugin as any).configureManagedStorage).toHaveBeenCalled();
         });
 
-        it("onChange false persists and does not trigger configureManagedStorage", async () => {
+        it("onChange false persists and moves content back out of the vault", async () => {
             const plugin = makePlugin({ serverMode: "managed", storeContentInVault: true });
             mockChatPicker(plugin);
             const tab = makeTab(plugin);
@@ -832,7 +832,8 @@ describe("LilbeeSettingTab", () => {
 
             await toggleByName.get(MESSAGES.LABEL_STORE_CONTENT_IN_VAULT)!(false);
             expect(plugin.settings.storeContentInVault).toBe(false);
-            expect((plugin as any).configureManagedStorage).not.toHaveBeenCalled();
+            // Off is a destination, not a no-op: the server has to be told.
+            expect((plugin as any).configureManagedStorage).toHaveBeenCalled();
         });
 
         it("is disabled and marks the row in external mode", async () => {
@@ -857,6 +858,43 @@ describe("LilbeeSettingTab", () => {
             await textAreaByName.get(MESSAGES.LABEL_RAG_SYSTEM_PROMPT)!("You are a pirate.");
             expect(plugin.settings.ragSystemPrompt).toBe("You are a pirate.");
             expect(plugin.saveSettings).toHaveBeenCalled();
+        });
+
+        it("sends the cited-answer prompt to the server", async () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const { textAreaByName } = captureSettingCallbacks(() => tab.display());
+
+            await textAreaByName.get(MESSAGES.LABEL_RAG_SYSTEM_PROMPT)!("You are a pirate.");
+            expect(plugin.api.updateConfig).toHaveBeenCalledWith({
+                rag_system_prompt: "You are a pirate.",
+            });
+        });
+
+        it("an empty prompt clears the override rather than setting an empty one", async () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const { textAreaByName } = captureSettingCallbacks(() => tab.display());
+
+            await textAreaByName.get(MESSAGES.LABEL_GENERAL_SYSTEM_PROMPT)!("   ");
+            expect(plugin.api.updateConfig).toHaveBeenCalledWith({ general_system_prompt: null });
+        });
+
+        it("reports a prompt the server refused", async () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            (plugin.api as any).updateConfig = vi.fn().mockRejectedValue(new Error("read-only config"));
+            const tab = makeTab(plugin);
+            const { textAreaByName } = captureSettingCallbacks(() => tab.display());
+
+            await textAreaByName.get(MESSAGES.LABEL_RAG_SYSTEM_PROMPT)!("You are a pirate.");
+            expect(
+                Notice.instances.some((n) =>
+                    n.message.includes(MESSAGES.NOTICE_FAILED_UPDATE(MESSAGES.LABEL_RAG_SYSTEM_PROMPT)),
+                ),
+            ).toBe(true);
         });
 
         it("saves generalSystemPrompt when the no-document textarea changes", async () => {


### PR DESCRIPTION
## Problem

"Store content in vault" only turns on. The toggle calls `configureManagedStorage` inside `if (value)`, and that method returns early when the setting is off. Two guards block the off path, so it changes nothing.

The server keeps `documents_dir` inside the vault. Crawls and imports keep landing there after the user opts out.

Both system-prompt boxes reach the server only at spawn. They travel in `buildSpawnEnv` as environment variables, read once when the process starts. Nothing sends them to `/api/config`, and `saveSettings` restarts the server only on a mode switch.

In external mode both boxes do nothing. In managed mode an edit waits for the next spawn. An adopted server never sees the change.

## Solution

`configureManagedStorage` computes a target for both states. Off moves content to the server's own data directory.

The server refuses to reset `documents_dir`, because its default is an unresolved sentinel. The plugin therefore sends an explicit path, which it can name in managed mode.

Both prompts go through `/api/config`, like every other server-backed setting. An empty box clears the override.

## Notes

Two tests asserted the old behaviour: that the off toggle skips `configureManagedStorage`, and that it is a no-op. Both now assert the move.
