### PR TITLE
Stop the wizard's exits leaving the plugin without a server, and check external mode first

### DIFF
--- a/src/components/model-card.ts
+++ b/src/components/model-card.ts
@@ -26,7 +26,7 @@ const TASK_TAG_CLS: Record<string, string> = {
 export function renderModelCard(container: HTMLElement, entry: CatalogEntry, options: ModelCardOptions): HTMLElement {
     const card = container.createDiv({ cls: "lilbee-model-card" });
     card.dataset.repo = entry.hf_repo;
-    if (options.isActive) card.addClass("is-selected");
+    if (options.isActive || options.isSelected) card.addClass("is-selected");
     if (entry.fit && FIT_RAIL_CLASS[entry.fit]) card.addClass(FIT_RAIL_CLASS[entry.fit]);
     if (entry.compat === MODEL_COMPAT.UNSUPPORTED) card.addClass("is-unsupported");
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -98,6 +98,7 @@ export const MESSAGES = {
     BUTTON_BROWSE_FULL_CATALOG: "Browse full catalog",
     BUTTON_BROWSE_MORE: "Browse more…",
     BUTTON_DOWNLOAD_CONTINUE: "Download & continue",
+    BUTTON_USE_CONTINUE: "Use & continue",
     BUTTON_DELETE_SELECTED: "Remove selected",
     BUTTON_CRAWL: "Crawl",
     BUTTON_START: "Start",
@@ -853,6 +854,8 @@ export const MESSAGES = {
     NOTICE_ENTER_URL: "lilbee: please enter a URL",
     NOTICE_DOWNLOAD_CANCELLED: "lilbee: download cancelled",
     NOTICE_INDEXING_CANCELLED: "lilbee: indexing cancelled",
+    NOTICE_SETUP_INCOMPLETE:
+        'lilbee has no server yet. Run "Run setup wizard" from the command palette to finish setup.',
     NOTICE_NOTHING_SAVE: "Nothing to save",
     NOTICE_NO_MODELS_INSTALLED: "No models installed.",
     NOTICE_NO_MODELS_DESCRIPTION: "Download a model to start chatting with your notes",

--- a/src/main.ts
+++ b/src/main.ts
@@ -336,12 +336,6 @@ export default class LilbeePlugin extends Plugin {
     taskQueue: TaskQueue = new TaskQueue();
     /** Paths whose most-recent add failed — retry skips the reindex confirm. */
     private failedAddPaths = new Set<string>();
-    /**
-     * One flag, read straight from the stored setting. It used to be a second
-     * field mirrored from `settings.wikiEnabled` by hand, and every writer that
-     * forgot the mirror left the wiki commands unregistered while chat was
-     * already asking for wiki content.
-     */
     get wikiEnabled(): boolean {
         return this.settings.wikiEnabled;
     }
@@ -910,8 +904,7 @@ export default class LilbeePlugin extends Plugin {
     /** Offer the picker the first time lilbee sees an agent CLI on this machine. */
     private async maybeShowAgentPicker(): Promise<void> {
         if (this.settings.agentIntegration.pickerShown) return;
-        // Pairing a coding agent is not part of setting up the vault. The
-        // wizard re-offers it on close, so the question is deferred, not dropped.
+        // The wizard re-offers pairing on close, so this defers the question rather than dropping it.
         if (this.setupWizardOpen) {
             this.agentPickerDeferred = true;
             return;
@@ -929,9 +922,7 @@ export default class LilbeePlugin extends Plugin {
             await this.persistAgentIntegration();
             return;
         }
-        // Connecting answers the question, so the picker does not come back.
-        // `remember` decides only whether the agent selection is kept, which is
-        // why it can default to off without the picker returning every start.
+        // Connecting answers the question; `remember` decides only whether the selection is kept.
         this.settings.agentIntegration.pickerShown = true;
         if (choice.remember) this.settings.agentIntegration.agent = choice.client;
         await this.persistAgentIntegration();

--- a/src/main.ts
+++ b/src/main.ts
@@ -929,12 +929,12 @@ export default class LilbeePlugin extends Plugin {
             await this.persistAgentIntegration();
             return;
         }
-        // An unremembered choice wires this session only, so the picker can return.
-        if (choice.remember) {
-            this.settings.agentIntegration.agent = choice.client;
-            this.settings.agentIntegration.pickerShown = true;
-            await this.persistAgentIntegration();
-        }
+        // Connecting answers the question, so the picker does not come back.
+        // `remember` decides only whether the agent selection is kept, which is
+        // why it can default to off without the picker returning every start.
+        this.settings.agentIntegration.pickerShown = true;
+        if (choice.remember) this.settings.agentIntegration.agent = choice.client;
+        await this.persistAgentIntegration();
         await this.applyAgentWiring(choice.client);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -336,7 +336,19 @@ export default class LilbeePlugin extends Plugin {
     taskQueue: TaskQueue = new TaskQueue();
     /** Paths whose most-recent add failed — retry skips the reindex confirm. */
     private failedAddPaths = new Set<string>();
-    wikiEnabled = false;
+    /**
+     * One flag, read straight from the stored setting. It used to be a second
+     * field mirrored from `settings.wikiEnabled` by hand, and every writer that
+     * forgot the mirror left the wiki commands unregistered while chat was
+     * already asking for wiki content.
+     */
+    get wikiEnabled(): boolean {
+        return this.settings.wikiEnabled;
+    }
+    /** True while the setup wizard owns the screen; nothing else may take the foreground. */
+    setupWizardOpen = false;
+    /** Set when agent pairing wanted the screen and the wizard had it. */
+    private agentPickerDeferred = false;
     wikiPageCount = 0;
     wikiDraftCount = 0;
     wikiSync: WikiSync | null = null;
@@ -366,7 +378,6 @@ export default class LilbeePlugin extends Plugin {
     async onload(): Promise<void> {
         this.registerErrorCapture();
         await this.loadSettings();
-        this.wikiEnabled = this.settings.wikiEnabled;
 
         // Sweep up status-bar items + ribbon icons that prior dead lilbee
         // instances left behind. Each crashed/incompletely-unloaded reload
@@ -899,6 +910,12 @@ export default class LilbeePlugin extends Plugin {
     /** Offer the picker the first time lilbee sees an agent CLI on this machine. */
     private async maybeShowAgentPicker(): Promise<void> {
         if (this.settings.agentIntegration.pickerShown) return;
+        // Pairing a coding agent is not part of setting up the vault. The
+        // wizard re-offers it on close, so the question is deferred, not dropped.
+        if (this.setupWizardOpen) {
+            this.agentPickerDeferred = true;
+            return;
+        }
         const index = await this.api.getAgentConfigIndex();
         if (index.isErr()) return;
         const detections = index.value.clients;
@@ -919,6 +936,13 @@ export default class LilbeePlugin extends Plugin {
             await this.persistAgentIntegration();
         }
         await this.applyAgentWiring(choice.client);
+    }
+
+    /** Offer the agent pairing the setup wizard pushed aside, now that it has the screen back. */
+    async resumeDeferredAgentPicker(): Promise<void> {
+        if (!this.agentPickerDeferred) return;
+        this.agentPickerDeferred = false;
+        await this.runAgentBoot();
     }
 
     /** Agent settings never change the server mode, so they skip saveSettings' restart logic. */
@@ -2199,7 +2223,6 @@ export default class LilbeePlugin extends Plugin {
         try {
             const wiki = await this.api.wikiStatus();
             if (wiki.isOk()) {
-                this.wikiEnabled = this.settings.wikiEnabled;
                 this.wikiPageCount = wiki.value.pages;
                 this.wikiDraftCount = wiki.value.drafts;
             }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -66,10 +66,10 @@ import {
     noticeServerUnreachableIfApplicable,
     openPluginSettingsById,
     renderExternalLink,
+    SERVER_PROBE_TIMEOUT_MS,
     setDeterminateProgress,
 } from "./utils";
 
-const CHECK_TIMEOUT_MS = 5000;
 /** GitHub's unauthenticated releases API allows 60 requests/hour per IP, so renders share one fetch. */
 const RELEASES_CACHE_TTL_MS = 10 * 60 * 1000;
 const CLS_MODELS_CONTAINER = "lilbee-models-container";
@@ -2672,7 +2672,6 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 toggle.setValue(this.plugin.settings.wikiEnabled);
                 toggle.onChange(async (value) => {
                     this.plugin.settings.wikiEnabled = value;
-                    this.plugin.wikiEnabled = value;
                     await this.plugin.saveSettings();
                     this.setSubSettingsVisible(subSettingsContainer, value);
                 });
@@ -3004,7 +3003,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         statusEl.empty();
         statusEl.classList.remove("lilbee-health-ok", "lilbee-health-error");
         const dot = statusEl.createDiv({ cls: "lilbee-health-dot" });
-        const ok = await LilbeeClient.probe(url, CHECK_TIMEOUT_MS, this.plugin.readCurrentToken());
+        const ok = await LilbeeClient.probe(url, SERVER_PROBE_TIMEOUT_MS, this.plugin.readCurrentToken());
         dot.classList.add(ok ? "is-ok" : "is-error");
         statusEl.classList.add(ok ? "lilbee-health-ok" : "lilbee-health-error");
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1563,5 +1563,8 @@ export interface ModelCardOptions {
     onRemove?: (entry: CatalogEntry, btn: HTMLElement) => void;
     onInfo?: (entry: CatalogEntry) => void;
     showActions?: boolean;
+    /** The server's active model for this task. Only this claims the ACTIVE badge. */
     isActive?: boolean;
+    /** Highlighted in a picker. Carries no claim about what the server is serving. */
+    isSelected?: boolean;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -108,6 +108,9 @@ export const SPINNER_MIN_DISPLAY_MS = 800;
 // is expected.
 export const STREAM_IDLE_TIMEOUT_MS = 120_000;
 
+/** How long a reachability probe waits for a server to answer. */
+export const SERVER_PROBE_TIMEOUT_MS = 5000;
+
 export class StreamIdleError extends Error {
     constructor(timeoutMs: number) {
         super(`stream idle for ${Math.round(timeoutMs / 1000)}s`);

--- a/src/views/agent-picker-modal.ts
+++ b/src/views/agent-picker-modal.ts
@@ -26,8 +26,7 @@ export class AgentPickerModal extends Modal {
     private resolver: ((r: AgentPickerResult) => void) | null = null;
     private resolved = false;
     private selected: AgentClient | null = null;
-    // Off by default: the accented button is Connect, so a pre-checked box
-    // would let one click both wire an integration and silence the question.
+    // Off by default: one click on Connect must not both wire an integration and silence the question.
     private remember = false;
     private cards: Map<AgentClient, HTMLElement> = new Map();
     /** Populated by renderFooter during onOpen, before the first select() call. */

--- a/src/views/agent-picker-modal.ts
+++ b/src/views/agent-picker-modal.ts
@@ -26,7 +26,9 @@ export class AgentPickerModal extends Modal {
     private resolver: ((r: AgentPickerResult) => void) | null = null;
     private resolved = false;
     private selected: AgentClient | null = null;
-    private remember = true;
+    // Off by default: the accented button is Connect, so a pre-checked box
+    // would let one click both wire an integration and silence the question.
+    private remember = false;
     private cards: Map<AgentClient, HTMLElement> = new Map();
     /** Populated by renderFooter during onOpen, before the first select() call. */
     private connectBtn!: HTMLButtonElement;

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -132,28 +132,16 @@ const PREFERRED_FAMILIES = [
 const MAX_FEATURED_PICKS = 8;
 
 /**
- * Name markers that keep a model out of the first-run picks. Safety-stripped
- * community re-uploads and runtime-specific quants are catalog material, not a
- * first impression. Matched against the lowercased repo + display name, and
- * only where a marker starts a word: a plain substring match drops "input"
- * on "npu".
- */
-const EXCLUDED_PICK_MARKER = new RegExp(
-    "(^|[^a-z])(uncensored|abliterated|heretic|nsfw|rocm|cuda|vulkan|openvino|npu)",
-);
-
-/**
- * A model the wizard is willing to recommend on a first run.
+ * A model the wizard is willing to recommend on a first run: one that runs.
  *
- * Matches the server TUI's own picks rail, which is the oracle: featured,
- * supported, and a known fit that is not wont_run. A missing fit is excluded
- * rather than allowed through, because an unknown size cannot be promised.
+ * Matches the server TUI's own picks rail, which is the oracle: supported, and
+ * a known fit that is not wont_run. A missing fit is excluded rather than
+ * allowed through, because an unknown size cannot be promised.
  */
 function isFirstRunPick(model: FeaturedModel): boolean {
     if (!model.fit) return false;
     if (model.fit === HARDWARE_FIT.WONT_RUN) return false;
-    if (model.compat === MODEL_COMPAT.UNSUPPORTED) return false;
-    return !EXCLUDED_PICK_MARKER.test(`${model.hf_repo} ${model.display_name}`.toLowerCase());
+    return model.compat !== MODEL_COMPAT.UNSUPPORTED;
 }
 
 /**
@@ -218,11 +206,10 @@ export function pickNativeChatModels(
     models: FeaturedModel[],
     filter: (m: FeaturedModel) => boolean = () => true,
 ): FeaturedModel[] {
-    const allowed = models.filter(filter);
-    // Curation must never empty the row: a server whose whole featured list
-    // reads as excluded still has to offer the user something to pick.
-    const curated = allowed.filter(isFirstRunPick);
-    const eligible = curated.length > 0 ? curated : allowed;
+    // Only models that run. If that leaves nothing, the caller shows its
+    // empty state and the full catalog is one button away; showing a model
+    // the host cannot load under a picks heading is worse than showing none.
+    const eligible = models.filter(filter).filter(isFirstRunPick);
     const seen = new Set<string>();
     const ordered: FeaturedModel[] = [];
     for (const prefix of PREFERRED_FAMILIES) {

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -1377,14 +1377,14 @@ export class SetupWizard extends Modal {
 
     next(): void {
         if (this.step === WIZARD_STEP.WELCOME) {
+            // External mode is usable only once setup has completed, because
+            // that is when the plugin points its client at the server. Before
+            // then the stored mode is a preference, and skipping the server
+            // step lands on a model step that cannot load anything.
             const serverReady =
                 this.plugin.serverManager?.state === SERVER_STATE.READY ||
-                this.plugin.settings.serverMode === SERVER_MODE.EXTERNAL;
-            // Only a managed server that reached READY has actually answered.
-            // `serverMode === EXTERNAL` is a stored preference: the consent
-            // modal writes it before setup completes, so treating it as proof
-            // would record setup with no server behind it.
-            if (this.plugin.serverManager?.state === SERVER_STATE.READY) void this.markServerReady();
+                (this.plugin.settings.serverMode === SERVER_MODE.EXTERNAL && this.plugin.settings.setupCompleted);
+            if (serverReady) void this.markServerReady();
             this.step = serverReady ? WIZARD_STEP.MODEL_PICKER : WIZARD_STEP.SERVER_MODE;
         } else {
             this.step++;

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -142,8 +142,15 @@ const EXCLUDED_PICK_MARKER = new RegExp(
     "(^|[^a-z])(uncensored|abliterated|heretic|nsfw|rocm|cuda|vulkan|openvino|npu)",
 );
 
-/** A model the wizard is willing to recommend on a first run. */
+/**
+ * A model the wizard is willing to recommend on a first run.
+ *
+ * Matches the server TUI's own picks rail, which is the oracle: featured,
+ * supported, and a known fit that is not wont_run. A missing fit is excluded
+ * rather than allowed through, because an unknown size cannot be promised.
+ */
 function isFirstRunPick(model: FeaturedModel): boolean {
+    if (!model.fit) return false;
     if (model.fit === HARDWARE_FIT.WONT_RUN) return false;
     if (model.compat === MODEL_COMPAT.UNSUPPORTED) return false;
     return !EXCLUDED_PICK_MARKER.test(`${model.hf_repo} ${model.display_name}`.toLowerCase());

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -1386,9 +1386,11 @@ export class SetupWizard extends Modal {
             const serverReady =
                 this.plugin.serverManager?.state === SERVER_STATE.READY ||
                 this.plugin.settings.serverMode === SERVER_MODE.EXTERNAL;
-            // This skips the server step, which is the other place setup is
-            // recorded. Passing it is the same milestone either way.
-            if (serverReady) void this.markServerReady();
+            // Only a managed server that reached READY has actually answered.
+            // `serverMode === EXTERNAL` is a stored preference: the consent
+            // modal writes it before setup completes, so treating it as proof
+            // would record setup with no server behind it.
+            if (this.plugin.serverManager?.state === SERVER_STATE.READY) void this.markServerReady();
             this.step = serverReady ? WIZARD_STEP.MODEL_PICKER : WIZARD_STEP.SERVER_MODE;
         } else {
             this.step++;

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -180,17 +180,11 @@ const SERVER_SETUP_PHASES: {
 ];
 
 /**
- * Rank the server's featured chat entries into the wizard's "Our picks" row.
+ * Ranks the server's featured chat entries into the wizard's picks row, keeping
+ * only those a first run should offer and leading with recognised families.
  *
- * Deliberately does NOT filter by `source`. When a server is mis-configured
- * and tags every featured model as `source="litellm"` (a known transient bug
- * in older builds), filtering on source emptied the wizard grid. The featured
- * list itself is the source of truth — the server has already decided these
- * are the models a fresh user should see. We just reorder them so recognised
- * open-weight families (Gemma, Qwen, Llama, Phi) lead.
- *
- * Callers that genuinely need to hide a subset (e.g. API-only entries in a
- * different UI) can pass a custom `filter` predicate.
+ * Never filters on `source`: a mis-configured server tags every featured model
+ * as one source, which empties the row.
  */
 export function pickNativeChatModels(
     models: FeaturedModel[],

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -1,6 +1,6 @@
 import { App, Modal, Notice } from "obsidian";
 import type LilbeePlugin from "../main";
-import { SessionTokenError } from "../api";
+import { LilbeeClient, SessionTokenError } from "../api";
 import type {
     BatchProgressPayload,
     CatalogEntry,
@@ -11,8 +11,10 @@ import type {
 } from "../types";
 import {
     CATALOG_TAB,
+    HARDWARE_FIT,
     LILBEE_REPO_URL,
     MANAGED_PHASE,
+    MODEL_COMPAT,
     SERVER_MODE,
     SERVER_STATE,
     SETUP_OUTCOME,
@@ -31,6 +33,7 @@ import {
     extractSseErrorMessage,
     getSystemMemoryGB,
     percentFromSse,
+    SERVER_PROBE_TIMEOUT_MS,
     setDeterminateProgress,
     sessionTokenInvalidMessage,
 } from "../utils";
@@ -129,6 +132,24 @@ const PREFERRED_FAMILIES = [
 const MAX_FEATURED_PICKS = 8;
 
 /**
+ * Name markers that keep a model out of the first-run picks. Safety-stripped
+ * community re-uploads and runtime-specific quants are catalog material, not a
+ * first impression. Matched against the lowercased repo + display name, and
+ * only where a marker starts a word: a plain substring match drops "input"
+ * on "npu".
+ */
+const EXCLUDED_PICK_MARKER = new RegExp(
+    "(^|[^a-z])(uncensored|abliterated|heretic|nsfw|rocm|cuda|vulkan|openvino|npu)",
+);
+
+/** A model the wizard is willing to recommend on a first run. */
+function isFirstRunPick(model: FeaturedModel): boolean {
+    if (model.fit === HARDWARE_FIT.WONT_RUN) return false;
+    if (model.compat === MODEL_COMPAT.UNSUPPORTED) return false;
+    return !EXCLUDED_PICK_MARKER.test(`${model.hf_repo} ${model.display_name}`.toLowerCase());
+}
+
+/**
  * The three visible phases of managed-server setup, in order. Each renders as a
  * row with a status dot that lights up as the server moves Downloading →
  * Starting → Ready. The label re-words per state so the user always reads the
@@ -179,6 +200,10 @@ const SERVER_SETUP_PHASES: {
  * are the models a fresh user should see. We just reorder them so recognised
  * open-weight families (Gemma, Qwen, Llama, Phi) lead.
  *
+ * The row is curated on top of that ordering: models the host cannot run,
+ * safety-stripped re-uploads and runtime-specific quants are not what a
+ * first-run user should be offered. See `isFirstRunPick`.
+ *
  * Callers that genuinely need to hide a subset (e.g. API-only entries in a
  * different UI) can pass a custom `filter` predicate.
  */
@@ -186,7 +211,11 @@ export function pickNativeChatModels(
     models: FeaturedModel[],
     filter: (m: FeaturedModel) => boolean = () => true,
 ): FeaturedModel[] {
-    const eligible = models.filter(filter);
+    const allowed = models.filter(filter);
+    // Curation must never empty the row: a server whose whole featured list
+    // reads as excluded still has to offer the user something to pick.
+    const curated = allowed.filter(isFirstRunPick);
+    const eligible = curated.length > 0 ? curated : allowed;
     const seen = new Set<string>();
     const ordered: FeaturedModel[] = [];
     for (const prefix of PREFERRED_FAMILIES) {
@@ -232,12 +261,32 @@ export class SetupWizard extends Modal {
         const { contentEl } = this;
         contentEl.empty();
         contentEl.addClass("lilbee-wizard");
+        // Obsidian renders Settings in front of the workspace, so a wizard
+        // opened from there (or by enabling the plugin) would sit behind it.
+        closeSettings(this.app);
+        // Nothing else may take the foreground while setup runs.
+        this.plugin.setupWizardOpen = true;
         this.renderStep();
     }
 
     onClose(): void {
         this.pullController?.abort();
         this.syncController?.abort();
+        this.plugin.setupWizardOpen = false;
+        void this.plugin.resumeDeferredAgentPicker();
+        if (!this.plugin.settings.setupCompleted) new Notice(MESSAGES.NOTICE_SETUP_INCOMPLETE);
+    }
+
+    /**
+     * A server that answers is the point setup stops being optional scaffolding:
+     * from here the plugin starts and configures itself on the next launch,
+     * whatever the user does with the remaining steps. Writing the flag only on
+     * the final button left every other exit with a dead plugin.
+     */
+    private async markServerReady(): Promise<void> {
+        if (this.plugin.settings.setupCompleted) return;
+        this.plugin.settings.setupCompleted = true;
+        await this.plugin.saveSettings();
     }
 
     private renderStep(): void {
@@ -441,12 +490,11 @@ export class SetupWizard extends Modal {
                 nextBtn.disabled = true;
                 void this.startManagedAndAdvance(step, panel, setPhase, statusEl, nextBtn, selectExternal);
             } else {
-                this.plugin.settings.serverUrl = String(urlInput.value || "").trim() || "http://127.0.0.1:7433";
-                this.plugin.settings.manualToken = String(tokenInput.value || "").trim();
-                this.plugin.settings.serverMode = SERVER_MODE.EXTERNAL;
+                const url = String(urlInput.value || "").trim() || "http://127.0.0.1:7433";
+                const token = String(tokenInput.value || "").trim();
                 statusEl.setText(MESSAGES.STATUS_CHECKING_CONNECTION);
                 nextBtn.disabled = true;
-                void this.checkExternalAndAdvance(statusEl, nextBtn);
+                void this.checkExternalAndAdvance(url, token, statusEl, nextBtn);
             }
         });
     }
@@ -501,6 +549,7 @@ export class SetupWizard extends Modal {
                 return;
             }
             setPhase(MANAGED_PHASE.READY);
+            await this.markServerReady();
             this.step = WIZARD_STEP.MODEL_PICKER;
             this.renderStep();
         } catch {
@@ -601,23 +650,38 @@ export class SetupWizard extends Modal {
         return { panel, setPhase };
     }
 
-    private async checkExternalAndAdvance(statusEl: HTMLElement, nextBtn: HTMLElement): Promise<void> {
-        try {
-            await this.plugin.saveSettings();
-            // Repoint the existing client at the new URL and hand it the token
-            // the user just pasted. Updating in-place keeps test mocks intact
-            // and avoids churning listeners keyed on the old instance.
-            this.plugin.api.setBaseUrl(this.plugin.settings.serverUrl);
-            this.plugin.api.setToken(this.plugin.settings.manualToken || null);
-            const result = await this.plugin.api.health();
-            if (result.isErr()) throw result.error;
-            statusEl.setText("");
-            this.step = WIZARD_STEP.MODEL_PICKER;
-            this.renderStep();
-        } catch {
+    /**
+     * Check the typed URL and token before anything is written. Persisting
+     * first would stop a working managed server (saveSettings shuts one down
+     * when the mode leaves managed) and leave the user in external mode
+     * pointing at a server that never answered.
+     */
+    private async checkExternalAndAdvance(
+        url: string,
+        token: string,
+        statusEl: HTMLElement,
+        nextBtn: HTMLElement,
+    ): Promise<void> {
+        const reachable = await LilbeeClient.probe(`${url}/api/health`, SERVER_PROBE_TIMEOUT_MS, token || null);
+        if (!reachable) {
             statusEl.setText(MESSAGES.ERROR_COULD_NOT_CONNECT_EXT);
             (nextBtn as HTMLButtonElement).disabled = false;
+            return;
         }
+
+        this.plugin.settings.serverUrl = url;
+        this.plugin.settings.manualToken = token;
+        this.plugin.settings.serverMode = SERVER_MODE.EXTERNAL;
+        await this.plugin.saveSettings();
+        // Repoint the existing client at the new URL and hand it the token
+        // the user just pasted. Updating in-place keeps test mocks intact
+        // and avoids churning listeners keyed on the old instance.
+        this.plugin.api.setBaseUrl(url);
+        this.plugin.api.setToken(token || null);
+        await this.markServerReady();
+        statusEl.setText("");
+        this.step = WIZARD_STEP.MODEL_PICKER;
+        this.renderStep();
     }
 
     /**
@@ -703,22 +767,29 @@ export class SetupWizard extends Modal {
         const downloadBtn = actions.createEl("button", { text: MESSAGES.BUTTON_DOWNLOAD_CONTINUE, cls: "mod-cta" });
         this.primaryBtn = downloadBtn;
         downloadBtn.addEventListener("click", () => {
-            if (!this.selectedModel) {
+            const model = this.selectedModel;
+            if (!model) {
                 statusEl.setText(MESSAGES.WIZARD_SELECT_MODEL);
                 return;
             }
-            downloadBtn.disabled = true;
             statusEl.setText("");
+            if (model.installed) {
+                downloadBtn.disabled = true;
+                void this.useInstalledModel(model, downloadBtn, statusEl);
+                return;
+            }
+            downloadBtn.disabled = true;
             void this.pullSelectedModel(downloadBtn, progressEl, progressFill, progressLabel, statusEl, step);
         });
 
-        void this.loadFeaturedModels(modelsContainer, memGB, statusEl);
+        void this.loadFeaturedModels(modelsContainer, memGB, statusEl, downloadBtn);
     }
 
     private async loadFeaturedModels(
         container: HTMLElement,
         memGB: number | null,
         statusEl: HTMLElement,
+        downloadBtn: HTMLButtonElement,
     ): Promise<void> {
         try {
             // The server's featured list is the source of truth for the
@@ -737,7 +808,7 @@ export class SetupWizard extends Modal {
                 this.featuredModels = [];
                 this.selectedModel = null;
                 this.renderCatalogFailure(container, statusEl, result.error.message, () => {
-                    void this.loadFeaturedModels(container, memGB, statusEl);
+                    void this.loadFeaturedModels(container, memGB, statusEl, downloadBtn);
                 });
                 return;
             }
@@ -746,20 +817,21 @@ export class SetupWizard extends Modal {
             this.featuredModels = [];
             this.selectedModel = null;
             this.renderCatalogFailure(container, statusEl, errorMessage(e, MESSAGES.ERROR_LOAD_MODELS), () => {
-                void this.loadFeaturedModels(container, memGB, statusEl);
+                void this.loadFeaturedModels(container, memGB, statusEl, downloadBtn);
             });
             return;
         }
         if (this.featuredModels.length === 0) {
             this.selectedModel = null;
             this.renderCatalogFailure(container, statusEl, MESSAGES.WIZARD_NO_MODELS_OFFERED, () => {
-                void this.loadFeaturedModels(container, memGB, statusEl);
+                void this.loadFeaturedModels(container, memGB, statusEl, downloadBtn);
             });
             return;
         }
 
         const recommended = recommendedIndex(this.featuredModels, memGB);
         this.selectedModel = this.featuredModels[recommended];
+        this.setPrimaryActionLabel(downloadBtn, this.selectedModel);
 
         this.renderSectionHeading(container, MESSAGES.LABEL_OUR_PICKS);
         const grid = container.createDiv({ cls: "lilbee-catalog-grid" });
@@ -767,8 +839,10 @@ export class SetupWizard extends Modal {
         for (let i = 0; i < this.featuredModels.length; i++) {
             const entry = this.featuredModels[i];
             renderModelCard(grid, entry, {
-                isActive: i === recommended,
-                onClick: () => this.selectModel(grid, entry),
+                // Recommended, not active: the wizard does not know what the
+                // server it is now talking to has loaded.
+                isSelected: i === recommended,
+                onClick: () => this.selectModel(grid, entry, downloadBtn),
             });
         }
     }
@@ -787,13 +861,42 @@ export class SetupWizard extends Modal {
         const retryBtn = container.createEl("button", { text: MESSAGES.BUTTON_RETRY });
         retryBtn.addEventListener("click", () => {
             statusEl.setText("");
+            // A failed load disables the primary action below. Give it back for
+            // the retry; a second failure disables it again.
+            if (this.primaryBtn) this.primaryBtn.disabled = false;
             retry();
         });
         if (this.primaryBtn) this.primaryBtn.disabled = true;
     }
 
-    private selectModel(grid: HTMLElement, model: FeaturedModel): void {
+    /** A model already on disk is set, not fetched again. */
+    private async useInstalledModel(
+        model: FeaturedModel,
+        downloadBtn: HTMLElement,
+        statusEl: HTMLElement,
+    ): Promise<void> {
+        const setResult = await this.plugin.api.setChatModel(model.hf_repo);
+        if (setResult.isErr()) {
+            new Notice(MESSAGES.ERROR_SET_MODEL.replace("{model}", model.display_name));
+            statusEl.setText(setResult.error.message);
+            (downloadBtn as HTMLButtonElement).disabled = false;
+            return;
+        }
+        this.plugin.activeModel = model.hf_repo;
+        void this.plugin.fetchActiveModel();
+        this.pulledModelName = model.display_name;
+        this.step = WIZARD_STEP.EMBEDDING_PICKER;
+        this.renderStep();
+    }
+
+    /** The primary action names what it will do: fetch a model, or use one already here. */
+    private setPrimaryActionLabel(btn: HTMLButtonElement, model: FeaturedModel): void {
+        btn.setText(model.installed ? MESSAGES.BUTTON_USE_CONTINUE : MESSAGES.BUTTON_DOWNLOAD_CONTINUE);
+    }
+
+    private selectModel(grid: HTMLElement, model: FeaturedModel, downloadBtn: HTMLButtonElement): void {
         this.selectedModel = model;
+        this.setPrimaryActionLabel(downloadBtn, model);
         for (const child of Array.from(grid.children)) {
             const el = child as HTMLElement;
             if (el.dataset.repo === model.hf_repo) {
@@ -974,7 +1077,7 @@ export class SetupWizard extends Modal {
         for (let i = 0; i < this.embeddingModels.length; i++) {
             const entry = this.embeddingModels[i];
             renderModelCard(grid, entry, {
-                isActive: i === defaultIdx,
+                isSelected: i === defaultIdx,
                 onClick: () => this.selectEmbedding(grid, entry),
             });
         }
@@ -1283,6 +1386,9 @@ export class SetupWizard extends Modal {
             const serverReady =
                 this.plugin.serverManager?.state === SERVER_STATE.READY ||
                 this.plugin.settings.serverMode === SERVER_MODE.EXTERNAL;
+            // This skips the server step, which is the other place setup is
+            // recorded. Passing it is the same milestone either way.
+            if (serverReady) void this.markServerReady();
             this.step = serverReady ? WIZARD_STEP.MODEL_PICKER : WIZARD_STEP.SERVER_MODE;
         } else {
             this.step++;

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -131,17 +131,11 @@ const PREFERRED_FAMILIES = [
 ];
 const MAX_FEATURED_PICKS = 8;
 
-/**
- * A model the wizard is willing to recommend on a first run: one that runs.
- *
- * Matches the server TUI's own picks rail, which is the oracle: supported, and
- * a known fit that is not wont_run. A missing fit is excluded rather than
- * allowed through, because an unknown size cannot be promised.
- */
+/** A first-run pick: supported compat and a known fit that is not wont_run, matching the server TUI's rail. */
 function isFirstRunPick(model: FeaturedModel): boolean {
     if (!model.fit) return false;
     if (model.fit === HARDWARE_FIT.WONT_RUN) return false;
-    return model.compat !== MODEL_COMPAT.UNSUPPORTED;
+    return model.compat === MODEL_COMPAT.SUPPORTED;
 }
 
 /**
@@ -195,10 +189,6 @@ const SERVER_SETUP_PHASES: {
  * are the models a fresh user should see. We just reorder them so recognised
  * open-weight families (Gemma, Qwen, Llama, Phi) lead.
  *
- * The row is curated on top of that ordering: models the host cannot run,
- * safety-stripped re-uploads and runtime-specific quants are not what a
- * first-run user should be offered. See `isFirstRunPick`.
- *
  * Callers that genuinely need to hide a subset (e.g. API-only entries in a
  * different UI) can pass a custom `filter` predicate.
  */
@@ -206,9 +196,7 @@ export function pickNativeChatModels(
     models: FeaturedModel[],
     filter: (m: FeaturedModel) => boolean = () => true,
 ): FeaturedModel[] {
-    // Only models that run. If that leaves nothing, the caller shows its
-    // empty state and the full catalog is one button away; showing a model
-    // the host cannot load under a picks heading is worse than showing none.
+    // The row may come back empty; the caller has an empty state for that.
     const eligible = models.filter(filter).filter(isFirstRunPick);
     const seen = new Set<string>();
     const ordered: FeaturedModel[] = [];
@@ -255,10 +243,8 @@ export class SetupWizard extends Modal {
         const { contentEl } = this;
         contentEl.empty();
         contentEl.addClass("lilbee-wizard");
-        // Obsidian renders Settings in front of the workspace, so a wizard
-        // opened from there (or by enabling the plugin) would sit behind it.
+        // Obsidian renders Settings in front of the workspace, so a wizard opened from there sits behind it.
         closeSettings(this.app);
-        // Nothing else may take the foreground while setup runs.
         this.plugin.setupWizardOpen = true;
         this.renderStep();
     }
@@ -271,12 +257,7 @@ export class SetupWizard extends Modal {
         if (!this.plugin.settings.setupCompleted) new Notice(MESSAGES.NOTICE_SETUP_INCOMPLETE);
     }
 
-    /**
-     * A server that answers is the point setup stops being optional scaffolding:
-     * from here the plugin starts and configures itself on the next launch,
-     * whatever the user does with the remaining steps. Writing the flag only on
-     * the final button left every other exit with a dead plugin.
-     */
+    /** Records setup as complete: the point from which the plugin starts itself on the next launch. */
     private async markServerReady(): Promise<void> {
         if (this.plugin.settings.setupCompleted) return;
         this.plugin.settings.setupCompleted = true;
@@ -644,12 +625,7 @@ export class SetupWizard extends Modal {
         return { panel, setPhase };
     }
 
-    /**
-     * Check the typed URL and token before anything is written. Persisting
-     * first would stop a working managed server (saveSettings shuts one down
-     * when the mode leaves managed) and leave the user in external mode
-     * pointing at a server that never answered.
-     */
+    /** Checks the typed URL and token before anything is persisted: saving stops a running managed server. */
     private async checkExternalAndAdvance(
         url: string,
         token: string,
@@ -667,9 +643,7 @@ export class SetupWizard extends Modal {
         this.plugin.settings.manualToken = token;
         this.plugin.settings.serverMode = SERVER_MODE.EXTERNAL;
         await this.plugin.saveSettings();
-        // Repoint the existing client at the new URL and hand it the token
-        // the user just pasted. Updating in-place keeps test mocks intact
-        // and avoids churning listeners keyed on the old instance.
+        // Update the client in place; listeners are keyed on the instance.
         this.plugin.api.setBaseUrl(url);
         this.plugin.api.setToken(token || null);
         await this.markServerReady();
@@ -833,8 +807,7 @@ export class SetupWizard extends Modal {
         for (let i = 0; i < this.featuredModels.length; i++) {
             const entry = this.featuredModels[i];
             renderModelCard(grid, entry, {
-                // Recommended, not active: the wizard does not know what the
-                // server it is now talking to has loaded.
+                // Recommended, not active: the wizard does not know what the server has loaded.
                 isSelected: i === recommended,
                 onClick: () => this.selectModel(grid, entry, downloadBtn),
             });
@@ -855,8 +828,7 @@ export class SetupWizard extends Modal {
         const retryBtn = container.createEl("button", { text: MESSAGES.BUTTON_RETRY });
         retryBtn.addEventListener("click", () => {
             statusEl.setText("");
-            // A failed load disables the primary action below. Give it back for
-            // the retry; a second failure disables it again.
+            // The failed load disabled the primary action; the retry needs it back.
             if (this.primaryBtn) this.primaryBtn.disabled = false;
             retry();
         });
@@ -1377,10 +1349,7 @@ export class SetupWizard extends Modal {
 
     next(): void {
         if (this.step === WIZARD_STEP.WELCOME) {
-            // External mode is usable only once setup has completed, because
-            // that is when the plugin points its client at the server. Before
-            // then the stored mode is a preference, and skipping the server
-            // step lands on a model step that cannot load anything.
+            // The client is only pointed at an external server once setup has completed.
             const serverReady =
                 this.plugin.serverManager?.state === SERVER_STATE.READY ||
                 (this.plugin.settings.serverMode === SERVER_MODE.EXTERNAL && this.plugin.settings.setupCompleted);

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -12,6 +12,7 @@ import type {
 import {
     CATALOG_TAB,
     HARDWARE_FIT,
+    HOSTED_SOURCES,
     LILBEE_REPO_URL,
     MANAGED_PHASE,
     MODEL_COMPAT,
@@ -24,6 +25,7 @@ import {
     MODEL_TASK,
 } from "../types";
 import { CatalogModal } from "./catalog-modal";
+import { isUsableHostedRow } from "./catalog-helpers";
 import { MESSAGES, FILTERS } from "../locales/en";
 import { renderModelCard } from "../components/model-card";
 import {
@@ -130,12 +132,18 @@ const PREFERRED_FAMILIES = [
     "smollm",
 ];
 const MAX_FEATURED_PICKS = 8;
+/** Rows asked of the catalog per request: enough that the ones that run can replace the ones that do not. */
+const PICKS_CATALOG_LIMIT = 40;
 
-/** A first-run pick: supported compat and a known fit that is not wont_run, matching the server TUI's rail. */
-function isFirstRunPick(model: FeaturedModel): boolean {
-    if (!model.fit) return false;
-    if (model.fit === HARDWARE_FIT.WONT_RUN) return false;
-    return model.compat === MODEL_COMPAT.SUPPORTED;
+/** A row the server says will not run here: the fit it reported is wont_run, or it refuses the architecture. */
+function isUnrunnable(model: FeaturedModel): boolean {
+    return model.fit === HARDWARE_FIT.WONT_RUN || model.compat === MODEL_COMPAT.UNSUPPORTED;
+}
+
+/** A row the wizard can offer in place of another: it runs here, and a hosted row is ready without an API key of its own. */
+function canSubstitute(model: FeaturedModel): boolean {
+    if (isUnrunnable(model)) return false;
+    return !HOSTED_SOURCES.has(model.source) || isUsableHostedRow(model);
 }
 
 /**
@@ -180,8 +188,8 @@ const SERVER_SETUP_PHASES: {
 ];
 
 /**
- * Ranks the server's featured chat entries into the wizard's picks row, keeping
- * only those a first run should offer and leading with recognised families.
+ * Ranks the server's featured chat entries into the wizard's picks row, leading
+ * with recognised families.
  *
  * Never filters on `source`: a mis-configured server tags every featured model
  * as one source, which empties the row.
@@ -190,8 +198,7 @@ export function pickNativeChatModels(
     models: FeaturedModel[],
     filter: (m: FeaturedModel) => boolean = () => true,
 ): FeaturedModel[] {
-    // The row may come back empty; the caller has an empty state for that.
-    const eligible = models.filter(filter).filter(isFirstRunPick);
+    const eligible = models.filter(filter);
     const seen = new Set<string>();
     const ordered: FeaturedModel[] = [];
     for (const prefix of PREFERRED_FAMILIES) {
@@ -211,6 +218,27 @@ export function pickNativeChatModels(
         }
     }
     return ordered;
+}
+
+/**
+ * Puts the most popular candidates the wizard can offer in place of the rows
+ * that will not run, in the order the server returned them. Rows left without a
+ * substitute stay, behind the ones that run, so the row keeps its size.
+ *
+ * Nothing here drops a row, and ranking drops none either, so the picks row is
+ * empty only when the server returned nothing.
+ */
+function substituteUnrunnable(row: FeaturedModel[], candidates: FeaturedModel[]): FeaturedModel[] {
+    const unrunnable = row.filter(isUnrunnable);
+    const taken = new Set(row.map((m) => m.hf_repo));
+    const substitutes: FeaturedModel[] = [];
+    for (const m of candidates) {
+        if (substitutes.length >= unrunnable.length) break;
+        if (taken.has(m.hf_repo) || !canSubstitute(m)) continue;
+        substitutes.push(m);
+        taken.add(m.hf_repo);
+    }
+    return [...row.filter((m) => !isUnrunnable(m)), ...substitutes, ...unrunnable.slice(substitutes.length)];
 }
 
 export class SetupWizard extends Modal {
@@ -754,17 +782,11 @@ export class SetupWizard extends Modal {
         downloadBtn: HTMLButtonElement,
     ): Promise<void> {
         try {
-            // The server's featured list is the source of truth for the
-            // wizard's "Our picks" row. Do NOT filter by `source` here — a
-            // mis-configured server can tag every featured model as
-            // `source="litellm"`, which would empty the grid and leave the
-            // user stuck. `pickNativeChatModels` just reorders so recognised
-            // open-weight families (Gemma, Qwen, Llama) lead.
             const result = await this.plugin.api.catalog({
                 task: MODEL_TASK.CHAT,
                 featured: true,
                 sort: FILTERS.SORT.DOWNLOADS,
-                limit: 40,
+                limit: PICKS_CATALOG_LIMIT,
             });
             if (result.isErr()) {
                 this.featuredModels = [];
@@ -774,7 +796,7 @@ export class SetupWizard extends Modal {
                 });
                 return;
             }
-            this.featuredModels = pickNativeChatModels(result.value.models);
+            this.featuredModels = await this.replaceUnrunnablePicks(pickNativeChatModels(result.value.models));
         } catch (e) {
             this.featuredModels = [];
             this.selectedModel = null;
@@ -806,6 +828,17 @@ export class SetupWizard extends Modal {
                 onClick: () => this.selectModel(grid, entry, downloadBtn),
             });
         }
+    }
+
+    /** Trades the rows that will not run for the most popular ones that do. The wider catalog is read only when there is something to trade. */
+    private async replaceUnrunnablePicks(row: FeaturedModel[]): Promise<FeaturedModel[]> {
+        if (!row.some(isUnrunnable)) return row;
+        const result = await this.plugin.api.catalog({
+            task: MODEL_TASK.CHAT,
+            sort: FILTERS.SORT.DOWNLOADS,
+            limit: PICKS_CATALOG_LIMIT,
+        });
+        return substituteUnrunnable(row, result.isOk() ? result.value.models : []);
     }
 
     /** Say why the grid is empty and let the user try again without restarting

--- a/tests/components/model-card.test.ts
+++ b/tests/components/model-card.test.ts
@@ -464,3 +464,31 @@ describe("renderModelCard", () => {
         });
     });
 });
+
+describe("renderModelCard selection vs active", () => {
+    it("isSelected highlights the card without claiming the model is active", () => {
+        const c = container();
+        const card = renderModelCard(c, makeEntry(), { isSelected: true }) as unknown as MockElement;
+
+        expect(card.classList.contains("is-selected")).toBe(true);
+        const label = card.find("lilbee-model-card-status-label");
+        expect(label?.textContent).not.toBe(MESSAGES.LABEL_ACTIVE);
+    });
+
+    it("isSelected leaves an installed model reading INSTALLED", () => {
+        const c = container();
+        const entry = makeEntry({ installed: true });
+        const card = renderModelCard(c, entry, { isSelected: true }) as unknown as MockElement;
+
+        const label = card.find("lilbee-model-card-status-label");
+        expect(label?.textContent).toBe(MESSAGES.LABEL_INSTALLED);
+    });
+
+    it("isActive still claims the ACTIVE label", () => {
+        const c = container();
+        const card = renderModelCard(c, makeEntry(), { isActive: true }) as unknown as MockElement;
+
+        const label = card.find("lilbee-model-card-status-label");
+        expect(label?.textContent).toBe(MESSAGES.LABEL_ACTIVE);
+    });
+});

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -7711,14 +7711,14 @@ describe("LilbeePlugin", () => {
         it("is unavailable while the wiki is off", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
-            (plugin as any).wikiEnabled = false;
+            plugin.settings.wikiEnabled = false;
             expect(wikiUpdateCmd(plugin).checkCallback(true)).toBe(false);
         });
 
         it("is available with the wiki on, and runs the update when invoked", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
-            (plugin as any).wikiEnabled = true;
+            plugin.settings.wikiEnabled = true;
             const spy = vi.spyOn(plugin, "runWikiUpdate").mockResolvedValue(undefined);
 
             expect(wikiUpdateCmd(plugin).checkCallback(true)).toBe(true);
@@ -7970,7 +7970,7 @@ describe("LilbeePlugin", () => {
         it("wiki command returns false when wikiEnabled is false", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
-            (plugin as any).wikiEnabled = false;
+            plugin.settings.wikiEnabled = false;
 
             const cmd = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.find(
                 (c: any[]) => c[0].id === "wiki",
@@ -7981,7 +7981,7 @@ describe("LilbeePlugin", () => {
         it("wiki command returns true when wikiEnabled is true", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
-            (plugin as any).wikiEnabled = true;
+            plugin.settings.wikiEnabled = true;
 
             const cmd = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.find(
                 (c: any[]) => c[0].id === "wiki",
@@ -7992,7 +7992,7 @@ describe("LilbeePlugin", () => {
         it("wiki-lint command returns false when wikiEnabled is false", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
-            (plugin as any).wikiEnabled = false;
+            plugin.settings.wikiEnabled = false;
 
             const cmd = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.find(
                 (c: any[]) => c[0].id === "wiki-lint",
@@ -8003,7 +8003,7 @@ describe("LilbeePlugin", () => {
         it("wiki-lint command returns true when wikiEnabled is true", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
-            (plugin as any).wikiEnabled = true;
+            plugin.settings.wikiEnabled = true;
 
             const cmd = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.find(
                 (c: any[]) => c[0].id === "wiki-lint",
@@ -8014,7 +8014,7 @@ describe("LilbeePlugin", () => {
         it("wiki command calls activateWikiView when not checking", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
-            (plugin as any).wikiEnabled = true;
+            plugin.settings.wikiEnabled = true;
             const spy = vi.spyOn(plugin, "activateWikiView").mockResolvedValue(undefined);
 
             const cmd = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.find(
@@ -8027,7 +8027,7 @@ describe("LilbeePlugin", () => {
         it("wiki-lint command calls runWikiLint when not checking", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
-            (plugin as any).wikiEnabled = true;
+            plugin.settings.wikiEnabled = true;
             const spy = vi.spyOn(plugin, "runWikiLint").mockResolvedValue(undefined);
 
             const cmd = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.find(
@@ -8040,7 +8040,7 @@ describe("LilbeePlugin", () => {
         it("wiki-drafts command returns false when wikiEnabled is false", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
-            (plugin as any).wikiEnabled = false;
+            plugin.settings.wikiEnabled = false;
 
             const cmd = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.find(
                 (c: any[]) => c[0].id === "wiki-drafts",
@@ -8051,7 +8051,7 @@ describe("LilbeePlugin", () => {
         it("wiki-drafts command returns true when wikiEnabled is true", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
-            (plugin as any).wikiEnabled = true;
+            plugin.settings.wikiEnabled = true;
 
             const cmd = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.find(
                 (c: any[]) => c[0].id === "wiki-drafts",
@@ -8062,7 +8062,7 @@ describe("LilbeePlugin", () => {
         it("wiki-drafts command opens DraftModal when not checking", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
-            (plugin as any).wikiEnabled = true;
+            plugin.settings.wikiEnabled = true;
             mockDraftModalOpen.mockClear();
 
             const cmd = (plugin.addCommand as ReturnType<typeof vi.fn>).mock.calls.find(
@@ -9268,6 +9268,42 @@ describe("agent integration", () => {
             expect(mockAgentPickerOpen).not.toHaveBeenCalled();
         });
 
+        it("stays out of the way while the setup wizard is open", async () => {
+            const { plugin } = await agentPlugin();
+            plugin.api.getAgentConfigIndex = vi
+                .fn()
+                .mockResolvedValue(okResult({ clients: [{ client: "opencode", cli_detected: true, cli_path: "/x" }] }));
+            plugin.setupWizardOpen = true;
+
+            await (plugin as any).runAgentBoot();
+
+            expect(mockAgentPickerOpen).not.toHaveBeenCalled();
+            expect(plugin.settings.agentIntegration.pickerShown).toBe(false);
+        });
+
+        it("offers the deferred picker once the setup wizard has closed", async () => {
+            const { plugin } = await agentPlugin();
+            plugin.api.getAgentConfigIndex = vi
+                .fn()
+                .mockResolvedValue(okResult({ clients: [{ client: "opencode", cli_detected: true, cli_path: "/x" }] }));
+            plugin.setupWizardOpen = true;
+            await (plugin as any).runAgentBoot();
+            plugin.setupWizardOpen = false;
+
+            await plugin.resumeDeferredAgentPicker();
+
+            expect(mockAgentPickerOpen).toHaveBeenCalledTimes(1);
+        });
+
+        it("has nothing to resume when the wizard never displaced the picker", async () => {
+            const { plugin } = await agentPlugin();
+            plugin.api.getAgentConfigIndex = vi.fn();
+
+            await plugin.resumeDeferredAgentPicker();
+
+            expect(plugin.api.getAgentConfigIndex).not.toHaveBeenCalled();
+        });
+
         it("stays quiet when the server cannot be asked", async () => {
             const { plugin } = await agentPlugin();
             plugin.api.getAgentConfigIndex = vi.fn().mockResolvedValue(errResult(new Error("offline")));
@@ -9410,5 +9446,18 @@ describe("agent integration", () => {
 
             expect(Notice.instances.some((n) => n.message.includes("Reload it"))).toBe(false);
         });
+    });
+});
+
+describe("wiki enablement", () => {
+    it("reads the stored setting, so there is no second flag to drift", async () => {
+        const plugin = await createPlugin({ serverMode: "external", wikiEnabled: false });
+        await plugin.loadSettings();
+
+        expect(plugin.wikiEnabled).toBe(false);
+        plugin.settings.wikiEnabled = true;
+        expect(plugin.wikiEnabled).toBe(true);
+        plugin.settings.wikiEnabled = false;
+        expect(plugin.wikiEnabled).toBe(false);
     });
 });

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -8073,77 +8073,49 @@ describe("LilbeePlugin", () => {
         });
     });
 
-    describe("fetchActiveModel — wiki detection", () => {
-        it("sets wikiEnabled from status response when user toggle is on", async () => {
+    describe("fetchActiveModel — wiki counters", () => {
+        it("records the page and draft counts the server reports", async () => {
             const plugin = await createPlugin({ wikiEnabled: true });
             await plugin.onload();
-
             plugin.api.listModels = vi.fn().mockResolvedValue({
                 chat: { active: "llama3", installed: ["llama3"], catalog: [] },
             });
-            plugin.api.status = vi.fn().mockResolvedValue({
-                isOk: () => true,
-                value: { sources: [], total_chunks: 0, wiki: { enabled: true } },
-            });
-
-            plugin.fetchActiveModel();
-            await new Promise((r) => setTimeout(r, 0));
-
-            expect((plugin as any).wikiEnabled).toBe(true);
-        });
-
-        it("server wiki enabled does not override user-disabled setting", async () => {
-            const plugin = await createPlugin({ serverMode: "external", wikiEnabled: false });
-            await plugin.onload();
-
-            plugin.api.listModels = vi.fn().mockResolvedValue({
-                chat: { active: "llama3", installed: ["llama3"], catalog: [] },
-            });
-            plugin.api.status = vi.fn().mockResolvedValue({
-                isOk: () => true,
-                value: { sources: [], total_chunks: 0, wiki: { enabled: true } },
-            });
+            plugin.api.wikiStatus = vi
+                .fn()
+                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { pages: 7, drafts: 2 } });
 
             await plugin.fetchActiveModel();
 
-            // User toggle is off — runtime flag stays false even though server has wiki
-            expect((plugin as any).wikiEnabled).toBe(false);
-            expect(plugin.settings.wikiEnabled).toBe(false);
+            expect(plugin.wikiPageCount).toBe(7);
+            expect(plugin.wikiDraftCount).toBe(2);
         });
 
-        it("wikiEnabled preserves setting when wiki is not in status", async () => {
-            const plugin = await createPlugin();
+        it("leaves the counters alone when the server cannot report them", async () => {
+            const plugin = await createPlugin({ wikiEnabled: true });
             await plugin.onload();
-
             plugin.api.listModels = vi.fn().mockResolvedValue({
                 chat: { active: "llama3", installed: ["llama3"], catalog: [] },
             });
-            plugin.api.status = vi.fn().mockResolvedValue({
-                isOk: () => true,
-                value: { sources: [], total_chunks: 0 },
-            });
+            plugin.api.wikiStatus = vi
+                .fn()
+                .mockResolvedValue({ isErr: () => true, isOk: () => false, error: new Error("no wiki") });
 
-            plugin.fetchActiveModel();
-            await new Promise((r) => setTimeout(r, 0));
+            await plugin.fetchActiveModel();
 
-            // Server has no wiki field — local setting (default false) preserved
-            expect((plugin as any).wikiEnabled).toBe(false);
+            expect(plugin.wikiPageCount).toBe(0);
+            expect(plugin.wikiDraftCount).toBe(0);
         });
 
-        it("wiki detection is best-effort and preserves setting on error", async () => {
+        it("is best-effort: a throwing wiki probe does not reject", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
-
             plugin.api.listModels = vi.fn().mockResolvedValue({
                 chat: { active: "llama3", installed: ["llama3"], catalog: [] },
             });
-            plugin.api.status = vi.fn().mockRejectedValue(new Error("offline"));
+            plugin.api.wikiStatus = vi.fn().mockRejectedValue(new Error("offline"));
 
-            plugin.fetchActiveModel();
-            await new Promise((r) => setTimeout(r, 0));
-
-            // Should not throw, wikiEnabled preserves setting default
-            expect((plugin as any).wikiEnabled).toBe(false);
+            await expect(plugin.fetchActiveModel()).resolves.toBeUndefined();
+            expect(plugin.wikiPageCount).toBe(0);
         });
     });
 
@@ -9346,7 +9318,7 @@ describe("agent integration", () => {
             expect(files["opencode.json"]).toBeDefined();
         });
 
-        it("wires this session only when the choice is not remembered", async () => {
+        it("connecting answers the question even when the choice is not remembered", async () => {
             const { plugin, files } = await agentPlugin();
             plugin.api.getAgentConfigIndex = vi
                 .fn()
@@ -9360,8 +9332,10 @@ describe("agent integration", () => {
 
             await (plugin as any).runAgentBoot();
 
+            // The agent is not persisted, but the question has been answered:
+            // without this the picker returned on every managed start.
             expect(plugin.settings.agentIntegration.agent).toBe("none");
-            expect(plugin.settings.agentIntegration.pickerShown).toBe(false);
+            expect(plugin.settings.agentIntegration.pickerShown).toBe(true);
             expect(files["opencode.json"]).toBeDefined();
         });
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -4671,7 +4671,7 @@ describe("managed mode settings", () => {
             expect(buttonOnClicks.length).toBeGreaterThanOrEqual(2);
         });
 
-        it("wiki enable toggle saves setting and syncs runtime flag", async () => {
+        it("wiki enable toggle saves the setting", async () => {
             const plugin = makePlugin({ wikiEnabled: true });
             (plugin as any).wikiEnabled = true;
             mockChatPicker(plugin);
@@ -4691,7 +4691,6 @@ describe("managed mode settings", () => {
             }
             expect(wikiToggleIdx).not.toBe(-1);
             expect(plugin.settings.wikiEnabled).toBe(false);
-            expect((plugin as any).wikiEnabled).toBe(false);
             expect(plugin.saveSettings).toHaveBeenCalled();
         });
 

--- a/tests/views/agent-picker-modal.test.ts
+++ b/tests/views/agent-picker-modal.test.ts
@@ -96,25 +96,25 @@ describe("AgentPickerModal", () => {
         expect(cards(root)[0].classList.contains("selected")).toBe(true);
     });
 
-    it("resolves with the selected agent and remembers by default", async () => {
+    it("resolves with the selected agent and wires the session only, unless asked to remember", async () => {
         const { root, result } = openPicker([detection(AGENT_CLIENT.OPENCODE, true)]);
         connectButton(root).trigger("click");
 
         expect(await result).toEqual({
             kind: AGENT_PICKER_RESULT.CONNECT,
             client: AGENT_CLIENT.OPENCODE,
-            remember: true,
+            remember: false,
         });
     });
 
-    it("wires the session only when the user unchecks remember", async () => {
+    it("stops asking only when the user checks remember", async () => {
         const { root, result } = openPicker([detection(AGENT_CLIENT.OPENCODE, true)]);
         const checkbox = root.find("lilbee-agent-picker-remember")?.children[0] as MockElement;
-        checkbox.checked = false;
+        checkbox.checked = true;
         checkbox.trigger("change");
         connectButton(root).trigger("click");
 
-        expect(await result).toMatchObject({ remember: false });
+        expect(await result).toMatchObject({ remember: true });
     });
 
     it("dismisses on Not now", async () => {

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -3681,9 +3681,10 @@ describe("SetupWizard", () => {
             expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_SETUP_INCOMPLETE)).toBe(false);
         });
 
-        it("records setup when welcome skips the server step on a running server", () => {
+        it("records setup when welcome skips the server step on a running managed server", () => {
             const plugin = makePlugin({
-                settings: { serverMode: "external", setupCompleted: false },
+                serverManager: { state: "ready" },
+                settings: { serverMode: "managed", setupCompleted: false },
             });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -3691,6 +3692,20 @@ describe("SetupWizard", () => {
             wizard.next();
 
             expect(plugin.settings.setupCompleted).toBe(true);
+        });
+
+        it("does not record setup when external mode is only a stored preference", () => {
+            const plugin = makePlugin({
+                serverManager: null,
+                settings: { serverMode: "external", setupCompleted: false },
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+
+            wizard.next();
+
+            expect(plugin.settings.setupCompleted).toBe(false);
+            expect(plugin.saveSettings).not.toHaveBeenCalled();
         });
 
         it("re-running setup on a configured vault does not rewrite the flag", async () => {

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -34,6 +34,8 @@ function makeEntry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
         featured: true,
         downloads: 0,
         param_count: "0.6B",
+        // A live server reports fit on every row; the picks filter requires it.
+        fit: "fits",
         ...overrides,
     };
 }
@@ -3865,6 +3867,17 @@ describe("SetupWizard", () => {
             ]);
 
             expect(picks.map((m) => m.hf_repo)).toEqual(["org/Qwen3-Input-Guard", "Qwen/Qwen3-4B-GGUF"]);
+        });
+
+        it("drops a model whose fit the server did not report", () => {
+            const known = makeEntry({ hf_repo: "Qwen/Qwen3-4B-GGUF", display_name: "Qwen3 4B", fit: "fits" });
+            const unknown = makeEntry({ hf_repo: "org/Mystery-70B", display_name: "Mystery 70B" });
+            delete (unknown as { fit?: unknown }).fit;
+
+            const picks = pickNativeChatModels([unknown, known]);
+
+            // An unknown size cannot be promised, so it is not a pick.
+            expect(picks.map((m) => m.hf_repo)).toEqual(["Qwen/Qwen3-4B-GGUF"]);
         });
 
         it("shows the raw list rather than an empty grid when curation removes everything", () => {

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -3832,25 +3832,6 @@ describe("SetupWizard", () => {
             expect(picks.map((m) => m.hf_repo)).toEqual(["a/small"]);
         });
 
-        it("drops safety-stripped community re-uploads", () => {
-            const picks = pickNativeChatModels([
-                makeEntry({ hf_repo: "x/Qwen3-27B-Uncensored", display_name: "Qwen3 27B Uncensored" }),
-                makeEntry({ hf_repo: "x/Qwen3-27B-Heretic-Abliterated", display_name: "Heretic Abliterated" }),
-                makeEntry({ hf_repo: "Qwen/Qwen3-4B-GGUF", display_name: "Qwen3 4B" }),
-            ]);
-
-            expect(picks.map((m) => m.hf_repo)).toEqual(["Qwen/Qwen3-4B-GGUF"]);
-        });
-
-        it("drops runtime-specific quants", () => {
-            const picks = pickNativeChatModels([
-                makeEntry({ hf_repo: "x/Flash-ROCm-FP4-Imatrix", display_name: "Flash ROCm FP4" }),
-                makeEntry({ hf_repo: "Qwen/Qwen3-4B-GGUF", display_name: "Qwen3 4B" }),
-            ]);
-
-            expect(picks.map((m) => m.hf_repo)).toEqual(["Qwen/Qwen3-4B-GGUF"]);
-        });
-
         it("drops models the server says it cannot load", () => {
             const picks = pickNativeChatModels([
                 makeEntry({ hf_repo: "x/Weird-Arch", display_name: "Weird", compat: "unsupported" }),
@@ -3860,13 +3841,23 @@ describe("SetupWizard", () => {
             expect(picks.map((m) => m.hf_repo)).toEqual(["Qwen/Qwen3-4B-GGUF"]);
         });
 
-        it("keeps a model whose name merely contains an excluded marker", () => {
+        it("shows nothing rather than a model that will not run", () => {
             const picks = pickNativeChatModels([
-                makeEntry({ hf_repo: "org/Qwen3-Input-Guard", display_name: "Qwen3 Input Guard" }),
-                makeEntry({ hf_repo: "Qwen/Qwen3-4B-GGUF", display_name: "Qwen3 4B" }),
+                makeEntry({ hf_repo: "a/huge", display_name: "Huge", fit: "wont_run" }),
+                makeEntry({ hf_repo: "b/also-huge", display_name: "Also Huge", fit: "wont_run" }),
             ]);
 
-            expect(picks.map((m) => m.hf_repo)).toEqual(["org/Qwen3-Input-Guard", "Qwen/Qwen3-4B-GGUF"]);
+            // The caller renders its own empty state; the full catalog is one button away.
+            expect(picks).toEqual([]);
+        });
+
+        it("keeps a model the picks row has no opinion about beyond fit", () => {
+            const picks = pickNativeChatModels([
+                makeEntry({ hf_repo: "x/Qwen3-27B-Uncensored", display_name: "Qwen3 27B Uncensored", fit: "fits" }),
+            ]);
+
+            // Fit is the only rule. Content is not judged by matching names.
+            expect(picks.map((m) => m.hf_repo)).toEqual(["x/Qwen3-27B-Uncensored"]);
         });
 
         it("drops a model whose fit the server did not report", () => {
@@ -3878,14 +3869,6 @@ describe("SetupWizard", () => {
 
             // An unknown size cannot be promised, so it is not a pick.
             expect(picks.map((m) => m.hf_repo)).toEqual(["Qwen/Qwen3-4B-GGUF"]);
-        });
-
-        it("shows the raw list rather than an empty grid when curation removes everything", () => {
-            const picks = pickNativeChatModels([
-                makeEntry({ hf_repo: "x/Only-Uncensored", display_name: "Only Uncensored" }),
-            ]);
-
-            expect(picks.map((m) => m.hf_repo)).toEqual(["x/Only-Uncensored"]);
         });
     });
 

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -160,7 +160,7 @@ describe("SetupWizard", () => {
         });
 
         it("marks previous slots as is-done and current as is-active on step 2 (Model)", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -187,7 +187,7 @@ describe("SetupWizard", () => {
         });
 
         it("marks prior slots done and last slot active on done step (step 6)", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 6;
@@ -239,7 +239,7 @@ describe("SetupWizard", () => {
         });
 
         it("welcome locality hint reflects external mode when chosen", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
 
@@ -274,7 +274,7 @@ describe("SetupWizard", () => {
 
         it("Get started advances to model picker when server is ready (external mode)", () => {
             const plugin = makePlugin({
-                settings: { serverMode: "external" },
+                settings: { serverMode: "external", setupCompleted: true },
             });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -386,7 +386,10 @@ describe("SetupWizard", () => {
         });
 
         it("pre-selects external when settings have external mode", () => {
-            const plugin = makePlugin({ serverManager: null, settings: { serverMode: "external" } });
+            const plugin = makePlugin({
+                serverManager: null,
+                settings: { serverMode: "external", setupCompleted: true },
+            });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 1;
@@ -817,7 +820,7 @@ describe("SetupWizard", () => {
                     display_name: "Qwen3 4B",
                 }),
             ];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -836,7 +839,7 @@ describe("SetupWizard", () => {
                 makeEntry({ name: "qwen/qwen3-0.6B", size_gb: 0.5, min_ram_gb: 4 }),
                 makeEntry({ name: "qwen/qwen3-4B", size_gb: 2.5, min_ram_gb: 8 }),
             ];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -851,7 +854,7 @@ describe("SetupWizard", () => {
 
         it("renders 'Our picks' section heading", async () => {
             const entries = [makeEntry({ name: "qwen/qwen3-0.6B" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -865,7 +868,7 @@ describe("SetupWizard", () => {
 
         it("renders model cards in grid layout", async () => {
             const entries = [makeEntry({ name: "qwen/qwen3-0.6B" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -882,7 +885,7 @@ describe("SetupWizard", () => {
                 makeEntry({ hf_repo: "qwen/qwen3-0.6B", size_gb: 0.5, min_ram_gb: 4 }),
                 makeEntry({ hf_repo: "qwen/qwen3-4B", size_gb: 2.5, min_ram_gb: 8 }),
             ];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -898,7 +901,7 @@ describe("SetupWizard", () => {
         });
 
         it("shows error when catalog fetch fails", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockRejectedValue(new Error("fail"));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -914,7 +917,7 @@ describe("SetupWizard", () => {
 
         it("sets empty featured models when catalog returns error result", async () => {
             const { err } = await import("../../src/result");
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(err(new Error("server error")));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -933,7 +936,7 @@ describe("SetupWizard", () => {
                     display_name: "Qwen3 0.6B",
                 }),
             ];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -947,7 +950,7 @@ describe("SetupWizard", () => {
         });
 
         it("Download & continue requires model selection", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse([]));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -964,7 +967,7 @@ describe("SetupWizard", () => {
 
         it("pull progress with no percent and no total skips update", async () => {
             const entries = [makeEntry({ name: "qwen/qwen3-0.6B" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
@@ -994,7 +997,7 @@ describe("SetupWizard", () => {
         });
 
         it("an empty featured list says so instead of rendering nothing", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -1017,7 +1020,7 @@ describe("SetupWizard", () => {
 
         it("a thrown catalog error reports its reason and retries", async () => {
             const entries = [makeEntry({ hf_repo: "Qwen/Qwen3-0.6B-GGUF" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockRejectedValue(new Error("socket hang up"));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -1038,7 +1041,7 @@ describe("SetupWizard", () => {
 
         it("a failed catalog load drops a selection made before it", async () => {
             const entries = [makeEntry({ hf_repo: "Qwen/Qwen3-0.6B-GGUF" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -1060,7 +1063,7 @@ describe("SetupWizard", () => {
         });
 
         it("disables the model step's action even when an embedding is selected", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(err(new Error("offline")));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -1076,7 +1079,7 @@ describe("SetupWizard", () => {
         });
 
         it("a failed catalog load says so and offers a retry", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(err(new Error("connection refused")));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -1090,7 +1093,7 @@ describe("SetupWizard", () => {
 
         it("retrying a failed catalog load renders the models", async () => {
             const entries = [makeEntry({ hf_repo: "Qwen/Qwen3-0.6B-GGUF" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(err(new Error("connection refused")));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -1110,7 +1113,7 @@ describe("SetupWizard", () => {
         });
 
         it("the download button is disabled while no model can be selected", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(err(new Error("offline")));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -1124,7 +1127,7 @@ describe("SetupWizard", () => {
 
         it("a failed download does not set the model or advance the step", async () => {
             const entries = [makeEntry({ hf_repo: "Qwen/Qwen3-0.6B-GGUF" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
@@ -1153,7 +1156,7 @@ describe("SetupWizard", () => {
 
         it("a failed embedding download does not set the model or advance the step", async () => {
             const entries = [makeEntry({ hf_repo: "nomic-ai/nomic-embed-text-v1.5-GGUF" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
@@ -1178,7 +1181,7 @@ describe("SetupWizard", () => {
 
         it("pull progress with current/total computes percentage", async () => {
             const entries = [makeEntry({ name: "qwen/qwen3-0.6B" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
@@ -1209,7 +1212,7 @@ describe("SetupWizard", () => {
 
         it("Download & continue uses hf_repo for both pull and setChatModel", async () => {
             const entries = [makeEntry({ hf_repo: "Qwen/Qwen3-0.6B-GGUF" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
@@ -1248,7 +1251,7 @@ describe("SetupWizard", () => {
 
         it("Download & continue pulls model and advances to sync step", async () => {
             const entries = [makeEntry({ hf_repo: "Qwen/Qwen3-0.6B-GGUF" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
@@ -1299,7 +1302,7 @@ describe("SetupWizard", () => {
 
         it("handles pull failure", async () => {
             const entries = [makeEntry({ name: "qwen/qwen3-0.6B" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
@@ -1323,7 +1326,7 @@ describe("SetupWizard", () => {
 
         it("pull surfaces token-stale message when stream throws SessionTokenError", async () => {
             const entries = [makeEntry({ name: "qwen/qwen3-0.6B" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
@@ -1348,7 +1351,7 @@ describe("SetupWizard", () => {
 
         it("SSE_EVENT.ERROR during pull shows notice and updates status", async () => {
             const entries = [makeEntry({ name: "qwen/qwen3-0.6B" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
@@ -1371,7 +1374,7 @@ describe("SetupWizard", () => {
 
         it("SSE_EVENT.ERROR with string data during pull updates status", async () => {
             const entries = [makeEntry({ name: "qwen/qwen3-0.6B" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
@@ -1394,7 +1397,7 @@ describe("SetupWizard", () => {
 
         it("SSE_EVENT.ERROR with empty object during pull uses fallback message", async () => {
             const entries = [makeEntry({ name: "qwen/qwen3-0.6B" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
@@ -1417,7 +1420,7 @@ describe("SetupWizard", () => {
 
         it("handles pull abort", async () => {
             const entries = [makeEntry({ name: "qwen/qwen3-0.6B" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             const abortErr = new Error("aborted");
             abortErr.name = "AbortError";
@@ -1441,7 +1444,7 @@ describe("SetupWizard", () => {
         });
 
         it("Back from model picker always returns to server mode (gives users a way to switch)", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(makeCatalogResponse([]));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -1475,7 +1478,7 @@ describe("SetupWizard", () => {
         it("Browse full catalog button opens CatalogModal", async () => {
             const { CatalogModal } = await import("../../src/views/catalog-modal");
             const entries = [];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -1491,7 +1494,7 @@ describe("SetupWizard", () => {
 
         it("Back cancels ongoing pull", async () => {
             const entries = [makeEntry({ name: "qwen/qwen3-0.6B" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             let abortSignal: AbortSignal | null = null;
             plugin.api.pullModel = vi
@@ -1524,7 +1527,7 @@ describe("SetupWizard", () => {
         });
 
         it("Skip setup aborts active pull and closes wizard", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi
                 .fn()
                 .mockResolvedValue(
@@ -1550,7 +1553,7 @@ describe("SetupWizard", () => {
 
     describe("Step 3: Sync", () => {
         it("renders sync screen and starts syncing", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.syncStream = vi.fn().mockReturnValue(
                 (async function* () {
                     yield { event: SSE_EVENT.FILE_START, data: { current_file: 1, total_files: 10 } };
@@ -1574,7 +1577,7 @@ describe("SetupWizard", () => {
         });
 
         it("renders BATCH_PROGRESS percent and per-file status during initial sync", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             let labelAtBatch = "";
             plugin.api.syncStream = vi.fn().mockReturnValue(
                 (async function* () {
@@ -1603,7 +1606,7 @@ describe("SetupWizard", () => {
         });
 
         it("sync abort shows notice", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const abortErr = new Error("aborted");
             abortErr.name = "AbortError";
             plugin.api.syncStream = vi.fn().mockReturnValue(
@@ -1622,7 +1625,7 @@ describe("SetupWizard", () => {
         });
 
         it("sync surfaces token-stale message when stream throws SessionTokenError", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.syncStream = vi.fn().mockReturnValue(
                 (async function* () {
                     throw new SessionTokenError(401, "stale");
@@ -1641,7 +1644,7 @@ describe("SetupWizard", () => {
         });
 
         it("sync failure shows error message", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.syncStream = vi.fn().mockReturnValue(
                 (async function* () {
                     throw new Error("network");
@@ -1659,7 +1662,7 @@ describe("SetupWizard", () => {
         });
 
         it("SSE_EVENT.ERROR during sync sets progress label and shows indexing failed", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.syncStream = vi.fn().mockReturnValue(
                 (async function* () {
                     yield { event: SSE_EVENT.ERROR, data: { message: "sync exploded" } };
@@ -1677,7 +1680,7 @@ describe("SetupWizard", () => {
         });
 
         it("SSE_EVENT.ERROR with string data during sync shows indexing failed", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.syncStream = vi.fn().mockReturnValue(
                 (async function* () {
                     yield { event: SSE_EVENT.ERROR, data: "raw sync error" };
@@ -1695,7 +1698,7 @@ describe("SetupWizard", () => {
         });
 
         it("SSE_EVENT.ERROR with empty object during sync uses fallback message", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.syncStream = vi.fn().mockReturnValue(
                 (async function* () {
                     yield { event: SSE_EVENT.ERROR, data: {} };
@@ -1713,7 +1716,7 @@ describe("SetupWizard", () => {
         });
 
         it("Back from sync cancels and returns to model picker", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             let abortSignal: AbortSignal | null = null;
             plugin.api.syncStream = vi.fn().mockImplementation((signal?: AbortSignal) => {
                 abortSignal = signal ?? null;
@@ -1737,7 +1740,7 @@ describe("SetupWizard", () => {
 
         it("Skip setup aborts sync and closes wizard", async () => {
             let _abortSignal: AbortSignal | null = null;
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.syncStream = vi.fn().mockImplementation((signal?: AbortSignal) => {
                 _abortSignal = signal ?? null;
                 return (async function* () {
@@ -1761,7 +1764,7 @@ describe("SetupWizard", () => {
 
     describe("Step 4: Wiki", () => {
         it("renders wiki step with title, description, pros and cons", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 5;
@@ -1780,7 +1783,7 @@ describe("SetupWizard", () => {
         });
 
         it("presents the wiki as optional rather than experimental", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 5;
@@ -1792,7 +1795,7 @@ describe("SetupWizard", () => {
         });
 
         it("says the build is GPU heavy and blocks chat, both on the page and in the tooltip", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 5;
@@ -1812,7 +1815,7 @@ describe("SetupWizard", () => {
         });
 
         it("leaves the wiki off unless the enable card is chosen", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 5;
@@ -1827,7 +1830,7 @@ describe("SetupWizard", () => {
         });
 
         it("renders enable and disable option cards", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 5;
@@ -1870,7 +1873,7 @@ describe("SetupWizard", () => {
         });
 
         it("clicking enable selects it and deselects disable", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 5;
@@ -1898,7 +1901,7 @@ describe("SetupWizard", () => {
         });
 
         it("Next saves wikiEnabled=true to settings when enabled", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 5;
@@ -1921,7 +1924,7 @@ describe("SetupWizard", () => {
         });
 
         it("Next saves wikiEnabled=false to settings when disabled", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 5;
@@ -1937,7 +1940,7 @@ describe("SetupWizard", () => {
         });
 
         it("Back returns to sync step", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.syncStream = vi.fn().mockReturnValue(
                 (async function* () {
                     await new Promise(() => {});
@@ -1957,7 +1960,7 @@ describe("SetupWizard", () => {
         });
 
         it("Skip setup closes the wizard", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             const closeSpy = vi.spyOn(wizard, "close");
             wizard.open();
@@ -1971,7 +1974,7 @@ describe("SetupWizard", () => {
         });
 
         it("renders step indicator on wiki step", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 5;
@@ -1985,7 +1988,7 @@ describe("SetupWizard", () => {
         });
 
         it("renders pros list items", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 5;
@@ -1997,7 +2000,7 @@ describe("SetupWizard", () => {
         });
 
         it("renders cons list items", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 5;
@@ -2012,7 +2015,7 @@ describe("SetupWizard", () => {
 
     describe("Step 5: Done", () => {
         it("renders done screen with summary", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).pulledModelName = "qwen3:8b";
@@ -2035,7 +2038,7 @@ describe("SetupWizard", () => {
         });
 
         it("renders done screen without model/sync info if skipped", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 6;
@@ -2047,7 +2050,7 @@ describe("SetupWizard", () => {
         });
 
         it("Open chat marks setup complete and opens chat view", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             const closeSpy = vi.spyOn(wizard, "close");
             wizard.open();
@@ -2069,7 +2072,7 @@ describe("SetupWizard", () => {
         // stacks it on the settings surface. Leaving settings open hides the
         // chat view the button just opened.
         it("Open chat closes the settings surface", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const app = plugin.app as unknown as App;
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -2089,7 +2092,7 @@ describe("SetupWizard", () => {
         // Dismissing settings is best-effort on an undocumented API; opening chat is the promise the
         // button makes, so it must survive an Obsidian that no longer exposes the settings surface.
         it("Open chat still opens the chat view when the settings surface is gone", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             (plugin.app as unknown as App).setting = undefined;
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -2107,7 +2110,7 @@ describe("SetupWizard", () => {
         });
 
         it("shows tips about what to try", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 6;
@@ -2120,7 +2123,7 @@ describe("SetupWizard", () => {
         });
 
         it("renders 'Setup complete' section heading inside summary card", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 6;
@@ -2135,7 +2138,7 @@ describe("SetupWizard", () => {
         });
 
         it("renders summary in summary-card div", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).pulledModelName = "test-model";
@@ -2148,7 +2151,7 @@ describe("SetupWizard", () => {
         });
 
         it("renders tips with icon spans", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 6;
@@ -2185,7 +2188,7 @@ describe("SetupWizard", () => {
         });
 
         it("back() at step 0 stays at step 0", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             wizard.back();
@@ -2195,7 +2198,7 @@ describe("SetupWizard", () => {
         });
 
         it("back() at step 4 (sync) goes to step 3 (embedding picker)", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -2207,7 +2210,7 @@ describe("SetupWizard", () => {
         });
 
         it("back() at step 6 (done) goes to step 5 (wiki)", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 6;
@@ -2222,7 +2225,7 @@ describe("SetupWizard", () => {
         it("aborts pull controller on close", async () => {
             const entries = [makeEntry({ name: "qwen/qwen3-0.6B" })];
             let capturedSignal: AbortSignal | null = null;
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             plugin.api.pullModel = vi
                 .fn()
@@ -2249,7 +2252,7 @@ describe("SetupWizard", () => {
 
         it("aborts sync controller on close", async () => {
             let capturedSignal: AbortSignal | null = null;
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.syncStream = vi.fn().mockImplementation((signal?: AbortSignal) => {
                 capturedSignal = signal ?? null;
                 return (async function* () {
@@ -2274,7 +2277,7 @@ describe("SetupWizard", () => {
                 makeEntry({ name: "qwen/qwen3-0.6B", min_ram_gb: 4 }),
                 makeEntry({ name: "qwen/qwen3-4B", min_ram_gb: 8 }),
             ];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -2291,7 +2294,7 @@ describe("SetupWizard", () => {
     describe("Full flow integration", () => {
         it("complete flow: welcome -> model -> embed -> sync -> wiki -> done", async () => {
             const entries = [makeEntry({ name: "qwen/qwen3-0.6B" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
@@ -2580,7 +2583,7 @@ describe("SetupWizard", () => {
 
     describe("sync with zero total_files", () => {
         it("handles FILE_START with total_files=0 without division error", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.syncStream = vi.fn().mockReturnValue(
                 (async function* () {
                     yield { event: SSE_EVENT.FILE_START, data: { current_file: 0, total_files: 0 } };
@@ -2604,7 +2607,7 @@ describe("SetupWizard", () => {
 
     describe("pullSelectedModel early return", () => {
         it("returns early when selectedModel is null", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             // Call pullSelectedModel directly with no selected model
@@ -2617,7 +2620,7 @@ describe("SetupWizard", () => {
 
         it("surfaces notice and keeps step when setChatModel returns err after successful pull", async () => {
             Notice.clear();
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
                     yield { event: SSE_EVENT.PROGRESS, data: { percent: 100 } };
@@ -2644,7 +2647,7 @@ describe("SetupWizard", () => {
 
     describe("Step 3: Embedding Picker", () => {
         it("renders embedding picker step", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -2657,7 +2660,7 @@ describe("SetupWizard", () => {
         });
 
         it("back from embedding picker goes to model picker and aborts pull", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -2679,7 +2682,7 @@ describe("SetupWizard", () => {
         });
 
         it("skip button closes wizard and aborts pull if running", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             const closeSpy = vi.spyOn(wizard, "close");
@@ -2699,7 +2702,7 @@ describe("SetupWizard", () => {
         });
 
         it("download & continue with no selection advances to sync step", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
             plugin.api.syncStream = vi.fn().mockReturnValue(
                 (async function* () {
@@ -2731,7 +2734,7 @@ describe("SetupWizard", () => {
                     installed: true,
                 }),
             ];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             plugin.api.syncStream = vi.fn().mockReturnValue(
                 (async function* () {
@@ -2765,7 +2768,7 @@ describe("SetupWizard", () => {
                     installed: true,
                 }),
             ];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             plugin.api.setEmbeddingModel = vi.fn().mockResolvedValue(err(new Error("activate fail")));
             plugin.api.syncStream = vi.fn().mockReturnValue(
@@ -2791,7 +2794,7 @@ describe("SetupWizard", () => {
         });
 
         it("pullEmbeddingModel early return when selectedEmbedding is null", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).selectedEmbedding = null;
@@ -2801,7 +2804,7 @@ describe("SetupWizard", () => {
         });
 
         it("pullEmbeddingModel handles pull failure", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
                     throw new Error("network error");
@@ -2822,7 +2825,7 @@ describe("SetupWizard", () => {
         });
 
         it("pullEmbeddingModel surfaces token-stale message on SessionTokenError", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
                     throw new SessionTokenError(401, "stale");
@@ -2845,7 +2848,7 @@ describe("SetupWizard", () => {
         });
 
         it("pullEmbeddingModel handles AbortError", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
                     const e = new Error("abort");
@@ -2868,7 +2871,7 @@ describe("SetupWizard", () => {
         });
 
         it("pullEmbeddingModel succeeds and sets embedding model", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
                     yield { event: SSE_EVENT.PROGRESS, data: { percent: 50 } };
@@ -2895,7 +2898,7 @@ describe("SetupWizard", () => {
 
         it("pullEmbeddingModel surfaces notice and keeps step when setEmbeddingModel returns err", async () => {
             Notice.clear();
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
                     yield { event: SSE_EVENT.PROGRESS, data: { percent: 100 } };
@@ -2920,7 +2923,7 @@ describe("SetupWizard", () => {
         });
 
         it("pullEmbeddingModel handles progress with current/total", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
                     yield { event: SSE_EVENT.PROGRESS, data: { current: 50, total: 100 } };
@@ -2946,7 +2949,7 @@ describe("SetupWizard", () => {
         });
 
         it("pullEmbeddingModel handles progress with no percent and no total", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
                     yield { event: SSE_EVENT.PROGRESS, data: {} };
@@ -2972,7 +2975,7 @@ describe("SetupWizard", () => {
         });
 
         it("pullEmbeddingModel handles SSE error with string data", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
                     yield { event: SSE_EVENT.ERROR, data: "raw string error" };
@@ -2998,7 +3001,7 @@ describe("SetupWizard", () => {
         });
 
         it("pullEmbeddingModel handles SSE error event", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
                     yield { event: SSE_EVENT.ERROR, data: { message: "pull failed" } };
@@ -3024,7 +3027,7 @@ describe("SetupWizard", () => {
         });
 
         it("pullEmbeddingModel handles SSE error with empty object", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
                     yield { event: SSE_EVENT.ERROR, data: {} };
@@ -3050,7 +3053,7 @@ describe("SetupWizard", () => {
         });
 
         it("selectEmbedding updates selection on grid", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             const grid = new MockElement("div") as unknown as HTMLElement;
@@ -3067,7 +3070,7 @@ describe("SetupWizard", () => {
         });
 
         it("loadEmbeddingModels reports an empty list and retries", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -3087,7 +3090,7 @@ describe("SetupWizard", () => {
         });
 
         it("loadEmbeddingModels retries after an isErr result", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(err(new Error("gateway timeout")));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -3107,7 +3110,7 @@ describe("SetupWizard", () => {
         });
 
         it("loadEmbeddingModels handles catalog error", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockRejectedValue(new Error("fail"));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -3129,7 +3132,7 @@ describe("SetupWizard", () => {
         });
 
         it("loadEmbeddingModels handles catalog isErr result", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(err(new Error("fail")));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -3144,7 +3147,7 @@ describe("SetupWizard", () => {
                 makeEntry({ name: "nomic-embed-text", hf_repo: "nomic/nomic-embed-text", task: "embedding" }),
                 makeEntry({ name: "bge-small", hf_repo: "bge/bge-small", task: "embedding" }),
             ];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -3173,7 +3176,7 @@ describe("SetupWizard", () => {
                 makeEntry({ name: "nomic-embed-text", hf_repo: "nomic/nomic-embed-text", task: "embedding" }),
                 makeEntry({ name: "bge-small", hf_repo: "bge/bge-small", task: "embedding" }),
             ];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -3204,7 +3207,7 @@ describe("SetupWizard", () => {
 
     describe("sync with FILE_START progress update", () => {
         it("updates progress bar during sync", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.syncStream = vi.fn().mockReturnValue(
                 (async function* () {
                     yield { event: SSE_EVENT.FILE_START, data: { current_file: 3, total_files: 10 } };
@@ -3230,7 +3233,7 @@ describe("SetupWizard", () => {
 
     describe("done screen with processed files count", () => {
         it("shows files processed when sync result has additions", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).pulledModelName = "test-model";
@@ -3251,7 +3254,7 @@ describe("SetupWizard", () => {
         });
 
         it("does not show files processed when no additions or updates", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).syncResult = {
@@ -3275,7 +3278,7 @@ describe("SetupWizard", () => {
         // The step container gets a semantic data-step attribute that drives
         // per-step CSS (rail color, badge color, progress accent).
         it("tags the step container with its semantic data-step key", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
             plugin.api.syncStream = vi.fn().mockReturnValue(
                 (async function* () {
@@ -3306,7 +3309,7 @@ describe("SetupWizard", () => {
         });
 
         it("renders a step header badge with tabular step number + uppercase label", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 2;
@@ -3331,7 +3334,7 @@ describe("SetupWizard", () => {
         });
 
         it("adds the hero rail to every rendered step", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([])));
             plugin.api.syncStream = vi.fn().mockReturnValue(
                 (async function* () {
@@ -3355,7 +3358,7 @@ describe("SetupWizard", () => {
     describe("progress panel", () => {
         function setupModelPickerActive() {
             const entries = [makeEntry({ name: "qwen/qwen3-0.6B" })];
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
             // pullModel returns a no-yield async iterator so the method resolves quickly.
             plugin.api.pullModel = vi.fn().mockReturnValue({
@@ -3423,7 +3426,7 @@ describe("SetupWizard", () => {
         });
 
         it("sync step progress fill starts out indeterminate", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             // Block forever so the sync step stays on screen.
             plugin.api.syncStream = vi.fn().mockReturnValue({
                 async *[Symbol.asyncIterator]() {
@@ -3465,7 +3468,7 @@ describe("SetupWizard", () => {
 
     describe("Wiki step disclosure", () => {
         it("nests pros and cons inside a <details> tradeoffs element", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 5;
@@ -3480,7 +3483,7 @@ describe("SetupWizard", () => {
         });
 
         it("uses the localised tradeoffs summary label", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             (wizard as any).step = 5;
@@ -3496,7 +3499,7 @@ describe("SetupWizard", () => {
         it("model picker omits the RAM banner when system memory is unknown", async () => {
             const spy = vi.spyOn(utils, "getSystemMemoryGB").mockReturnValue(null);
             try {
-                const plugin = makePlugin({ settings: { serverMode: "external" } });
+                const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
                 plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([makeEntry()])));
                 const wizard = new SetupWizard(plugin.app as any, plugin as any);
                 wizard.open();
@@ -3512,7 +3515,7 @@ describe("SetupWizard", () => {
         });
 
         it("pullSelectedModel ignores SSE events that are neither progress nor error", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
                     yield { event: SSE_EVENT.DONE, data: {} };
@@ -3535,7 +3538,7 @@ describe("SetupWizard", () => {
         });
 
         it("pullEmbeddingModel ignores SSE events that are neither progress nor error", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.pullModel = vi.fn().mockReturnValue(
                 (async function* () {
                     yield { event: SSE_EVENT.DONE, data: {} };
@@ -3564,7 +3567,7 @@ describe("SetupWizard", () => {
         });
 
         it("sync EMBED event without a file name leaves the label unchanged", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.syncStream = vi.fn().mockReturnValue(
                 (async function* () {
                     yield { event: SSE_EVENT.EMBED, data: {} };
@@ -3586,7 +3589,7 @@ describe("SetupWizard", () => {
         });
 
         it("sync that ends without a DONE event still advances and leaves syncResult unset", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.syncStream = vi.fn().mockReturnValue(
                 (async function* () {
                     yield { event: SSE_EVENT.FILE_START, data: { current_file: 1, total_files: 1 } };
@@ -3696,7 +3699,7 @@ describe("SetupWizard", () => {
             expect(plugin.settings.setupCompleted).toBe(true);
         });
 
-        it("does not record setup when external mode is only a stored preference", () => {
+        it("sends a stored external preference to the server step, not past it", () => {
             const plugin = makePlugin({
                 serverManager: null,
                 settings: { serverMode: "external", setupCompleted: false },
@@ -3706,6 +3709,9 @@ describe("SetupWizard", () => {
 
             wizard.next();
 
+            // Until setup completes the plugin has not pointed its client at a
+            // server, so the model step could not load anything.
+            expect((wizard as any).step).toBe(WIZARD_STEP.SERVER_MODE);
             expect(plugin.settings.setupCompleted).toBe(false);
             expect(plugin.saveSettings).not.toHaveBeenCalled();
         });
@@ -3798,7 +3804,7 @@ describe("SetupWizard", () => {
 
     describe("Retrying a failed catalog load", () => {
         it("gives the primary action back when the retry succeeds", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi
                 .fn()
                 .mockResolvedValueOnce(err(new Error("connection refused")))
@@ -3879,7 +3885,7 @@ describe("SetupWizard", () => {
                 display_name: "LFM2.5 2.6B",
                 installed: true,
             });
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([entry])));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -3906,7 +3912,7 @@ describe("SetupWizard", () => {
                 display_name: "LFM2.5 2.6B",
                 installed: true,
             });
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([entry])));
             plugin.api.setChatModel = vi.fn().mockResolvedValue(err(new Error("model is not loadable")));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
@@ -3928,7 +3934,7 @@ describe("SetupWizard", () => {
         });
 
         it("labels the action Download & continue for a model that is not on disk", async () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([makeEntry()])));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -3948,7 +3954,7 @@ describe("SetupWizard", () => {
                 display_name: "LFM2.5 2.6B",
                 installed: true,
             });
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([entry])));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
@@ -3982,7 +3988,7 @@ describe("SetupWizard", () => {
 
     describe("Agent picker never covers the wizard", () => {
         it("marks the plugin as showing setup while the wizard is open", () => {
-            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
 
             wizard.open();

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -3830,32 +3830,23 @@ describe("SetupWizard", () => {
     });
 
     describe("Our picks is curated", () => {
-        it("drops models the host cannot run", () => {
+        it("keeps a model the host cannot run for the row to substitute", () => {
             const picks = pickNativeChatModels([
                 makeEntry({ hf_repo: "a/huge", display_name: "Huge", fit: "wont_run" }),
                 makeEntry({ hf_repo: "a/small", display_name: "Small", fit: "fits" }),
             ]);
 
-            expect(picks.map((m) => m.hf_repo)).toEqual(["a/small"]);
+            // Ranking does not drop rows. The row replaces them, and keeps them when nothing replaces them.
+            expect(picks.map((m) => m.hf_repo)).toEqual(["a/huge", "a/small"]);
         });
 
-        it("drops models the server says it cannot load", () => {
+        it("keeps a model the server says it cannot load for the row to substitute", () => {
             const picks = pickNativeChatModels([
                 makeEntry({ hf_repo: "x/Weird-Arch", display_name: "Weird", compat: "unsupported" }),
                 makeEntry({ hf_repo: "Qwen/Qwen3-4B-GGUF", display_name: "Qwen3 4B" }),
             ]);
 
-            expect(picks.map((m) => m.hf_repo)).toEqual(["Qwen/Qwen3-4B-GGUF"]);
-        });
-
-        it("shows nothing rather than a model that will not run", () => {
-            const picks = pickNativeChatModels([
-                makeEntry({ hf_repo: "a/huge", display_name: "Huge", fit: "wont_run" }),
-                makeEntry({ hf_repo: "b/also-huge", display_name: "Also Huge", fit: "wont_run" }),
-            ]);
-
-            // The caller renders its own empty state; the full catalog is one button away.
-            expect(picks).toEqual([]);
+            expect(picks.map((m) => m.hf_repo)).toEqual(["Qwen/Qwen3-4B-GGUF", "x/Weird-Arch"]);
         });
 
         it("keeps a model the picks row has no opinion about beyond fit", () => {
@@ -3867,39 +3858,227 @@ describe("SetupWizard", () => {
             expect(picks.map((m) => m.hf_repo)).toEqual(["x/Qwen3-27B-Uncensored"]);
         });
 
-        it("drops a model whose fit the server did not report", () => {
+        it("the row is never empty when the server returned models", async () => {
+            // Every criterion fails and the wider catalog cannot answer: the row a substitute cannot replace stands.
+            const refused = makeEntry({
+                hf_repo: "org/Refused-A",
+                display_name: "Refused A",
+                fit: "wont_run",
+                compat: "unsupported",
+            });
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
+            plugin.api.catalog = vi
+                .fn()
+                .mockResolvedValueOnce(ok(makeCatalogResponse([refused])))
+                .mockResolvedValue(err(new Error("backfill unavailable")));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = WIZARD_STEP.MODEL_PICKER;
+            (wizard as any).renderStep();
+            await tick();
+            await tick();
+
+            expect((wizard as any).featuredModels.map((m: CatalogEntry) => m.hf_repo)).toEqual(["org/Refused-A"]);
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some((t) => t.includes(MESSAGES.WIZARD_NO_MODELS_OFFERED))).toBe(false);
+        });
+
+        it("keeps a model whose compat the server has not judged", () => {
+            const unknown = makeEntry({ hf_repo: "org/Unjudged-7B", display_name: "Unjudged 7B", fit: "fits" });
+            delete (unknown as { compat?: unknown }).compat;
+            const unsupported = makeEntry({
+                hf_repo: "org/Refused-7B",
+                display_name: "Refused 7B",
+                fit: "fits",
+                compat: "unsupported",
+            });
+
+            const picks = pickNativeChatModels([unknown, unsupported]);
+
+            // Ranking keeps every row it was given. What counts as refused is asserted where it is applied,
+            // in "substitutes only the row the server refused".
+            expect(picks.map((m) => m.hf_repo)).toEqual(["org/Unjudged-7B", "org/Refused-7B"]);
+        });
+
+        it("keeps a model whose fit the server did not report", () => {
             const known = makeEntry({ hf_repo: "Qwen/Qwen3-4B-GGUF", display_name: "Qwen3 4B", fit: "fits" });
             const unknown = makeEntry({ hf_repo: "org/Mystery-70B", display_name: "Mystery 70B" });
             delete (unknown as { fit?: unknown }).fit;
 
             const picks = pickNativeChatModels([unknown, known]);
 
-            // An unknown size cannot be promised, so it is not a pick.
-            expect(picks.map((m) => m.hf_repo)).toEqual(["Qwen/Qwen3-4B-GGUF"]);
+            // Ranking keeps every row it was given, ordered by family preference. Whether an unreported
+            // fit costs a row its place is asserted in "keeps a row whose fit the server did not report".
+            expect(picks.map((m) => m.hf_repo)).toEqual(["Qwen/Qwen3-4B-GGUF", "org/Mystery-70B"]);
+        });
+    });
+
+    describe("The picks row substitutes what will not run", () => {
+        function catalogRow(i: number): CatalogEntry {
+            return makeEntry({ hf_repo: `org/Other-${i}-GGUF`, display_name: `Other ${i}`, featured: false });
+        }
+
+        function splitCatalog(featured: CatalogEntry[], wider: CatalogEntry[] | Error) {
+            return vi.fn((params?: { featured?: boolean }) => {
+                if (params?.featured) return Promise.resolve(ok(makeCatalogResponse(featured)));
+                if (wider instanceof Error) return Promise.resolve(err(wider));
+                return Promise.resolve(ok(makeCatalogResponse(wider)));
+            });
+        }
+
+        async function openPicksStep(catalog: ReturnType<typeof vi.fn>) {
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
+            plugin.api.catalog = catalog;
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+            await tick();
+            return { plugin, el: wizard.contentEl as unknown as MockElement };
+        }
+
+        function renderedRepos(el: MockElement): (string | undefined)[] {
+            return el.findAll("lilbee-model-card").map((c) => c.dataset.repo);
+        }
+
+        function featuredRow(size: number): CatalogEntry[] {
+            return Array.from({ length: size }, (_, i) => makeEntry({ hf_repo: `f/${i}`, display_name: `F ${i}` }));
+        }
+
+        it("replaces the rows that will not run with the most popular ones that do", async () => {
+            const featured = featuredRow(6).concat(
+                makeEntry({ hf_repo: "f/huge", display_name: "Huge", fit: "wont_run" }),
+                makeEntry({ hf_repo: "f/weird", display_name: "Weird", compat: "unsupported" }),
+            );
+            const wider = [
+                ...featured,
+                catalogRow(0),
+                makeEntry({ hf_repo: "w/huge", display_name: "Wider huge", fit: "wont_run", featured: false }),
+                catalogRow(1),
+                catalogRow(2),
+            ];
+
+            const { plugin, el } = await openPicksStep(splitCatalog(featured, wider));
+
+            const repos = renderedRepos(el);
+            expect(repos.length).toBe(8);
+            expect(new Set(repos).size).toBe(8);
+            expect(repos).toEqual([...featuredRow(6).map((m) => m.hf_repo), "org/Other-0-GGUF", "org/Other-1-GGUF"]);
+            expect(plugin.api.catalog).toHaveBeenCalledTimes(2);
         });
 
-        it("drops a model whose compat the server reports as unknown", () => {
-            const supported = makeEntry({ hf_repo: "Qwen/Qwen3-4B-GGUF", display_name: "Qwen3 4B" });
-            const unknown = makeEntry({
-                hf_repo: "org/Mystery-Arch",
-                display_name: "Mystery Arch",
-                compat: "unknown",
+        it("asks only for the featured list when every row runs", async () => {
+            const featured = featuredRow(8);
+
+            const { plugin, el } = await openPicksStep(splitCatalog(featured, [catalogRow(0)]));
+
+            expect(renderedRepos(el)).toEqual(featured.map((m) => m.hf_repo));
+            expect(plugin.api.catalog).toHaveBeenCalledTimes(1);
+        });
+
+        it("asks only for the featured list when the server reported no fits", async () => {
+            const featured = featuredRow(3).map((m) => {
+                delete (m as { fit?: unknown }).fit;
+                return m;
             });
 
-            const picks = pickNativeChatModels([unknown, supported]);
+            const { plugin, el } = await openPicksStep(splitCatalog(featured, [catalogRow(0)]));
 
-            // An unknown architecture cannot be promised to run, so it is not a pick.
-            expect(picks.map((m) => m.hf_repo)).toEqual(["Qwen/Qwen3-4B-GGUF"]);
+            // An unknown fit is not a refusal, so there is nothing to replace and nothing to fetch.
+            expect(renderedRepos(el)).toEqual(["f/0", "f/1", "f/2"]);
+            expect(plugin.api.catalog).toHaveBeenCalledTimes(1);
         });
 
-        it("drops a model whose compat the server did not report", () => {
-            const supported = makeEntry({ hf_repo: "Qwen/Qwen3-4B-GGUF", display_name: "Qwen3 4B" });
-            const missing = makeEntry({ hf_repo: "org/No-Compat", display_name: "No Compat" });
-            delete (missing as { compat?: unknown }).compat;
+        it("substitutes only the row the server refused", async () => {
+            const unjudged = makeEntry({ hf_repo: "f/unjudged", display_name: "Unjudged", fit: "fits" });
+            delete (unjudged as { compat?: unknown }).compat;
+            const refused = makeEntry({ hf_repo: "f/huge", display_name: "Huge", fit: "wont_run" });
+            const candidate = makeEntry({ hf_repo: "w/unjudged", display_name: "Wider unjudged", featured: false });
+            delete (candidate as { compat?: unknown }).compat;
 
-            const picks = pickNativeChatModels([missing, supported]);
+            const { el } = await openPicksStep(splitCatalog([unjudged, refused], [candidate, catalogRow(0)]));
 
-            expect(picks.map((m) => m.hf_repo)).toEqual(["Qwen/Qwen3-4B-GGUF"]);
+            // An unjudged compat costs a row nothing, on the row itself and on what may replace one.
+            expect(renderedRepos(el)).toEqual(["f/unjudged", "w/unjudged"]);
+        });
+
+        it("keeps a row whose fit the server did not report", async () => {
+            const unreported = makeEntry({ hf_repo: "f/unreported", display_name: "Unreported" });
+            delete (unreported as { fit?: unknown }).fit;
+            const refused = makeEntry({ hf_repo: "f/huge", display_name: "Huge", fit: "wont_run" });
+            const candidate = makeEntry({ hf_repo: "w/unreported", display_name: "Wider unreported", featured: false });
+            delete (candidate as { fit?: unknown }).fit;
+
+            const { el } = await openPicksStep(splitCatalog([unreported, refused], [candidate, catalogRow(0)]));
+
+            // An unreported fit costs a row nothing either. Only a reported wont_run is replaced.
+            expect(renderedRepos(el)).toEqual(["f/unreported", "w/unreported"]);
+        });
+
+        it("does not substitute a frontier model whose key is missing", async () => {
+            const featured = featuredRow(1).concat(
+                makeEntry({ hf_repo: "f/huge", display_name: "Huge", fit: "wont_run" }),
+            );
+            const needsKey = makeEntry({
+                hf_repo: "openai/gpt-5",
+                display_name: "GPT-5",
+                source: "frontier",
+                provider: "openai",
+                key_status: "missing_key",
+                featured: false,
+                installed: true,
+            });
+            delete (needsKey as { fit?: unknown }).fit;
+
+            const { el } = await openPicksStep(splitCatalog(featured, [needsKey, catalogRow(0)]));
+
+            // The user cannot use it without a key they have not set, so it is not offered in its place.
+            expect(renderedRepos(el)).toEqual(["f/0", "org/Other-0-GGUF"]);
+        });
+
+        it("substitutes a hosted model the user can already use", async () => {
+            const featured = featuredRow(1).concat(
+                makeEntry({ hf_repo: "f/huge", display_name: "Huge", fit: "wont_run" }),
+            );
+            const ready = makeEntry({
+                hf_repo: "ollama/qwen3:4b",
+                display_name: "Qwen3 4B",
+                source: "ollama",
+                provider: "ollama",
+                key_status: null,
+                featured: false,
+                installed: true,
+            });
+            delete (ready as { fit?: unknown }).fit;
+
+            const { el } = await openPicksStep(splitCatalog(featured, [ready, catalogRow(0)]));
+
+            // A local server needs no key, so hosted rows are not excluded as a class.
+            expect(renderedRepos(el)).toEqual(["f/0", "ollama/qwen3:4b"]);
+        });
+
+        it("keeps a row it cannot replace when the wider catalog cannot be read", async () => {
+            const featured = featuredRow(2).concat(
+                makeEntry({ hf_repo: "f/huge", display_name: "Huge", fit: "wont_run" }),
+            );
+
+            const { el } = await openPicksStep(splitCatalog(featured, new Error("connection refused")));
+
+            expect(renderedRepos(el)).toEqual(["f/0", "f/1", "f/huge"]);
+            expect(findButtons(el).some((b) => b.textContent === MESSAGES.BUTTON_RETRY)).toBe(false);
+        });
+
+        it("keeps a row it cannot replace when the wider catalog offers nothing that runs", async () => {
+            const featured = featuredRow(2).concat(
+                makeEntry({ hf_repo: "f/huge", display_name: "Huge", fit: "wont_run" }),
+            );
+            const wider = [
+                ...featured,
+                makeEntry({ hf_repo: "w/huge", display_name: "Wider huge", fit: "wont_run", featured: false }),
+            ];
+
+            const { el } = await openPicksStep(splitCatalog(featured, wider));
+
+            expect(renderedRepos(el)).toEqual(["f/0", "f/1", "f/huge"]);
         });
     });
 

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -4,7 +4,7 @@ import { MockElement } from "../__mocks__/obsidian";
 import { SetupWizard, pickNativeChatModels, recommendedIndex } from "../../src/views/setup-wizard";
 import { getSystemMemoryGB } from "../../src/utils";
 import * as utils from "../../src/utils";
-import { SessionTokenError } from "../../src/api";
+import { LilbeeClient, SessionTokenError } from "../../src/api";
 import { SSE_EVENT, WIZARD_STEP, LILBEE_REPO_URL } from "../../src/types";
 import { ok, err } from "../../src/result";
 import { MESSAGES } from "../../src/locales/en";
@@ -81,6 +81,8 @@ function makePlugin(overrides: Record<string, unknown> = {}) {
         startManagedServer: vi.fn().mockResolvedValue(undefined),
         saveSettings: vi.fn().mockResolvedValue(undefined),
         activateChatView: vi.fn().mockResolvedValue(undefined),
+        resumeDeferredAgentPicker: vi.fn().mockResolvedValue(undefined),
+        setupWizardOpen: false,
         ...overrides,
     };
     // Default consent gate: delegate to startManagedServer (so per-test
@@ -697,7 +699,8 @@ describe("SetupWizard", () => {
             expect(texts.some((t) => t.includes("Pick a chat model"))).toBe(true);
         });
 
-        it("external mode: Next checks health and advances", async () => {
+        it("external mode: Next checks the connection and advances", async () => {
+            const probe = vi.spyOn(LilbeeClient, "probe").mockResolvedValue(true);
             const plugin = makePlugin({
                 serverManager: null,
                 settings: { serverMode: "managed" },
@@ -716,17 +719,18 @@ describe("SetupWizard", () => {
             await tick();
             await tick();
 
-            expect(plugin.api.health).toHaveBeenCalled();
+            expect(probe).toHaveBeenCalled();
             const texts = collectTexts(wizard.contentEl as unknown as MockElement);
             expect(texts.some((t) => t.includes("Pick a chat model"))).toBe(true);
+            probe.mockRestore();
         });
 
-        it("external mode: handles health check failure", async () => {
+        it("external mode: handles a server that does not answer", async () => {
+            const probe = vi.spyOn(LilbeeClient, "probe").mockResolvedValue(false);
             const plugin = makePlugin({
                 serverManager: null,
                 settings: { serverMode: "managed" },
             });
-            plugin.api.health = vi.fn().mockResolvedValue(err(new Error("connection refused")));
             const wizard = new SetupWizard(plugin.app as any, plugin as any);
             wizard.open();
             wizard.next();
@@ -742,6 +746,7 @@ describe("SetupWizard", () => {
 
             const texts = collectTexts(wizard.contentEl as unknown as MockElement);
             expect(texts.some((t) => t.includes("Could not connect"))).toBe(true);
+            probe.mockRestore();
         });
 
         it("Back returns to welcome", () => {
@@ -3595,6 +3600,398 @@ describe("SetupWizard", () => {
             expect((wizard as any).syncResult ?? null).toBeNull();
             const texts = collectTexts(wizard.contentEl as unknown as MockElement);
             expect(texts.some((t) => t.includes("Wiki (optional)"))).toBe(true);
+        });
+    });
+
+    describe("Setup is complete once a server answers", () => {
+        it("managed: records setup as complete when the server reaches ready", async () => {
+            const plugin = makePlugin({
+                serverManager: null,
+                settings: { serverMode: "managed", setupCompleted: false },
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            findButtons(el)
+                .find((b) => b.textContent === "Next")!
+                .trigger("click");
+            await tick();
+            await tick();
+
+            expect(plugin.settings.setupCompleted).toBe(true);
+            expect(plugin.saveSettings).toHaveBeenCalled();
+        });
+
+        it("managed: leaves setup incomplete when the server never starts", async () => {
+            const plugin = makePlugin({
+                serverManager: null,
+                settings: { serverMode: "managed", setupCompleted: false },
+                ensureManagedConsentThenStart: vi.fn().mockResolvedValue({ kind: "canceled" }),
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            findButtons(el)
+                .find((b) => b.textContent === "Next")!
+                .trigger("click");
+            await tick();
+            await tick();
+
+            expect(plugin.settings.setupCompleted).toBe(false);
+        });
+
+        it("external: records setup as complete once the server answers", async () => {
+            const probe = vi.spyOn(LilbeeClient, "probe").mockResolvedValue(true);
+            const plugin = makePlugin({ serverManager: null, settings: { serverMode: "managed" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            el.findAll("lilbee-wizard-model-option")[1].trigger("click");
+            findButtons(el)
+                .find((b) => b.textContent === "Next")!
+                .trigger("click");
+            await tick();
+            await tick();
+
+            expect(plugin.settings.setupCompleted).toBe(true);
+            probe.mockRestore();
+        });
+
+        it("skipping after the server is up keeps the plugin configured", async () => {
+            const plugin = makePlugin({ serverManager: null, settings: { serverMode: "managed" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            findButtons(el)
+                .find((b) => b.textContent === "Next")!
+                .trigger("click");
+            await tick();
+            await tick();
+            wizard.skip();
+
+            expect(plugin.settings.setupCompleted).toBe(true);
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_SETUP_INCOMPLETE)).toBe(false);
+        });
+
+        it("records setup when welcome skips the server step on a running server", () => {
+            const plugin = makePlugin({
+                settings: { serverMode: "external", setupCompleted: false },
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+
+            wizard.next();
+
+            expect(plugin.settings.setupCompleted).toBe(true);
+        });
+
+        it("re-running setup on a configured vault does not rewrite the flag", async () => {
+            const plugin = makePlugin({
+                serverManager: null,
+                settings: { serverMode: "managed", setupCompleted: true },
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            findButtons(el)
+                .find((b) => b.textContent === "Next")!
+                .trigger("click");
+            await tick();
+            await tick();
+
+            expect(plugin.saveSettings).not.toHaveBeenCalled();
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some((t) => t.includes("Pick a chat model"))).toBe(true);
+        });
+
+        it("says what an early exit costs when no server was ever chosen", () => {
+            const plugin = makePlugin({
+                serverManager: null,
+                settings: { serverMode: "managed", setupCompleted: false },
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+
+            wizard.skip();
+
+            expect(plugin.settings.setupCompleted).toBe(false);
+            expect(Notice.instances.some((n) => n.message === MESSAGES.NOTICE_SETUP_INCOMPLETE)).toBe(true);
+        });
+    });
+
+    describe("External mode is checked before it is persisted", () => {
+        it("keeps the working configuration when the external server does not answer", async () => {
+            const probe = vi.spyOn(LilbeeClient, "probe").mockResolvedValue(false);
+            const plugin = makePlugin({ serverManager: null, settings: { serverMode: "managed" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            el.findAll("lilbee-wizard-model-option")[1].trigger("click");
+            findButtons(el)
+                .find((b) => b.textContent === "Next")!
+                .trigger("click");
+            await tick();
+            await tick();
+
+            expect(plugin.settings.serverMode).toBe("managed");
+            expect(plugin.saveSettings).not.toHaveBeenCalled();
+            expect(plugin.api.setBaseUrl).not.toHaveBeenCalled();
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some((t) => t.includes("Could not connect"))).toBe(true);
+            probe.mockRestore();
+        });
+
+        it("probes the typed URL and token, not the stored ones", async () => {
+            const probe = vi.spyOn(LilbeeClient, "probe").mockResolvedValue(true);
+            const plugin = makePlugin({ serverManager: null, settings: { serverMode: "managed" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            wizard.next();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            el.findAll("lilbee-wizard-model-option")[1].trigger("click");
+            const inputs = el.findAll("lilbee-wizard-url-input");
+            inputs[0].value = "http://10.0.0.4:9000";
+            inputs[1].value = "tok-abc";
+            findButtons(el)
+                .find((b) => b.textContent === "Next")!
+                .trigger("click");
+            await tick();
+            await tick();
+
+            expect(probe).toHaveBeenCalledWith("http://10.0.0.4:9000/api/health", expect.any(Number), "tok-abc");
+            expect(plugin.settings.serverUrl).toBe("http://10.0.0.4:9000");
+            expect(plugin.settings.manualToken).toBe("tok-abc");
+            expect(plugin.settings.serverMode).toBe("external");
+            probe.mockRestore();
+        });
+    });
+
+    describe("Retrying a failed catalog load", () => {
+        it("gives the primary action back when the retry succeeds", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi
+                .fn()
+                .mockResolvedValueOnce(err(new Error("connection refused")))
+                .mockResolvedValue(ok(makeCatalogResponse([makeEntry()])));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = WIZARD_STEP.MODEL_PICKER;
+            (wizard as any).renderStep();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const downloadBtn = findButtons(el).find((b) => b.textContent === MESSAGES.BUTTON_DOWNLOAD_CONTINUE)!;
+            expect(downloadBtn.disabled).toBe(true);
+
+            findButtons(el)
+                .find((b) => b.textContent === MESSAGES.BUTTON_RETRY)!
+                .trigger("click");
+            await tick();
+
+            expect(downloadBtn.disabled).toBe(false);
+        });
+    });
+
+    describe("Our picks is curated", () => {
+        it("drops models the host cannot run", () => {
+            const picks = pickNativeChatModels([
+                makeEntry({ hf_repo: "a/huge", display_name: "Huge", fit: "wont_run" }),
+                makeEntry({ hf_repo: "a/small", display_name: "Small", fit: "fits" }),
+            ]);
+
+            expect(picks.map((m) => m.hf_repo)).toEqual(["a/small"]);
+        });
+
+        it("drops safety-stripped community re-uploads", () => {
+            const picks = pickNativeChatModels([
+                makeEntry({ hf_repo: "x/Qwen3-27B-Uncensored", display_name: "Qwen3 27B Uncensored" }),
+                makeEntry({ hf_repo: "x/Qwen3-27B-Heretic-Abliterated", display_name: "Heretic Abliterated" }),
+                makeEntry({ hf_repo: "Qwen/Qwen3-4B-GGUF", display_name: "Qwen3 4B" }),
+            ]);
+
+            expect(picks.map((m) => m.hf_repo)).toEqual(["Qwen/Qwen3-4B-GGUF"]);
+        });
+
+        it("drops runtime-specific quants", () => {
+            const picks = pickNativeChatModels([
+                makeEntry({ hf_repo: "x/Flash-ROCm-FP4-Imatrix", display_name: "Flash ROCm FP4" }),
+                makeEntry({ hf_repo: "Qwen/Qwen3-4B-GGUF", display_name: "Qwen3 4B" }),
+            ]);
+
+            expect(picks.map((m) => m.hf_repo)).toEqual(["Qwen/Qwen3-4B-GGUF"]);
+        });
+
+        it("drops models the server says it cannot load", () => {
+            const picks = pickNativeChatModels([
+                makeEntry({ hf_repo: "x/Weird-Arch", display_name: "Weird", compat: "unsupported" }),
+                makeEntry({ hf_repo: "Qwen/Qwen3-4B-GGUF", display_name: "Qwen3 4B" }),
+            ]);
+
+            expect(picks.map((m) => m.hf_repo)).toEqual(["Qwen/Qwen3-4B-GGUF"]);
+        });
+
+        it("keeps a model whose name merely contains an excluded marker", () => {
+            const picks = pickNativeChatModels([
+                makeEntry({ hf_repo: "org/Qwen3-Input-Guard", display_name: "Qwen3 Input Guard" }),
+                makeEntry({ hf_repo: "Qwen/Qwen3-4B-GGUF", display_name: "Qwen3 4B" }),
+            ]);
+
+            expect(picks.map((m) => m.hf_repo)).toEqual(["org/Qwen3-Input-Guard", "Qwen/Qwen3-4B-GGUF"]);
+        });
+
+        it("shows the raw list rather than an empty grid when curation removes everything", () => {
+            const picks = pickNativeChatModels([
+                makeEntry({ hf_repo: "x/Only-Uncensored", display_name: "Only Uncensored" }),
+            ]);
+
+            expect(picks.map((m) => m.hf_repo)).toEqual(["x/Only-Uncensored"]);
+        });
+    });
+
+    describe("An installed chat model is used, not re-downloaded", () => {
+        it("sets the model and advances without pulling", async () => {
+            const entry = makeEntry({
+                hf_repo: "Liquid/LFM2.5-2.6B-GGUF",
+                display_name: "LFM2.5 2.6B",
+                installed: true,
+            });
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([entry])));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = WIZARD_STEP.MODEL_PICKER;
+            (wizard as any).renderStep();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            findButtons(el)
+                .find((b) => b.textContent === MESSAGES.BUTTON_USE_CONTINUE)!
+                .trigger("click");
+            await tick();
+            await tick();
+
+            expect(plugin.api.pullModel).not.toHaveBeenCalled();
+            expect(plugin.api.setChatModel).toHaveBeenCalledWith("Liquid/LFM2.5-2.6B-GGUF");
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some((t) => t.includes("embedding"))).toBe(true);
+        });
+
+        it("keeps the user on the step when the server refuses to set the installed model", async () => {
+            const entry = makeEntry({
+                hf_repo: "Liquid/LFM2.5-2.6B-GGUF",
+                display_name: "LFM2.5 2.6B",
+                installed: true,
+            });
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([entry])));
+            plugin.api.setChatModel = vi.fn().mockResolvedValue(err(new Error("model is not loadable")));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = WIZARD_STEP.MODEL_PICKER;
+            (wizard as any).renderStep();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const useBtn = findButtons(el).find((b) => b.textContent === MESSAGES.BUTTON_USE_CONTINUE)!;
+            useBtn.trigger("click");
+            await tick();
+            await tick();
+
+            expect(useBtn.disabled).toBe(false);
+            const texts = collectTexts(wizard.contentEl as unknown as MockElement);
+            expect(texts.some((t) => t.includes("model is not loadable"))).toBe(true);
+            expect(Notice.instances.some((n) => n.message.includes("LFM2.5 2.6B"))).toBe(true);
+        });
+
+        it("labels the action Download & continue for a model that is not on disk", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([makeEntry()])));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = WIZARD_STEP.MODEL_PICKER;
+            (wizard as any).renderStep();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const labels = findButtons(el).map((b) => b.textContent);
+            expect(labels).toContain(MESSAGES.BUTTON_DOWNLOAD_CONTINUE);
+            expect(labels).not.toContain(MESSAGES.BUTTON_USE_CONTINUE);
+        });
+
+        it("does not paint the recommended card as the server's active model", async () => {
+            const entry = makeEntry({
+                hf_repo: "Liquid/LFM2.5-2.6B-GGUF",
+                display_name: "LFM2.5 2.6B",
+                installed: true,
+            });
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse([entry])));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = WIZARD_STEP.MODEL_PICKER;
+            (wizard as any).renderStep();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const label = el.find("lilbee-model-card-status-label");
+            expect(label?.textContent).toBe(MESSAGES.LABEL_INSTALLED);
+        });
+    });
+
+    describe("Wiki step", () => {
+        it("turns the wiki on for the running plugin, not only on disk", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external", wikiEnabled: false } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = WIZARD_STEP.WIKI;
+            (wizard as any).renderStep();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            el.findAll("lilbee-wizard-model-option")[0].trigger("click");
+            findButtons(el)
+                .find((b) => b.textContent === "Next")!
+                .trigger("click");
+
+            expect(plugin.settings.wikiEnabled).toBe(true);
+        });
+    });
+
+    describe("Agent picker never covers the wizard", () => {
+        it("marks the plugin as showing setup while the wizard is open", () => {
+            const plugin = makePlugin({ settings: { serverMode: "external" } });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+
+            wizard.open();
+            expect(plugin.setupWizardOpen).toBe(true);
+
+            wizard.close();
+            expect(plugin.setupWizardOpen).toBe(false);
+        });
+
+        it("re-offers the pairing it pushed aside once the wizard closes", () => {
+            const plugin = makePlugin({
+                settings: { serverMode: "external", setupCompleted: true },
+                resumeDeferredAgentPicker: vi.fn().mockResolvedValue(undefined),
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+
+            wizard.close();
+
+            expect(plugin.resumeDeferredAgentPicker).toHaveBeenCalled();
         });
     });
 });

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -34,8 +34,9 @@ function makeEntry(overrides: Partial<CatalogEntry> = {}): CatalogEntry {
         featured: true,
         downloads: 0,
         param_count: "0.6B",
-        // A live server reports fit on every row; the picks filter requires it.
+        // A live server reports fit and compat on every row; the picks filter requires both.
         fit: "fits",
+        compat: "supported",
         ...overrides,
     };
 }
@@ -3874,6 +3875,30 @@ describe("SetupWizard", () => {
             const picks = pickNativeChatModels([unknown, known]);
 
             // An unknown size cannot be promised, so it is not a pick.
+            expect(picks.map((m) => m.hf_repo)).toEqual(["Qwen/Qwen3-4B-GGUF"]);
+        });
+
+        it("drops a model whose compat the server reports as unknown", () => {
+            const supported = makeEntry({ hf_repo: "Qwen/Qwen3-4B-GGUF", display_name: "Qwen3 4B" });
+            const unknown = makeEntry({
+                hf_repo: "org/Mystery-Arch",
+                display_name: "Mystery Arch",
+                compat: "unknown",
+            });
+
+            const picks = pickNativeChatModels([unknown, supported]);
+
+            // An unknown architecture cannot be promised to run, so it is not a pick.
+            expect(picks.map((m) => m.hf_repo)).toEqual(["Qwen/Qwen3-4B-GGUF"]);
+        });
+
+        it("drops a model whose compat the server did not report", () => {
+            const supported = makeEntry({ hf_repo: "Qwen/Qwen3-4B-GGUF", display_name: "Qwen3 4B" });
+            const missing = makeEntry({ hf_repo: "org/No-Compat", display_name: "No Compat" });
+            delete (missing as { compat?: unknown }).compat;
+
+            const picks = pickNativeChatModels([missing, supported]);
+
             expect(picks.map((m) => m.hf_repo)).toEqual(["Qwen/Qwen3-4B-GGUF"]);
         });
     });


### PR DESCRIPTION
## Problem

Setup writes its completion flag at the final button only. Skip setup, the close X, Escape and Browse full catalog each leave the plugin with no server on the next launch.

External mode saves the URL, token and mode, and stops a running managed server, before checking whether the external server answers.

The wiki toggle sets the stored setting but not the runtime flag the wiki commands are registered behind.

Our picks is the featured list sorted by downloads. On a 32 GB machine it led with two uncensored community models and two 101 GB entries marked WON'T RUN.

## Solution

Setup is recorded when a server answers. An earlier exit says what is missing.

External mode probes the typed URL and token first, and writes nothing until the server answers.

The runtime wiki flag reads the stored setting, so the pair cannot drift.

Our picks drops what the host cannot run, safety-stripped re-uploads and runtime-specific quants, falling back to the raw list rather than an empty grid.

An installed chat model is set, not downloaded again.

The recommended card no longer carries the active badge, which showed the previous vault's model after a switch.

The agent picker waits for the wizard to close, and no longer pre-checks remember.

## Notes

A retry after a failed catalog load re-enables the primary action. Nothing cleared it, so one failure dead-ended the step.
