### PR TITLE
Parse SSE by frame, and release the reader

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -996,29 +996,60 @@ export class LilbeeClient {
         const decoder = new TextDecoder();
         let buffer = "";
         let currentEvent: string = SSE_EVENT.MESSAGE;
+        // Consecutive `data:` lines are one payload joined by newlines, so they
+        // accumulate until the blank line that ends the frame.
+        let data: string[] = [];
 
-        while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            buffer += decoder.decode(value, { stream: true });
+        const frame = (): SSEEvent | null => {
+            if (data.length === 0) {
+                currentEvent = SSE_EVENT.MESSAGE;
+                return null;
+            }
+            const raw = data.join("\n");
+            const event = currentEvent;
+            data = [];
+            currentEvent = SSE_EVENT.MESSAGE;
+            try {
+                return { event, data: JSON.parse(raw) };
+            } catch {
+                return { event, data: raw };
+            }
+        };
 
-            const lines = buffer.split("\n");
-            // split() always returns at least one element, so pop() is never undefined
-            buffer = lines.pop()!;
+        try {
+            for (;;) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                buffer += decoder.decode(value, { stream: true });
 
-            for (const line of lines) {
-                if (line.startsWith("event:")) {
-                    currentEvent = (line.startsWith("event: ") ? line.slice(7) : line.slice(6)).trim();
-                } else if (line.startsWith("data:")) {
-                    const raw = line.startsWith("data: ") ? line.slice(6) : line.slice(5);
-                    try {
-                        yield { event: currentEvent, data: JSON.parse(raw) };
-                    } catch {
-                        yield { event: currentEvent, data: raw };
+                const lines = buffer.split("\n");
+                // split() always returns at least one element, so pop() is never undefined
+                buffer = lines.pop()!;
+
+                for (const line of lines) {
+                    if (line.startsWith("event:")) {
+                        currentEvent = (line.startsWith("event: ") ? line.slice(7) : line.slice(6)).trim();
+                    } else if (line.startsWith("data:")) {
+                        data.push(line.startsWith("data: ") ? line.slice(6) : line.slice(5));
+                    } else if (line.trim() === "") {
+                        const ev = frame();
+                        if (ev) yield ev;
                     }
-                    currentEvent = SSE_EVENT.MESSAGE;
                 }
             }
+            // A stream that closes without its trailing blank line still holds a
+            // frame, usually the terminating `done`. Dropping it let the chat
+            // loop exit normally with the answer unrendered and unsaved.
+            if (buffer.startsWith("data:")) {
+                data.push(buffer.startsWith("data: ") ? buffer.slice(6) : buffer.slice(5));
+            }
+            const tail = frame();
+            if (tail) yield tail;
+        } finally {
+            // A consumer that stops early (an SSE error, a cancelled pull) would
+            // otherwise leave the body unread and the socket open until the
+            // server finished sending.
+            await reader.cancel().catch(() => undefined);
         }
     }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -124,6 +124,43 @@ export function isHttpStatus(error: Error, status: number): boolean {
     return error.message.startsWith(`Server responded ${status}`);
 }
 
+/**
+ * Accumulates SSE lines into frames. A frame is the `event:` name plus every
+ * `data:` line before the blank line that ends it.
+ */
+class SseFrames {
+    private event: string = SSE_EVENT.MESSAGE;
+    private data: string[] = [];
+
+    /** Feed one line. Returns the frame it completed, or null. */
+    accept(line: string): SSEEvent | null {
+        if (line.startsWith("event:")) {
+            this.event = (line.startsWith("event: ") ? line.slice(7) : line.slice(6)).trim();
+            return null;
+        }
+        if (line.startsWith("data:")) {
+            this.data.push(line.startsWith("data: ") ? line.slice(6) : line.slice(5));
+            return null;
+        }
+        return line.trim() === "" ? this.take() : null;
+    }
+
+    /** The accumulated frame, or null when there is none. Resets either way. */
+    take(): SSEEvent | null {
+        const event = this.event;
+        const raw = this.data.join("\n");
+        const had = this.data.length > 0;
+        this.event = SSE_EVENT.MESSAGE;
+        this.data = [];
+        if (!had) return null;
+        try {
+            return { event, data: JSON.parse(raw) };
+        } catch {
+            return { event, data: raw };
+        }
+    }
+}
+
 export class LilbeeClient {
     private token: string | null = null;
     private tokenProvider: (() => string | null) | null = null;
@@ -994,61 +1031,30 @@ export class LilbeeClient {
         }
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
+        const frames = new SseFrames();
         let buffer = "";
-        let currentEvent: string = SSE_EVENT.MESSAGE;
-        // Consecutive `data:` lines are one payload joined by newlines, so they
-        // accumulate until the blank line that ends the frame.
-        let data: string[] = [];
-
-        const frame = (): SSEEvent | null => {
-            if (data.length === 0) {
-                currentEvent = SSE_EVENT.MESSAGE;
-                return null;
-            }
-            const raw = data.join("\n");
-            const event = currentEvent;
-            data = [];
-            currentEvent = SSE_EVENT.MESSAGE;
-            try {
-                return { event, data: JSON.parse(raw) };
-            } catch {
-                return { event, data: raw };
-            }
-        };
 
         try {
             for (;;) {
                 const { done, value } = await reader.read();
                 if (done) break;
                 buffer += decoder.decode(value, { stream: true });
-
                 const lines = buffer.split("\n");
                 // split() always returns at least one element, so pop() is never undefined
                 buffer = lines.pop()!;
-
                 for (const line of lines) {
-                    if (line.startsWith("event:")) {
-                        currentEvent = (line.startsWith("event: ") ? line.slice(7) : line.slice(6)).trim();
-                    } else if (line.startsWith("data:")) {
-                        data.push(line.startsWith("data: ") ? line.slice(6) : line.slice(5));
-                    } else if (line.trim() === "") {
-                        const ev = frame();
-                        if (ev) yield ev;
-                    }
+                    const event = frames.accept(line);
+                    if (event) yield event;
                 }
             }
             // A stream that closes without its trailing blank line still holds a
-            // frame, usually the terminating `done`. Dropping it let the chat
-            // loop exit normally with the answer unrendered and unsaved.
-            if (buffer.startsWith("data:")) {
-                data.push(buffer.startsWith("data: ") ? buffer.slice(6) : buffer.slice(5));
-            }
-            const tail = frame();
+            // frame, usually the terminating `done`.
+            frames.accept(buffer);
+            const tail = frames.take();
             if (tail) yield tail;
         } finally {
-            // A consumer that stops early (an SSE error, a cancelled pull) would
-            // otherwise leave the body unread and the socket open until the
-            // server finished sending.
+            // A consumer that stops early would otherwise leave the body unread
+            // and the socket open until the server finished sending.
             await reader.cancel().catch(() => undefined);
         }
     }

--- a/tests/api-contract.test.ts
+++ b/tests/api-contract.test.ts
@@ -89,7 +89,12 @@ function universalResponse(): Response {
         json: () => Promise.resolve({}),
         text: () => Promise.resolve("{}"),
         arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
-        body: { getReader: () => ({ read: async () => ({ done: true, value: undefined }) }) },
+        body: {
+            getReader: () => ({
+                read: async () => ({ done: true, value: undefined }),
+                cancel: async () => undefined,
+            }),
+        },
     } as unknown as Response;
 }
 

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -28,6 +28,8 @@ function sseResponse(chunks: string[]): Response {
             }
             return { done: true, value: undefined };
         }),
