### PR TITLE
Bump js-yaml to 4.3.2 to clear the high audit advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4492,9 +4492,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Problem

The Security Scan workflow has been red on main since the run for e51820a on 2026-09-09. Both the npm audit job and the OSV-Scanner job fail on one advisory: js-yaml 4.3.1, GHSA-2883-xcg3-v3hh (high, CVSS 7.5), maxTotalMergeKeys does not limit CPU use for empty merge sources.

The package is dev-only. It reaches the tree through eslint-plugin-obsidianmd, eslint and @eslint/eslintrc. The bundle does not carry it: main.js is byte-identical before and after this change.

## Solution

js-yaml 4.3.1 to 4.3.2 in the lockfile, from `npm audit fix` with no `--force`. package.json is unchanged: the existing override for js-yaml is a floor at ^4.3.0 and already admits 4.3.2.

`npm audit --audit-level=high` goes from `1 high severity vulnerability` to `found 0 vulnerabilities`. OSV-Scanner 2.5.1 with the repo config goes from `1 High` to `No issues found`.

## Notes

No other advisories are open at this tip. The fast-uri and vitest advisories reported earlier this week are already clear on main.
