### PR TITLE
Use the setter response for reindex and model refs

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -48,6 +48,7 @@ import type {
     SearchChunkType,
     SourceContent,
     SSEEvent,
+    SetModelResponse,
     StatusResponse,
     SyncOptions,
     LintResult,
@@ -600,8 +601,8 @@ export class LilbeeClient {
         yield* this.parseSSE(res);
     }
 
-    async setChatModel(model: string): Promise<Result<void, Error>> {
-        return this.fetchResult<void>(`${this.baseUrl}/api/models/chat`, {
+    async setChatModel(model: string): Promise<Result<SetModelResponse, Error>> {
+        return this.fetchResult<SetModelResponse>(`${this.baseUrl}/api/models/chat`, {
             method: "PUT",
             headers: { ...JSON_HEADERS, ...this.authHeaders() },
             body: JSON.stringify({ model }),
@@ -751,24 +752,24 @@ export class LilbeeClient {
         return (await res.json()) as ConfigUpdateResponse;
     }
 
-    async setEmbeddingModel(model: string): Promise<Result<void, Error>> {
-        return this.fetchResult<void>(`${this.baseUrl}/api/models/embedding`, {
+    async setEmbeddingModel(model: string): Promise<Result<SetModelResponse, Error>> {
+        return this.fetchResult<SetModelResponse>(`${this.baseUrl}/api/models/embedding`, {
             method: "PUT",
             headers: { ...JSON_HEADERS, ...this.authHeaders() },
             body: JSON.stringify({ model }),
         });
     }
 
-    async setRerankerModel(model: string): Promise<Result<void, Error>> {
-        return this.fetchResult<void>(`${this.baseUrl}/api/models/reranker`, {
+    async setRerankerModel(model: string): Promise<Result<SetModelResponse, Error>> {
+        return this.fetchResult<SetModelResponse>(`${this.baseUrl}/api/models/reranker`, {
             method: "PUT",
             headers: { ...JSON_HEADERS, ...this.authHeaders() },
             body: JSON.stringify({ model }),
         });
     }
 
-    async setVisionModel(model: string): Promise<Result<void, Error>> {
-        return this.fetchResult<void>(`${this.baseUrl}/api/models/vision`, {
+    async setVisionModel(model: string): Promise<Result<SetModelResponse, Error>> {
+        return this.fetchResult<SetModelResponse>(`${this.baseUrl}/api/models/vision`, {
             method: "PUT",
             headers: { ...JSON_HEADERS, ...this.authHeaders() },
             body: JSON.stringify({ model }),

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2067,6 +2067,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
                                 return;
                             }
                             new Notice(MESSAGES.NOTICE_EMBEDDING_UPDATED);
+                            if (!result.value.reindex_required) return;
                             new Notice(MESSAGES.NOTICE_REINDEX_REQUIRED);
                             void this.plugin.triggerSync();
                         });
@@ -2408,6 +2409,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
                             return;
                         }
                         new Notice(MESSAGES.NOTICE_EMBEDDING_UPDATED);
+                        if (!result.value.reindex_required) return;
                         new Notice(MESSAGES.NOTICE_REINDEX_REQUIRED);
                         void this.plugin.triggerSync();
                     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -251,6 +251,13 @@ export const DISCOVER_RAIL = {
     FRESH: "fresh",
 } as const satisfies Record<string, DiscoverRail>;
 
+/** `PUT /api/models/<role>`. The server resolves the ref it was given and says
+ *  whether the change invalidates the index. */
+export interface SetModelResponse {
+    model: string;
+    reindex_required: boolean;
+}
+
 export interface StatusResponse {
     config: Record<string, string>;
     document_count: number;

--- a/src/utils/model-ref.ts
+++ b/src/utils/model-ref.ts
@@ -10,11 +10,11 @@ const STRIP_SUFFIXES = [/-GGUF$/i, /-Instruct$/i, /-Chat$/i, /-v\d+(\.\d+)*$/i, 
 const META_PREFIX = /^Meta-/;
 
 /**
- * Build the ref to send when activating a catalog entry. A multi-quant GGUF
- * repo (e.g. "bartowski/SmolLM2-360M-Instruct-GGUF") has no single default
- * file, so the server rejects the bare repo with "not available"; send the
- * concrete "<repo>/<filename>.gguf" instead. Falls back to the bare repo when
- * the filename is missing or a glob (sharded/pattern entries).
+ * Build the ref to send when activating a catalog entry. The server resolves a
+ * bare multi-quant repo by taking the first installed quant in sort order, so
+ * sending "<repo>/<filename>.gguf" is what makes the user's choice exact.
+ * Falls back to the bare repo when the filename is missing or a glob
+ * (sharded/pattern entries).
  */
 export function nativeModelRef(hfRepo: string, ggufFilename: string | null | undefined): string {
     const f = ggufFilename ?? "";

--- a/src/views/catalog-helpers.ts
+++ b/src/views/catalog-helpers.ts
@@ -161,7 +161,11 @@ export function forYouRail(entries: CatalogEntry[]): CatalogEntry[] {
 }
 
 export function yourCollectionRail(entries: CatalogEntry[]): CatalogEntry[] {
-    return entries.filter((e) => e.installed).slice(0, DISCOVER_RAIL_LIMIT);
+    // Hosted rows report installed=true because they are usable, not because
+    // they are on disk. "Your collection" answers what this machine holds.
+    return localRowsOnly(entries)
+        .filter((e) => e.installed)
+        .slice(0, DISCOVER_RAIL_LIMIT);
 }
 
 /**

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -860,9 +860,9 @@ export class CatalogModal extends Modal {
     }
 
     private async setActiveFor(entry: CatalogEntry): ReturnType<typeof this.plugin.api.setChatModel> {
-        // Activate by the concrete GGUF file ref, not the bare repo: multi-quant
-        // repos have no single default file and the server rejects the bare repo
-        // with "not available", surfacing a spurious "Failed to set" toast.
+        // Activate by the concrete GGUF file ref: the server resolves a bare
+        // multi-quant repo to whichever quant sorts first, which is not
+        // necessarily the one the user clicked.
         const ref = nativeModelRef(entry.hf_repo, entry.gguf_filename);
         if (entry.task === MODEL_TASK.EMBEDDING) {
             return this.plugin.api.setEmbeddingModel(ref);

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -536,7 +536,8 @@ export class CatalogModal extends Modal {
     private renderLibraryTab(): void {
         /* v8 ignore next 2 */
         if (!this.resultsEl) return;
-        const installed = this.entries.filter((e) => e.installed);
+        // Hosted rows are installed=true server-side; the Library is the on-disk view.
+        const installed = localRowsOnly(this.entries).filter((e) => e.installed);
         if (installed.length === 0) {
             this.resultsEl.createDiv({
                 cls: "lilbee-catalog-empty",

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -636,8 +636,10 @@ export class ChatView extends ItemView {
         void this.plugin.api.setChatModel(value).then((result) => {
             if (result.isOk()) {
                 // Keep the menu's checkmark in sync without waiting for a refetch.
-                this.chatActive = value;
-                this.plugin.activeModel = value;
+                // Store what the server resolved, not what was sent: a bare repo
+                // comes back as the concrete quant it picked.
+                this.chatActive = result.value.model;
+                this.plugin.activeModel = result.value.model;
                 void this.plugin.fetchActiveModel();
                 this.plugin.refreshSettingsTab();
             } else {
@@ -667,10 +669,14 @@ export class ChatView extends ItemView {
                 this.revertEmbeddingTrigger(previous);
                 return;
             }
-            this.activeEmbeddingModel = value;
+            // The server resolved the ref and knows whether the index still
+            // matches. Re-selecting the model already in use rebuilt the whole
+            // index when it said otherwise.
+            this.activeEmbeddingModel = result.value.model;
             new Notice(MESSAGES.NOTICE_EMBEDDING_UPDATED);
-            new Notice(MESSAGES.NOTICE_REINDEX_REQUIRED);
             this.plugin.refreshSettingsTab();
+            if (!result.value.reindex_required) return;
+            new Notice(MESSAGES.NOTICE_REINDEX_REQUIRED);
             void this.plugin.triggerSync();
         });
     }

--- a/src/views/model-picker-modal.ts
+++ b/src/views/model-picker-modal.ts
@@ -1,7 +1,7 @@
 import { App, Modal, Notice } from "obsidian";
 import type { Result } from "../result";
 import type LilbeePlugin from "../main";
-import type { CatalogEntry, ModelTask } from "../types";
+import type { CatalogEntry, ModelTask, SetModelResponse } from "../types";
 import { CATALOG_SOURCE, HOSTED_SOURCES, KEY_STATUS, MODEL_TASK } from "../types";
 import { MESSAGES } from "../locales/en";
 import {
@@ -235,8 +235,8 @@ export class ModelPickerModal extends Modal {
      * took, so a transient not-ready response no longer surfaces as "Failed to
      * set" while the model quietly activates.
      */
-    private async setActiveModelWithRetry(repo: string): Promise<Result<void, Error>> {
-        const set = (m: string): Promise<Result<void, Error>> =>
+    private async setActiveModelWithRetry(repo: string): Promise<Result<SetModelResponse, Error>> {
+        const set = (m: string): Promise<Result<SetModelResponse, Error>> =>
             this.pickerScope === MODEL_TASK.CHAT
                 ? this.plugin.api.setChatModel(m)
                 : this.plugin.api.setEmbeddingModel(m);

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -149,7 +149,7 @@ function makePlugin(
         config: vi.fn().mockRejectedValue(new Error("unreachable")),
         configDefaults: vi.fn().mockRejectedValue(new Error("unreachable")),
         updateConfig: vi.fn().mockResolvedValue({ updated: [], reindex_required: false }),
-        setEmbeddingModel: vi.fn().mockResolvedValue(ok(undefined)),
+        setEmbeddingModel: vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: true }))),
         setRerankerModel: vi.fn().mockResolvedValue(ok(undefined)),
         setVisionModel: vi.fn().mockResolvedValue(ok(undefined)),
         installedModels: vi.fn().mockResolvedValue({ models: [] }),
@@ -1239,7 +1239,9 @@ describe("LilbeeSettingTab", () => {
 
         it("dropdown switch to installed featured ref calls setChatModel", async () => {
             const plugin = makePlugin();
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             const { tab, captured } = renderPicker(plugin, LLAMA_REF, true);
             const displaySpy = vi.spyOn(tab, "render").mockImplementation(() => {});
             await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
@@ -1250,7 +1252,9 @@ describe("LilbeeSettingTab", () => {
 
         it("setting model to empty string shows 'not set' in notice", async () => {
             const plugin = makePlugin();
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             const { captured } = renderPicker(plugin, "");
             await captured.dropdownOnChanges[0]("");
             expect(Notice.instances.some((n) => n.message.includes("not set"))).toBe(true);
@@ -1506,7 +1510,9 @@ describe("LilbeeSettingTab", () => {
             const plugin = makePlugin();
             (plugin as any).activeModel = LLAMA_REF;
             (plugin.api.deleteModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             mockChatPicker(plugin);
 
             const { tab, deleteBtn } = setupDeleteButton(plugin, LLAMA_REF);
@@ -1625,7 +1631,9 @@ describe("LilbeeSettingTab", () => {
             const plugin = makePlugin();
             async function* fakePull() {}
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
 
             const { captured } = renderPickerWithPhi(plugin);
             await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
@@ -1670,7 +1678,9 @@ describe("LilbeeSettingTab", () => {
                 yield { event: "progress", data: { percent: 50 } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
 
             const updateSpy = vi.spyOn(plugin.taskQueue, "update");
             const { captured } = renderPickerWithPhi(plugin);
@@ -1729,7 +1739,9 @@ describe("LilbeeSettingTab", () => {
                 yield { event: SSE_EVENT.ERROR, data: { message: "pull exploded" } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(errorPull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
 
             const { captured } = renderPickerWithPhi(plugin);
             await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
@@ -1743,7 +1755,9 @@ describe("LilbeeSettingTab", () => {
                 yield { event: SSE_EVENT.ERROR, data: "raw error string" };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(errorPull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
 
             const { captured } = renderPickerWithPhi(plugin);
             await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
@@ -1757,7 +1771,9 @@ describe("LilbeeSettingTab", () => {
                 yield { event: SSE_EVENT.ERROR, data: {} };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(errorPull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
 
             const { captured } = renderPickerWithPhi(plugin);
             await captured.dropdownOnChanges[0]("microsoft/Phi-3-mini-4k-Instruct-GGUF");
@@ -1813,7 +1829,9 @@ describe("LilbeeSettingTab", () => {
                 yield { event: "progress", data: { percent: 75 } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             mockChatPicker(plugin);
 
             const updateSpy = vi.spyOn(plugin.taskQueue, "update");
@@ -1837,7 +1855,9 @@ describe("LilbeeSettingTab", () => {
                 yield { event: "progress", data: {} };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             mockChatPicker(plugin);
 
             const updateSpy = vi.spyOn(plugin.taskQueue, "update");
@@ -1856,7 +1876,9 @@ describe("LilbeeSettingTab", () => {
                 yield { event: "progress", data: { current: 50, total: 100 } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             mockChatPicker(plugin);
 
             const updateSpy = vi.spyOn(plugin.taskQueue, "update");
@@ -1875,7 +1897,9 @@ describe("LilbeeSettingTab", () => {
                 yield { event: "progress", data: { percent: 0 } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             mockChatPicker(plugin);
 
             const updateSpy = vi.spyOn(plugin.taskQueue, "update");
@@ -1920,7 +1944,9 @@ describe("LilbeeSettingTab", () => {
                 yield { event: SSE_EVENT.ERROR, data: { message: "pull exploded" } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(errorPull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             mockChatPicker(plugin);
 
             const { clickHandler } = await setupPullButton(plugin);
@@ -1935,7 +1961,9 @@ describe("LilbeeSettingTab", () => {
                 yield { event: SSE_EVENT.ERROR, data: "raw error string" };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(errorPull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             mockChatPicker(plugin);
 
             const { clickHandler } = await setupPullButton(plugin);
@@ -1950,7 +1978,9 @@ describe("LilbeeSettingTab", () => {
                 yield { event: SSE_EVENT.ERROR, data: {} };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(errorPull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             mockChatPicker(plugin);
 
             const { clickHandler } = await setupPullButton(plugin);
@@ -1963,7 +1993,9 @@ describe("LilbeeSettingTab", () => {
             const plugin = makePlugin();
             async function* fakePull() {}
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             mockChatPicker(plugin);
 
             const { clickHandler } = await setupPullButton(plugin);
@@ -1975,7 +2007,9 @@ describe("LilbeeSettingTab", () => {
             const plugin = makePlugin();
             async function* fakePull() {}
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             mockChatPicker(plugin);
 
             const { tab, clickHandler } = await setupPullButton(plugin);
@@ -1994,7 +2028,9 @@ describe("LilbeeSettingTab", () => {
                 yield { event: "progress", data: { percent: 50 } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             mockChatPicker(plugin);
 
             const { tab, clickHandler } = await setupPullButton(plugin);
@@ -2010,7 +2046,9 @@ describe("LilbeeSettingTab", () => {
                 yield { event: "other", data: {} };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             mockChatPicker(plugin);
 
             const { tab, clickHandler } = await setupPullButton(plugin);
@@ -2249,7 +2287,9 @@ describe("LilbeeSettingTab", () => {
                 yield { event: "progress", data: { percent: 50 } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             mockChatPicker(plugin);
 
             const { captured } = pickerSetup(plugin);
@@ -2298,7 +2338,9 @@ describe("LilbeeSettingTab", () => {
                 yield { event: "progress", data: { percent: 75 } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             mockChatPicker(plugin);
 
             const { captured } = pickerSetup(plugin);
@@ -2312,7 +2354,9 @@ describe("LilbeeSettingTab", () => {
                 yield { event: "progress", data: { current: 60, total: 100 } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             mockChatPicker(plugin);
 
             const { captured } = pickerSetup(plugin);
@@ -2327,7 +2371,9 @@ describe("LilbeeSettingTab", () => {
                 yield { event: "progress", data: {} };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             mockChatPicker(plugin);
 
             const { captured } = pickerSetup(plugin);
@@ -2342,7 +2388,9 @@ describe("LilbeeSettingTab", () => {
                 yield { event: "progress", data: { percent: 50 } };
             }
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             mockChatPicker(plugin);
 
             const { captured } = pickerSetup(plugin);
@@ -2353,7 +2401,9 @@ describe("LilbeeSettingTab", () => {
             const plugin = makePlugin();
             async function* fakePull() {}
             (plugin.api.pullModel as ReturnType<typeof vi.fn>).mockReturnValue(fakePull());
-            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setChatModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: false }),
+            );
             mockChatPicker(plugin);
 
             const { tab, captured } = pickerSetup(plugin);
@@ -3127,7 +3177,9 @@ describe("managed mode settings", () => {
         it("embedding dropdown onChange sets model and triggers sync", async () => {
             const plugin = makePlugin();
             mockChatPicker(plugin);
-            (plugin.api.setEmbeddingModel as ReturnType<typeof vi.fn>).mockResolvedValue(ok(undefined));
+            (plugin.api.setEmbeddingModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "m", reindex_required: true }),
+            );
             (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
                 ok({
                     total: 2,
@@ -3165,6 +3217,48 @@ describe("managed mode settings", () => {
             expect(dropdowns.length).toBe(1);
             await dropdowns[0]("nomic-embed-text");
             expect(plugin.api.setEmbeddingModel).toHaveBeenCalledWith("nomic-embed-text");
+        });
+
+        it("does not reindex when the server says the index still matches", async () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            (plugin.api.setEmbeddingModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "nomic-embed-text", reindex_required: false }),
+            );
+            (plugin.api.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({
+                    total: 1,
+                    limit: 20,
+                    offset: 0,
+                    models: [{ name: "nomic-embed-text", installed: true, task: "embedding" }],
+                    has_more: false,
+                }),
+            );
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+
+            const dropdowns: DropdownOnChange[] = [];
+            const origAddDropdown = Setting.prototype.addDropdown;
+            Setting.prototype.addDropdown = function (cb: (dropdown: any) => void) {
+                const fakeDropdown = {
+                    addOption: () => fakeDropdown,
+                    setValue: () => fakeDropdown,
+                    onChange: (handler: DropdownOnChange) => {
+                        dropdowns.push(handler);
+                        return fakeDropdown;
+                    },
+                };
+                cb(fakeDropdown);
+                return this;
+            };
+            await (tab as any).loadEmbeddingDropdown(container);
+            await new Promise((r) => setTimeout(r, 0));
+            Setting.prototype.addDropdown = origAddDropdown;
+
+            await dropdowns[0]("nomic-embed-text");
+            expect(plugin.api.setEmbeddingModel).toHaveBeenCalledWith("nomic-embed-text");
+            // Re-selecting the model already backing the store must not re-embed.
+            expect(plugin.triggerSync).not.toHaveBeenCalled();
         });
 
         it("embedding dropdown onChange aborts when user cancels confirm", async () => {
@@ -3333,6 +3427,37 @@ describe("managed mode settings", () => {
             expect(texts.length).toBe(1);
             await texts[0]("nomic-embed-text");
             expect(plugin.api.setEmbeddingModel).toHaveBeenCalledWith("nomic-embed-text");
+        });
+
+        it("fallback text input does not reindex when the index still matches", async () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            (plugin.api.setEmbeddingModel as ReturnType<typeof vi.fn>).mockResolvedValue(
+                ok({ model: "nomic-embed-text", reindex_required: false }),
+            );
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const tab = makeTab(plugin);
+
+            const texts: TextOnChange[] = [];
+            const origAddText = Setting.prototype.addText;
+            Setting.prototype.addText = function (cb: (text: any) => void) {
+                const fakeText = {
+                    setPlaceholder: () => fakeText,
+                    setValue: () => fakeText,
+                    onChange: (handler: TextOnChange) => {
+                        texts.push(handler);
+                        return fakeText;
+                    },
+                    inputEl: { placeholder: "", addEventListener: vi.fn() },
+                };
+                cb(fakeText);
+                return this;
+            };
+            (tab as any).renderEmbeddingFallback(container);
+            Setting.prototype.addText = origAddText;
+
+            await texts[0]("nomic-embed-text");
+            expect(plugin.triggerSync).not.toHaveBeenCalled();
         });
 
         it("fallback text input skips empty value", async () => {

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -67,10 +67,10 @@ function makePlugin(overrides: Record<string, unknown> = {}) {
         api: {
             catalog: vi.fn().mockResolvedValue(ok(makeCatalogResponse([]))),
             pullModel: vi.fn(),
-            setChatModel: vi.fn().mockResolvedValue(ok(undefined)),
-            setEmbeddingModel: vi.fn().mockResolvedValue(ok(undefined)),
-            setRerankerModel: vi.fn().mockResolvedValue(ok(undefined)),
-            setVisionModel: vi.fn().mockResolvedValue(ok(undefined)),
+            setChatModel: vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false }))),
+            setEmbeddingModel: vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false }))),
+            setRerankerModel: vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false }))),
+            setVisionModel: vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false }))),
             deleteModel: vi.fn().mockResolvedValue(ok({ deleted: true, model: "", freed_gb: 2.5 })),
         },
         activeModel: "",
@@ -557,7 +557,7 @@ describe("CatalogModal", () => {
 
         it("list-view Use button activates the model via setChatModel", async () => {
             const plugin = makePlugin();
-            plugin.api.setChatModel = vi.fn().mockResolvedValue(ok(undefined));
+            plugin.api.setChatModel = vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false })));
             plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry({ installed: true })])));
             const modal = await openModal(plugin);
             const content = contentEl(modal);
@@ -588,7 +588,7 @@ describe("CatalogModal", () => {
             plugin.api.pullModel = vi.fn().mockImplementation(async function* () {
                 yield { event: SSE_EVENT.PROGRESS, data: { percent: 100 } };
             });
-            plugin.api.setChatModel = vi.fn().mockResolvedValue(ok(undefined));
+            plugin.api.setChatModel = vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false })));
             plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry()])));
             const modal = await openModal(plugin);
             const content = contentEl(modal);
@@ -776,7 +776,7 @@ describe("CatalogModal", () => {
             const plugin = makePlugin();
             plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry()])));
             plugin.api.pullModel = vi.fn().mockImplementation(() => emptyStream());
-            plugin.api.setChatModel = vi.fn().mockResolvedValue(ok(undefined));
+            plugin.api.setChatModel = vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false })));
             const modal = await openModal(plugin);
             const content = contentEl(modal);
             const pullBtn = findButtons(content).find((b) => b.textContent === MESSAGES.BUTTON_PULL)!;
@@ -807,7 +807,7 @@ describe("CatalogModal", () => {
             plugin.api.pullModel = vi.fn().mockImplementation(async function* () {
                 yield { event: SSE_EVENT.DONE, data: {} };
             });
-            plugin.api.setChatModel = vi.fn().mockResolvedValue(ok(undefined));
+            plugin.api.setChatModel = vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false })));
             const modal = await openModal(plugin);
             const content = contentEl(modal);
             const pullBtn = findButtons(content).find((b) => b.textContent === MESSAGES.BUTTON_PULL)!;
@@ -824,7 +824,7 @@ describe("CatalogModal", () => {
             plugin.api.pullModel = vi.fn().mockImplementation(async function* () {
                 yield { event: SSE_EVENT.PROGRESS, data: { percent: 50 } };
             });
-            plugin.api.setChatModel = vi.fn().mockResolvedValue(ok(undefined));
+            plugin.api.setChatModel = vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false })));
             const modal = await openModal(plugin);
             const content = contentEl(modal);
             const pullBtn = findButtons(content).find((b) => b.textContent === MESSAGES.BUTTON_PULL)!;
@@ -840,7 +840,7 @@ describe("CatalogModal", () => {
             plugin.api.pullModel = vi.fn().mockImplementation(async function* () {
                 yield { event: SSE_EVENT.PROGRESS, data: {} };
             });
-            plugin.api.setChatModel = vi.fn().mockResolvedValue(ok(undefined));
+            plugin.api.setChatModel = vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false })));
             const modal = await openModal(plugin);
             const content = contentEl(modal);
             const pullBtn = findButtons(content).find((b) => b.textContent === MESSAGES.BUTTON_PULL)!;
@@ -856,7 +856,7 @@ describe("CatalogModal", () => {
             plugin.api.pullModel = vi.fn().mockImplementation(async function* () {
                 yield { event: SSE_EVENT.PROGRESS, data: { current: 50, total: 100 } };
             });
-            plugin.api.setChatModel = vi.fn().mockResolvedValue(ok(undefined));
+            plugin.api.setChatModel = vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false })));
             const modal = await openModal(plugin);
             const content = contentEl(modal);
             const pullBtn = findButtons(content).find((b) => b.textContent === MESSAGES.BUTTON_PULL)!;
@@ -882,7 +882,7 @@ describe("CatalogModal", () => {
 
         it("activates by the concrete GGUF file ref when the filename is not a glob", async () => {
             const plugin = makePlugin();
-            plugin.api.setChatModel = vi.fn().mockResolvedValue(ok(undefined));
+            plugin.api.setChatModel = vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false })));
             plugin.api.catalog.mockResolvedValue(
                 ok(
                     makeCatalogResponse([
@@ -935,7 +935,7 @@ describe("CatalogModal", () => {
             const plugin = makePlugin();
             plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry()])));
             plugin.api.pullModel = vi.fn().mockImplementation(() => emptyStream());
-            plugin.api.setChatModel = vi.fn().mockResolvedValue(ok(undefined));
+            plugin.api.setChatModel = vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false })));
             const modal = await openModal(plugin);
             const content = contentEl(modal);
             const pullBtn = findButtons(content).find((b) => b.textContent === MESSAGES.BUTTON_PULL)!;

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -168,8 +168,8 @@ function makePlugin(): LilbeePlugin {
                     ],
                 });
             }),
-            setChatModel: vi.fn().mockResolvedValue(ok(undefined)),
-            setEmbeddingModel: vi.fn().mockResolvedValue(ok(undefined)),
+            setChatModel: vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false }))),
+            setEmbeddingModel: vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: true }))),
             setVisionModel: vi.fn().mockResolvedValue(ok(undefined)),
             setRerankerModel: vi.fn().mockResolvedValue(ok(undefined)),
             pullModel: vi.fn(),
@@ -2122,7 +2122,7 @@ describe("ChatView.onOpen — model selector", () => {
             yield { event: "progress", data: { percent: 50 } };
         }
         plugin.api.pullModel = vi.fn().mockReturnValue(fakePull());
-        plugin.api.setChatModel = vi.fn().mockResolvedValue(ok(undefined));
+        plugin.api.setChatModel = vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false })));
 
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
@@ -2154,7 +2154,7 @@ describe("ChatView.onOpen — model selector", () => {
             yield { event: "progress", data: {} };
         }
         plugin.api.pullModel = vi.fn().mockReturnValue(fakePull());
-        plugin.api.setChatModel = vi.fn().mockResolvedValue(ok(undefined));
+        plugin.api.setChatModel = vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false })));
 
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
@@ -2183,7 +2183,7 @@ describe("ChatView.onOpen — model selector", () => {
             yield { event: "progress", data: { current: 50, total: 100 } };
         }
         plugin.api.pullModel = vi.fn().mockReturnValue(fakePull());
-        plugin.api.setChatModel = vi.fn().mockResolvedValue(ok(undefined));
+        plugin.api.setChatModel = vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false })));
 
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
@@ -2387,7 +2387,7 @@ describe("ChatView.onOpen — model selector", () => {
             yield { event: "progress", data: { percent: 0 } };
         }
         plugin.api.pullModel = vi.fn().mockReturnValue(fakePull());
-        plugin.api.setChatModel = vi.fn().mockResolvedValue(ok(undefined));
+        plugin.api.setChatModel = vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false })));
 
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
@@ -3117,7 +3117,7 @@ describe("ChatView.onClose — aborts both controllers", () => {
             await waitPromise;
         }
         plugin.api.pullModel = vi.fn().mockReturnValue(slowPull());
-        plugin.api.setChatModel = vi.fn().mockResolvedValue(ok(undefined));
+        plugin.api.setChatModel = vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false })));
 
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
@@ -3766,6 +3766,26 @@ describe("ChatView — embedding model selector", () => {
         // 4u1: embedding success path must also refresh the Settings tab so
         // the dropdown / subtitle reflect the new active embedding.
         expect(plugin.refreshSettingsTab).toHaveBeenCalled();
+    });
+
+    it("does not rebuild the index when the server says no reindex is needed", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        plugin.api.config = vi.fn().mockResolvedValue({ chat_model: "llama3", embedding_model: "previous-embed" });
+        // Re-selecting the model already backing the store: the server says the
+        // index still matches, so a full re-embed would be pure waste.
+        plugin.api.setEmbeddingModel = vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false })));
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        pickRailItem(container, "lilbee-embed-model-select", "nomic-embed-text");
+        await tick();
+
+        expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_EMBEDDING_UPDATED)).toBe(true);
+        expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_REINDEX_REQUIRED)).toBe(false);
+        expect(plugin.triggerSync).not.toHaveBeenCalled();
     });
 
     it("4u1: embedding setEmbeddingModel failure does NOT refresh the Settings tab", async () => {
@@ -4690,7 +4710,7 @@ describe("ChatView — pull stream non-error events", () => {
         // exercising the else-if false branch (711).
         const { mockFn } = makeStream([{ event: SSE_EVENT.DONE, data: {} }]);
         plugin.api.pullModel = mockFn;
-        plugin.api.setChatModel = vi.fn().mockResolvedValue(ok(undefined));
+        plugin.api.setChatModel = vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false })));
         const view = new ChatView(makeLeaf(), plugin);
         await view.onOpen();
         const entry = {

--- a/tests/views/model-picker-modal.test.ts
+++ b/tests/views/model-picker-modal.test.ts
@@ -51,8 +51,8 @@ function makePlugin(catalogModels: CatalogEntry[] = [localRow()]) {
                 .mockResolvedValue(
                     ok({ total: catalogModels.length, limit: 50, offset: 0, models: catalogModels, has_more: false }),
                 ),
-            setChatModel: vi.fn().mockResolvedValue(ok(undefined)),
-            setEmbeddingModel: vi.fn().mockResolvedValue(ok(undefined)),
+            setChatModel: vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false }))),
+            setEmbeddingModel: vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false }))),
         },
         activeModel: "",
         settings: {},

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -62,14 +62,14 @@ function makePlugin(overrides: Record<string, unknown> = {}) {
         api: {
             catalog: vi.fn().mockResolvedValue(ok(makeCatalogResponse())),
             pullModel: vi.fn(),
-            setChatModel: vi.fn().mockResolvedValue(ok(undefined)),
+            setChatModel: vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false }))),
             health: vi.fn().mockResolvedValue(ok({ status: "ok", version: "1.0.0" })),
             syncStream: vi.fn(),
             listModels: vi.fn().mockResolvedValue({
                 chat: { active: "", catalog: [], installed: [] },
             }),
-            setEmbeddingModel: vi.fn().mockResolvedValue(ok(undefined)),
-            setVisionModel: vi.fn().mockResolvedValue(ok(undefined)),
+            setEmbeddingModel: vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false }))),
+            setVisionModel: vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false }))),
             setBaseUrl: vi.fn(),
             setToken: vi.fn(),
             setTokenProvider: vi.fn(),
@@ -3276,7 +3276,7 @@ describe("SetupWizard", () => {
                     yield { event: SSE_EVENT.DONE, data: {} };
                 })(),
             );
