### PR TITLE
Advance the catalog page by the server's window

### DIFF
--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -441,7 +441,8 @@ export class CatalogModal extends Modal {
         // Some servers and frontier providers tag rows loosely, so the task is filtered again.
         const filtered = this.filterTask ? response.models.filter((m) => m.task === this.filterTask) : response.models;
         this.entries.push(...filtered);
-        this.offset += response.models.length;
+        // The server's window, not the rows received: a page can hold fewer rows than limit.
+        this.offset = response.offset + response.limit;
 
         this.updateHostedTabVisibility();
         this.renderResults();

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -790,6 +790,45 @@ describe("CatalogModal", () => {
             modal.close();
             expect(removeSpy).toHaveBeenCalledWith("scroll", expect.any(Function));
         });
+
+        function secondRequest(plugin: ReturnType<typeof makePlugin>): Record<string, unknown> {
+            return plugin.api.catalog.mock.calls[1][0] as Record<string, unknown>;
+        }
+
+        it("asks for the next page window when a page comes back short with has_more true", async () => {
+            const plugin = makePlugin();
+            const shortPage = Array.from({ length: 17 }, (_, i) =>
+                makeEntry({ hf_repo: `owner/model-${i}-GGUF`, display_name: `Model ${i}` }),
+            );
+            plugin.api.catalog
+                .mockResolvedValueOnce(ok({ total: 40, limit: 20, offset: 0, models: shortPage, has_more: true }))
+                .mockResolvedValueOnce(ok({ total: 40, limit: 20, offset: 20, models: [], has_more: false }));
+            const modal = await openModal(plugin);
+            setScroll(modal, { scrollTop: 800, clientHeight: 400, scrollHeight: 1100 });
+            (modal as any).onScroll();
+            await tick();
+            await tick();
+            expect(plugin.api.catalog).toHaveBeenCalledTimes(2);
+            expect(secondRequest(plugin)).toMatchObject({ offset: 20, limit: 20 });
+            modal.close();
+        });
+
+        it("still advances past a page whose rows were all filtered out", async () => {
+            const plugin = makePlugin();
+            plugin.api.catalog
+                .mockResolvedValueOnce(ok({ total: 40, limit: 20, offset: 0, models: [], has_more: true }))
+                .mockResolvedValueOnce(
+                    ok({ total: 40, limit: 20, offset: 20, models: [makeEntry()], has_more: false }),
+                );
+            const modal = await openModal(plugin);
+            setScroll(modal, { scrollTop: 800, clientHeight: 400, scrollHeight: 1100 });
+            (modal as any).onScroll();
+            await tick();
+            await tick();
+            expect(plugin.api.catalog).toHaveBeenCalledTimes(2);
+            expect(secondRequest(plugin)).toMatchObject({ offset: 20, limit: 20 });
+            modal.close();
+        });
     });
 
     describe("search paging", () => {


### PR DESCRIPTION
## Problem

The catalog modal advanced its offset by the number of rows a page held. The server can return a page shorter than `limit` with `has_more` true: it deduplicates HuggingFace rows against the picks, drops rows its filters reject, and a `max_fit` page can come back empty. The modal then asked for rows it already had, and an empty page left the offset where it was, so scrolling never moved on.

Walking the chat listing against a live server for 80 pages, the old advance repeated 8 rows.

## Solution

The offset now moves to the window the server echoes, `offset` plus `limit`, which is the window the server paged. The same 80-page walk yields 0 duplicates, and an empty page with `has_more` true still advances.
