### PR TITLE
Make the shared text mock write setValue through

### DIFF
--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -870,8 +870,12 @@ class MockTextComponent {
         this.inputEl.placeholder = p;
         return this;
     }
-    setValue(_v: string): this {
+    setValue(v: string): this {
+        this.inputEl.value = v;
         return this;
+    }
+    getValue(): string {
+        return this.inputEl.value;
     }
     onChange(cb: (v: string) => void): this {
         this._onChange = cb;
@@ -889,8 +893,12 @@ class MockTextAreaComponent {
         this.inputEl.placeholder = p;
         return this;
     }
-    setValue(_v: string): this {
+    setValue(v: string): this {
+        this.inputEl.value = v;
         return this;
+    }
+    getValue(): string {
+        return this.inputEl.value;
     }
     onChange(cb: (v: string) => void): this {
         this._onChange = cb;

--- a/tests/obsidian-mock.test.ts
+++ b/tests/obsidian-mock.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { MockElement, Setting } from "./__mocks__/obsidian";
+
+describe("Setting text components", () => {
+    it("addText writes setValue through to the input and reads it back with getValue", () => {
+        const setting = new Setting(new MockElement());
+        let getValue = (): string => "";
+        let inputEl = { value: "" };
+        setting.addText((text) => {
+            text.setValue("hf_stored");
+            getValue = () => text.getValue();
+            inputEl = text.inputEl;
+        });
+        expect(inputEl.value).toBe("hf_stored");
+        expect(getValue()).toBe("hf_stored");
+    });
+
+    it("addTextArea writes setValue through to the textarea and reads it back with getValue", () => {
+        const setting = new Setting(new MockElement());
+        let getValue = (): string => "";
+        let inputEl = { value: "" };
+        setting.addTextArea((text) => {
+            text.setValue("line one\nline two");
+            getValue = () => text.getValue();
+            inputEl = text.inputEl;
+        });
+        expect(inputEl.value).toBe("line one\nline two");
+        expect(getValue()).toBe("line one\nline two");
+    });
+});

--- a/tests/settings-vault-sections.test.ts
+++ b/tests/settings-vault-sections.test.ts
@@ -134,17 +134,14 @@ function captureSettingCallbacks(fn: () => void) {
 
     const origAddText = Setting.prototype.addText;
     Setting.prototype.addText = function (cb: (text: any) => void) {
-        const fakeText = {
-            setPlaceholder: () => fakeText,
-            setValue: () => fakeText,
-            onChange: (handler: (value: string) => void | Promise<void>) => {
+        return origAddText.call(this, (text: any) => {
+            const origOnChange = text.onChange.bind(text);
+            text.onChange = (handler: (value: string) => void | Promise<void>) => {
                 textOnChanges.push(handler);
-                return fakeText;
-            },
-            inputEl: { placeholder: "", type: "text", value: "", addEventListener: vi.fn() },
-        };
-        cb(fakeText);
-        return this;
+                return origOnChange(handler);
+            };
+            cb(text);
+        });
     };
     // Capture button labels + onClick handlers without replacing the mock —
     // settings.ts calls .setWarning(), .setTooltip(), .setIcon() on buttons

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -7,6 +7,7 @@ import {
     DEFAULT_SETTINGS,
     MEMORY_CONFIG_KEY,
     MODEL_TASK,
+    SERVER_MODE,
     SERVER_VARIANT,
     SSE_EVENT,
     TABLE_MODEL,
@@ -301,6 +302,8 @@ interface Captured {
     /** Callbacks keyed by the row's display name, so a test names the field it
      * means instead of counting rows to it. */
     textByName: Map<string, TextOnChange>;
+    /** The rendered input of each text row, keyed by the row's display name. */
+    textInputByName: Map<string, { value: string; type: string }>;
     toggleByName: Map<string, ToggleOnChange>;
     dropdownByName: Map<string, DropdownOnChange>;
     textAreaByName: Map<string, TextOnChange>;
@@ -351,6 +354,7 @@ function captureSettingCallbacks(fn: () => void): Captured {
     // the page, which is how one settings change takes 40 unrelated tests down.
     // Record each Setting's name so a test can ask for the row it means.
     const textByName = new Map<string, TextOnChange>();
+    const textInputByName = new Map<string, { value: string; type: string }>();
     const blurByName = new Map<string, BlurCapture>();
     const toggleByName = new Map<string, ToggleOnChange>();
     const dropdownByName = new Map<string, DropdownOnChange>();
@@ -382,73 +386,45 @@ function captureSettingCallbacks(fn: () => void): Captured {
 
     Setting.prototype.addText = function (cb: (text: any) => void) {
         const name = currentName;
-        const listeners = new Map<string, () => void>();
-        const fakeText = {
-            setPlaceholder: () => fakeText,
-            // Obsidian's TextComponent writes through to the element, and rows seeded from
-            // stored state are only honest in a test if the element carries that value.
-            setValue: (v: string) => {
-                fakeText.inputEl.value = v;
-                return fakeText;
-            },
-            onChange: (handler: TextOnChange) => {
+        return origAddText.call(this, (text: any) => {
+            const listeners = new Map<string, () => void>();
+            const origOnChange = text.onChange.bind(text);
+            text.onChange = (handler: TextOnChange) => {
                 textOnChanges.push(handler);
-                if (currentName) textByName.set(currentName, handler);
-                return fakeText;
-            },
-            inputEl: {
-                placeholder: "",
-                type: "text",
-                value: "",
-                addClass: vi.fn(),
-                classList: { add: vi.fn(), remove: vi.fn() },
-                attributes: {} as Record<string, string>,
-                setAttribute(name: string, value: string): void {
-                    this.attributes[name] = value;
-                },
-                getAttribute(name: string): string | null {
-                    return this.attributes[name] ?? null;
-                },
-                addEventListener: (event: string, handler: BlurHandler) => {
-                    listeners.set(event, handler);
-                    if (event === "blur") {
-                        const capture: BlurCapture = {
-                            handler,
-                            inputEl: fakeText.inputEl,
-                            edit: (value: string) => {
-                                fakeText.inputEl.value = value;
-                                listeners.get("input")?.();
-                            },
-                        };
-                        blurHandlers.push(capture);
-                        blurByName.set(name, capture);
-                    }
-                },
-            },
-        };
-        cb(fakeText);
-        return this;
+                if (name) textByName.set(name, handler);
+                return origOnChange(handler);
+            };
+            text.inputEl.addEventListener = (event: string, handler: BlurHandler) => {
+                listeners.set(event, handler);
+                if (event === "blur") {
+                    const capture: BlurCapture = {
+                        handler,
+                        inputEl: text.inputEl,
+                        edit: (value: string) => {
+                            text.inputEl.value = value;
+                            listeners.get("input")?.();
+                        },
+                    };
+                    blurHandlers.push(capture);
+                    blurByName.set(name, capture);
+                }
+            };
+            if (name) textInputByName.set(name, text.inputEl);
+            cb(text);
+        });
     };
 
     (Setting.prototype as any).addTextArea = function (cb: (text: any) => void) {
-        const fakeText = {
-            setPlaceholder: () => fakeText,
-            setValue: () => fakeText,
-            onChange: (handler: TextOnChange) => {
+        const name = currentName;
+        return origAddTextArea.call(this, (text: any) => {
+            const origOnChange = text.onChange.bind(text);
+            text.onChange = (handler: TextOnChange) => {
                 textAreaOnChanges.push(handler);
-                if (currentName) textAreaByName.set(currentName, handler);
-                return fakeText;
-            },
-            inputEl: {
-                placeholder: "",
-                value: "",
-                addClass: vi.fn(),
-                classList: { add: vi.fn(), remove: vi.fn() },
-                addEventListener: vi.fn(),
-            },
-        };
-        cb(fakeText);
-        return this;
+                if (name) textAreaByName.set(name, handler);
+                return origOnChange(handler);
+            };
+            cb(text);
+        });
     };
 
     Setting.prototype.addSlider = function (cb: (slider: any) => void) {
@@ -578,6 +554,7 @@ function captureSettingCallbacks(fn: () => void): Captured {
 
     return {
         textByName,
+        textInputByName,
         toggleByName,
         dropdownByName,
         textAreaByName,
@@ -698,6 +675,14 @@ describe("LilbeeSettingTab", () => {
             await textOnChanges[0]("http://localhost:9999");
             expect(plugin.settings.serverUrl).toBe("http://localhost:9999");
             expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
+        });
+
+        it("renders the stored URL in the field", () => {
+            const plugin = makePlugin({ serverMode: SERVER_MODE.EXTERNAL, serverUrl: "http://remote:9999" });
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            const { textInputByName } = captureSettingCallbacks(() => tab.display());
+            expect(textInputByName.get(MESSAGES.LABEL_SERVER_URL)?.value).toBe("http://remote:9999");
         });
     });
 


### PR DESCRIPTION
## Problem

The shared Obsidian test mock dropped the value passed to a text or textarea field's setValue and had no getValue. Every settings row seeded from stored state rendered into an empty box under test, so no test could see a seeded field or read one back.

The HuggingFace token fix worked around this with a private write-through fake in the settings test helper, so two doubles for one component disagreed.

## Solution

The shared text and textarea doubles now write the value to the input element and read it back with getValue, as the Obsidian type declarations describe.

The settings test helpers wrap the shared component to record callbacks instead of building their own text fakes, so one double serves every row.

A new test pins the mock contract for both components. A new settings test seeds the server URL from stored settings and checks that the rendered field holds it.

## Notes

No existing test changed colour once the shared mock wrote through, so no row was found seeding the wrong value.

Individual settings tests that build one-off text fakes to record placeholders, change handlers, or input types are recorders, not value doubles, and are left alone.

Nothing checks the mock against a real Obsidian build. The live QA pass should confirm that the real component does not fire the change callback from setValue; the declarations do not say, and the mock does not.
