### PR TITLE
Apply the audit cleanups from the operator-surface round

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -913,7 +913,7 @@ export default class LilbeePlugin extends Plugin {
     /** Offer the picker the first time lilbee sees an agent CLI on this machine. */
     private async maybeShowAgentPicker(): Promise<void> {
         if (this.settings.agentIntegration.pickerShown) return;
-        // The wizard re-offers pairing on close, so this defers the question rather than dropping it.
+        // Deferred, not dropped: the wizard re-offers pairing on close.
         if (this.setupWizardOpen) {
             this.agentPickerDeferred = true;
             return;
@@ -978,7 +978,7 @@ export default class LilbeePlugin extends Plugin {
 
     /** The layout the plugin wants, or null while the data dir is unknown. */
     private wantedStorageLayout(): StorageMoveTarget | null {
-        // The server refuses to reset documents_dir, so opting out names its data dir explicitly.
+        // Opting out names the data dir explicitly; the server has no reset for documents_dir.
         const storeInVault = this.settings.storeContentInVault;
         const vaultBase = this.getVaultBasePath();
         const documentsDir = storeInVault ? `${vaultBase}/lilbee` : this.serverOwnedDocumentsDir();

--- a/src/server-uninstall.ts
+++ b/src/server-uninstall.ts
@@ -61,7 +61,7 @@ async function stopSharedEngine(sharedRoot: string, vaultDataDir: string): Promi
     try {
         await node.execFile(binary.path, engineStopArgs(vaultDataDir), { timeout: ENGINE_STOP_TIMEOUT_MS });
     } catch {
-        // An engine that will not stop is not a reason to refuse the uninstall.
+        // The uninstall continues without the stop.
     }
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -149,11 +149,11 @@ interface RowSpec {
     desc: string;
     /** Set when the connected server has to report the key before the row means anything. */
     key?: string;
-    /** Set only by gated(), which is never nested, so it is safe to overwrite. */
+    /** Set only by gated(), which is never nested. */
     visible?: () => boolean;
     /** False for rows that carry a section's own DOM rather than a setting a user searches for. */
     searchable?: boolean;
-    /** Extra search terms, so a row that reveals hidden rows answers for their names too. */
+    /** Extra search terms: the names of the hidden rows this row reveals. */
     aliases?: string[];
     /** `container` is where a row that needs more than one element puts the rest. */
     apply: (setting: Setting, container: HTMLElement) => void;
@@ -480,8 +480,7 @@ interface GenerationField extends ConfigRowSpec {
     hideable?: boolean;
 }
 
-// num_ctx is intentionally not surfaced: the server picks a context window appropriate to the
-// active model, and asking for more than the model supports only wastes RAM.
+// num_ctx is not surfaced; the server picks the context window for the active model.
 const GENERATION_FIELDS: GenerationField[] = [
     { key: "temperature", name: MESSAGES.LABEL_GEN_TEMPERATURE, desc: MESSAGES.DESC_GEN_TEMPERATURE, integer: false },
     { key: "top_p", name: MESSAGES.LABEL_GEN_TOP_P, desc: MESSAGES.DESC_GEN_TOP_P, integer: false },
@@ -656,7 +655,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         return { ...spec, apply: (setting) => this.applyNumberFieldWithReset(setting, spec, opts) };
     }
 
-    /** OCR languages and the like: always shown, because the server answers with a default. */
+    /** OCR languages and the like: always shown; the server answers with a default. */
     private listRow(spec: ConfigRowSpec): RowSpec {
         return this.localRow(spec.name, spec.desc, (setting) => this.applyConfigList(setting, spec));
     }
@@ -1867,7 +1866,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         this.applyChatModeFromConfig(cfg);
         this.applyHideableConfigFields(cfg);
         if (!this.usesDefinitions()) return;
-        // The first config decides which rows exist and what they start at, so rebuild once.
+        // The first config rebuilds the tab; later ones only re-evaluate visibility.
         if (first) this.refresh();
         else this.refreshVisibility();
     }
@@ -1976,7 +1975,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
     }
 
     private applyChatModeFromConfig(cfg: ConfigResponse): void {
-        // On 1.13 the row's visible predicate hides it instead, so only the value and the embedding guard apply.
+        // On 1.13 the row's visible predicate owns its visibility.
         this.setRowVisible(this.chatModeSettingEl, cfg.chat_mode !== undefined);
         if (cfg.chat_mode === undefined) return;
         if (this.chatModeDropdown) {
@@ -2051,7 +2050,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             desc: MESSAGES.DESC_GENERAL_SYSTEM_PROMPT,
         };
         return [
-            // Both prompts reach the server through /api/config, so external mode sees them too.
+            // Both prompts are server config, shown in external mode too.
             this.localRow(rag.name, rag.desc, (setting) =>
                 this.applySystemPromptRow(setting, rag, "ragSystemPrompt", this.plugin.settings.ragSystemPrompt),
             ),
@@ -2964,7 +2963,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             ...CRAWL_FIELDS.map((field) => this.crawlRow(field)),
             {
                 ...renderMode,
-                // Picking browser mode installs the browser, so this row carries the setup offer's search terms.
+                // The setup offer's search terms; picking browser mode installs the browser.
                 aliases: [MESSAGES.LABEL_CRAWL_BROWSER_SETUP],
                 apply: (setting) => this.applyCrawlRenderModeRow(setting, renderMode),
             },
@@ -3040,12 +3039,12 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 dropdown.addOption(CRAWL_RENDER_MODE.BROWSER, MESSAGES.LABEL_CRAWL_RENDER_MODE_BROWSER);
                 dropdown.setValue(CRAWL_RENDER_MODE.HTTP);
                 dropdown.onChange(async (value) => {
-                    // The choice can arrive before the gating probe lands, so read the capability now.
+                    // A fresh read: the gating probe can still be in flight.
                     if (
                         value === CRAWL_RENDER_MODE.BROWSER &&
                         !(await this.plugin.api.getCapability(CAPABILITY.CRAWLING_BROWSER))
                     ) {
-                        // Choosing browser mode is the request for a browser, so fetch it rather than refuse.
+                        // Browser mode without a browser installs one.
                         if (!(await this.plugin.installCrawlerBrowser())) {
                             dropdown.setValue(CRAWL_RENDER_MODE.HTTP);
                             return;
@@ -3431,7 +3430,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             .addText((text) => {
                 text.setPlaceholder(MESSAGES.PLACEHOLDER_HF_TOKEN).setValue(this.plugin.getSharedHfToken());
                 text.inputEl.type = "password";
-                // Nothing reads the token back from the server, so re-entering the stored value must still send.
+                // Tracks input events, not a value change: re-entering the stored value still sends.
                 let edited = false;
                 text.inputEl.addEventListener("input", () => {
                     edited = true;
@@ -3444,13 +3443,12 @@ export class LilbeeSettingTab extends PluginSettingTab {
                         await this.plugin.api.updateConfig({ hf_token: trimmed });
                     } catch {
                         new Notice(MESSAGES.NOTICE_FAILED_HF_TOKEN);
-                        // A refused save leaves unsaved work, so the next blur must retry it.
+                        // Still unsaved; the next blur retries.
                         edited = true;
                         return;
                     }
-                    // An edit that landed while the request was open owns the stored copy.
+                    // An edit made during the request owns the stored copy.
                     if (text.inputEl.value.trim() !== trimmed) return;
-                    // The shared copy only mirrors a token the server took, clearing included.
                     this.plugin.setSharedHfToken(trimmed);
                     new Notice(MESSAGES.NOTICE_HF_TOKEN_SAVED);
                 };

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -177,7 +177,6 @@ const ADAPTIVE_THRESHOLD: ConfigRowSpec = {
 };
 const TOP_K_LIMITS: SliderLimits = { min: 1, max: 20, step: 1 };
 const WIKI_FAITHFULNESS_LIMITS: SliderLimits = { min: 0, max: 1, step: 0.05 };
-const DEFAULT_WIKI_VAULT_FOLDER = "lilbee-wiki";
 
 /** A crawl number typed into a text box. */
 interface CrawlNumericField extends ConfigRowSpec {
@@ -3264,7 +3263,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             .addText((text) => {
                 text.setValue(this.plugin.settings.wikiVaultFolder);
                 text.onChange(async (value) => {
-                    this.plugin.settings.wikiVaultFolder = value || DEFAULT_WIKI_VAULT_FOLDER;
+                    this.plugin.settings.wikiVaultFolder = value || DEFAULT_SETTINGS.wikiVaultFolder;
                     await this.plugin.saveSettings();
                     if (this.plugin.settings.wikiSyncToVault && this.plugin.wikiEnabled) {
                         this.plugin.initWikiSync();

--- a/src/types.ts
+++ b/src/types.ts
@@ -349,7 +349,7 @@ export interface SyncDone {
 
 /** An add stream's terminal summary: the sync it ran, plus the add-only outcomes. */
 export interface AddDone extends SyncDone {
-    /** Sources the knowledge base already tracks, so nothing was registered. Needs no user action. */
+    /** Sources the knowledge base already tracks; not registered again, and no user action needed. */
     tracked: string[];
 }
 
@@ -931,7 +931,7 @@ export interface CrawlerStatusResponse {
 
 export type CrawlerStatusField = keyof CrawlerStatusResponse;
 
-/** `PACKAGE` is the bundled crawler package; `WITH_BROWSER` also requires Chromium. */
+/** The status fields for `CAPABILITY.CRAWLING` and `CAPABILITY.CRAWLING_BROWSER`, in that order. */
 export const CRAWLER_STATUS_FIELD = {
     PACKAGE: "package_installed",
     WITH_BROWSER: "installed",

--- a/src/views/agent-picker-modal.ts
+++ b/src/views/agent-picker-modal.ts
@@ -26,7 +26,7 @@ export class AgentPickerModal extends Modal {
     private resolver: ((r: AgentPickerResult) => void) | null = null;
     private resolved = false;
     private selected: AgentClient | null = null;
-    // Off by default: one click on Connect must not both wire an integration and silence the question.
+    // Off by default; Connect alone does not silence the question.
     private remember = false;
     private cards: Map<AgentClient, HTMLElement> = new Map();
     /** Populated by renderFooter during onOpen, before the first select() call. */

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -46,7 +46,7 @@ import {
 } from "./catalog-helpers";
 
 const PAGE_SIZE = 20;
-// Search matches are spread across the hub, not sitting at one offset.
+// Page size for search; matches are spread across the hub.
 const SEARCH_PAGE_SIZE = 50;
 const SCROLL_BOTTOM_THRESHOLD_PX = 200;
 const DRAWER_BREAKPOINT_PX = 800;
@@ -438,7 +438,7 @@ export class CatalogModal extends Modal {
 
     private applyPage(response: CatalogResponse): void {
         this.hasMore = response.has_more;
-        // Some servers and frontier providers tag rows loosely, so the task is filtered again.
+        // Filtered by task again; some servers and frontier providers tag rows loosely.
         const filtered = this.filterTask ? response.models.filter((m) => m.task === this.filterTask) : response.models;
         this.entries.push(...filtered);
         // The server's window, not the rows received: a page can hold fewer rows than limit.

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -11,6 +11,7 @@ import type {
 } from "../types";
 import {
     CATALOG_TAB,
+    DEFAULT_SETTINGS,
     HARDWARE_FIT,
     HOSTED_SOURCES,
     LILBEE_REPO_URL,
@@ -487,7 +488,7 @@ export class SetupWizard extends Modal {
                 nextBtn.disabled = true;
                 void this.startManagedAndAdvance(step, panel, setPhase, statusEl, nextBtn, selectExternal);
             } else {
-                const url = String(urlInput.value || "").trim() || "http://127.0.0.1:7433";
+                const url = String(urlInput.value || "").trim() || DEFAULT_SETTINGS.serverUrl;
                 const token = String(tokenInput.value || "").trim();
                 statusEl.setText(MESSAGES.STATUS_CHECKING_CONNECTION);
                 nextBtn.disabled = true;

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -117,8 +117,8 @@ function largestFitIndex(models: FeaturedModel[], memGB: number): number {
  * as the first four tiles gets an immediate sense of what's familiar. Any
  * native models outside these families backfill after.
  */
-// Substrings (lowercase) matched against `hf_repo`. Featured chat repos ship under varied orgs
-// (`Qwen/`, `unsloth/`, `ggml-org/`, `bartowski/`, …), so we don't pin to `<org>/<family>`.
+// Lowercase substrings matched against `hf_repo`, with no org prefix: featured chat repos
+// ship under varied orgs (`Qwen/`, `unsloth/`, `ggml-org/`, `bartowski/`, ...).
 // Order matters: more specific families (Qwen3 Coder) come before less specific (Qwen3).
 const PREFERRED_FAMILIES = [
     "gemma-4",
@@ -222,12 +222,9 @@ export function pickNativeChatModels(
 }
 
 /**
- * Puts the most popular candidates the wizard can offer in place of the rows
- * that will not run, in the order the server returned them. Rows left without a
- * substitute stay, behind the ones that run, so the row keeps its size.
- *
- * Nothing here drops a row, and ranking drops none either, so the picks row is
- * empty only when the server returned nothing.
+ * Replaces the rows that will not run with the most popular candidates, in server
+ * order. Rows left without a substitute stay, behind the ones that run. Never
+ * drops a row.
  */
 function substituteUnrunnable(row: FeaturedModel[], candidates: FeaturedModel[]): FeaturedModel[] {
     const unrunnable = row.filter(isUnrunnable);
@@ -856,7 +853,7 @@ export class SetupWizard extends Modal {
         const retryBtn = container.createEl("button", { text: MESSAGES.BUTTON_RETRY });
         retryBtn.addEventListener("click", () => {
             statusEl.setText("");
-            // The failed load disabled the primary action; the retry needs it back.
+            // Re-enables the primary action the failed load disabled.
             if (this.primaryBtn) this.primaryBtn.disabled = false;
             retry();
         });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -5189,7 +5189,7 @@ describe("managed mode settings", () => {
             for (let i = 0; i < textOnChanges.length; i++) {
                 plugin.settings.wikiVaultFolder = "something";
                 await textOnChanges[i]("");
-                if (plugin.settings.wikiVaultFolder === "lilbee-wiki") {
+                if (plugin.settings.wikiVaultFolder === DEFAULT_SETTINGS.wikiVaultFolder) {
                     return;
                 }
             }


### PR DESCRIPTION
## Problem

An audit of the operator-surface round (#265, #266, #268, #269) against AGENTS.md found two defaults kept in a second copy beside `DEFAULT_SETTINGS`, and about twenty comments that narrate why a line exists instead of stating what it is.

## Solution

The wiki vault folder reset reads the shared default instead of a private copy of it.

The setup wizard's fallback for an empty server URL reads the default server URL.

The justifying comments each name their invariant in one line or are gone, and the crawler status fields point at the capability constants instead of repeating their explanation.

## Notes

The `1.13.0` version literal stays at its three call sites: the community store lint rule needs a literal guard in scope of each 1.13-only API call, and a helper call does not satisfy it. Import order is left as is; the guide asks for obsidian imports first and has no alphabetical rule.

A test in the settings suite pins known-wrong behaviour on purpose: when the server reports an empty answer prompt, the row's Default placeholder is cleared, and the fix that keeps it will redden that test.

Deferred, each for its own change: the 51 rows that restate their name and description; the duplicate provider row in the advanced section; the version guard inside the 1.13-only render callback; the three field-spec vocabularies; the long row builders; the scattered HTTP status constants; the storage check that logs a config failure without a notice (a defect); the two crawler setup switches in the plugin entry; the copied test mocks and the parametrize candidates; the localhost placeholder string in the locale table that repeats the default server URL.