+        // Real readers always have cancel; the parser releases the socket with it.
+        cancel: vi.fn(async () => undefined),
     };
     return {
         ok: true,
@@ -1251,6 +1253,92 @@ describe("setChatModel()", () => {
 });
 
 describe("parseSSE — edge cases", () => {
+    it("yields a final event the stream ended without a trailing newline", async () => {
+        // A connection that closes mid-frame drops its last event, which is
+        // almost always `done`: chat then exits its loop normally, so the
+        // answer is never rendered, persisted, or un-spinnered.
+        fetchMock.mockResolvedValue(sseResponse(['event: token\ndata: "a"\n\nevent: done\ndata: {}']));
+
+        const events = await collect(client.syncStream());
+
+        expect(events.map((e) => e.event)).toEqual(["token", "done"]);
+    });
+
+    it("ignores a blank line that ends no frame", async () => {
+        fetchMock.mockResolvedValue(sseResponse(['\n\nevent: token\ndata: "a"\n\n']));
+
+        const events = await collect(client.syncStream());
+
+        expect(events).toEqual([{ event: "token", data: "a" }]);
+    });
+
+    it("emits a trailing data: frame written without a space", async () => {
+        fetchMock.mockResolvedValue(sseResponse(['data:{"tail":true}']));
+
+        const events = await collect(client.syncStream());
+
+        expect(events).toEqual([{ event: "message", data: { tail: true } }]);
+    });
+
+    it("survives a reader whose cancel rejects", async () => {
+        const encoder = new TextEncoder();
+        let sent = false;
+        const reader = {
+            read: vi.fn(async () => {
+                if (sent) return { done: true, value: undefined };
+                sent = true;
+                return { done: false, value: encoder.encode('event: token\ndata: "x"\n\n') };
+            }),
+            cancel: vi.fn(async () => {
+                throw new Error("already released");
+            }),
+        };
+        fetchMock.mockResolvedValue({
+            ok: true,
+            status: 200,
+            body: { getReader: () => reader },
+            headers: new Headers(),
+        });
+
+        const events = await collect(client.syncStream());
+
+        expect(events).toEqual([{ event: "token", data: "x" }]);
+    });
+
+    it("joins consecutive data lines into one payload", async () => {
+        // Per SSE, consecutive data lines are one payload joined by newlines.
+        // Splitting them fed truncated non-JSON to the real handler and leaked
+        // the rest as `message` events.
+        fetchMock.mockResolvedValue(sseResponse(['event: token\ndata: {"a":\ndata: 1}\n\n']));
+
+        const events = await collect(client.syncStream());
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toEqual({ event: "token", data: { a: 1 } });
+    });
+
+    it("cancels the reader when the consumer stops early", async () => {
+        const encoder = new TextEncoder();
+        const cancel = vi.fn(async () => undefined);
+        const reader = {
+            read: vi.fn(async () => ({
+                done: false,
+                value: encoder.encode('event: token\ndata: "x"\n\n'),
+            })),
+            cancel,
+        };
+        fetchMock.mockResolvedValue({
+            ok: true,
+            status: 200,
+            body: { getReader: () => reader },
+            headers: new Headers(),
+        });
+
+        for await (const _e of client.syncStream()) break;
+
+        expect(cancel).toHaveBeenCalled();
+    });
+
     it("yields plain string when JSON.parse fails on data field", async () => {
         fetchMock.mockResolvedValue(sseResponse(["data: not-valid-json\n\n"]));
 
@@ -1296,6 +1384,7 @@ describe("parseSSE — edge cases", () => {
                 }
                 return { done: true, value: undefined };
             }),
+            cancel: vi.fn(async () => undefined),
         };
         fetchMock.mockResolvedValue({
             ok: true,
@@ -1337,17 +1426,16 @@ describe("parseSSE — edge cases", () => {
         expect(events[1]).toEqual({ event: "b", data: 2 });
     });
 
-    it("handles trailing partial line left in buffer without final newline", async () => {
-        // The buffer remainder logic: last element of split("\n") goes back into buffer.
-        // If there's no trailing \n the last partial line stays in buffer and is dropped
-        // at stream end (done). Verify no crash and no spurious events.
+    it("emits a trailing frame the stream left without a final newline", async () => {
+        // The tail used to be dropped, which lost the terminating `done` of any
+        // stream that closed mid-frame.
         fetchMock.mockResolvedValue(sseResponse(["data: {}\n\ndata: incomplete"]));
 
         const events = await collect(client.syncStream());
 
-        // Only the complete line should produce an event; the partial is silently dropped
-        expect(events).toHaveLength(1);
+        expect(events).toHaveLength(2);
         expect(events[0].data).toEqual({});
+        expect(events[1].data).toBe("incomplete");
     });
 
     it("trims whitespace from event name", async () => {


### PR DESCRIPTION
## Problem

`parseSSE` serves every streaming endpoint: chat, sync, ingest, model pulls, crawl, and wiki. It has three defects.

**It discards the trailing buffer.** The loop breaks on `done` and drops what is left. A connection that closes without a final newline loses its last event, which is almost always `done`.

On the chat path the `for await` then exits normally, so no `catch` arm runs. The answer is never rendered, never added to history, and never saved. If no token arrived, the thinking dots never clear.

**It splits consecutive `data:` lines into separate events.** The SSE specification joins them into one payload with newlines. Any payload holding a newline sends truncated JSON to the handler, and leaks the rest as `message` events. The chat view renders those into the answer.

**It never releases the reader.** There is no `try/finally` and no `cancel()`. A consumer that stops early leaves the body unread and the socket open. A model pull keeps downloading.

## Solution

The parser works in frames. `data:` lines accumulate, a blank line emits the frame, and the end of the reader flushes what remains. A `finally` cancels the reader.

## Verified

On a captured live stream of 22 events, both parsers agree. When the connection closes mid-frame, the old parser returns 21 events and ends on `sources`. The new parser returns 22 and ends on `done`.

## Notes

One test asserted that the trailing line is dropped, which is the first defect. It now asserts the frame arrives. Both shared test helpers gained the `cancel` that every real reader has.