-            plugin.api.setChatModel = vi.fn().mockResolvedValue(ok(undefined));
+            plugin.api.setChatModel = vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false })));
             plugin.api.syncStream = vi.fn().mockReturnValue(
                 (async function* () {
                     await new Promise(() => {});
@@ -3299,7 +3299,9 @@ describe("SetupWizard", () => {
                     yield { event: SSE_EVENT.DONE, data: {} };
                 })(),
             );
-            plugin.api.setEmbeddingModel = vi.fn().mockResolvedValue(ok(undefined));
+            plugin.api.setEmbeddingModel = vi.fn((m: string) =>
+                Promise.resolve(ok({ model: m, reindex_required: false })),
+            );
             plugin.api.syncStream = vi.fn().mockReturnValue(
                 (async function* () {
                     await new Promise(() => {});


### PR DESCRIPTION
## Problem

The four model setters return `Result<void>`, so the client discards the response body. The server sends two useful fields in it.

**`reindex_required` is ignored.** Selecting an embedding model always claims a reindex and always starts one. The server computes that flag against the reference that built the store. Re-selecting the model already in use therefore re-embeds the whole vault.

**The resolved reference is discarded.** The server normalizes what it receives. A bare repository comes back as the concrete quantization it chose. The plugin stores the string it sent, so the chip can disagree with the server's config.

**The catalog treats cloud models as local.** The server marks frontier, ollama and LM Studio rows `installed=true`, because they are usable. "Your collection" and the Library filter on that flag. Both list dozens of cloud models at 0 GB, each with a Remove button for a file that is not on disk.

## Solution

All four setters return `SetModelResponse`. The embedding paths start a sync only when the server asks for one. Both rails store the reference the server returned.

`yourCollectionRail` and the Library tab filter through `localRowsOnly`, which the local task tab already uses.

## Verified

Against a live server, all 47 hosted rows returned `installed=true` and `size_gb=0.0`. A bare repository returned 200 with the resolved quantization and `reindex_required: false`.

## Notes

The chat rail was fixed first. Its two sibling sites in the settings tab had the same defect and are fixed here.

Two comments claimed the server rejects a bare repository. A live test disproved that. They now state the real reason to send the file reference: the server resolves a bare repository by sort order, so the choice is arbitrary.
