### PR TITLE
Stop the uninstall deleting models under a running engine, and five other surfaces that misreported state

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ The download streams to disk and reports its progress as a percentage. Every ser
 
 In **managed mode** (the default) the plugin downloaded a server executable and a model cache. Both live outside your vault, and Obsidian doesn't know about either, so removing the plugin won't remove them.
 
-Open Settings → lilbee → **Uninstall server** first. It deletes the executable, the downloaded models, and this vault's search index, and it tells you how much space that frees before you confirm. Your notes are never touched. Then remove the plugin the usual way, from **Community plugins**.
+Open Settings → lilbee → **Uninstall server** first. It deletes the executable, this vault's index and saved chats, and the models every vault on this computer shares. It tells you how much space that frees before you confirm. Your notes are never touched. Then remove the plugin the usual way, from **Community plugins**.
 
 Uninstalling the server doesn't disable the plugin. Settings shows an **Install server** button, and lilbee stays quiet until you click it.
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -5,6 +5,7 @@ import {
     OCTET_STREAM_HEADERS,
     REQUEST_OUTCOME,
     SEARCH_CHUNK_TYPE,
+    SERVER_STATUS_PREFIX,
     SSE_EVENT,
     ERROR_NAME,
 } from "./types";
@@ -124,7 +125,7 @@ export class RateLimitedError extends Error {
  * failure) can branch on the status without a bespoke error type per route.
  */
 export function isHttpStatus(error: Error, status: number): boolean {
-    return error.message.startsWith(`Server responded ${status}`);
+    return error.message.startsWith(`${SERVER_STATUS_PREFIX} ${status}`);
 }
 
 /**
@@ -245,7 +246,7 @@ export class LilbeeClient {
         }
         if (!res.ok) {
             const text = await res.text().catch(() => "");
-            throw new Error(`Server responded ${res.status}: ${text}`);
+            throw new Error(`${SERVER_STATUS_PREFIX} ${res.status}: ${text}`);
         }
         return res;
     }
@@ -351,11 +352,11 @@ export class LilbeeClient {
                     this.recordOutcome(REQUEST_OUTCOME.SERVER_ERROR);
                     throw err;
                 }
-                if (err instanceof Error && err.message.startsWith("Server responded")) {
+                if (err instanceof Error && err.message.startsWith(SERVER_STATUS_PREFIX)) {
                     // A 4xx is a reachable server rejecting this request (validation,
                     // not-found, conflict) that the caller handles — don't flag a
                     // global server error. Only 5xx flips the status to error.
-                    const status = parseInt(err.message.slice("Server responded ".length), 10);
+                    const status = parseInt(err.message.slice(SERVER_STATUS_PREFIX.length + 1), 10);
                     this.recordOutcome(status >= 500 ? REQUEST_OUTCOME.SERVER_ERROR : REQUEST_OUTCOME.OK);
                     throw err;
                 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,6 @@
 import {
     CAPABILITY,
+    CRAWLER_STATUS_FIELD,
     bearerHeaders,
     JSON_HEADERS,
     OCTET_STREAM_HEADERS,
@@ -18,6 +19,7 @@ import type {
     Capability,
     CatalogResponse,
     ConfigResponse,
+    CrawlerStatusField,
     CrawlerStatusResponse,
     ConfigUpdateResponse,
     ConversationState,
@@ -118,6 +120,32 @@ export class RateLimitedError extends Error {
     }
 }
 
+const HTTP_SERVER_ERROR = 500;
+
+/** True when the error carries the status line `assertOk` writes, so the server answered. */
+export function hasStatusLine(error: unknown): error is Error {
+    return error instanceof Error && error.message.startsWith(SERVER_STATUS_PREFIX);
+}
+
+/** The status in that line, or null when it carries no number to read. */
+function httpStatusOf(error: unknown): number | null {
+    if (!hasStatusLine(error)) return null;
+    const status = parseInt(error.message.slice(SERVER_STATUS_PREFIX.length + 1), 10);
+    return Number.isNaN(status) ? null : status;
+}
+
+/** True when the server rejected the request itself, so re-sending it unchanged will not help. */
+export function isClientError(error: unknown): boolean {
+    const status = httpStatusOf(error);
+    return status !== null && status < HTTP_SERVER_ERROR;
+}
+
+/** True when the server failed rather than refused. An unreadable status is not a failure. */
+function isServerError(error: unknown): boolean {
+    const status = httpStatusOf(error);
+    return status !== null && status >= HTTP_SERVER_ERROR;
+}
+
 /**
  * True when a `fetchResult` error came from a specific HTTP status. `assertOk`
  * formats non-ok responses as `Server responded <status>: <body>`, so callers
@@ -125,7 +153,7 @@ export class RateLimitedError extends Error {
  * failure) can branch on the status without a bespoke error type per route.
  */
 export function isHttpStatus(error: Error, status: number): boolean {
-    return error.message.startsWith(`${SERVER_STATUS_PREFIX} ${status}`);
+    return httpStatusOf(error) === status;
 }
 
 /**
@@ -352,12 +380,9 @@ export class LilbeeClient {
                     this.recordOutcome(REQUEST_OUTCOME.SERVER_ERROR);
                     throw err;
                 }
-                if (err instanceof Error && err.message.startsWith(SERVER_STATUS_PREFIX)) {
-                    // A 4xx is a reachable server rejecting this request (validation,
-                    // not-found, conflict) that the caller handles — don't flag a
-                    // global server error. Only 5xx flips the status to error.
-                    const status = parseInt(err.message.slice(SERVER_STATUS_PREFIX.length + 1), 10);
-                    this.recordOutcome(status >= 500 ? REQUEST_OUTCOME.SERVER_ERROR : REQUEST_OUTCOME.OK);
+                if (hasStatusLine(err)) {
+                    // A 4xx is the caller's to handle, not a global server fault; only a 5xx is.
+                    this.recordOutcome(isServerError(err) ? REQUEST_OUTCOME.SERVER_ERROR : REQUEST_OUTCOME.OK);
                     throw err;
                 }
                 // An abort is the caller's decision, never a server fault. The
@@ -415,9 +440,9 @@ export class LilbeeClient {
             case CAPABILITY.API_KEYS:
                 return this.probeLitellmInstalled();
             case CAPABILITY.CRAWLING:
-                return this.probeCrawlerInstalled("package_installed");
+                return this.probeCrawlerInstalled(CRAWLER_STATUS_FIELD.PACKAGE);
             case CAPABILITY.CRAWLING_BROWSER:
-                return this.probeCrawlerInstalled("installed");
+                return this.probeCrawlerInstalled(CRAWLER_STATUS_FIELD.WITH_BROWSER);
             case CAPABILITY.WIKI:
                 return this.probeWikiEnabled();
         }
@@ -429,8 +454,7 @@ export class LilbeeClient {
         return body.error === null || body.error === undefined;
     }
 
-    /** `package_installed` is the bundled crawler package; `installed` also requires Chromium. */
-    private async probeCrawlerInstalled(field: "package_installed" | "installed"): Promise<boolean> {
+    private async probeCrawlerInstalled(field: CrawlerStatusField): Promise<boolean> {
         const res = await this.fetchWithRetry(`${this.baseUrl}/setup/crawler/status`);
         const body = (await res.json()) as CrawlerStatusResponse;
         return body[field] === true;

--- a/src/api.ts
+++ b/src/api.ts
@@ -17,6 +17,7 @@ import type {
     Capability,
     CatalogResponse,
     ConfigResponse,
+    CrawlerStatusResponse,
     ConfigUpdateResponse,
     ConversationState,
     CrawlRenderMode,
@@ -413,7 +414,9 @@ export class LilbeeClient {
             case CAPABILITY.API_KEYS:
                 return this.probeLitellmInstalled();
             case CAPABILITY.CRAWLING:
-                return this.probeCrawlerInstalled();
+                return this.probeCrawlerInstalled("package_installed");
+            case CAPABILITY.CRAWLING_BROWSER:
+                return this.probeCrawlerInstalled("installed");
             case CAPABILITY.WIKI:
                 return this.probeWikiEnabled();
         }
@@ -425,10 +428,11 @@ export class LilbeeClient {
         return body.error === null || body.error === undefined;
     }
 
-    private async probeCrawlerInstalled(): Promise<boolean> {
+    /** `package_installed` is the bundled crawler package; `installed` also requires Chromium. */
+    private async probeCrawlerInstalled(field: "package_installed" | "installed"): Promise<boolean> {
         const res = await this.fetchWithRetry(`${this.baseUrl}/setup/crawler/status`);
-        const body = (await res.json()) as { package_installed?: boolean };
-        return body.package_installed === true;
+        const body = (await res.json()) as CrawlerStatusResponse;
+        return body[field] === true;
     }
 
     private async probeWikiEnabled(): Promise<boolean> {
@@ -766,6 +770,15 @@ export class LilbeeClient {
                 body: JSON.stringify(body),
                 signal,
             },
+            { stream: true },
+        );
+        yield* this.parseSSE(res);
+    }
+
+    async *setupCrawler(signal?: AbortSignal): AsyncGenerator<SSEEvent, void> {
+        const res = await this.fetchWithRetry(
+            `${this.baseUrl}/setup/crawler`,
+            { method: "POST", signal },
             { stream: true },
         );
         yield* this.parseSSE(res);

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -10,7 +10,11 @@ import {
     SERVER_VARIANT,
     type ServerVariant,
     type WorkerRole,
+    LOG_FILE,
 } from "../types";
+
+/** The toggle a user flips to move lilbee content in or out of the vault. */
+const STORE_CONTENT_IN_VAULT_LABEL = "Store lilbee content in vault";
 
 /** How each server build is named in Settings and notices. */
 const SERVER_BUILD_LABEL: Record<ServerVariant, string> = {
@@ -284,12 +288,24 @@ export const MESSAGES = {
         "Reset every server-backed setting to its default? API keys and local plugin preferences are preserved.",
     BUTTON_RESET_ALL: "Reset all",
     LABEL_ADVANCED: "Advanced",
-    LABEL_STORE_CONTENT_IN_VAULT: "Store lilbee content in vault",
+    LABEL_STORE_CONTENT_IN_VAULT: STORE_CONTENT_IN_VAULT_LABEL,
     DESC_STORE_CONTENT_IN_VAULT:
         "Materialize crawled pages and imported files inside your vault so you can browse them in Obsidian. Disabled for external servers — their files live on the server machine, not your computer.",
     NOTICE_STORAGE_REORGANIZING: "Reorganizing lilbee storage into your vault…",
     NOTICE_STORAGE_REORGANIZED: "Lilbee storage is now inside your vault.",
-    NOTICE_STORAGE_REORGANIZE_FAILED: "Could not move lilbee storage into your vault: ",
+    NOTICE_STORAGE_REORGANIZE_FAILED: (reason: string | null, logPath: string | null, willRetry: boolean): string =>
+        [
+            "Could not move lilbee storage.",
+            reason,
+            logPath === null
+                ? `Check ${LOG_FILE.SERVER} in the lilbee data directory.`
+                : `Check the server log at ${logPath}.`,
+            willRetry
+                ? null
+                : `lilbee will not try again until you toggle "${STORE_CONTENT_IN_VAULT_LABEL}" in settings.`,
+        ]
+            .filter((part): part is string => part !== null)
+            .join(" "),
     NOTICE_TAKE_OVER_SUCCESS: (vaultName: string): string => `lilbee switched from "${vaultName}" to this vault.`,
     NOTICE_TAKE_OVER_DECLINED: (vaultName: string): string =>
         `lilbee stays with "${vaultName}". This vault will run without managed lilbee until you take over or close the other vault.`,

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1235,6 +1235,11 @@ export const MESSAGES = {
     PLACEMENT_STATE_MANUAL: "manual",
     PLACEMENT_STATE_EDITED: "edited",
     PLACEMENT_STATE_APPLYING: "applying…",
+    PLACEMENT_STATE_SPEC_IGNORED: "auto, manual ignored",
+    PLACEMENT_SPEC_IGNORED:
+        "A saved manual placement does not fit this hardware, so auto placement is running instead. " +
+        "The saved placement stays and applies again once the hardware fits it. " +
+        "Clear it or save a new one if you do not want it back.",
     PLACEMENT_AUTO_MANAGED: "Auto-managed. The planner balances roles across your hardware.",
     PLACEMENT_EDIT: "Edit manually",
     PLACEMENT_PREVIEW: "Preview",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -269,6 +269,10 @@ export const MESSAGES = {
         "How pages are fetched. Lightweight is a fast HTTP fetch with no JavaScript. Browser runs Chromium so JavaScript-rendered pages work, at the cost of more memory and slower crawls.",
     LABEL_CRAWL_RENDER_MODE_HTTP: "Lightweight (HTTP, no JavaScript)",
     LABEL_CRAWL_RENDER_MODE_BROWSER: "Browser (Chromium, JavaScript)",
+    LABEL_CRAWL_BROWSER_SETUP: "Browser rendering",
+    DESC_CRAWL_BROWSER_SETUP:
+        "Browser render mode needs Chromium, which the server downloads once. The download is about 180 MB.",
+    BUTTON_INSTALL_CHROMIUM: "Install Chromium",
     LABEL_CRAWL_EXCLUDE_PATTERNS: "URL exclude patterns",
     DESC_CRAWL_EXCLUDE_PATTERNS:
         "Regex patterns that skip URLs at link-discovery during recursive crawls. One per line. Blank = no filtering.",
@@ -731,6 +735,9 @@ export const MESSAGES = {
     STATUS_TASK_BATCH: (current: number, total: number, file: string, status: string) =>
         `${status} ${current}/${total} ${file}`,
     STATUS_TASK_CRAWLER_PREPARING: "Preparing crawler…",
+    TASK_CRAWLER_BROWSER_SETUP: "Chromium setup",
+    NOTICE_CRAWL_BROWSER_MISSING: "Browser render mode needs Chromium. Install it first, then pick browser mode.",
+    NOTICE_CRAWLER_BROWSER_READY: "Chromium is ready. Browser render mode is now available.",
     STATUS_TASK_SETUP_PROGRESS: "chromium: {downloaded}/{total} MB",
     STATUS_TASK_SETUP_PROGRESS_INDETERMINATE: "chromium: {downloaded} MB",
     STATUS_INDEXING: "Indexing: {file}",
@@ -781,6 +788,7 @@ export const MESSAGES = {
     ERROR_CRAWLER_SETUP_FAILED:
         "Crawler setup failed: {error}. Run 'make crawl-setup' in the lilbee repo or 'lilbee setup crawler' to retry.",
     ERROR_CRAWLER_SETUP_FAILED_SHORT: "Chromium setup failed — see setup task",
+    ERROR_CRAWLER_SETUP_INCOMPLETE: "The server stopped the Chromium download before it finished.",
     ERROR_SERVER_UNREACHABLE: "Could not connect to lilbee server. Is it running?",
     ERROR_STREAM: (msg: string) => `lilbee: ${msg}`,
     ERROR_CHAT_FAILED: (reason: string) => `Chat failed: ${reason}`,

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -493,11 +493,12 @@ export const MESSAGES = {
         "Obsidian does not manage the lilbee server executable or its models, this plugin does. " +
         "Removing the plugin from Obsidian's Community plugins pane leaves both on disk. Uninstall here first.",
     CALLOUT_UNINSTALL_FIRST:
-        "Removing the plugin does not remove the server. The executable, the downloaded models, and this vault's " +
-        "index live outside your vault, so Obsidian never touches them. Uninstall here before you remove the plugin " +
-        "and nothing is left behind.",
+        "Removing the plugin does not remove the server. The executable, this vault's index and saved chats, and " +
+        "the shared model cache live outside your vault. Obsidian never touches them. Uninstall here before you " +
+        "remove the plugin and nothing is left behind.",
     DESC_UNINSTALL_SERVER: (size: string) =>
-        `Deletes the executable, the models, and this vault's index. Frees ${size}. Your notes are not touched.`,
+        `Deletes the executable, this vault's index and saved chats, and the models every vault on this computer ` +
+        `shares. Frees ${size}. Your notes are not touched.`,
     DESC_INSTALL_SERVER: (size: string) =>
         `Downloads the lilbee server, about ${size}. Models are pulled on demand afterwards.`,
     DESC_SERVER_DOWNLOADING: "The lilbee server is downloading. Progress is in the status bar.",
@@ -506,11 +507,11 @@ export const MESSAGES = {
 
     CONFIRM_UNINSTALL_TITLE: "Uninstall the lilbee server?",
     CONFIRM_UNINSTALL_BODY:
-        "This removes everything lilbee downloaded or built for this vault. It cannot be undone, but you can " +
-        "install the server again at any time.",
+        "This removes what lilbee downloaded or built. It deletes this vault's saved chats and the models that " +
+        "every vault on this computer shares. You cannot undo it, but you can install the server again at any time.",
     LABEL_UNINSTALL_BINARY: "Server executable",
-    LABEL_UNINSTALL_MODELS: "Downloaded models",
-    LABEL_UNINSTALL_INDEX: "Search index for this vault",
+    LABEL_UNINSTALL_MODELS: "Models shared by every vault on this computer",
+    LABEL_UNINSTALL_INDEX: "This vault's index, saved chats, and logs",
     LABEL_UNINSTALL_CACHE: "Unpacked server files",
     LABEL_UNINSTALL_KEEP: "Your notes and attachments",
     LABEL_UNINSTALL_KEEP_VALUE: "untouched",

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,6 +75,7 @@ import {
     type SetupProgressPayload,
     type SetupStartPayload,
     INDETERMINATE_PROGRESS,
+    type AddDone,
     type SyncDone,
     type SSEEvent,
     type WarmProgress,
@@ -162,7 +163,7 @@ function formatSetupDetail(downloaded: number, total: number | null): string {
     return MESSAGES.STATUS_TASK_SETUP_PROGRESS.replace("{downloaded}", dlMB).replace("{total}", totalMB);
 }
 
-function summarizeSyncResult(done: SyncDone): string {
+function summarizeSyncResult(done: AddDone): string {
     const parts: string[] = [];
     if (done.added.length > 0) parts.push(`${done.added.length} added`);
     if (done.updated.length > 0) parts.push(`${done.updated.length} updated`);
@@ -170,6 +171,7 @@ function summarizeSyncResult(done: SyncDone): string {
     if (done.failed.length > 0) parts.push(`${done.failed.length} failed`);
     if (done.skipped.length > 0) parts.push(`${done.skipped.length} skipped`);
     if (done.held_out.length > 0) parts.push(`${done.held_out.length} held out`);
+    if (done.tracked.length > 0) parts.push(`${done.tracked.length} already tracked`);
     return parts.join(", ");
 }
 
@@ -238,13 +240,14 @@ export class FileProgressTracker {
     }
 }
 
-export function parseAddDoneEvent(data: unknown): SyncDone | null {
+export function parseAddDoneEvent(data: unknown): AddDone | null {
     if (!data || typeof data !== "object") return null;
     const obj = data as Record<string, unknown>;
-    if (obj.sync && typeof obj.sync === "object") {
-        return coerceSyncDone(obj.sync as Record<string, unknown>);
-    }
-    return coerceSyncDone(obj);
+    // `tracked` sits on the add envelope beside `sync`, never inside it.
+    const tracked = Array.isArray(obj.tracked) ? (obj.tracked as string[]) : [];
+    const sync = obj.sync && typeof obj.sync === "object" ? (obj.sync as Record<string, unknown>) : obj;
+    const done = coerceSyncDone(sync);
+    return done === null ? null : { ...done, tracked };
 }
 
 function coerceSyncDone(obj: Record<string, unknown>): SyncDone | null {
@@ -2514,7 +2517,7 @@ export default class LilbeePlugin extends Plugin {
             return;
         }
         const total = files.length;
-        const merged: SyncDone = {
+        const merged: AddDone = {
             added: [],
             updated: [],
             removed: [],
@@ -2522,6 +2525,7 @@ export default class LilbeePlugin extends Plugin {
             failed: [],
             skipped: [],
             held_out: [],
+            tracked: [],
         };
         let done = 0;
         for (const batch of batches) {
@@ -2535,6 +2539,7 @@ export default class LilbeePlugin extends Plugin {
                         merged.failed.push(...parsed.failed);
                         merged.skipped.push(...parsed.skipped);
                         merged.held_out.push(...parsed.held_out);
+                        merged.tracked.push(...parsed.tracked);
                         merged.unchanged += parsed.unchanged;
                     }
                 } else if (event.event === SSE_EVENT.FILE_START) {
@@ -2578,7 +2583,7 @@ export default class LilbeePlugin extends Plugin {
 
         try {
             const progress = new FileProgressTracker();
-            let syncResult: SyncDone | null = null;
+            let syncResult: AddDone | null = null;
             const controller = this.syncController;
             const rawStream = makeStream
                 ? makeStream(controller.signal)
@@ -3222,7 +3227,7 @@ export default class LilbeePlugin extends Plugin {
 
         try {
             const progress = new FileProgressTracker();
-            let syncResult: SyncDone | null = null;
+            let syncResult: AddDone | null = null;
             const controller = this.syncController;
             const rawStream = this.api.syncStream(controller.signal, options);
             for await (const event of withIdleTimeout(rawStream, STREAM_IDLE_TIMEOUT_MS, () => controller.abort())) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1023,7 +1023,7 @@ export default class LilbeePlugin extends Plugin {
         // ask it to exit before deleting the tree out from under it.
         if (owner !== null) await askServerToExit(owner.dataDir, TAKE_OVER_SHUTDOWN_TIMEOUT_MS);
 
-        executeUninstall(plan);
+        await executeUninstall(plan, registry.sharedRoot, ownDataDir);
 
         registry.saveConfig({
             ...registry.loadConfig(),

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ import {
     reloadClaudian,
     type AgentWireOutcome,
 } from "./agent-integration";
-import { LilbeeClient, SessionTokenError } from "./api";
+import { LilbeeClient, SessionTokenError, hasStatusLine, isClientError } from "./api";
 import { node } from "./node";
 import { exportDatasetToDisk, importDatasetFromDisk } from "./dataset-io";
 import { exportDiagnostics } from "./diagnostics-export";
@@ -47,7 +47,6 @@ import {
     REQUEST_OUTCOME,
     SERVER_MODE,
     SERVER_STATE,
-    SERVER_STATUS_PREFIX,
     SETUP_OUTCOME,
     SSE_EVENT,
     SYNC_TRIGGER,
@@ -949,52 +948,53 @@ export default class LilbeePlugin extends Plugin {
         return dataDir === null ? null : node.join(dataDir, "documents");
     }
 
-    /**
-     * Tell the managed server where to keep content: under the vault, or in its
-     * own data directory. The server relocates what is already there. No-op when
-     * the server is external, when the current values already match, or when the
-     * server has already refused this same layout.
-     */
+    /** Tell the managed server where to keep content: under the vault, or in its own data dir. */
     async configureManagedStorage(): Promise<void> {
         if (this.settings.serverMode !== SERVER_MODE.MANAGED) return;
-
-        // Off is a real destination, not a no-op: leaving documents_dir inside
-        // the vault means content keeps landing there after the user opted out.
-        // The server refuses to reset this field (its default is a sentinel), so
-        // the way back is an explicit path to the server's own data dir.
-        const storeInVault = this.settings.storeContentInVault;
-        const vaultBase = this.getVaultBasePath();
-        const desiredDocsDir = storeInVault ? `${vaultBase}/lilbee` : this.serverOwnedDocumentsDir();
-        if (desiredDocsDir === null) return;
-        const target: StorageMoveTarget = {
-            documentsDir: desiredDocsDir,
-            vaultBase: storeInVault ? vaultBase : null,
-        };
-
-        const refused = this.settings.rejectedStorageMove;
-        if (
-            refused !== null &&
-            refused.documentsDir === target.documentsDir &&
-            refused.vaultBase === target.vaultBase
-        ) {
+        const target = this.wantedStorageLayout();
+        if (target === null) return;
+        if (this.alreadyRefusedStorage(target)) {
             this.journal.lifecycle("storage move skipped: the server already refused this layout");
             return;
         }
+        if (await this.serverStorageMatches(target)) return;
+        await this.sendStorageMove(target);
+    }
 
+    /** The layout the plugin wants, or null while the data dir is unknown. */
+    private wantedStorageLayout(): StorageMoveTarget | null {
+        // The server refuses to reset documents_dir, so opting out names its data dir explicitly.
+        const storeInVault = this.settings.storeContentInVault;
+        const vaultBase = this.getVaultBasePath();
+        const documentsDir = storeInVault ? `${vaultBase}/lilbee` : this.serverOwnedDocumentsDir();
+        if (documentsDir === null) return null;
+        return { documentsDir, vaultBase: storeInVault ? vaultBase : null };
+    }
+
+    /** True when the server already refused this exact layout. */
+    private alreadyRefusedStorage(target: StorageMoveTarget): boolean {
+        const refused = this.settings.rejectedStorageMove;
+        return (
+            refused !== null && refused.documentsDir === target.documentsDir && refused.vaultBase === target.vaultBase
+        );
+    }
+
+    /** True when the server already has this layout. An unreadable config counts as a match. */
+    private async serverStorageMatches(target: StorageMoveTarget): Promise<boolean> {
         let current: Record<string, unknown>;
         try {
             current = await this.api.config();
         } catch (err) {
             console.error("[lilbee] could not read server config for vault setup", err);
-            return;
+            return true;
         }
-
         const currentDocs = typeof current.documents_dir === "string" ? current.documents_dir : "";
         const currentVault = typeof current.vault_base === "string" ? current.vault_base : null;
-        if (currentDocs === target.documentsDir && currentVault === target.vaultBase) {
-            return;
-        }
+        return currentDocs === target.documentsDir && currentVault === target.vaultBase;
+    }
 
+    /** Move the server's storage, clearing any remembered refusal once it lands. */
+    private async sendStorageMove(target: StorageMoveTarget): Promise<void> {
         const notice = new Notice(MESSAGES.NOTICE_STORAGE_REORGANIZING, NOTICE_PERMANENT);
         try {
             await this.api.updateConfig({
@@ -1013,18 +1013,17 @@ export default class LilbeePlugin extends Plugin {
 
     /** Say why a move failed, and remember a layout the server itself refused. */
     private async reportStorageMoveFailure(target: StorageMoveTarget, err: unknown): Promise<void> {
-        // An unanswered request is not a refusal: remembering it would strand
-        // the user on a blip that the next start would have got past.
+        // Only a 4xx is a refusal; a 5xx or an unanswered request is retried next start.
         const message = errorMessage(err, String(err));
-        const refused = message.startsWith(SERVER_STATUS_PREFIX);
+        const answered = hasStatusLine(err);
+        const refused = isClientError(err);
         if (refused) {
             this.settings.rejectedStorageMove = target;
             await this.persistAll();
         }
 
-        // A status line is not a reason. Show the server's own detail when it
-        // has one, otherwise point at the log that does.
-        const reason = refused ? extractServerErrorDetail(message) : message;
+        // A status line is not a reason: show the server's detail when it answered.
+        const reason = answered ? extractServerErrorDetail(message) : message;
         const dataDir = this.ownDataDir();
         const logPath = dataDir === null ? null : node.join(dataDir, LOGS_DIR, LOG_FILE.SERVER);
         new Notice(MESSAGES.NOTICE_STORAGE_REORGANIZE_FAILED(reason, logPath, !refused), NOTICE_ERROR_DURATION_MS);
@@ -1996,8 +1995,7 @@ export default class LilbeePlugin extends Plugin {
         if (health?.isOk()) {
             this.healthFailureStreak = 0;
             if (this.settings.serverMode === SERVER_MODE.EXTERNAL) this.externalServerVersion = health.value.version;
-            // Only a reconnect refetches the model: a restarted server may be
-            // on a different one. A steady probe asks for health and nothing else.
+            // Only a reconnect refetches the model: a restarted server may be on a different one.
             if (this.serverUnreachable) {
                 this.serverUnreachable = false;
                 void this.fetchActiveModel();
@@ -3052,10 +3050,7 @@ export default class LilbeePlugin extends Plugin {
         }
     }
 
-    /**
-     * Download Playwright Chromium so the crawler can render with a browser.
-     * Resolves true when the server reports the component installed.
-     */
+    /** Download Chromium so the crawler can render with a browser. True once it is installed. */
     async installCrawlerBrowser(): Promise<boolean> {
         const taskId = this.taskQueue.enqueue(MESSAGES.TASK_CRAWLER_BROWSER_SETUP, TASK_TYPE.SETUP);
         if (taskId === null) {
@@ -3210,8 +3205,7 @@ export default class LilbeePlugin extends Plugin {
 
     async triggerSync(options?: SyncOptions, trigger: SyncTrigger = SYNC_TRIGGER.USER): Promise<void> {
         if (!this.statusBarEl) return;
-        // One sync at a time. A user trigger reports the running one; an automatic one is
-        // carried to the next run, because nothing else re-issues it.
+        // One sync at a time: a user trigger reports the running one, an automatic one defers.
         if (this.taskQueue.hasPending(TASK_TYPE.SYNC)) {
             if (trigger === SYNC_TRIGGER.USER) new Notice(MESSAGES.NOTICE_SYNC_IN_PROGRESS);
             else this.deferredSync = { options };

--- a/src/main.ts
+++ b/src/main.ts
@@ -318,6 +318,8 @@ export default class LilbeePlugin extends Plugin {
     vaultRegistry: VaultRegistry | null = null;
     vaultId = "";
     syncController: AbortController | null = null;
+    /** An automatic sync requested while another ran; the running one carries it. */
+    private deferredSync: { options?: SyncOptions } | null = null;
     private pendingSyncCount = 0;
     private pendingHintTimeout: number | null = null;
     private previousServerMode: ServerMode = SERVER_MODE.MANAGED;
@@ -3122,9 +3124,11 @@ export default class LilbeePlugin extends Plugin {
 
     async triggerSync(options?: SyncOptions, trigger: SyncTrigger = SYNC_TRIGGER.USER): Promise<void> {
         if (!this.statusBarEl) return;
-        // One sync at a time; only a user trigger reports a pending one.
+        // One sync at a time. A user trigger reports the running one; an automatic one is
+        // carried to the next run, because nothing else re-issues it.
         if (this.taskQueue.hasPending(TASK_TYPE.SYNC)) {
             if (trigger === SYNC_TRIGGER.USER) new Notice(MESSAGES.NOTICE_SYNC_IN_PROGRESS);
+            else this.deferredSync = { options };
             return;
         }
         const taskId = this.taskQueue.enqueue(syncTaskLabel(options), TASK_TYPE.SYNC);
@@ -3217,6 +3221,15 @@ export default class LilbeePlugin extends Plugin {
         } finally {
             this.syncController = null;
             this.schedulePendingSyncHint();
+            this.runDeferredSync();
         }
+    }
+
+    /** Runs the sync deferred during this one; the sync task is terminal before this fires. */
+    private runDeferredSync(): void {
+        const deferred = this.deferredSync;
+        if (!deferred) return;
+        this.deferredSync = null;
+        void this.triggerSync(deferred.options, SYNC_TRIGGER.AUTOMATIC);
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,7 @@ import {
     DEFAULT_SETTINGS,
     DOT_STATE,
     ENSURE_SOURCE,
+    CAPABILITY,
     ERROR_NAME,
     LOGS_DIR,
     MANAGED_CONSENT_RESULT,
@@ -3024,6 +3025,66 @@ export default class LilbeePlugin extends Plugin {
         }
     }
 
+    /**
+     * Download Playwright Chromium so the crawler can render with a browser.
+     * Resolves true when the server reports the component installed.
+     */
+    async installCrawlerBrowser(): Promise<boolean> {
+        const taskId = this.taskQueue.enqueue(MESSAGES.TASK_CRAWLER_BROWSER_SETUP, TASK_TYPE.SETUP);
+        if (taskId === null) {
+            new Notice(MESSAGES.NOTICE_QUEUE_FULL);
+            return false;
+        }
+        const controller = new AbortController();
+        this.taskQueue.registerAbort(taskId, controller);
+        try {
+            const error = await this.drainCrawlerSetup(taskId, controller.signal);
+            if (error !== null) {
+                this.taskQueue.fail(taskId, error);
+                new Notice(MESSAGES.ERROR_CRAWLER_SETUP_FAILED.replace("{error}", error));
+                return false;
+            }
+            this.taskQueue.complete(taskId);
+            this.api.invalidateCapability(CAPABILITY.CRAWLING_BROWSER);
+            new Notice(MESSAGES.NOTICE_CRAWLER_BROWSER_READY, NOTICE_DURATION_MS);
+            return true;
+        } catch (err) {
+            const msg = errorMessage(err, MESSAGES.ERROR_UNKNOWN);
+            this.taskQueue.fail(taskId, msg);
+            new Notice(MESSAGES.ERROR_CRAWLER_SETUP_FAILED.replace("{error}", msg));
+            return false;
+        }
+    }
+
+    /** A download with no announced total stays indeterminate rather than dividing by zero. */
+    private renderSetupProgress(taskId: string, d: SetupProgressPayload): void {
+        const pct = d.total_bytes ? (d.downloaded_bytes / d.total_bytes) * 100 : -1;
+        this.taskQueue.update(taskId, pct, formatSetupDetail(d.downloaded_bytes, d.total_bytes));
+    }
+
+    /** Renders the setup stream onto `taskId`. Returns null on success, else the error text. */
+    private async drainCrawlerSetup(taskId: string, signal: AbortSignal): Promise<string | null> {
+        let outcome: string | null = MESSAGES.ERROR_CRAWLER_SETUP_INCOMPLETE;
+        for await (const event of this.api.setupCrawler(signal)) {
+            switch (event.event) {
+                case SSE_EVENT.SETUP_START: {
+                    const d = event.data as SetupStartPayload;
+                    this.taskQueue.update(taskId, 0, formatSetupDetail(0, d.size_estimate_bytes));
+                    break;
+                }
+                case SSE_EVENT.SETUP_PROGRESS:
+                    this.renderSetupProgress(taskId, event.data as SetupProgressPayload);
+                    break;
+                case SSE_EVENT.SETUP_DONE: {
+                    const d = event.data as SetupDonePayload;
+                    outcome = d.success ? null : (d.error ?? MESSAGES.ERROR_UNKNOWN);
+                    break;
+                }
+            }
+        }
+        return outcome;
+    }
+
     async runCrawl(
         url: string,
         depth: number | null,
@@ -3063,9 +3124,7 @@ export default class LilbeePlugin extends Plugin {
                     }
                     case SSE_EVENT.SETUP_PROGRESS: {
                         if (setupTaskId === null) break;
-                        const d = event.data as SetupProgressPayload;
-                        const pct = d.total_bytes ? (d.downloaded_bytes / d.total_bytes) * 100 : -1;
-                        this.taskQueue.update(setupTaskId, pct, formatSetupDetail(d.downloaded_bytes, d.total_bytes));
+                        this.renderSetupProgress(setupTaskId, event.data as SetupProgressPayload);
                         break;
                     }
                     case SSE_EVENT.SETUP_DONE: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,12 +40,14 @@ import {
     CAPABILITY,
     ERROR_NAME,
     LOGS_DIR,
+    LOG_FILE,
     MANAGED_CONSENT_RESULT,
     MANAGED_PHASE,
     MODEL_TASK,
     REQUEST_OUTCOME,
     SERVER_MODE,
     SERVER_STATE,
+    SERVER_STATUS_PREFIX,
     SETUP_OUTCOME,
     SSE_EVENT,
     SYNC_TRIGGER,
@@ -68,6 +70,7 @@ import {
     type SetupOutcome,
     type ServerState,
     type ServerVariant,
+    type StorageMoveTarget,
     type SetupDonePayload,
     type SetupProgressPayload,
     type SetupStartPayload,
@@ -90,6 +93,7 @@ import { AGENT_LABELS, MESSAGES } from "./locales/en";
 import { displayLabelForRef, extractHfRepo } from "./utils/model-ref";
 import {
     errorMessage,
+    extractServerErrorDetail,
     extractSseErrorMessage,
     formatDiskSize,
     isVersionOlder,
@@ -930,22 +934,24 @@ export default class LilbeePlugin extends Plugin {
         this.refreshSettingsTab();
     }
 
-    /**
-     * Tell the managed server to store content under the vault.
-     *
-     * PATCHes ``documents_dir`` to ``<vault>/lilbee`` and ``vault_base`` to the
-     * vault root. Server performs a locked relocation if paths changed, then
-     * stamps ``vault_path`` on every Source response so chat-chip clicks can
-     * deep-link into the local editor. No-op when the toggle is off, the
-     * server is external, or the current values already match.
-     */
-    /** Where the managed server keeps content when it is not stored in the vault. */
-    private serverOwnedDocumentsDir(): string | null {
+    /** This vault's server data directory, or null before the registry loads. */
+    private ownDataDir(): string | null {
         const registry = this.vaultRegistry;
-        if (!registry) return null;
-        return node.join(registry.resolveDataDir(this.vaultId), "documents");
+        return registry ? registry.resolveDataDir(this.vaultId) : null;
     }
 
+    /** Where the managed server keeps content when it is not stored in the vault. */
+    private serverOwnedDocumentsDir(): string | null {
+        const dataDir = this.ownDataDir();
+        return dataDir === null ? null : node.join(dataDir, "documents");
+    }
+
+    /**
+     * Tell the managed server where to keep content: under the vault, or in its
+     * own data directory. The server relocates what is already there. No-op when
+     * the server is external, when the current values already match, or when the
+     * server has already refused this same layout.
+     */
     async configureManagedStorage(): Promise<void> {
         if (this.settings.serverMode !== SERVER_MODE.MANAGED) return;
 
@@ -956,8 +962,21 @@ export default class LilbeePlugin extends Plugin {
         const storeInVault = this.settings.storeContentInVault;
         const vaultBase = this.getVaultBasePath();
         const desiredDocsDir = storeInVault ? `${vaultBase}/lilbee` : this.serverOwnedDocumentsDir();
-        const desiredVaultBase = storeInVault ? vaultBase : null;
         if (desiredDocsDir === null) return;
+        const target: StorageMoveTarget = {
+            documentsDir: desiredDocsDir,
+            vaultBase: storeInVault ? vaultBase : null,
+        };
+
+        const refused = this.settings.rejectedStorageMove;
+        if (
+            refused !== null &&
+            refused.documentsDir === target.documentsDir &&
+            refused.vaultBase === target.vaultBase
+        ) {
+            this.journal.lifecycle("storage move skipped: the server already refused this layout");
+            return;
+        }
 
         let current: Record<string, unknown>;
         try {
@@ -969,24 +988,44 @@ export default class LilbeePlugin extends Plugin {
 
         const currentDocs = typeof current.documents_dir === "string" ? current.documents_dir : "";
         const currentVault = typeof current.vault_base === "string" ? current.vault_base : null;
-        if (currentDocs === desiredDocsDir && currentVault === desiredVaultBase) {
+        if (currentDocs === target.documentsDir && currentVault === target.vaultBase) {
             return;
         }
 
         const notice = new Notice(MESSAGES.NOTICE_STORAGE_REORGANIZING, NOTICE_PERMANENT);
         try {
             await this.api.updateConfig({
-                documents_dir: desiredDocsDir,
-                vault_base: desiredVaultBase,
+                documents_dir: target.documentsDir,
+                vault_base: target.vaultBase,
             });
             notice.hide();
+            this.settings.rejectedStorageMove = null;
+            await this.persistAll();
             new Notice(MESSAGES.NOTICE_STORAGE_REORGANIZED);
         } catch (err) {
             notice.hide();
-            const detail = errorMessage(err, String(err));
-            new Notice(`${MESSAGES.NOTICE_STORAGE_REORGANIZE_FAILED}${detail}`, NOTICE_ERROR_DURATION_MS);
-            console.error("[lilbee] storage reorganisation failed", err);
+            await this.reportStorageMoveFailure(target, err);
         }
+    }
+
+    /** Say why a move failed, and remember a layout the server itself refused. */
+    private async reportStorageMoveFailure(target: StorageMoveTarget, err: unknown): Promise<void> {
+        // An unanswered request is not a refusal: remembering it would strand
+        // the user on a blip that the next start would have got past.
+        const message = errorMessage(err, String(err));
+        const refused = message.startsWith(SERVER_STATUS_PREFIX);
+        if (refused) {
+            this.settings.rejectedStorageMove = target;
+            await this.persistAll();
+        }
+
+        // A status line is not a reason. Show the server's own detail when it
+        // has one, otherwise point at the log that does.
+        const reason = refused ? extractServerErrorDetail(message) : message;
+        const dataDir = this.ownDataDir();
+        const logPath = dataDir === null ? null : node.join(dataDir, LOGS_DIR, LOG_FILE.SERVER);
+        new Notice(MESSAGES.NOTICE_STORAGE_REORGANIZE_FAILED(reason, logPath, !refused), NOTICE_ERROR_DURATION_MS);
+        console.error("[lilbee] storage reorganisation failed", err);
     }
 
     /** True when the shared bin dir holds a server binary this vault can run. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -1993,14 +1993,11 @@ export default class LilbeePlugin extends Plugin {
         if (health?.isOk()) {
             this.healthFailureStreak = 0;
             if (this.settings.serverMode === SERVER_MODE.EXTERNAL) this.externalServerVersion = health.value.version;
+            // Only a reconnect refetches the model: a restarted server may be
+            // on a different one. A steady probe asks for health and nothing else.
             if (this.serverUnreachable) {
                 this.serverUnreachable = false;
                 void this.fetchActiveModel();
-            } else {
-                // Keep the status-bar model in sync with out-of-band changes
-                // (CLI/TUI/another client switching the chat model) while the
-                // server stays connected.
-                void this.refreshActiveModel();
             }
             this.reflectChatStatus(health.value);
             return;
@@ -2211,20 +2208,6 @@ export default class LilbeePlugin extends Plugin {
             return;
         }
         new ModelInfoModal(this.app, this, entry).open();
-    }
-
-    /** Lightweight active-model resync used on every healthy probe tick, so the
-     *  status bar reflects an out-of-band chat-model change. Cheaper than
-     *  fetchActiveModel (no wiki/reasoning work); repaints only on a change. */
-    private async refreshActiveModel(): Promise<void> {
-        try {
-            const models = await this.api.listModels();
-            if (models.chat.active === this.activeModel) return;
-            this.activeModel = models.chat.active;
-            if (this.chatStatus !== CHAT_STATUS.LOADING) this.setStatusReady();
-        } catch {
-            // best-effort; the next probe tick retries
-        }
     }
 
     async fetchActiveModel(): Promise<void> {

--- a/src/server-uninstall.ts
+++ b/src/server-uninstall.ts
@@ -49,20 +49,12 @@ export function planUninstall(sharedRoot: string, vaultDataDir: string): Uninsta
 /** How long the stop may run before the child is killed and the uninstall goes on. */
 const ENGINE_STOP_TIMEOUT_MS = 15_000;
 
-/**
- * The binary's off switch for the shared engine, whoever started it. The data dir
- * names the vault whose private engine is stopped alongside the machine-wide one,
- * and it precedes the command because the server binds it on the root command.
- */
+/** Stop args for the shared engine; the data dir precedes the command, as the binary requires. */
 function engineStopArgs(vaultDataDir: string): string[] {
     return ["--data-dir", vaultDataDir, "engine", "stop"];
 }
 
-/**
- * Stop the shared engine, which outlives any one plugin process and holds the model
- * files open. A missing binary, one too old to know the command, and a stop past its
- * bound are all ignored.
- */
+/** Stop the shared engine, which holds the model files open. Every failure is ignored. */
 async function stopSharedEngine(sharedRoot: string, vaultDataDir: string): Promise<void> {
     const binary = new ServerBinary(sharedBinDir(sharedRoot)).installed();
     if (binary === null) return;
@@ -73,10 +65,7 @@ async function stopSharedEngine(sharedRoot: string, vaultDataDir: string): Promi
     }
 }
 
-/**
- * Stop the engine, then delete every planned path. Missing paths are not an error.
- * The order is the contract: deleting a file a live engine holds open fails on Windows.
- */
+/** Stop the engine before deleting: Windows cannot delete a file a live engine holds open. */
 export async function executeUninstall(plan: UninstallPlan, sharedRoot: string, vaultDataDir: string): Promise<void> {
     await stopSharedEngine(sharedRoot, vaultDataDir);
     for (const t of plan.targets) {

--- a/src/server-uninstall.ts
+++ b/src/server-uninstall.ts
@@ -3,6 +3,7 @@
  * shared model cache, and one vault's index. Never touches the Obsidian vault.
  */
 import { node } from "./node";
+import { ServerBinary } from "./server-binary";
 import { dirSizeBytes } from "./storage-stats";
 import { sharedBinDir, sharedModelsDir } from "./vault-registry";
 import {
@@ -45,8 +46,39 @@ export function planUninstall(sharedRoot: string, vaultDataDir: string): Uninsta
     return { targets, totalBytes: targets.reduce((sum, t) => sum + t.bytes, 0) };
 }
 
-/** Delete every planned path. Missing paths are not an error. */
-export function executeUninstall(plan: UninstallPlan): void {
+/** How long the stop may run before the child is killed and the uninstall goes on. */
+const ENGINE_STOP_TIMEOUT_MS = 15_000;
+
+/**
+ * The binary's off switch for the shared engine, whoever started it. The data dir
+ * names the vault whose private engine is stopped alongside the machine-wide one,
+ * and it precedes the command because the server binds it on the root command.
+ */
+function engineStopArgs(vaultDataDir: string): string[] {
+    return ["--data-dir", vaultDataDir, "engine", "stop"];
+}
+
+/**
+ * Stop the shared engine, which outlives any one plugin process and holds the model
+ * files open. A missing binary, one too old to know the command, and a stop past its
+ * bound are all ignored.
+ */
+async function stopSharedEngine(sharedRoot: string, vaultDataDir: string): Promise<void> {
+    const binary = new ServerBinary(sharedBinDir(sharedRoot)).installed();
+    if (binary === null) return;
+    try {
+        await node.execFile(binary.path, engineStopArgs(vaultDataDir), { timeout: ENGINE_STOP_TIMEOUT_MS });
+    } catch {
+        // An engine that will not stop is not a reason to refuse the uninstall.
+    }
+}
+
+/**
+ * Stop the engine, then delete every planned path. Missing paths are not an error.
+ * The order is the contract: deleting a file a live engine holds open fails on Windows.
+ */
+export async function executeUninstall(plan: UninstallPlan, sharedRoot: string, vaultDataDir: string): Promise<void> {
+    await stopSharedEngine(sharedRoot, vaultDataDir);
     for (const t of plan.targets) {
         node.rmSync(t.path, { recursive: true, force: true });
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -138,6 +138,9 @@ export class LilbeeSettingTab extends PluginSettingTab {
     private chatModeSelectEl: HTMLSelectElement | null = null;
     private apiKeysContainerEl: HTMLElement | null = null;
     private crawlingContainerEl: HTMLElement | null = null;
+    private crawlerBrowserSetupEl: HTMLElement | null = null;
+    // Fail open: an unreachable probe must not block a render mode that works.
+    private crawlerBrowserReady = true;
     private wikiContainerEl: HTMLElement | null = null;
     /** Last successful release-list fetch; failures are not cached, so a retry always refetches. */
     private releasesCache: { at: number; releases: ReleaseInfo[] } | null = null;
@@ -200,14 +203,18 @@ export class LilbeeSettingTab extends PluginSettingTab {
     }
 
     private async applyCapabilityGating(): Promise<void> {
-        const [apiKeys, crawling, wiki] = await Promise.all([
+        const [apiKeys, crawling, crawlingBrowser, wiki] = await Promise.all([
             this.plugin.api.getCapability(CAPABILITY.API_KEYS),
             this.plugin.api.getCapability(CAPABILITY.CRAWLING),
+            this.plugin.api.getCapability(CAPABILITY.CRAWLING_BROWSER),
             this.plugin.api.getCapability(CAPABILITY.WIKI),
         ]);
         if (!apiKeys && this.apiKeysContainerEl) this.apiKeysContainerEl.hide();
         if (!crawling && this.crawlingContainerEl) this.crawlingContainerEl.hide();
         if (!wiki && this.wikiContainerEl) this.wikiContainerEl.hide();
+        this.crawlerBrowserReady = crawlingBrowser;
+        // The offer belongs inside a visible Crawling section, never on its own.
+        if (crawling && !crawlingBrowser && this.crawlerBrowserSetupEl) this.crawlerBrowserSetupEl.show();
     }
 
     private filterSettings(containerEl: HTMLElement, query: string): void {
@@ -2623,6 +2630,11 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 dropdown.addOption(CRAWL_RENDER_MODE.BROWSER, MESSAGES.LABEL_CRAWL_RENDER_MODE_BROWSER);
                 dropdown.setValue(CRAWL_RENDER_MODE.HTTP);
                 dropdown.onChange(async (value) => {
+                    if (value === CRAWL_RENDER_MODE.BROWSER && !this.crawlerBrowserReady) {
+                        dropdown.setValue(CRAWL_RENDER_MODE.HTTP);
+                        new Notice(MESSAGES.NOTICE_CRAWL_BROWSER_MISSING);
+                        return;
+                    }
                     try {
                         await this.plugin.api.updateConfig({ [CONFIG_KEY.CRAWL_RENDER_MODE]: value });
                         new Notice(MESSAGES.NOTICE_FIELD_UPDATED(MESSAGES.LABEL_CRAWL_RENDER_MODE));
@@ -2635,6 +2647,23 @@ export class LilbeeSettingTab extends PluginSettingTab {
         this.appendResetAffordance(renderModeSetting, CONFIG_KEY.CRAWL_RENDER_MODE, MESSAGES.LABEL_CRAWL_RENDER_MODE);
         renderModeContainer.hide();
         this.serverConfigHideableEls.set(CONFIG_KEY.CRAWL_RENDER_MODE, renderModeContainer);
+
+        const browserSetupContainer = containerEl.createDiv();
+        new Setting(browserSetupContainer)
+            .setName(MESSAGES.LABEL_CRAWL_BROWSER_SETUP)
+            .setDesc(MESSAGES.DESC_CRAWL_BROWSER_SETUP)
+            .addButton((btn) =>
+                btn.setButtonText(MESSAGES.BUTTON_INSTALL_CHROMIUM).onClick(async () => {
+                    btn.setDisabled(true);
+                    const installed = await this.plugin.installCrawlerBrowser();
+                    btn.setDisabled(false);
+                    if (!installed) return;
+                    this.crawlerBrowserReady = true;
+                    browserSetupContainer.hide();
+                }),
+            );
+        browserSetupContainer.hide();
+        this.crawlerBrowserSetupEl = browserSetupContainer;
 
         const patternsSetting = new Setting(containerEl)
             .setName(MESSAGES.LABEL_CRAWL_EXCLUDE_PATTERNS)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2864,6 +2864,8 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 toggle.setDisabled(this.plugin.settings.serverMode !== SERVER_MODE.MANAGED);
                 toggle.onChange(async (value) => {
                     this.plugin.settings.storeContentInVault = value;
+                    // Flipping the toggle is the way out of a refused move.
+                    this.plugin.settings.rejectedStorageMove = null;
                     await this.plugin.saveSettings();
                     // Both directions move content; off is not a no-op.
                     void this.plugin.configureManagedStorage();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -139,8 +139,6 @@ export class LilbeeSettingTab extends PluginSettingTab {
     private apiKeysContainerEl: HTMLElement | null = null;
     private crawlingContainerEl: HTMLElement | null = null;
     private crawlerBrowserSetupEl: HTMLElement | null = null;
-    // Fail open: an unreachable probe must not block a render mode that works.
-    private crawlerBrowserReady = true;
     private wikiContainerEl: HTMLElement | null = null;
     /** Last successful release-list fetch; failures are not cached, so a retry always refetches. */
     private releasesCache: { at: number; releases: ReleaseInfo[] } | null = null;
@@ -212,7 +210,6 @@ export class LilbeeSettingTab extends PluginSettingTab {
         if (!apiKeys && this.apiKeysContainerEl) this.apiKeysContainerEl.hide();
         if (!crawling && this.crawlingContainerEl) this.crawlingContainerEl.hide();
         if (!wiki && this.wikiContainerEl) this.wikiContainerEl.hide();
-        this.crawlerBrowserReady = crawlingBrowser;
         // The offer belongs inside a visible Crawling section, never on its own.
         if (crawling && !crawlingBrowser && this.crawlerBrowserSetupEl) this.crawlerBrowserSetupEl.show();
     }
@@ -2448,6 +2445,65 @@ export class LilbeeSettingTab extends PluginSettingTab {
             });
     }
 
+    /** Apply a render-mode choice, fetching Chromium first when browser mode needs it. */
+    private async applyCrawlRenderMode(dropdown: { setValue: (v: string) => unknown }, value: string): Promise<void> {
+        // The choice can arrive before the gating probe lands, so read the capability now.
+        if (
+            value === CRAWL_RENDER_MODE.BROWSER &&
+            !(await this.plugin.api.getCapability(CAPABILITY.CRAWLING_BROWSER))
+        ) {
+            // Choosing browser mode is the request for a browser, so fetch it rather than refuse.
+            if (!(await this.plugin.installCrawlerBrowser())) {
+                dropdown.setValue(CRAWL_RENDER_MODE.HTTP);
+                return;
+            }
+            this.crawlerBrowserSetupEl?.hide();
+        }
+        try {
+            await this.plugin.api.updateConfig({ [CONFIG_KEY.CRAWL_RENDER_MODE]: value });
+            new Notice(MESSAGES.NOTICE_FIELD_UPDATED(MESSAGES.LABEL_CRAWL_RENDER_MODE));
+        } catch {
+            new Notice(MESSAGES.NOTICE_FAILED_UPDATE(MESSAGES.LABEL_CRAWL_RENDER_MODE));
+        }
+    }
+
+    /** The render-mode row, in its own div so hide-until-supported targets just this row. */
+    private renderCrawlRenderMode(containerEl: HTMLElement): void {
+        const renderModeContainer = containerEl.createDiv();
+        const renderModeSetting = new Setting(renderModeContainer)
+            .setName(MESSAGES.LABEL_CRAWL_RENDER_MODE)
+            .setDesc(MESSAGES.DESC_CRAWL_RENDER_MODE)
+            .addDropdown((dropdown) => {
+                dropdown.addOption(CRAWL_RENDER_MODE.HTTP, MESSAGES.LABEL_CRAWL_RENDER_MODE_HTTP);
+                dropdown.addOption(CRAWL_RENDER_MODE.BROWSER, MESSAGES.LABEL_CRAWL_RENDER_MODE_BROWSER);
+                dropdown.setValue(CRAWL_RENDER_MODE.HTTP);
+                dropdown.onChange((value) => this.applyCrawlRenderMode(dropdown, value));
+                this.serverConfigDropdowns.set(CONFIG_KEY.CRAWL_RENDER_MODE, dropdown);
+            });
+        this.appendResetAffordance(renderModeSetting, CONFIG_KEY.CRAWL_RENDER_MODE, MESSAGES.LABEL_CRAWL_RENDER_MODE);
+        renderModeContainer.hide();
+        this.serverConfigHideableEls.set(CONFIG_KEY.CRAWL_RENDER_MODE, renderModeContainer);
+    }
+
+    /** The Chromium install offer, hidden until the capability probe says it is needed. */
+    private renderCrawlerBrowserSetup(containerEl: HTMLElement): void {
+        const browserSetupContainer = containerEl.createDiv();
+        new Setting(browserSetupContainer)
+            .setName(MESSAGES.LABEL_CRAWL_BROWSER_SETUP)
+            .setDesc(MESSAGES.DESC_CRAWL_BROWSER_SETUP)
+            .addButton((btn) =>
+                btn.setButtonText(MESSAGES.BUTTON_INSTALL_CHROMIUM).onClick(async () => {
+                    btn.setDisabled(true);
+                    const installed = await this.plugin.installCrawlerBrowser();
+                    btn.setDisabled(false);
+                    if (!installed) return;
+                    browserSetupContainer.hide();
+                }),
+            );
+        browserSetupContainer.hide();
+        this.crawlerBrowserSetupEl = browserSetupContainer;
+    }
+
     private renderCrawlingSettings(containerEl: HTMLElement): void {
         new Setting(containerEl).setName(MESSAGES.LABEL_CRAWLING).setHeading();
 
@@ -2619,57 +2675,8 @@ export class LilbeeSettingTab extends PluginSettingTab {
             this.appendResetAffordance(numSetting, numField.key, numField.name);
         }
 
-        // Wrap the render-mode row in its own child div so the hide-until-supported
-        // toggle targets just this row, not the capability-gated crawling container.
-        const renderModeContainer = containerEl.createDiv();
-        const renderModeSetting = new Setting(renderModeContainer)
-            .setName(MESSAGES.LABEL_CRAWL_RENDER_MODE)
-            .setDesc(MESSAGES.DESC_CRAWL_RENDER_MODE)
-            .addDropdown((dropdown) => {
-                dropdown.addOption(CRAWL_RENDER_MODE.HTTP, MESSAGES.LABEL_CRAWL_RENDER_MODE_HTTP);
-                dropdown.addOption(CRAWL_RENDER_MODE.BROWSER, MESSAGES.LABEL_CRAWL_RENDER_MODE_BROWSER);
-                dropdown.setValue(CRAWL_RENDER_MODE.HTTP);
-                dropdown.onChange(async (value) => {
-                    if (value === CRAWL_RENDER_MODE.BROWSER && !this.crawlerBrowserReady) {
-                        // Choosing browser mode is the request for a browser. The
-                        // server fetches Chromium on demand and streams progress,
-                        // so fetch it here rather than refusing the choice.
-                        if (!(await this.plugin.installCrawlerBrowser())) {
-                            dropdown.setValue(CRAWL_RENDER_MODE.HTTP);
-                            return;
-                        }
-                        this.crawlerBrowserReady = true;
-                        this.crawlerBrowserSetupEl?.hide();
-                    }
-                    try {
-                        await this.plugin.api.updateConfig({ [CONFIG_KEY.CRAWL_RENDER_MODE]: value });
-                        new Notice(MESSAGES.NOTICE_FIELD_UPDATED(MESSAGES.LABEL_CRAWL_RENDER_MODE));
-                    } catch {
-                        new Notice(MESSAGES.NOTICE_FAILED_UPDATE(MESSAGES.LABEL_CRAWL_RENDER_MODE));
-                    }
-                });
-                this.serverConfigDropdowns.set(CONFIG_KEY.CRAWL_RENDER_MODE, dropdown);
-            });
-        this.appendResetAffordance(renderModeSetting, CONFIG_KEY.CRAWL_RENDER_MODE, MESSAGES.LABEL_CRAWL_RENDER_MODE);
-        renderModeContainer.hide();
-        this.serverConfigHideableEls.set(CONFIG_KEY.CRAWL_RENDER_MODE, renderModeContainer);
-
-        const browserSetupContainer = containerEl.createDiv();
-        new Setting(browserSetupContainer)
-            .setName(MESSAGES.LABEL_CRAWL_BROWSER_SETUP)
-            .setDesc(MESSAGES.DESC_CRAWL_BROWSER_SETUP)
-            .addButton((btn) =>
-                btn.setButtonText(MESSAGES.BUTTON_INSTALL_CHROMIUM).onClick(async () => {
-                    btn.setDisabled(true);
-                    const installed = await this.plugin.installCrawlerBrowser();
-                    btn.setDisabled(false);
-                    if (!installed) return;
-                    this.crawlerBrowserReady = true;
-                    browserSetupContainer.hide();
-                }),
-            );
-        browserSetupContainer.hide();
-        this.crawlerBrowserSetupEl = browserSetupContainer;
+        this.renderCrawlRenderMode(containerEl);
+        this.renderCrawlerBrowserSetup(containerEl);
 
         const patternsSetting = new Setting(containerEl)
             .setName(MESSAGES.LABEL_CRAWL_EXCLUDE_PATTERNS)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2631,9 +2631,15 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 dropdown.setValue(CRAWL_RENDER_MODE.HTTP);
                 dropdown.onChange(async (value) => {
                     if (value === CRAWL_RENDER_MODE.BROWSER && !this.crawlerBrowserReady) {
-                        dropdown.setValue(CRAWL_RENDER_MODE.HTTP);
-                        new Notice(MESSAGES.NOTICE_CRAWL_BROWSER_MISSING);
-                        return;
+                        // Choosing browser mode is the request for a browser. The
+                        // server fetches Chromium on demand and streams progress,
+                        // so fetch it here rather than refusing the choice.
+                        if (!(await this.plugin.installCrawlerBrowser())) {
+                            dropdown.setValue(CRAWL_RENDER_MODE.HTTP);
+                            return;
+                        }
+                        this.crawlerBrowserReady = true;
+                        this.crawlerBrowserSetupEl?.hide();
                     }
                     try {
                         await this.plugin.api.updateConfig({ [CONFIG_KEY.CRAWL_RENDER_MODE]: value });

--- a/src/types.ts
+++ b/src/types.ts
@@ -250,11 +250,13 @@ export const KEY_STATUS = {
     MISSING_KEY: "missing_key",
 } as const satisfies Record<string, KeyStatus>;
 
-export type Capability = "api_keys" | "crawling" | "wiki";
+export type Capability = "api_keys" | "crawling" | "crawling_browser" | "wiki";
 
 export const CAPABILITY = {
     API_KEYS: "api_keys",
+    // CRAWLING is the crawler package; CRAWLING_BROWSER also needs Playwright Chromium.
     CRAWLING: "crawling",
+    CRAWLING_BROWSER: "crawling_browser",
     WIKI: "wiki",
 } as const satisfies Record<string, Capability>;
 
@@ -902,6 +904,12 @@ export interface WikiPagePayload {
     pages: number;
     current: number;
     total: number;
+}
+
+export interface CrawlerStatusResponse {
+    installed?: boolean;
+    package_installed?: boolean;
+    chromium_installed?: boolean;
 }
 
 export interface SetupStartPayload {

--- a/src/types.ts
+++ b/src/types.ts
@@ -685,11 +685,7 @@ export interface LilbeeSettings {
      * external servers keep their own documents_dir.
      */
     storeContentInVault: boolean;
-    /**
-     * The storage layout the server refused. While it still matches the layout
-     * the plugin wants, no move is sent, so a failure is not retried at every
-     * start. Cleared when either value changes or the user flips the toggle.
-     */
+    /** The storage layout the server refused; no move is sent while it still matches. */
     rejectedStorageMove: StorageMoveTarget | null;
     lastCatalogTab: CatalogTab;
     /**
@@ -929,10 +925,17 @@ export interface WikiPagePayload {
 }
 
 export interface CrawlerStatusResponse {
-    installed?: boolean;
-    package_installed?: boolean;
-    chromium_installed?: boolean;
+    installed: boolean;
+    package_installed: boolean;
 }
+
+export type CrawlerStatusField = keyof CrawlerStatusResponse;
+
+/** `PACKAGE` is the bundled crawler package; `WITH_BROWSER` also requires Chromium. */
+export const CRAWLER_STATUS_FIELD = {
+    PACKAGE: "package_installed",
+    WITH_BROWSER: "installed",
+} as const satisfies Record<string, CrawlerStatusField>;
 
 export interface SetupStartPayload {
     component: string;
@@ -1365,9 +1368,8 @@ export interface PlacementResponse {
     unplaceable: string[];
     manual: boolean;
     spec_json: string | null;
-    /** A saved manual spec this hardware no longer satisfies. The auto plan runs, the spec
-     *  stays saved and reapplies once it fits again. Absent on older servers. */
-    rejected_spec_json?: string | null;
+    /** A saved manual spec this hardware no longer satisfies; it reapplies once it fits. */
+    rejected_spec_json: string | null;
     /** Host-level fix instruction, present only when GPU monitoring is degraded. */
     notice?: GpuNotice;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -347,6 +347,12 @@ export interface SyncDone {
     held_out: SkippedSource[];
 }
 
+/** An add stream's terminal summary: the sync it ran, plus the add-only outcomes. */
+export interface AddDone extends SyncDone {
+    /** Sources the knowledge base already tracks, so nothing was registered. Needs no user action. */
+    tracked: string[];
+}
+
 /** Recovery options for a sync. Both default off (a plain incremental sync). */
 export interface SyncOptions {
     /** Drop the whole index and re-embed every document from scratch. */
@@ -1359,6 +1365,9 @@ export interface PlacementResponse {
     unplaceable: string[];
     manual: boolean;
     spec_json: string | null;
+    /** A saved manual spec this hardware no longer satisfies. The auto plan runs, the spec
+     *  stays saved and reapplies once it fits again. Absent on older servers. */
+    rejected_spec_json?: string | null;
     /** Host-level fix instruction, present only when GPU monitoring is degraded. */
     notice?: GpuNotice;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -496,6 +496,9 @@ export const SERVER_MODE = {
     EXTERNAL: "external",
 } as const satisfies Record<string, ServerMode>;
 
+/** How the API client opens the message it throws for a non-ok response. */
+export const SERVER_STATUS_PREFIX = "Server responded";
+
 /** Three-way result of the managed-mode consent modal. */
 export type ManagedConsentResultKind = "download" | "external" | "cancel";
 
@@ -652,6 +655,12 @@ export const DEFAULT_AGENT_INTEGRATION: AgentIntegrationSettings = {
 /** Below this the agent runs out of room mid-task, so the settings row warns. */
 export const AGENT_MIN_CONTEXT_TOKENS = 20_000;
 
+/** Where the plugin wants the managed server to keep content. */
+export interface StorageMoveTarget {
+    documentsDir: string;
+    vaultBase: string | null;
+}
+
 export interface LilbeeSettings {
     serverUrl: string;
     topK: number;
@@ -670,6 +679,12 @@ export interface LilbeeSettings {
      * external servers keep their own documents_dir.
      */
     storeContentInVault: boolean;
+    /**
+     * The storage layout the server refused. While it still matches the layout
+     * the plugin wants, no move is sent, so a failure is not retried at every
+     * start. Cleared when either value changes or the user flips the toggle.
+     */
+    rejectedStorageMove: StorageMoveTarget | null;
     lastCatalogTab: CatalogTab;
     /**
      * Filesystem root that holds the shared lilbee binary, models cache, and
@@ -709,6 +724,7 @@ export const DEFAULT_SETTINGS: LilbeeSettings = {
     wikiVaultFolder: "lilbee-wiki",
     manualToken: "",
     storeContentInVault: true,
+    rejectedStorageMove: null,
     lastCatalogTab: "discover",
     sharedRoot: "",
     reasoningDefaulted: false,

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -438,9 +438,7 @@ export class CatalogModal extends Modal {
 
     private applyPage(response: CatalogResponse): void {
         this.hasMore = response.has_more;
-        // Defensive client-side task filter — older server builds and some
-        // frontier providers tag rows loosely, leaking embedding/vision
-        // models into the chat tab and vice versa.
+        // Some servers and frontier providers tag rows loosely, so the task is filtered again.
         const filtered = this.filterTask ? response.models.filter((m) => m.task === this.filterTask) : response.models;
         this.entries.push(...filtered);
         this.offset += response.models.length;

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -1,6 +1,6 @@
 import { App, Modal, Notice, setIcon } from "obsidian";
 import type LilbeePlugin from "../main";
-import type { CatalogEntry, CatalogTab, CatalogViewMode, KeyStatus, ModelTask } from "../types";
+import type { CatalogEntry, CatalogResponse, CatalogTab, CatalogViewMode, KeyStatus, ModelTask } from "../types";
 import {
     CATALOG_SOURCE,
     CATALOG_TAB,
@@ -46,6 +46,8 @@ import {
 } from "./catalog-helpers";
 
 const PAGE_SIZE = 20;
+// Search matches are spread across the hub, not sitting at one offset.
+const SEARCH_PAGE_SIZE = 50;
 const SCROLL_BOTTOM_THRESHOLD_PX = 200;
 const DRAWER_BREAKPOINT_PX = 800;
 const DRAWER_FOCUS_DEBOUNCE_MS = 30;
@@ -98,6 +100,8 @@ export class CatalogModal extends Modal {
     private filterSort: SortFilter = FILTERS.SORT.FEATURED;
     private filterSearch = "";
     private offset = 0;
+    // The query the offset was fetched under.
+    private fetchedQuery = "";
     private hasMore = false;
     private isFetching = false;
     private entries: CatalogEntry[] = [];
@@ -409,48 +413,68 @@ export class CatalogModal extends Modal {
             this.viewMode === CATALOG_VIEW_MODE.GRID ? MESSAGES.LABEL_SWITCH_TO_LIST : MESSAGES.LABEL_SWITCH_TO_GRID;
     }
 
-    private resetAndFetch(): void {
-        this.offset = 0;
+    private clearResults(): void {
         this.entries = [];
         if (this.resultsEl) this.resultsEl.empty();
+    }
+
+    private resetAndFetch(): void {
+        this.offset = 0;
+        this.clearResults();
         void this.fetchPage();
     }
 
-    private async fetchPage(): Promise<void> {
-        if (this.isFetching) return;
-        this.isFetching = true;
+    private catalogParams(query: string): Parameters<typeof this.plugin.api.catalog>[0] {
         const params: Parameters<typeof this.plugin.api.catalog>[0] = {
-            limit: PAGE_SIZE,
+            limit: query ? SEARCH_PAGE_SIZE : PAGE_SIZE,
             offset: this.offset,
             sort: this.filterSort,
         };
         if (this.filterTask) params.task = this.filterTask;
         if (this.filterSize) params.size = this.filterSize;
-        if (this.filterSearch) params.search = this.filterSearch;
+        if (query) params.search = query;
+        return params;
+    }
 
+    private applyPage(response: CatalogResponse): void {
+        this.hasMore = response.has_more;
+        // Defensive client-side task filter — older server builds and some
+        // frontier providers tag rows loosely, leaking embedding/vision
+        // models into the chat tab and vice versa.
+        const filtered = this.filterTask ? response.models.filter((m) => m.task === this.filterTask) : response.models;
+        this.entries.push(...filtered);
+        this.offset += response.models.length;
+
+        this.updateHostedTabVisibility();
+        this.renderResults();
+    }
+
+    private async fetchPage(): Promise<void> {
+        if (this.isFetching) return;
+        const query = this.filterSearch;
+        // The offset belongs to one query; a different term restarts the result set.
+        if (query !== this.fetchedQuery) {
+            this.fetchedQuery = query;
+            this.offset = 0;
+            this.clearResults();
+        }
+        this.isFetching = true;
+
+        let superseded = false;
         try {
-            const result = await this.plugin.api.catalog(params);
+            const result = await this.plugin.api.catalog(this.catalogParams(query));
             if (result.isErr()) {
                 new Notice(noticeForResultError(result.error, MESSAGES.ERROR_LOAD_CATALOG));
-                return;
+            } else if (query !== this.filterSearch) {
+                // The term moved on while this page was in flight.
+                superseded = true;
+            } else {
+                this.applyPage(result.value);
             }
-
-            const response = result.value;
-            this.hasMore = response.has_more;
-            // Defensive client-side task filter — older server builds and some
-            // frontier providers tag rows loosely, leaking embedding/vision
-            // models into the chat tab and vice versa.
-            const filtered = this.filterTask
-                ? response.models.filter((m) => m.task === this.filterTask)
-                : response.models;
-            this.entries.push(...filtered);
-            this.offset += response.models.length;
-
-            this.updateHostedTabVisibility();
-            this.renderResults();
         } finally {
             this.isFetching = false;
         }
+        if (superseded) await this.fetchPage();
     }
 
     private renderResults(): void {

--- a/src/views/crawl-modal.ts
+++ b/src/views/crawl-modal.ts
@@ -2,7 +2,7 @@ import { App, Modal, Notice, setIcon } from "obsidian";
 import type LilbeePlugin from "../main";
 import { MESSAGES } from "../locales/en";
 import { bindEscapeToClose, ensureUrlScheme } from "../utils";
-import { CONFIG_KEY, CRAWL_RENDER_MODE, type CrawlRenderMode } from "../types";
+import { CAPABILITY, CONFIG_KEY, CRAWL_RENDER_MODE, type CrawlRenderMode } from "../types";
 
 type ParseResult = { value: number | null; error: string | null };
 
@@ -95,15 +95,40 @@ export class CrawlModal extends Modal {
         asInput(browserInput).checked = false;
         browserLabel.createSpan({ text: MESSAGES.LABEL_CRAWL_USE_BROWSER });
 
-        // Pre-set the toggle from the server's current crawl_render_mode (sticky default).
-        void this.plugin.api
-            .config()
-            .then((cfg) => {
-                asInput(browserInput).checked = cfg.crawl_render_mode === CRAWL_RENDER_MODE.BROWSER;
-            })
-            .catch(() => {
-                /* Leave the toggle at its lightweight default if config is unreachable. */
+        const browserSetup = contentEl.createDiv({ cls: "lilbee-crawl-browser-setup" });
+        browserSetup.createSpan({ text: MESSAGES.NOTICE_CRAWL_BROWSER_MISSING });
+        const installBtn = browserSetup.createEl("button", {
+            text: MESSAGES.BUTTON_INSTALL_CHROMIUM,
+            attr: { type: "button" },
+        });
+        browserSetup.hide();
+        installBtn.addEventListener("click", () => {
+            installBtn.disabled = true;
+            void this.plugin.installCrawlerBrowser().then((installed) => {
+                installBtn.disabled = false;
+                if (!installed) return;
+                asInput(browserInput).disabled = false;
+                asInput(browserInput).checked = true;
+                browserSetup.hide();
             });
+        });
+
+        // Resolve both before touching the toggle: the sticky default must not
+        // re-check a box that the missing Chromium just disabled.
+        void (async () => {
+            const [cfg, browserReady] = await Promise.all([
+                this.plugin.api.config().catch(() => null),
+                this.plugin.api.getCapability(CAPABILITY.CRAWLING_BROWSER),
+            ]);
+            if (!browserReady) {
+                asInput(browserInput).disabled = true;
+                browserSetup.show();
+                return;
+            }
+            if (cfg !== null) {
+                asInput(browserInput).checked = cfg.crawl_render_mode === CRAWL_RENDER_MODE.BROWSER;
+            }
+        })();
 
         const advanced = contentEl.createEl("details", { cls: "lilbee-crawl-advanced" });
         advanced.createEl("summary", { text: MESSAGES.LABEL_CRAWL_ADVANCED });

--- a/src/views/crawl-modal.ts
+++ b/src/views/crawl-modal.ts
@@ -31,6 +31,45 @@ export class CrawlModal extends Modal {
         bindEscapeToClose(this);
     }
 
+    /** The Chromium install offer, shown only when the server cannot render with a browser. */
+    private renderBrowserSetup(contentEl: HTMLElement, browserInput: HTMLElement): void {
+        const browserSetup = contentEl.createDiv({ cls: "lilbee-crawl-browser-setup" });
+        browserSetup.createSpan({ text: MESSAGES.NOTICE_CRAWL_BROWSER_MISSING });
+        const installBtn = browserSetup.createEl("button", {
+            text: MESSAGES.BUTTON_INSTALL_CHROMIUM,
+            attr: { type: "button" },
+        });
+        browserSetup.hide();
+        installBtn.addEventListener("click", () => {
+            installBtn.disabled = true;
+            void this.plugin.installCrawlerBrowser().then((installed) => {
+                installBtn.disabled = false;
+                if (!installed) return;
+                asInput(browserInput).disabled = false;
+                asInput(browserInput).checked = true;
+                browserSetup.hide();
+            });
+        });
+
+        void this.applyBrowserCapability(browserInput, browserSetup);
+    }
+
+    /** Resolve both before touching the toggle: the sticky default must not re-check a disabled box. */
+    private async applyBrowserCapability(browserInput: HTMLElement, browserSetup: HTMLElement): Promise<void> {
+        const [cfg, browserReady] = await Promise.all([
+            this.plugin.api.config().catch(() => null),
+            this.plugin.api.getCapability(CAPABILITY.CRAWLING_BROWSER),
+        ]);
+        if (!browserReady) {
+            asInput(browserInput).disabled = true;
+            browserSetup.show();
+            return;
+        }
+        if (cfg !== null) {
+            asInput(browserInput).checked = cfg.crawl_render_mode === CRAWL_RENDER_MODE.BROWSER;
+        }
+    }
+
     onOpen(): void {
         const { contentEl } = this;
         contentEl.empty();
@@ -95,40 +134,7 @@ export class CrawlModal extends Modal {
         asInput(browserInput).checked = false;
         browserLabel.createSpan({ text: MESSAGES.LABEL_CRAWL_USE_BROWSER });
 
-        const browserSetup = contentEl.createDiv({ cls: "lilbee-crawl-browser-setup" });
-        browserSetup.createSpan({ text: MESSAGES.NOTICE_CRAWL_BROWSER_MISSING });
-        const installBtn = browserSetup.createEl("button", {
-            text: MESSAGES.BUTTON_INSTALL_CHROMIUM,
-            attr: { type: "button" },
-        });
-        browserSetup.hide();
-        installBtn.addEventListener("click", () => {
-            installBtn.disabled = true;
-            void this.plugin.installCrawlerBrowser().then((installed) => {
-                installBtn.disabled = false;
-                if (!installed) return;
-                asInput(browserInput).disabled = false;
-                asInput(browserInput).checked = true;
-                browserSetup.hide();
-            });
-        });
-
-        // Resolve both before touching the toggle: the sticky default must not
-        // re-check a box that the missing Chromium just disabled.
-        void (async () => {
-            const [cfg, browserReady] = await Promise.all([
-                this.plugin.api.config().catch(() => null),
-                this.plugin.api.getCapability(CAPABILITY.CRAWLING_BROWSER),
-            ]);
-            if (!browserReady) {
-                asInput(browserInput).disabled = true;
-                browserSetup.show();
-                return;
-            }
-            if (cfg !== null) {
-                asInput(browserInput).checked = cfg.crawl_render_mode === CRAWL_RENDER_MODE.BROWSER;
-            }
-        })();
+        this.renderBrowserSetup(contentEl, browserInput);
 
         const advanced = contentEl.createEl("details", { cls: "lilbee-crawl-advanced" });
         advanced.createEl("summary", { text: MESSAGES.LABEL_CRAWL_ADVANCED });

--- a/src/views/placement-view.ts
+++ b/src/views/placement-view.ts
@@ -207,6 +207,9 @@ export class PlacementView extends ItemView {
         this.bodyEl.empty();
         this.renderHeader(this.bodyEl, data);
         this.renderNotice(this.bodyEl, data.notice ?? null);
+        if (data.rejected_spec_json) {
+            this.bodyEl.createDiv({ cls: "lilbee-placement-spec-ignored", text: MESSAGES.PLACEMENT_SPEC_IGNORED });
+        }
         if (data.gpus.length < 2) {
             this.renderSingleDevice(this.bodyEl, data);
         } else {
@@ -221,6 +224,8 @@ export class PlacementView extends ItemView {
         if (this.mode === PLACEMENT_MODE.MANUAL) {
             return this.isEdited(data) ? MESSAGES.PLACEMENT_STATE_EDITED : MESSAGES.PLACEMENT_STATE_MANUAL;
         }
+        // The plan in force is auto, but a saved spec is sitting rejected behind it.
+        if (data.rejected_spec_json) return MESSAGES.PLACEMENT_STATE_SPEC_IGNORED;
         return MESSAGES.PLACEMENT_STATE_AUTO;
     }
 

--- a/styles.css
+++ b/styles.css
@@ -4366,7 +4366,8 @@ button.lilbee-model-chip-select:focus-visible {
     padding: 28px 0;
     text-align: center;
 }
-.lilbee-placement-notice {
+.lilbee-placement-notice,
+.lilbee-placement-spec-ignored {
     margin: 0 0 var(--size-4-2, 8px);
     padding: var(--size-4-2, 8px) var(--size-4-3, 12px);
     border-left: 3px solid var(--text-warning);

--- a/styles.css
+++ b/styles.css
@@ -1360,6 +1360,21 @@
     background-color: color-mix(in srgb, var(--interactive-accent) 12%, transparent);
 }
 
+.lilbee-crawl-browser-setup {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--size-4-2, 8px);
+    margin: 0 0 var(--size-4-2, 8px);
+    padding: var(--size-4-2, 8px) var(--size-4-3, 12px);
+    border-left: 3px solid var(--interactive-accent);
+    background-color: color-mix(in srgb, var(--interactive-accent) 6%, transparent);
+    border-radius: 0 var(--radius-s, 4px) var(--radius-s, 4px) 0;
+    color: var(--text-muted);
+    font-size: var(--font-smaller, 12px);
+    line-height: var(--line-height-normal, 1.5);
+}
+
 .lilbee-crawl-notice {
     margin: 0 0 var(--size-4-2, 8px);
     padding: var(--size-4-2, 8px) var(--size-4-3, 12px);

--- a/tests/api-contract.test.ts
+++ b/tests/api-contract.test.ts
@@ -137,6 +137,7 @@ const INVOCATIONS: Record<string, unknown[]> = {
     exportDataset: ["parquet"],
     importDataset: [new ArrayBuffer(8), "parquet"],
     crawl: ["https://example.com"],
+    setupCrawler: [],
     config: [],
     configDefaults: [],
     updateConfig: [{}],
@@ -258,7 +259,7 @@ describe("api.ts route contract", () => {
     });
 
     it("probes capabilities against routes the server serves", async () => {
-        for (const capability of ["api_keys", "crawling", "wiki"]) {
+        for (const capability of ["api_keys", "crawling", "crawling_browser", "wiki"]) {
             client.invalidateCapability();
             const calls = await record("getCapability", [capability]);
             expect(calls.length).toBeGreaterThan(0);

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -5,6 +5,15 @@ import type { Message, PlacementResponse, PlacementSpec } from "../src/types";
 const BASE_URL = "http://localhost:7433";
 
 /** Build a fake fetch response with a JSON body. */
+// Measured on a fresh pod running the release binary lilbee-linux-x86_64-cu124.
+const CRAWLER_STATUS_NO_CHROMIUM = {
+    installed: false,
+    package_installed: true,
+    chromium_installed: false,
+    component: "chromium",
+    browsers_path: "/root/.cache/ms-playwright",
+};
+
 function jsonResponse(data: unknown): Response {
     return {
         ok: true,
@@ -2491,6 +2500,19 @@ describe("getCapability()", () => {
         await expect(client.getCapability("crawling")).resolves.toBe(false);
     });
 
+    it("CRAWLING_BROWSER is false on a server that has the package but no Chromium", async () => {
+        fetchMock.mockResolvedValue(jsonResponse(CRAWLER_STATUS_NO_CHROMIUM));
+        await expect(client.getCapability("crawling")).resolves.toBe(true);
+        await expect(client.getCapability("crawling_browser")).resolves.toBe(false);
+    });
+
+    it("CRAWLING_BROWSER is true once Chromium is installed as well", async () => {
+        fetchMock.mockResolvedValue(
+            jsonResponse({ installed: true, package_installed: true, chromium_installed: true }),
+        );
+        await expect(client.getCapability("crawling_browser")).resolves.toBe(true);
+    });
+
     it("WIKI returns the boolean from /api/config.wiki", async () => {
         fetchMock.mockResolvedValueOnce(jsonResponse({ wiki: true }));
         await expect(client.getCapability("wiki")).resolves.toBe(true);
@@ -2721,6 +2743,31 @@ describe("crawl() include_subdomains", () => {
         await collect(client.crawl("https://x.com", undefined, 0, undefined, undefined, true));
         const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
         expect(body).toMatchObject({ url: "https://x.com", max_pages: 0, include_subdomains: true });
+    });
+});
+
+describe("setupCrawler()", () => {
+    it("POSTs to /setup/crawler and yields the setup events", async () => {
+        fetchMock.mockResolvedValue(
+            sseResponse([
+                'event: setup_start\ndata: {"component":"chromium","size_estimate_bytes":157286400}\n\n',
+                'event: setup_done\ndata: {"component":"chromium","success":true,"error":null}\n\n',
+            ]),
+        );
+
+        const events = await collect(client.setupCrawler());
+
+        expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/setup/crawler`, { method: "POST", headers: {} });
+        expect(events.map((e) => e.event)).toEqual(["setup_start", "setup_done"]);
+    });
+
+    it("passes the abort signal through so a download can be cancelled", async () => {
+        fetchMock.mockResolvedValue(sseResponse([]));
+        const controller = new AbortController();
+
+        await collect(client.setupCrawler(controller.signal));
+
+        expect(fetchMock.mock.calls[0][1].signal).toBe(controller.signal);
     });
 });
 

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -2462,6 +2462,22 @@ describe("setOutcomeCallback", () => {
         expect(outcomes).not.toContain("server_error");
     });
 
+    it("treats a status line with no number as reachable, not a server error", async () => {
+        fetchMock.mockRejectedValue(new Error("Server responded"));
+        const result = await client.health();
+        expect(result.isErr()).toBe(true);
+        expect(outcomes).toContain("ok");
+        expect(outcomes).not.toContain("server_error");
+    });
+
+    it("treats a status line with trailing junk as reachable, not a server error", async () => {
+        fetchMock.mockRejectedValue(new Error("Server respondedX"));
+        const result = await client.health();
+        expect(result.isErr()).toBe(true);
+        expect(outcomes).toContain("ok");
+        expect(outcomes).not.toContain("server_error");
+    });
+
     it("fires 'unreachable' when fetch keeps rejecting", async () => {
         fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
         const result = await client.health();
@@ -2615,6 +2631,7 @@ const PLACEMENT: PlacementResponse = {
     unplaceable: [],
     manual: false,
     spec_json: null,
+    rejected_spec_json: null,
 };
 
 describe("gpuStatsStream()", () => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -30,7 +30,9 @@ import { ok, err } from "../src/result";
 vi.mock("../src/diagnostics-export", () => ({
     exportDiagnostics: vi.fn().mockResolvedValue(undefined),
 }));
-vi.mock("../src/api", () => ({
+vi.mock("../src/api", async (importOriginal) => ({
+    // The status helpers stay real: main.ts classifies a failed config PATCH with them.
+    ...(await importOriginal<typeof import("../src/api")>()),
     SessionTokenError: class SessionTokenError extends Error {
         readonly status: number;
         constructor(status: number, body: string) {
@@ -8987,10 +8989,52 @@ describe("LilbeePlugin", () => {
             expect(message).toContain("data directory");
         });
 
+        it("re-sends the move at the next start after the server answered 503", async () => {
+            const updateConfig = vi
+                .fn()
+                .mockRejectedValue(
+                    new Error('Server responded 503: {"detail":"Close the program that holds config.toml open."}'),
+                );
+            const serverConfig = { documents_dir: "/old/docs", vault_base: null };
+            const first = await setupConfiguredPlugin(
+                {},
+                { config: vi.fn().mockResolvedValue(serverConfig), updateConfig },
+            );
+            await first.configureManagedStorage();
+            expect(updateConfig).toHaveBeenCalledTimes(1);
+            expect(first.settings.rejectedStorageMove).toBeNull();
+
+            const messages = Notice.instances.map((n) => n.message);
+            expect(messages.some((m) => m.includes("Close the program that holds config.toml open."))).toBe(true);
+            expect(messages.some((m) => m.includes("will not try again"))).toBe(false);
+
+            const second = await setupConfiguredPlugin(
+                { ...first.settings },
+                { config: vi.fn().mockResolvedValue(serverConfig), updateConfig },
+            );
+            await second.configureManagedStorage();
+            expect(updateConfig).toHaveBeenCalledTimes(2);
+        });
+
+        it("does not remember a refusal when the status line carries no number", async () => {
+            const updateConfig = vi.fn().mockRejectedValue(new Error("Server responded"));
+            const plugin = await setupConfiguredPlugin(
+                {},
+                {
+                    config: vi.fn().mockResolvedValue({ documents_dir: "/old/docs", vault_base: null }),
+                    updateConfig,
+                },
+            );
+            await plugin.configureManagedStorage();
+            expect(plugin.settings.rejectedStorageMove).toBeNull();
+            const messages = Notice.instances.map((n) => n.message);
+            expect(messages.some((m) => m.includes("will not try again"))).toBe(false);
+        });
+
         it("does not re-send the move at the next start after a failure", async () => {
             const updateConfig = vi
                 .fn()
-                .mockRejectedValue(new Error('Server responded 500: {"detail":"the move failed"}'));
+                .mockRejectedValue(new Error('Server responded 422: {"detail":"the move failed"}'));
             const serverConfig = { documents_dir: "/old/docs", vault_base: null };
             const first = await setupConfiguredPlugin(
                 {},

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1596,6 +1596,34 @@ describe("LilbeePlugin", () => {
             expect(plugin.api.syncStream).toHaveBeenCalledTimes(1);
         });
 
+        it("carries the options of a deferred automatic sync into the follow-up run", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            let releaseFirstSync!: () => void;
+            const firstSyncHeld = new Promise<void>((resolve) => (releaseFirstSync = resolve));
+            let started!: () => void;
+            const syncRunning = new Promise<void>((resolve) => (started = resolve));
+            let calls = 0;
+            plugin.api.syncStream = vi.fn().mockImplementation(() => {
+                const call = ++calls;
+                return (async function* () {
+                    if (call === 1) {
+                        started();
+                        await firstSyncHeld;
+                    }
+                })();
+            });
+
+            const firstSync = plugin.triggerSync();
+            await syncRunning;
+            await plugin.triggerSync({ forceRebuild: true }, SYNC_TRIGGER.AUTOMATIC);
+            releaseFirstSync();
+            await firstSync;
+
+            const secondCall = (plugin.api.syncStream as ReturnType<typeof vi.fn>).mock.calls[1];
+            expect(secondCall?.[1]).toEqual({ forceRebuild: true });
+        });
+
         it("shows Notice with all stats when done event has populated arrays", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
@@ -3907,6 +3935,54 @@ describe("LilbeePlugin", () => {
             expect(Notice.instances.some((n) => n.message.includes("crawl done"))).toBe(true);
             expect(syncSpy).toHaveBeenCalled();
             expect(plugin.taskQueue.completed.length).toBeGreaterThan(0);
+        });
+
+        it("indexes pages crawled during a running sync without any further user action", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+
+            // Stand-in server: a sync indexes the pages that exist when it starts,
+            // so a sync already running cannot see pages a later crawl writes.
+            const crawled: string[] = [];
+            const indexed: string[] = [];
+            let firstSyncStarted!: () => void;
+            const syncRunning = new Promise<void>((resolve) => (firstSyncStarted = resolve));
+            let releaseFirstSync!: () => void;
+            const firstSyncHeld = new Promise<void>((resolve) => (releaseFirstSync = resolve));
+            let secondSyncDone!: () => void;
+            const secondSyncFinished = new Promise<void>((resolve) => (secondSyncDone = resolve));
+            let syncCalls = 0;
+            plugin.api.syncStream = vi.fn().mockImplementation(() => {
+                const plan = [...crawled];
+                const call = ++syncCalls;
+                return (async function* () {
+                    if (call === 1) {
+                        firstSyncStarted();
+                        await firstSyncHeld;
+                    }
+                    indexed.push(...plan);
+                    if (call === 2) secondSyncDone();
+                })();
+            });
+
+            const firstSync = plugin.triggerSync();
+            await syncRunning;
+
+            plugin.api.crawl = vi.fn().mockReturnValue(
+                (async function* () {
+                    crawled.push("https://example.com/a");
+                    yield { event: SSE_EVENT.CRAWL_PAGE, data: { url: "https://example.com/a" } };
+                    yield { event: SSE_EVENT.CRAWL_DONE, data: { pages_crawled: 1 } };
+                })(),
+            );
+            await plugin.runCrawl("https://example.com", 0, 50);
+
+            releaseFirstSync();
+            await firstSync;
+
+            expect(plugin.api.syncStream).toHaveBeenCalledTimes(2);
+            await secondSyncFinished;
+            expect(indexed).toEqual(["https://example.com/a"]);
         });
 
         it("forwards null depth/max_pages to api.crawl for unbounded crawls", async () => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -3,6 +3,7 @@ import { windowStub } from "./window-stub";
 import { Notice, TFile, TFolder } from "obsidian";
 import { App, MockElement, Plugin, WorkspaceLeaf } from "./__mocks__/obsidian";
 import {
+    CAPABILITY,
     CHAT_STATUS,
     DEFAULT_SHARED_CONFIG,
     INDETERMINATE_PROGRESS,
@@ -4225,6 +4226,134 @@ describe("LilbeePlugin", () => {
             expect(setupTasks[0]!.status).toBe("done");
             expect(crawlTasks.length).toBe(1);
             expect(crawlTasks[0]!.status).toBe("done");
+        });
+
+        it("installCrawlerBrowser drives the setup stream and reports success", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.api.invalidateCapability = vi.fn();
+            plugin.api.setupCrawler = vi.fn().mockReturnValue(
+                (async function* () {
+                    yield {
+                        event: SSE_EVENT.SETUP_START,
+                        data: { component: "chromium", size_estimate_bytes: 180_000_000 },
+                    };
+                    yield {
+                        event: SSE_EVENT.SETUP_PROGRESS,
+                        data: {
+                            component: "chromium",
+                            downloaded_bytes: 90_000_000,
+                            total_bytes: 180_000_000,
+                            detail: "Downloading…",
+                        },
+                    };
+                    yield { event: SSE_EVENT.SETUP_DONE, data: { component: "chromium", success: true, error: null } };
+                })(),
+            );
+
+            await expect(plugin.installCrawlerBrowser()).resolves.toBe(true);
+
+            const setupTasks = plugin.taskQueue.completed.filter((t) => t.type === "setup");
+            expect(setupTasks.length).toBe(1);
+            expect(setupTasks[0]!.status).toBe("done");
+            expect(plugin.api.invalidateCapability).toHaveBeenCalledWith(CAPABILITY.CRAWLING_BROWSER);
+        });
+
+        it("installCrawlerBrowser reports an indeterminate download with no total", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.api.invalidateCapability = vi.fn();
+            plugin.api.setupCrawler = vi.fn().mockReturnValue(
+                (async function* () {
+                    yield { event: SSE_EVENT.SETUP_START, data: { component: "chromium", size_estimate_bytes: null } };
+                    yield {
+                        event: SSE_EVENT.SETUP_PROGRESS,
+                        data: {
+                            component: "chromium",
+                            downloaded_bytes: 5_000_000,
+                            total_bytes: null,
+                            detail: "Downloading…",
+                        },
+                    };
+                    yield { event: SSE_EVENT.SETUP_DONE, data: { component: "chromium", success: true, error: null } };
+                })(),
+            );
+
+            await expect(plugin.installCrawlerBrowser()).resolves.toBe(true);
+            expect(plugin.taskQueue.completed.filter((t) => t.type === "setup")[0]!.status).toBe("done");
+        });
+
+        it("installCrawlerBrowser fails the task and reports the server error", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.api.invalidateCapability = vi.fn();
+            plugin.api.setupCrawler = vi.fn().mockReturnValue(
+                (async function* () {
+                    yield { event: SSE_EVENT.SETUP_START, data: { component: "chromium", size_estimate_bytes: null } };
+                    yield {
+                        event: SSE_EVENT.SETUP_DONE,
+                        data: { component: "chromium", success: false, error: "no disk space" },
+                    };
+                })(),
+            );
+
+            await expect(plugin.installCrawlerBrowser()).resolves.toBe(false);
+
+            const setup = plugin.taskQueue.completed.find((t) => t.type === "setup");
+            expect(setup?.status).toBe("failed");
+            expect(Notice.instances.some((n: any) => n.message.includes("no disk space"))).toBe(true);
+            expect(plugin.api.invalidateCapability).not.toHaveBeenCalled();
+        });
+
+        it("installCrawlerBrowser falls back to a generic error when the server sends none", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.api.setupCrawler = vi.fn().mockReturnValue(
+                (async function* () {
+                    yield { event: SSE_EVENT.SETUP_DONE, data: { component: "chromium", success: false, error: null } };
+                })(),
+            );
+
+            await expect(plugin.installCrawlerBrowser()).resolves.toBe(false);
+            expect(plugin.taskQueue.completed.find((t) => t.type === "setup")?.error).toBe(MESSAGES.ERROR_UNKNOWN);
+        });
+
+        it("installCrawlerBrowser fails the task when the stream throws", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.api.setupCrawler = vi.fn().mockReturnValue(
+                (async function* () {
+                    yield { event: SSE_EVENT.SETUP_START, data: { component: "chromium", size_estimate_bytes: null } };
+                    throw new Error("connection reset");
+                })(),
+            );
+
+            await expect(plugin.installCrawlerBrowser()).resolves.toBe(false);
+            expect(plugin.taskQueue.completed.find((t) => t.type === "setup")?.error).toContain("connection reset");
+        });
+
+        it("installCrawlerBrowser reports a full queue instead of starting a download", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            vi.spyOn(plugin.taskQueue, "enqueue").mockReturnValue(null);
+            plugin.api.setupCrawler = vi.fn();
+
+            await expect(plugin.installCrawlerBrowser()).resolves.toBe(false);
+            expect(plugin.api.setupCrawler).not.toHaveBeenCalled();
+            expect(Notice.instances.some((n: any) => n.message === MESSAGES.NOTICE_QUEUE_FULL)).toBe(true);
+        });
+
+        it("installCrawlerBrowser ends without a setup_done when the stream closes early", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.api.setupCrawler = vi.fn().mockReturnValue(
+                (async function* () {
+                    yield { event: SSE_EVENT.SETUP_START, data: { component: "chromium", size_estimate_bytes: null } };
+                })(),
+            );
+
+            await expect(plugin.installCrawlerBrowser()).resolves.toBe(false);
+            expect(plugin.taskQueue.completed.find((t) => t.type === "setup")?.status).toBe("failed");
         });
 
         it("ignores setup_progress when no setup_start was seen", async () => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -713,6 +713,7 @@ describe("LilbeePlugin", () => {
                             failed: [],
                             skipped: [],
                             held_out: [{ filename: `${batch[0].name}.pdf`, reason: "no text extracted" }],
+                            tracked: [`${batch[0].name}.tracked`],
                         },
                     };
                 })(),
@@ -734,6 +735,9 @@ describe("LilbeePlugin", () => {
                 "f0.py.pdf",
                 "f90.py.pdf",
             ]);
+            // Every batch's tracked names survive the merge; the sibling path must
+            // not drop what the single-request path reports.
+            expect(dones[0].data.tracked).toEqual(["f0.py.tracked", "f90.py.tracked"]);
         });
 
         it("uploadInBatches ignores an unparseable done from a batch", async () => {
@@ -2673,6 +2677,46 @@ describe("LilbeePlugin", () => {
 
             expect(Notice.instances.some((n) => n.message.includes("adding test.md"))).toBe(true);
             expect(Notice.instances.some((n) => n.message.includes("nothing new to add"))).toBe(true);
+        });
+
+        it("addToLilbee reports already-tracked sources as their own outcome, not as failures", async () => {
+            const plugin = await createPlugin();
+            await plugin.onload();
+            plugin.activeModel = "llama3";
+
+            // The real /api/add terminal frame: tracked lives on the AddSummary
+            // envelope, beside the nested sync summary, not inside it.
+            async function* trackedDone() {
+                yield {
+                    event: SSE_EVENT.DONE,
+                    data: {
+                        copied: [],
+                        skipped: [],
+                        tracked: ["notes"],
+                        errors: [],
+                        sync: {
+                            added: [],
+                            updated: [],
+                            removed: [],
+                            unchanged: 3,
+                            relocated: [],
+                            failed: [],
+                            skipped: [],
+                            held_out: [],
+                            truncated: 0,
+                        },
+                        already_ingesting: [],
+                    },
+                };
+            }
+            plugin.api.uploadFiles = vi.fn().mockReturnValue(trackedDone());
+
+            await (plugin as any).addToLilbee(Object.assign(new TFile(), { path: "notes", name: "notes" }));
+
+            const summary = Notice.instances.map((n) => n.message).find((m) => m.includes("already tracked"));
+            expect(summary).toBe("lilbee: 1 already tracked");
+            expect(summary).not.toContain("failed");
+            expect(Notice.instances.some((n) => n.message.includes("nothing new to add"))).toBe(false);
         });
 
         it("addToLilbee falls back to path when name is undefined", async () => {
@@ -4697,6 +4741,7 @@ describe("LilbeePlugin", () => {
                 failed: ["d"],
                 skipped: ["e"],
                 held_out: [{ filename: "f", reason: "no text extracted" }],
+                tracked: [],
             });
 
             // Partial SyncDone shape — missing fields get sensible defaults.
@@ -4708,13 +4753,16 @@ describe("LilbeePlugin", () => {
                 failed: [],
                 skipped: [],
                 held_out: [],
+                tracked: [],
             });
 
             // Nested {sync: SyncDone} shape (the second `done` event server sends).
+            // `tracked` sits on the envelope, not inside `sync`.
             expect(
                 parseAddDoneEvent({
                     copied: [],
                     skipped: [],
+                    tracked: ["already-there"],
                     errors: [],
                     sync: { added: ["y"], updated: [], removed: [], unchanged: 1, failed: [], skipped: ["z.pdf"] },
                 }),
@@ -4726,6 +4774,7 @@ describe("LilbeePlugin", () => {
                 failed: [],
                 skipped: ["z.pdf"],
                 held_out: [],
+                tracked: ["already-there"],
             });
 
             // Malformed inputs return null.

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -13,6 +13,8 @@ import {
     SSE_EVENT,
     SYNC_TRIGGER,
 } from "../src/types";
+import { HEALTH_PROBE_INTERVAL_MS } from "../src/utils";
+import { displayLabelForRef } from "../src/utils/model-ref";
 import { VaultRegistry } from "../src/vault-registry";
 import { FileProgressTracker } from "../src/main";
 import { MESSAGES } from "../src/locales/en";
@@ -4834,56 +4836,42 @@ describe("LilbeePlugin", () => {
             expect((plugin.statusBarEl as any)?.textContent).not.toContain("error");
         });
 
-        it("refreshActiveModel repaints the status bar when the model changed out of band", async () => {
-            const plugin = await createPlugin({ serverMode: "external" });
-            await plugin.onload();
-            plugin.activeModel = "old-model";
-            (plugin as any).chatStatus = CHAT_STATUS.READY;
-            plugin.api.listModels = vi
-                .fn()
-                .mockResolvedValue({ chat: { active: "Qwen/Qwen3-235B-A22B", catalog: [], installed: [] } });
-            await (plugin as any).refreshActiveModel();
-            expect(plugin.activeModel).toBe("Qwen/Qwen3-235B-A22B");
-            expect((plugin.statusBarEl as any)?.textContent).toContain("ready");
-        });
-
-        it("refreshActiveModel is a no-op when the active model is unchanged", async () => {
-            const plugin = await createPlugin({ serverMode: "external" });
-            await plugin.onload();
-            plugin.activeModel = "same-model";
-            const setReady = vi.spyOn(plugin as any, "setStatusReady");
-            plugin.api.listModels = vi
-                .fn()
-                .mockResolvedValue({ chat: { active: "same-model", catalog: [], installed: [] } });
-            await (plugin as any).refreshActiveModel();
-            expect(setReady).not.toHaveBeenCalled();
-        });
-
-        it("refreshActiveModel updates the field but does not force ready while warming", async () => {
-            const plugin = await createPlugin({ serverMode: "external" });
-            await plugin.onload();
-            plugin.activeModel = "old";
-            (plugin as any).chatStatus = CHAT_STATUS.LOADING;
-            const setReady = vi.spyOn(plugin as any, "setStatusReady");
-            plugin.api.listModels = vi.fn().mockResolvedValue({ chat: { active: "new", catalog: [], installed: [] } });
-            await (plugin as any).refreshActiveModel();
-            expect(plugin.activeModel).toBe("new");
-            expect(setReady).not.toHaveBeenCalled();
-        });
-
-        it("refreshActiveModel swallows listModels errors", async () => {
-            const plugin = await createPlugin({ serverMode: "external" });
-            await plugin.onload();
-            plugin.activeModel = "keep";
-            plugin.api.listModels = vi.fn().mockRejectedValue(new Error("down"));
-            await (plugin as any).refreshActiveModel();
-            expect(plugin.activeModel).toBe("keep");
-        });
-
-        it("a healthy probe resyncs the active model while the server stays connected", async () => {
+        it("asks for health and nothing else on every tick", async () => {
+            vi.useFakeTimers();
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
             (plugin as any).serverUnreachable = false;
+            plugin.activeModel = "Qwen/Qwen3-4B";
+            plugin.api.health = vi
+                .fn()
+                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { chat_ready: true } });
+            plugin.api.listModels = vi
+                .fn()
+                .mockResolvedValue({ chat: { active: "Qwen/Qwen3-4B", catalog: [], installed: [] } });
+            await vi.advanceTimersByTimeAsync(HEALTH_PROBE_INTERVAL_MS * 5);
+            expect(plugin.api.health).toHaveBeenCalledTimes(5);
+            expect(plugin.api.listModels).not.toHaveBeenCalled();
+            vi.useRealTimers();
+        });
+
+        it("shows a newly activated model without a probe having run", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            (plugin as any).chatStatus = CHAT_STATUS.READY;
+            plugin.api.health = vi.fn();
+            plugin.api.listModels = vi
+                .fn()
+                .mockResolvedValue({ chat: { active: "Qwen/Qwen3-235B-A22B", catalog: [], installed: [] } });
+            await plugin.fetchActiveModel();
+            expect(plugin.activeModel).toBe("Qwen/Qwen3-235B-A22B");
+            expect((plugin.statusBarEl as any)?.textContent).toContain(displayLabelForRef("Qwen/Qwen3-235B-A22B"));
+            expect(plugin.api.health).not.toHaveBeenCalled();
+        });
+
+        it("refetches the model on a reconnect, so a restarted server cannot leave a stale label", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            (plugin as any).serverUnreachable = true;
             plugin.activeModel = "old";
             plugin.api.health = vi
                 .fn()

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -7,6 +7,8 @@ import {
     CHAT_STATUS,
     DEFAULT_SHARED_CONFIG,
     INDETERMINATE_PROGRESS,
+    LOGS_DIR,
+    LOG_FILE,
     SETUP_OUTCOME,
     SSE_EVENT,
     SYNC_TRIGGER,
@@ -8892,8 +8894,129 @@ describe("LilbeePlugin", () => {
             );
             await plugin.configureManagedStorage();
             const messages = Notice.instances.map((n) => n.message);
-            expect(messages.some((m) => m.startsWith(MESSAGES.NOTICE_STORAGE_REORGANIZE_FAILED))).toBe(true);
+            expect(messages.some((m) => m.includes("Could not move lilbee storage."))).toBe(true);
             expect(messages.some((m) => m.includes("disk full"))).toBe(true);
+            // The server never answered, so there is no refusal to remember.
+            expect(plugin.settings.rejectedStorageMove).toBeNull();
+            expect(messages.some((m) => m.includes("will not try again"))).toBe(false);
+        });
+
+        it("shows the server's own reason and the server log instead of the status code", async () => {
+            const updateConfig = vi
+                .fn()
+                .mockRejectedValue(new Error('Server responded 500: {"detail":"the target folder is read-only"}'));
+            const plugin = await setupConfiguredPlugin(
+                {},
+                {
+                    config: vi.fn().mockResolvedValue({ documents_dir: "/old/docs", vault_base: null }),
+                    updateConfig,
+                },
+            );
+            await plugin.configureManagedStorage();
+            const message = Notice.instances.map((n) => n.message).find((m) => m.includes("Could not move"));
+            expect(message).toContain("the target folder is read-only");
+            expect(message).toContain(`${LOGS_DIR}/${LOG_FILE.SERVER}`);
+            expect(message).not.toContain("500");
+        });
+
+        it("drops a status line that carries no reason and still names the server log", async () => {
+            const updateConfig = vi.fn().mockRejectedValue(new Error("Server responded 500: Internal server error"));
+            const plugin = await setupConfiguredPlugin(
+                {},
+                {
+                    config: vi.fn().mockResolvedValue({ documents_dir: "/old/docs", vault_base: null }),
+                    updateConfig,
+                },
+            );
+            await plugin.configureManagedStorage();
+            const message = Notice.instances.map((n) => n.message).find((m) => m.includes("Could not move"));
+            expect(message).not.toContain("500");
+            expect(message).toContain(`${LOGS_DIR}/${LOG_FILE.SERVER}`);
+        });
+
+        it("names the data directory generically when the registry is unavailable", async () => {
+            const updateConfig = vi.fn().mockRejectedValue(new Error("Server responded 500: nope"));
+            const plugin = await setupConfiguredPlugin(
+                {},
+                {
+                    config: vi.fn().mockResolvedValue({ documents_dir: "/old/docs", vault_base: null }),
+                    updateConfig,
+                },
+            );
+            (plugin as any).vaultRegistry = null;
+            await plugin.configureManagedStorage();
+            const message = Notice.instances.map((n) => n.message).find((m) => m.includes("Could not move"));
+            expect(message).toContain(LOG_FILE.SERVER);
+            expect(message).toContain("data directory");
+        });
+
+        it("does not re-send the move at the next start after a failure", async () => {
+            const updateConfig = vi
+                .fn()
+                .mockRejectedValue(new Error('Server responded 500: {"detail":"the move failed"}'));
+            const serverConfig = { documents_dir: "/old/docs", vault_base: null };
+            const first = await setupConfiguredPlugin(
+                {},
+                { config: vi.fn().mockResolvedValue(serverConfig), updateConfig },
+            );
+            await first.configureManagedStorage();
+            expect(updateConfig).toHaveBeenCalledTimes(1);
+
+            const persisted = (first.saveData as any).mock.calls.at(-1)[0] as Record<string, unknown>;
+            expect(persisted.rejectedStorageMove).toEqual({
+                documentsDir: "/test/vault/lilbee",
+                vaultBase: "/test/vault",
+            });
+
+            Notice.clear();
+            const second = await setupConfiguredPlugin(persisted, {
+                config: vi.fn().mockResolvedValue(serverConfig),
+                updateConfig,
+            });
+            await second.configureManagedStorage();
+            expect(updateConfig).toHaveBeenCalledTimes(1);
+            expect(Notice.instances).toHaveLength(0);
+        });
+
+        it("re-sends the move when the wanted documents dir changes", async () => {
+            const updateConfig = vi.fn().mockResolvedValue({ updated: ["documents_dir", "vault_base"] });
+            const plugin = await setupConfiguredPlugin(
+                { rejectedStorageMove: { documentsDir: "/somewhere/else", vaultBase: "/test/vault" } },
+                {
+                    config: vi.fn().mockResolvedValue({ documents_dir: "/old/docs", vault_base: null }),
+                    updateConfig,
+                },
+            );
+            await plugin.configureManagedStorage();
+            expect(updateConfig).toHaveBeenCalledTimes(1);
+        });
+
+        it("re-sends the move when the wanted vault base changes", async () => {
+            const updateConfig = vi.fn().mockResolvedValue({ updated: ["documents_dir", "vault_base"] });
+            const plugin = await setupConfiguredPlugin(
+                { rejectedStorageMove: { documentsDir: "/test/vault/lilbee", vaultBase: "/other/vault" } },
+                {
+                    config: vi.fn().mockResolvedValue({ documents_dir: "/old/docs", vault_base: null }),
+                    updateConfig,
+                },
+            );
+            await plugin.configureManagedStorage();
+            expect(updateConfig).toHaveBeenCalledTimes(1);
+        });
+
+        it("forgets a refused layout once a move succeeds", async () => {
+            const updateConfig = vi.fn().mockResolvedValue({ updated: ["documents_dir", "vault_base"] });
+            const plugin = await setupConfiguredPlugin(
+                { rejectedStorageMove: { documentsDir: "/somewhere/else", vaultBase: null } },
+                {
+                    config: vi.fn().mockResolvedValue({ documents_dir: "/old/docs", vault_base: null }),
+                    updateConfig,
+                },
+            );
+            await plugin.configureManagedStorage();
+            expect(plugin.settings.rejectedStorageMove).toBeNull();
+            const persisted = (plugin.saveData as any).mock.calls.at(-1)[0] as Record<string, unknown>;
+            expect(persisted.rejectedStorageMove).toBeNull();
         });
 
         it("returns silently when fetching current config fails", async () => {

--- a/tests/server-uninstall.test.ts
+++ b/tests/server-uninstall.test.ts
@@ -1,10 +1,12 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 
-const { rmSync, existsSync, readdirSync, statSync } = vi.hoisted(() => ({
+const { rmSync, existsSync, readdirSync, statSync, execFile, installed } = vi.hoisted(() => ({
     rmSync: vi.fn(),
     existsSync: vi.fn(),
     readdirSync: vi.fn(),
     statSync: vi.fn(),
+    execFile: vi.fn(),
+    installed: vi.fn(),
 }));
 
 vi.mock("../src/node", () => ({
@@ -13,11 +15,19 @@ vi.mock("../src/node", () => ({
         existsSync,
         readdirSync,
         statSync,
+        execFile,
         join: (...parts: string[]) => parts.join("/"),
         homedir: () => "/home/u",
     },
 }));
 
+vi.mock("../src/server-binary", () => ({
+    ServerBinary: vi.fn().mockImplementation(function () {
+        return { installed };
+    }),
+}));
+
+import { ServerBinary } from "../src/server-binary";
 import { executeUninstall, planUninstall } from "../src/server-uninstall";
 import { UNINSTALL_TARGET } from "../src/types";
 
@@ -53,6 +63,9 @@ let restorePlatform: () => void = () => {};
 beforeEach(() => {
     vi.clearAllMocks();
     restorePlatform = stubPlatform("linux");
+    installed.mockReturnValue({ path: "/root/bin/v0.6.90/lilbee" });
+    execFile.mockResolvedValue({ stdout: "", stderr: "" });
+    rmSync.mockImplementation(() => {});
 });
 
 afterEach(() => {
@@ -136,11 +149,13 @@ describe("planUninstall", () => {
 });
 
 describe("executeUninstall", () => {
-    it("removes every planned path recursively and tolerates missing ones", () => {
+    const DELETED = ["/root/bin", "/root/models", "/root/vaults/abc", "/home/u/.cache/lilbee"];
+
+    it("removes every planned path recursively and tolerates missing ones", async () => {
         mountFiles({});
         const plan = planUninstall("/root", "/root/vaults/abc");
 
-        executeUninstall(plan);
+        await executeUninstall(plan, "/root", "/root/vaults/abc");
 
         expect(rmSync.mock.calls).toEqual([
             ["/root/bin", { recursive: true, force: true }],
@@ -148,5 +163,73 @@ describe("executeUninstall", () => {
             ["/root/vaults/abc", { recursive: true, force: true }],
             ["/home/u/.cache/lilbee", { recursive: true, force: true }],
         ]);
+    });
+
+    it("stops the shared engine and waits for it before deleting anything", async () => {
+        mountFiles({});
+        const order: string[] = [];
+        let finishStop!: () => void;
+        execFile.mockImplementation(() => {
+            order.push("engine stop");
+            return new Promise((resolve) => {
+                finishStop = () => resolve({ stdout: "", stderr: "" });
+            });
+        });
+        rmSync.mockImplementation((path: string) => {
+            order.push(`rm ${path}`);
+        });
+        const plan = planUninstall("/root", "/root/vaults/abc");
+
+        const uninstall = executeUninstall(plan, "/root", "/root/vaults/abc");
+        await Promise.resolve();
+
+        // The engine holds the model files open, so nothing may be deleted while it runs.
+        expect(order).toEqual(["engine stop"]);
+
+        finishStop();
+        await uninstall;
+
+        expect(order).toEqual(["engine stop", ...DELETED.map((path) => `rm ${path}`)]);
+    });
+
+    it("asks the installed binary to stop the machine engine and this vault's own", async () => {
+        mountFiles({});
+
+        await executeUninstall(planUninstall("/root", "/root/vaults/abc"), "/root", "/root/vaults/abc");
+
+        expect(ServerBinary).toHaveBeenCalledWith("/root/bin");
+        expect(execFile).toHaveBeenCalledWith(
+            "/root/bin/v0.6.90/lilbee",
+            ["--data-dir", "/root/vaults/abc", "engine", "stop"],
+            { timeout: 15_000 },
+        );
+    });
+
+    it("deletes anyway when an older binary refuses the command", async () => {
+        mountFiles({});
+        execFile.mockRejectedValue(Object.assign(new Error("No such command 'engine'."), { code: 2 }));
+
+        await executeUninstall(planUninstall("/root", "/root/vaults/abc"), "/root", "/root/vaults/abc");
+
+        expect(rmSync.mock.calls.map(([path]) => path)).toEqual(DELETED);
+    });
+
+    it("deletes anyway when the stop hangs past its bound", async () => {
+        mountFiles({});
+        execFile.mockRejectedValue(Object.assign(new Error("Command failed"), { killed: true, signal: "SIGTERM" }));
+
+        await executeUninstall(planUninstall("/root", "/root/vaults/abc"), "/root", "/root/vaults/abc");
+
+        expect(rmSync.mock.calls.map(([path]) => path)).toEqual(DELETED);
+    });
+
+    it("runs nothing when no binary is installed", async () => {
+        mountFiles({});
+        installed.mockReturnValue(null);
+
+        await executeUninstall(planUninstall("/root", "/root/vaults/abc"), "/root", "/root/vaults/abc");
+
+        expect(execFile).not.toHaveBeenCalled();
+        expect(rmSync.mock.calls.map(([path]) => path)).toEqual(DELETED);
     });
 });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -854,6 +854,20 @@ describe("LilbeeSettingTab", () => {
             expect((plugin as any).configureManagedStorage).toHaveBeenCalled();
         });
 
+        it("clears a refused layout so the move is tried again", async () => {
+            const plugin = makePlugin({
+                serverMode: "managed",
+                storeContentInVault: false,
+                rejectedStorageMove: { documentsDir: "/test/vault/lilbee", vaultBase: "/test/vault" },
+            });
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const { toggleByName } = captureSettingCallbacks(() => tab.display());
+
+            await toggleByName.get(MESSAGES.LABEL_STORE_CONTENT_IN_VAULT)!(true);
+            expect(plugin.settings.rejectedStorageMove).toBeNull();
+        });
+
         it("is disabled and marks the row in external mode", async () => {
             const plugin = makePlugin({ serverMode: "external", storeContentInVault: true });
             mockChatPicker(plugin);

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -181,6 +181,7 @@ function makePlugin(
         triggerSync,
         runWikiLint,
         runWikiPrune,
+        installCrawlerBrowser: vi.fn().mockResolvedValue(true),
         initWikiSync,
         reconcileWiki,
         configureManagedStorage,
@@ -306,6 +307,8 @@ interface Captured {
     descByName: Map<string, string>;
     /** Every value pushed into a row's slider via setValue, in call order. */
     sliderSetValuesByName: Map<string, number[]>;
+    /** Every value pushed into a row's dropdown via setValue, in call order. */
+    dropdownSetValuesByName: Map<string, string[]>;
     textOnChanges: TextOnChange[];
     textAreaOnChanges: TextOnChange[];
     blurHandlers: BlurCapture[];
@@ -349,6 +352,7 @@ function captureSettingCallbacks(fn: () => void): Captured {
     const textAreaByName = new Map<string, TextOnChange>();
     const sliderByName = new Map<string, SliderOnChange>();
     const sliderSetValuesByName = new Map<string, number[]>();
+    const dropdownSetValuesByName = new Map<string, string[]>();
     const descByName = new Map<string, string>();
     let currentName = "";
     const origSetName = Setting.prototype.setName;
@@ -445,6 +449,7 @@ function captureSettingCallbacks(fn: () => void): Captured {
     };
 
     Setting.prototype.addDropdown = function (cb: (dropdown: any) => void) {
+        const name = currentName;
         const options: Record<string, string> = {};
         const setValues: string[] = [];
         const fakeDropdown = {
@@ -470,6 +475,7 @@ function captureSettingCallbacks(fn: () => void): Captured {
         cb(fakeDropdown);
         dropdownOptions.push(options);
         dropdownSetValues.push(setValues);
+        if (name) dropdownSetValuesByName.set(name, setValues);
         return this;
     };
 
@@ -554,6 +560,7 @@ function captureSettingCallbacks(fn: () => void): Captured {
         sliderByName,
         descByName,
         sliderSetValuesByName,
+        dropdownSetValuesByName,
         textOnChanges,
         textAreaOnChanges,
         blurHandlers,
@@ -1178,9 +1185,9 @@ describe("LilbeeSettingTab", () => {
             const tab = makeTab(plugin);
             const { buttonOnClicks } = captureSettingCallbacks(() => tab.display());
 
-            // Setup wizard + Start + Server version + Refresh + Browse Catalog + Wiki Lint + Wiki Prune
-            // + Export diagnostics + Reset all + Uninstall server = 10
-            expect(buttonOnClicks.length).toBe(10);
+            // Setup wizard + Start + Server version + Refresh + Browse Catalog + Install Chromium
+            // + Wiki Lint + Wiki Prune + Export diagnostics + Reset all + Uninstall server = 11
+            expect(buttonOnClicks.length).toBe(11);
             // Refresh is the fourth button (index 3)
             await expect(buttonOnClicks[3]()).resolves.not.toThrow();
         });
@@ -4624,6 +4631,76 @@ describe("managed mode settings", () => {
             expect((tab as any).crawlingContainerEl?.style.display).not.toBe("none");
             expect((tab as any).wikiContainerEl?.style.display).not.toBe("none");
             expect((tab as any).apiKeysContainerEl?.style.display).not.toBe("none");
+        });
+
+        it("offers the Chromium install and refuses browser render mode when Chromium is missing", async () => {
+            const plugin = makePlugin();
+            (plugin.api as any).getCapability = vi.fn(async (cap: string) => cap !== "crawling_browser");
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const captured = captureSettingCallbacks(() => tab.display());
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect((tab as any).crawlerBrowserSetupEl?.style.display).not.toBe("none");
+
+            await captured.dropdownByName.get(MESSAGES.LABEL_CRAWL_RENDER_MODE)!("browser");
+            expect(plugin.api.updateConfig).not.toHaveBeenCalledWith({ crawl_render_mode: "browser" });
+            const setValues = captured.dropdownSetValuesByName.get(MESSAGES.LABEL_CRAWL_RENDER_MODE)!;
+            expect(setValues[setValues.length - 1]).toBe("http");
+            expect(Notice.instances.some((n: any) => n.message === MESSAGES.NOTICE_CRAWL_BROWSER_MISSING)).toBe(true);
+        });
+
+        it("hides the Chromium install offer when the server can already render with a browser", async () => {
+            const plugin = makePlugin();
+            (plugin.api as any).getCapability = vi.fn().mockResolvedValue(true);
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const captured = captureSettingCallbacks(() => tab.display());
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect((tab as any).crawlerBrowserSetupEl?.style.display).toBe("none");
+            await captured.dropdownByName.get(MESSAGES.LABEL_CRAWL_RENDER_MODE)!("browser");
+            expect(plugin.api.updateConfig).toHaveBeenCalledWith({ crawl_render_mode: "browser" });
+        });
+
+        it("accepts browser render mode after the Chromium install succeeds", async () => {
+            const plugin = makePlugin();
+            (plugin.api as any).getCapability = vi.fn(async (cap: string) => cap !== "crawling_browser");
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const captured = captureSettingCallbacks(() => tab.display());
+            await new Promise((r) => setTimeout(r, 0));
+
+            await clickButton(captured, MESSAGES.LABEL_CRAWL_BROWSER_SETUP);
+            expect(plugin.installCrawlerBrowser).toHaveBeenCalled();
+            expect((tab as any).crawlerBrowserSetupEl?.style.display).toBe("none");
+
+            await captured.dropdownByName.get(MESSAGES.LABEL_CRAWL_RENDER_MODE)!("browser");
+            expect(plugin.api.updateConfig).toHaveBeenCalledWith({ crawl_render_mode: "browser" });
+        });
+
+        it("keeps the Chromium install offer up when the install fails", async () => {
+            const plugin = makePlugin();
+            (plugin.api as any).getCapability = vi.fn(async (cap: string) => cap !== "crawling_browser");
+            (plugin.installCrawlerBrowser as any).mockResolvedValue(false);
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const captured = captureSettingCallbacks(() => tab.display());
+            await new Promise((r) => setTimeout(r, 0));
+
+            await clickButton(captured, MESSAGES.LABEL_CRAWL_BROWSER_SETUP);
+            expect((tab as any).crawlerBrowserSetupEl?.style.display).not.toBe("none");
+        });
+
+        it("leaves the Chromium install offer hidden when the whole crawling section is gated off", async () => {
+            const plugin = makePlugin();
+            (plugin.api as any).getCapability = vi.fn().mockResolvedValue(false);
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            tab.display();
+            await new Promise((r) => setTimeout(r, 0));
+
+            expect((tab as any).crawlerBrowserSetupEl?.style.display).toBe("none");
         });
 
         it("calls invalidateCapability(API_KEYS) after a key save so the catalog refresh can pick up the new state", async () => {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -4666,6 +4666,31 @@ describe("managed mode settings", () => {
             expect(plugin.api.updateConfig).toHaveBeenCalledWith({ crawl_render_mode: "browser" });
         });
 
+        it("fetches Chromium when browser render mode is chosen before the probe lands", async () => {
+            const plugin = makePlugin();
+            let releaseProbe = (): void => {};
+            const probed = new Promise<void>((resolve) => {
+                releaseProbe = resolve;
+            });
+            (plugin.api as any).getCapability = vi.fn(async (cap: string) => {
+                if (cap !== "crawling_browser") return true;
+                await probed;
+                return false;
+            });
+            plugin.installCrawlerBrowser = vi.fn().mockResolvedValue(true);
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const captured = captureSettingCallbacks(() => tab.display());
+
+            // The user reaches the dropdown while the capability probe is still in flight.
+            const choice = captured.dropdownByName.get(MESSAGES.LABEL_CRAWL_RENDER_MODE)!("browser");
+            releaseProbe();
+            await choice;
+
+            expect(plugin.installCrawlerBrowser).toHaveBeenCalled();
+            expect(plugin.api.updateConfig).toHaveBeenCalledWith({ crawl_render_mode: "browser" });
+        });
+
         it("falls back to HTTP when the Chromium fetch fails", async () => {
             const plugin = makePlugin();
             (plugin.api as any).getCapability = vi.fn(async (cap: string) => cap !== "crawling_browser");
@@ -4697,7 +4722,15 @@ describe("managed mode settings", () => {
 
         it("accepts browser render mode after the Chromium install succeeds", async () => {
             const plugin = makePlugin();
-            (plugin.api as any).getCapability = vi.fn(async (cap: string) => cap !== "crawling_browser");
+            let chromium = false;
+            // The install invalidates the cached capability, so the next probe sees Chromium.
+            (plugin.api as any).getCapability = vi.fn(async (cap: string) =>
+                cap === "crawling_browser" ? chromium : true,
+            );
+            plugin.installCrawlerBrowser = vi.fn(async () => {
+                chromium = true;
+                return true;
+            });
             mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const captured = captureSettingCallbacks(() => tab.display());

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -4647,9 +4647,10 @@ describe("managed mode settings", () => {
             expect((tab as any).apiKeysContainerEl?.style.display).not.toBe("none");
         });
 
-        it("offers the Chromium install and refuses browser render mode when Chromium is missing", async () => {
+        it("fetches Chromium when browser render mode is chosen without it", async () => {
             const plugin = makePlugin();
             (plugin.api as any).getCapability = vi.fn(async (cap: string) => cap !== "crawling_browser");
+            plugin.installCrawlerBrowser = vi.fn().mockResolvedValue(true);
             mockChatPicker(plugin);
             const tab = makeTab(plugin);
             const captured = captureSettingCallbacks(() => tab.display());
@@ -4658,10 +4659,27 @@ describe("managed mode settings", () => {
             expect((tab as any).crawlerBrowserSetupEl?.style.display).not.toBe("none");
 
             await captured.dropdownByName.get(MESSAGES.LABEL_CRAWL_RENDER_MODE)!("browser");
+
+            // Choosing browser mode is the request for a browser, so it is fetched
+            // and the mode applies, rather than being refused.
+            expect(plugin.installCrawlerBrowser).toHaveBeenCalled();
+            expect(plugin.api.updateConfig).toHaveBeenCalledWith({ crawl_render_mode: "browser" });
+        });
+
+        it("falls back to HTTP when the Chromium fetch fails", async () => {
+            const plugin = makePlugin();
+            (plugin.api as any).getCapability = vi.fn(async (cap: string) => cap !== "crawling_browser");
+            plugin.installCrawlerBrowser = vi.fn().mockResolvedValue(false);
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const captured = captureSettingCallbacks(() => tab.display());
+            await new Promise((r) => setTimeout(r, 0));
+
+            await captured.dropdownByName.get(MESSAGES.LABEL_CRAWL_RENDER_MODE)!("browser");
+
             expect(plugin.api.updateConfig).not.toHaveBeenCalledWith({ crawl_render_mode: "browser" });
             const setValues = captured.dropdownSetValuesByName.get(MESSAGES.LABEL_CRAWL_RENDER_MODE)!;
             expect(setValues[setValues.length - 1]).toBe("http");
-            expect(Notice.instances.some((n: any) => n.message === MESSAGES.NOTICE_CRAWL_BROWSER_MISSING)).toBe(true);
         });
 
         it("hides the Chromium install offer when the server can already render with a browser", async () => {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -302,6 +302,8 @@ interface Captured {
     dropdownByName: Map<string, DropdownOnChange>;
     textAreaByName: Map<string, TextOnChange>;
     sliderByName: Map<string, SliderOnChange>;
+    /** Description text each row was given, keyed by the row's display name. */
+    descByName: Map<string, string>;
     /** Every value pushed into a row's slider via setValue, in call order. */
     sliderSetValuesByName: Map<string, number[]>;
     textOnChanges: TextOnChange[];
@@ -347,11 +349,18 @@ function captureSettingCallbacks(fn: () => void): Captured {
     const textAreaByName = new Map<string, TextOnChange>();
     const sliderByName = new Map<string, SliderOnChange>();
     const sliderSetValuesByName = new Map<string, number[]>();
+    const descByName = new Map<string, string>();
     let currentName = "";
     const origSetName = Setting.prototype.setName;
     Setting.prototype.setName = function (name: string) {
         currentName = typeof name === "string" ? name : String(name);
         return origSetName.call(this, name);
+    };
+
+    const origSetDesc = Setting.prototype.setDesc;
+    Setting.prototype.setDesc = function (desc: string) {
+        if (currentName) descByName.set(currentName, desc);
+        return origSetDesc.call(this, desc);
     };
 
     const origAddText = Setting.prototype.addText;
@@ -527,6 +536,7 @@ function captureSettingCallbacks(fn: () => void): Captured {
         fn();
     } finally {
         Setting.prototype.setName = origSetName;
+        Setting.prototype.setDesc = origSetDesc;
         Setting.prototype.addText = origAddText;
         (Setting.prototype as any).addTextArea = origAddTextArea;
         Setting.prototype.addSlider = origAddSlider;
@@ -542,6 +552,7 @@ function captureSettingCallbacks(fn: () => void): Captured {
         dropdownByName,
         textAreaByName,
         sliderByName,
+        descByName,
         sliderSetValuesByName,
         textOnChanges,
         textAreaOnChanges,
@@ -7709,6 +7720,24 @@ describe("managed-mode uninstall section", () => {
         expect(uninstall?.text).toBe("Uninstall server");
         const callout = tab.containerEl.find("lilbee-uninstall-callout");
         expect(callout?.textContent).toContain("Removing the plugin does not remove the server");
+        expect(callout?.textContent).toContain(
+            "The executable, this vault's index and saved chats, and the shared model cache live outside your vault.",
+        );
+    });
+
+    it("names the saved chats and the shared models in the uninstall row description", () => {
+        const plugin = makePlugin({ serverMode: "managed" });
+        (plugin as any).planServerUninstall = () => PLAN;
+        mockChatPicker(plugin);
+        const tab = makeTab(plugin);
+        (tab as any).storageTotalBytes = 13_632_000_000;
+
+        const captured = captureSettingCallbacks(() => tab.display());
+
+        expect(captured.descByName.get(MESSAGES.LABEL_UNINSTALL_SERVER)).toBe(
+            "Deletes the executable, this vault's index and saved chats, and the models every vault on this " +
+                "computer shares. Frees 13.6 GB. Your notes are not touched.",
+        );
     });
 
     it("uninstalls and reports the freed space when the user confirms", async () => {

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -75,6 +75,7 @@ describe("DEFAULT_SETTINGS", () => {
             "agentIntegration",
             "includeDevBuilds",
             "reasoningDefaulted",
+            "rejectedStorageMove",
             "manualToken",
             "searchChunkType",
             "serverMode",

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -696,6 +696,31 @@ describe("CatalogModal", () => {
             modal.close();
         });
 
+        it("restarts the result set when a scroll lands a new search term before the debounce", async () => {
+            const plugin = makePlugin();
+            const first = makeEntry({ display_name: "A" });
+            const second = makeEntry({ display_name: "B" });
+            plugin.api.catalog
+                .mockResolvedValueOnce(ok({ total: 2, limit: 1, offset: 0, models: [first], has_more: true }))
+                .mockResolvedValueOnce(ok({ total: 1, limit: 1, offset: 0, models: [second], has_more: false }));
+            const modal = await openModal(plugin);
+            const search = contentEl(modal).find("lilbee-catalog-search")! as unknown as {
+                value: string;
+                trigger(event: string): void;
+            };
+            search.value = "qwen";
+            search.trigger("input");
+
+            setScroll(modal, { scrollTop: 800, clientHeight: 400, scrollHeight: 1100 });
+            (modal as any).onScroll();
+            await tick();
+            await tick();
+
+            expect(plugin.api.catalog).toHaveBeenLastCalledWith(expect.objectContaining({ search: "qwen", offset: 0 }));
+            expect(((modal as any).entries as CatalogEntry[]).map((e) => e.display_name)).toEqual(["B"]);
+            modal.close();
+        });
+
         it("does not fetch when scrolling is not near the bottom", async () => {
             const plugin = makePlugin();
             plugin.api.catalog.mockResolvedValue(

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -767,6 +767,139 @@ describe("CatalogModal", () => {
         });
     });
 
+    describe("search paging", () => {
+        type SearchInput = { value: string; trigger(event: string): void };
+
+        function searchBox(modal: CatalogModal): SearchInput {
+            return contentEl(modal).find("lilbee-catalog-search")! as unknown as SearchInput;
+        }
+
+        /** Type a term and run the search the debounce would have run. */
+        function typeSearch(modal: CatalogModal, term: string): void {
+            const box = searchBox(modal);
+            box.value = term;
+            box.trigger("input");
+            (modal as unknown as { resetAndFetch(): void }).resetAndFetch();
+        }
+
+        function deferred<T>() {
+            let settle!: (value: T) => void;
+            const promise = new Promise<T>((resolve) => {
+                settle = resolve;
+            });
+            return { promise, settle };
+        }
+
+        function calls(plugin: ReturnType<typeof makePlugin>): Record<string, unknown>[] {
+            return plugin.api.catalog.mock.calls.map((c: unknown[]) => c[0] as Record<string, unknown>);
+        }
+
+        function repos(modal: CatalogModal): string[] {
+            return (modal as unknown as { entries: CatalogEntry[] }).entries.map((e) => e.hf_repo);
+        }
+
+        function page(models: CatalogEntry[], has_more: boolean) {
+            return ok({ total: models.length, limit: 50, offset: 0, models, has_more });
+        }
+
+        const qwenRow = makeEntry({ hf_repo: "Qwen/Qwen3-8B-GGUF", display_name: "Qwen3 8B" });
+        const llamaRow = makeEntry({ hf_repo: "meta/Llama-3.1-8B-GGUF", display_name: "Llama 3.1 8B" });
+
+        it("asks for a whole result set on a search, not a browse page", async () => {
+            const plugin = makePlugin();
+            const modal = await openModal(plugin);
+            const browseLimit = calls(plugin)[0].limit as number;
+
+            plugin.api.catalog.mockClear();
+            typeSearch(modal, "qwen");
+            await tick();
+            await tick();
+
+            const searchCall = calls(plugin)[0];
+            expect(searchCall).toMatchObject({ search: "qwen", offset: 0 });
+            expect(searchCall.limit as number).toBeGreaterThan(browseLimit);
+            expect(searchCall.limit).toBe(50);
+            modal.close();
+        });
+
+        it("pages a search by its own offset and keeps its rows", async () => {
+            const plugin = makePlugin();
+            const modal = await openModal(plugin);
+            const firstPage = Array.from({ length: 50 }, (_, i) =>
+                makeEntry({ hf_repo: `owner/qwen-${i}-GGUF`, display_name: `Qwen ${i}` }),
+            );
+            plugin.api.catalog.mockClear();
+            plugin.api.catalog.mockResolvedValue(page(firstPage, true));
+            typeSearch(modal, "qwen");
+            await tick();
+            await tick();
+
+            plugin.api.catalog.mockResolvedValue(page([qwenRow], false));
+            const view = modal as unknown as { resultsEl: MockElement; onScroll(): void };
+            Object.assign(view.resultsEl, { scrollTop: 800, clientHeight: 400, scrollHeight: 1100 });
+            view.onScroll();
+            await tick();
+            await tick();
+
+            expect(calls(plugin)[1]).toMatchObject({ search: "qwen", offset: 50, limit: 50 });
+            expect(repos(modal)).toHaveLength(51);
+            modal.close();
+        });
+
+        it("restarts the result set when the term changes while a page is in flight", async () => {
+            const plugin = makePlugin();
+            const modal = await openModal(plugin);
+            const inFlight = deferred<ReturnType<typeof page>>();
+
+            plugin.api.catalog.mockClear();
+            plugin.api.catalog.mockReturnValueOnce(inFlight.promise);
+            typeSearch(modal, "qwen");
+            await tick();
+            expect(calls(plugin)[0]).toMatchObject({ search: "qwen" });
+
+            // The user keeps typing before the first page lands.
+            plugin.api.catalog.mockResolvedValue(page([llamaRow], false));
+            typeSearch(modal, "llama");
+            await tick();
+
+            inFlight.settle(
+                page(
+                    Array.from({ length: 50 }, () => qwenRow),
+                    true,
+                ),
+            );
+            await tick();
+            await tick();
+            await tick();
+
+            const forLlama = calls(plugin).filter((c) => c.search === "llama");
+            expect(forLlama).toHaveLength(1);
+            expect(forLlama[0]).toMatchObject({ offset: 0, limit: 50 });
+            expect(repos(modal)).toEqual([llamaRow.hf_repo]);
+            modal.close();
+        });
+
+        it("returns to browse pages when the search is cleared", async () => {
+            const plugin = makePlugin();
+            const modal = await openModal(plugin);
+            plugin.api.catalog.mockResolvedValue(page([qwenRow], true));
+            typeSearch(modal, "qwen");
+            await tick();
+            await tick();
+
+            plugin.api.catalog.mockClear();
+            plugin.api.catalog.mockResolvedValue(page([llamaRow], false));
+            typeSearch(modal, "");
+            await tick();
+            await tick();
+
+            expect(calls(plugin)[0]).toMatchObject({ offset: 0, limit: 20 });
+            expect(calls(plugin)[0].search).toBeUndefined();
+            expect(repos(modal)).toEqual([llamaRow.hf_repo]);
+            modal.close();
+        });
+    });
+
     describe("pull / use / remove", () => {
         async function* emptyStream() {
             // no events
@@ -2310,7 +2443,7 @@ describe("CatalogModal", () => {
             const modal = await openModal(plugin);
             (modal as unknown as { resultsEl: unknown }).resultsEl = null;
             plugin.api.catalog.mockClear();
-            // resetAndFetch must not throw when resultsEl is null (415 false branch).
+            // resetAndFetch must not throw when resultsEl is null (clearResults false branch).
             (modal as unknown as { resetAndFetch(): void }).resetAndFetch();
             await tick();
             expect(plugin.api.catalog).toHaveBeenCalled();

--- a/tests/views/crawl-modal.test.ts
+++ b/tests/views/crawl-modal.test.ts
@@ -4,14 +4,28 @@ import { MockElement } from "../__mocks__/obsidian";
 import { CrawlModal } from "../../src/views/crawl-modal";
 import { MESSAGES } from "../../src/locales/en";
 
-function makePlugin(renderMode: string = "http") {
+function makePlugin(renderMode: string = "http", browserReady: boolean = true) {
     return {
         runCrawl: vi.fn(),
+        installCrawlerBrowser: vi.fn().mockResolvedValue(true),
         api: {
             config: vi.fn().mockResolvedValue({ crawl_render_mode: renderMode }),
             updateConfig: vi.fn().mockResolvedValue({}),
+            getCapability: vi.fn().mockResolvedValue(browserReady),
         },
     };
+}
+
+/** Obsidian's hide()/show() toggle inline display, which is what the mock records. */
+function isHidden(el: MockElement): boolean {
+    return el.style.display === "none";
+}
+
+/** Let the modal's config and capability probes settle. */
+async function settle(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
 }
 
 function collectTexts(el: MockElement): string[] {
@@ -32,9 +46,9 @@ function findButtons(el: MockElement): MockElement[] {
     return buttons;
 }
 
-function openModal() {
+function openModal(renderMode: string = "http", browserReady: boolean = true) {
     const app = new App();
-    const plugin = makePlugin();
+    const plugin = makePlugin(renderMode, browserReady);
     const modal = new CrawlModal(app as any, plugin as any);
     modal.onOpen();
     const el = modal.contentEl as unknown as MockElement;
@@ -403,8 +417,7 @@ describe("CrawlModal", () => {
         const modal = new CrawlModal(app as any, plugin as any);
         modal.onOpen();
         const el = modal.contentEl as unknown as MockElement;
-        await Promise.resolve();
-        await Promise.resolve();
+        await settle();
         expect((el.find("lilbee-crawl-browser-input") as any).checked).toBe(true);
         expect(plugin.api.config).toHaveBeenCalled();
     });
@@ -433,13 +446,13 @@ describe("CrawlModal", () => {
             api: {
                 config: vi.fn().mockRejectedValue(new Error("unreachable")),
                 updateConfig: vi.fn().mockResolvedValue({}),
+                getCapability: vi.fn().mockResolvedValue(true),
             },
         };
         const modal = new CrawlModal(app as any, plugin as any);
         modal.onOpen();
         const el = modal.contentEl as unknown as MockElement;
-        await Promise.resolve();
-        await Promise.resolve();
+        await settle();
         expect((el.find("lilbee-crawl-browser-input") as any).checked).toBe(false);
     });
 
@@ -452,5 +465,54 @@ describe("CrawlModal", () => {
         await Promise.resolve();
         await Promise.resolve();
         expect(plugin.runCrawl).toHaveBeenCalledWith("https://example.com", 0, null, "browser", undefined);
+    });
+
+    it("disables the Use-browser toggle and offers the install when Chromium is missing", async () => {
+        const { el } = openModal("http", false);
+        await settle();
+        const browser = el.find("lilbee-crawl-browser-input") as any;
+        expect(browser.disabled).toBe(true);
+        expect(browser.checked).toBe(false);
+        const setup = el.find("lilbee-crawl-browser-setup") as MockElement;
+        expect(isHidden(setup)).toBe(false);
+        expect(collectTexts(setup).some((t) => t.includes(MESSAGES.NOTICE_CRAWL_BROWSER_MISSING))).toBe(true);
+    });
+
+    it("ignores a server default of browser mode when Chromium is missing", async () => {
+        const { el } = openModal("browser", false);
+        await settle();
+        expect((el.find("lilbee-crawl-browser-input") as any).checked).toBe(false);
+    });
+
+    it("enables the toggle after the install succeeds", async () => {
+        const { plugin, el } = openModal("http", false);
+        await settle();
+        const setup = el.find("lilbee-crawl-browser-setup") as MockElement;
+        findButtons(setup)[0].trigger("click");
+        await settle();
+        expect(plugin.installCrawlerBrowser).toHaveBeenCalled();
+        const browser = el.find("lilbee-crawl-browser-input") as any;
+        expect(browser.disabled).toBe(false);
+        expect(browser.checked).toBe(true);
+        expect(isHidden(setup)).toBe(true);
+    });
+
+    it("re-enables the install button when the install fails", async () => {
+        const { plugin, el } = openModal("http", false);
+        (plugin.installCrawlerBrowser as any).mockResolvedValue(false);
+        await settle();
+        const setup = el.find("lilbee-crawl-browser-setup") as MockElement;
+        const btn = findButtons(setup)[0] as any;
+        btn.trigger("click");
+        await settle();
+        expect(btn.disabled).toBe(false);
+        expect((el.find("lilbee-crawl-browser-input") as any).disabled).toBe(true);
+    });
+
+    it("leaves the install offer hidden when Chromium is present", async () => {
+        const { el } = openModal();
+        await settle();
+        expect(isHidden(el.find("lilbee-crawl-browser-setup") as MockElement)).toBe(true);
+        expect((el.find("lilbee-crawl-browser-input") as any).disabled).toBe(false);
     });
 });

--- a/tests/views/placement-view.test.ts
+++ b/tests/views/placement-view.test.ts
@@ -75,6 +75,12 @@ function multiManual(): PlacementResponse {
     return { ...multi(), manual: true, spec_json: '{"chat":{"devices":[0,1]}}' };
 }
 
+// GET /api/placement when a saved spec no longer fits: the server reports the auto
+// plan (manual false, spec_json null) and hands back the spec it refused to apply.
+function multiSpecRejected(): PlacementResponse {
+    return { ...multi(), rejected_spec_json: '{"chat":{"devices":[0,1,2]}}' };
+}
+
 function noGpu(): PlacementResponse {
     return {
         gpus: [],
@@ -214,6 +220,37 @@ describe("PlacementView multi-GPU (auto)", () => {
         expect(Notice.instances.map((n) => n.message)).toContain(
             'Click "Edit manually" first to change GPU placement.',
         );
+    });
+});
+
+describe("PlacementView rejected saved placement", () => {
+    it("says the saved placement is being ignored instead of reporting plain auto", async () => {
+        const { contentEl } = await openView(
+            makePlugin(makeApi({ placement: vi.fn().mockResolvedValue(ok(multiSpecRejected())) })),
+        );
+        const banner = contentEl.find("lilbee-placement-spec-ignored");
+        expect(banner).not.toBeNull();
+        expect(banner!.textContent).toBe(
+            "A saved manual placement does not fit this hardware, so auto placement is running instead. " +
+                "The saved placement stays and applies again once the hardware fits it. " +
+                "Clear it or save a new one if you do not want it back.",
+        );
+        expect(contentEl.find("lilbee-placement-state")!.textContent).toBe("auto, manual ignored");
+    });
+
+    it("renders no banner and a plain auto state when no saved placement was rejected", async () => {
+        const { contentEl } = await openView(makePlugin(makeApi()));
+        expect(contentEl.find("lilbee-placement-spec-ignored")).toBeNull();
+        expect(contentEl.find("lilbee-placement-state")!.textContent).toBe("auto");
+    });
+
+    it("drops the banner once the saved placement is cleared", async () => {
+        const api = makeApi({ placement: vi.fn().mockResolvedValue(ok(multiSpecRejected())) });
+        const { view, contentEl } = await openView(makePlugin(api));
+        expect(contentEl.find("lilbee-placement-spec-ignored")).not.toBeNull();
+        (view as unknown as { mode: string }).mode = "manual";
+        await (view as unknown as { runReset: () => Promise<void> }).runReset();
+        expect(contentEl.find("lilbee-placement-spec-ignored")).toBeNull();
     });
 });
 

--- a/tests/views/placement-view.test.ts
+++ b/tests/views/placement-view.test.ts
@@ -51,6 +51,7 @@ function single(): PlacementResponse {
         unplaceable: [],
         manual: false,
         spec_json: null,
+        rejected_spec_json: null,
     };
 }
 
@@ -68,6 +69,7 @@ function multi(): PlacementResponse {
         unplaceable: [],
         manual: false,
         spec_json: null,
+        rejected_spec_json: null,
     };
 }
 
@@ -88,6 +90,7 @@ function noGpu(): PlacementResponse {
         unplaceable: [],
         manual: false,
         spec_json: null,
+        rejected_spec_json: null,
     };
 }
 

--- a/tests/views/uninstall-modal.test.ts
+++ b/tests/views/uninstall-modal.test.ts
@@ -38,10 +38,20 @@ describe("UninstallModal", () => {
 
         expect(texts).toContain("Server executable");
         expect(texts).toContain("412 MB");
-        expect(texts).toContain("Downloaded models");
+        expect(texts).toContain("Models shared by every vault on this computer");
         expect(texts).toContain("12.4 GB");
-        expect(texts).toContain("Search index for this vault");
+        expect(texts).toContain("This vault's index, saved chats, and logs");
         expect(texts).toContain("820 MB");
+    });
+
+    it("says the saved chats go and the models are shared by every vault", () => {
+        const texts = collectTexts(open().contentEl as unknown as MockElement);
+
+        expect(texts).toContain(
+            "This removes what lilbee downloaded or built. It deletes this vault's saved chats and the models " +
+                "that every vault on this computer shares. You cannot undo it, but you can install the server " +
+                "again at any time.",
+        );
     });
 
     it("promises the vault is untouched", () => {


### PR DESCRIPTION
## Problem

Uninstall deleted the models directory without stopping the shared engine holding those files open. On Windows that fails outright; elsewhere it leaves an engine serving deleted paths. Its dialog called the per-vault directory a search index, when it holds saved chats, and called the machine-wide model cache this vault's.

Pages crawled during a running sync stayed unindexed with no signal: the follow-up sync was dropped rather than queued.

The crawling capability was read from a field that is always true in the release binary, so browser render mode was offered on a server with no Chromium and the first such crawl stalled on an unannounced download. HTTP crawling needs no browser and worked all along.

A storage move the server refused was re-sent at every launch, showing a status code instead of a reason.

The health probe listed models on every tick: 384 requests to Ollama and about 260 to HuggingFace over seven hours on one user's laptop, none user-initiated.

The placement view reported plain auto while a saved manual spec sat rejected, and the ingest summary dropped the sources it already tracks.

## Solution

Uninstall stops the engine first, and still completes against a server too old to have the command. The dialog names the saved chats and the shared models.

A sync requested during a run is stored and drained when that run finishes.

Choosing browser render mode fetches Chromium through the existing progress renderer, rather than refusing the choice. The crawling section still opens on a server without a browser, because HTTP crawling is unaffected.

A refused storage move is remembered as the pair refused, so it is not re-sent until either value changes or the user acts.

The probe hits health and nothing else; the status bar follows the model changes the plugin already makes.

## Notes

A model switched by another client no longer self-corrects within 30 seconds. It recovers on the next reconnect or user action.

A retry after a failed catalog load re-enables the primary action, which nothing cleared.
