### PR TITLE
Prune ignored sources on every plugin sync

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -633,8 +633,9 @@ export class LilbeeClient {
         yield* this.parseSSE(res);
     }
 
+    /** Streams a sync. Always prunes the sources a .lilbeeignore excludes. */
     async *syncStream(signal?: AbortSignal, options?: SyncOptions): AsyncGenerator<SSEEvent, void> {
-        const body: Record<string, unknown> = {};
+        const body: Record<string, unknown> = { prune_ignored: true };
         if (options?.forceRebuild) body.force_rebuild = true;
         if (options?.retrySkipped) body.retry_skipped = true;
         const res = await this.fetchWithRetry(

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -516,7 +516,7 @@ describe("uploadFiles()", () => {
 });
 
 describe("syncStream()", () => {
-    it("POSTs to /api/sync with empty body by default", async () => {
+    it("POSTs to /api/sync with only prune_ignored by default", async () => {
         fetchMock.mockResolvedValue(
             sseResponse(['event: progress\ndata: {"file":"a.md","status":"ingested","current":1,"total":1}\n\n']),
         );
@@ -526,9 +526,22 @@ describe("syncStream()", () => {
         expect(fetchMock).toHaveBeenCalledWith(`${BASE_URL}/api/sync`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({}),
+            body: JSON.stringify({ prune_ignored: true }),
         });
         expect(events[0].event).toBe("progress");
+    });
+
+    it.each([
+        ["no options", undefined],
+        ["forceRebuild", { forceRebuild: true }],
+        ["retrySkipped", { retrySkipped: true }],
+    ])("sends prune_ignored true with %s so a .lilbeeignore governs the whole index", async (_label, options) => {
+        fetchMock.mockResolvedValue(sseResponse([]));
+
+        await collect(client.syncStream(undefined, options));
+
+        const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+        expect(body.prune_ignored).toBe(true);
     });
 
     it("never sends a legacy enable_ocr flag", async () => {
@@ -564,7 +577,7 @@ describe("syncStream()", () => {
         await collect(client.syncStream(undefined, { forceRebuild: true, retrySkipped: true }));
 
         const body = JSON.parse(fetchMock.mock.calls[0][1].body);
-        expect(body).toEqual({ force_rebuild: true, retry_skipped: true });
+        expect(body).toEqual({ force_rebuild: true, retry_skipped: true, prune_ignored: true });
     });
 
     it("omits the recovery flags when they are false", async () => {


### PR DESCRIPTION
## Problem

A user who writes a `.lilbeeignore` by hand and then syncs sees the excluded files stay searchable. The server drops already-indexed sources only when a sync sends `prune_ignored`, and the plugin never sent it. The pattern governed future discovery and nothing else, which reads as a broken feature.

## Solution

Every sync the plugin starts now sends `prune_ignored: true`, with or without the rebuild and retry options. The ignore file governs the whole index. With no `.lilbeeignore` the prune pass matches nothing and removes nothing. Pruned documents show up in the sync summary's removed count.

## Notes

A settings UI for excluding file types is a separate piece of work.
