### PR TITLE
Prefer active server models in wizard, skip hosted rows in picks

### DIFF
--- a/src/components/model-card.ts
+++ b/src/components/model-card.ts
@@ -1,6 +1,6 @@
 import { setIcon } from "obsidian";
 import type { CatalogEntry, HardwareFit, ModelCardOptions } from "../types";
-import { HARDWARE_FIT, HOSTED_SOURCES, MODEL_COMPAT, MODEL_TASK } from "../types";
+import { HARDWARE_FIT, HOSTED_SOURCES, KEY_STATUS, MODEL_COMPAT, MODEL_TASK } from "../types";
 import { MESSAGES } from "../locales/en";
 import { formatAbbreviatedCount } from "../utils";
 
@@ -123,7 +123,8 @@ function renderCardStatus(card: HTMLElement, entry: CatalogEntry, options: Model
         text: tone.label,
         cls: `lilbee-model-card-status-label ${tone.labelCls}`,
     });
-    if (entry.installed) {
+    const hostedMissingKey = HOSTED_SOURCES.has(entry.source) && entry.key_status === KEY_STATUS.MISSING_KEY;
+    if (entry.installed && !hostedMissingKey) {
         label.setAttribute("title", MESSAGES.TOOLTIP_MODEL_INSTALLED_SHARED);
     }
     if (entry.fit && FIT_LABEL[entry.fit]) {
@@ -141,7 +142,8 @@ function statusTone(
     if (options.isActive) {
         return { dotCls: "is-active", labelCls: "is-active", label: MESSAGES.LABEL_ACTIVE };
     }
-    if (entry.installed) {
+    const hostedMissingKey = HOSTED_SOURCES.has(entry.source) && entry.key_status === KEY_STATUS.MISSING_KEY;
+    if (entry.installed && !hostedMissingKey) {
         return { dotCls: "is-installed", labelCls: "is-installed", label: MESSAGES.LABEL_INSTALLED };
     }
     if (entry.downloads > 0) {

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -90,6 +90,7 @@ function bestInstalledFitIndex(models: FeaturedModel[], memGB: number | null): n
     for (let i = 0; i < models.length; i++) {
         const m = models[i];
         if (!m.installed) continue;
+        if (HOSTED_SOURCES.has(m.source)) continue;
         if (memGB !== null && m.min_ram_gb > memGB) continue;
         if (m.min_ram_gb >= bestRam) {
             best = i;
@@ -811,7 +812,9 @@ export class SetupWizard extends Modal {
             return;
         }
 
-        const recommended = recommendedIndex(this.featuredModels, memGB);
+        const activeRef = await this.activeChatRef();
+        const activeIdx = activeRef ? this.featuredModels.findIndex((m) => m.hf_repo === activeRef) : -1;
+        const recommended = activeIdx >= 0 ? activeIdx : recommendedIndex(this.featuredModels, memGB);
         this.selectedModel = this.featuredModels[recommended];
         this.setPrimaryActionLabel(downloadBtn, this.selectedModel);
 
@@ -821,10 +824,31 @@ export class SetupWizard extends Modal {
         for (let i = 0; i < this.featuredModels.length; i++) {
             const entry = this.featuredModels[i];
             renderModelCard(grid, entry, {
-                // Recommended, not active: the wizard does not know what the server has loaded.
                 isSelected: i === recommended,
                 onClick: () => this.selectModel(grid, entry, downloadBtn),
             });
+        }
+    }
+
+    /** The ref of the chat model the server has active, or null if unknown. */
+    private async activeChatRef(): Promise<string | null> {
+        try {
+            const models = await this.plugin.api.listModels();
+            const ref = models.chat.active;
+            return ref && ref.length > 0 ? ref : null;
+        } catch {
+            return null;
+        }
+    }
+
+    /** The ref of the embedding model the server has active, or null if unknown. */
+    private async activeEmbeddingRef(): Promise<string | null> {
+        try {
+            const models = await this.plugin.api.listModels();
+            const ref = models.embedding?.active;
+            return ref && ref.length > 0 ? ref : null;
+        } catch {
+            return null;
         }
     }
 
@@ -1058,8 +1082,9 @@ export class SetupWizard extends Modal {
             return;
         }
 
-        const recommended = this.embeddingModels.findIndex((m) => m.hf_repo.toLowerCase().includes("nomic-embed-text"));
-        const defaultIdx = recommended >= 0 ? recommended : 0;
+        const activeRef = await this.activeEmbeddingRef();
+        const activeIdx = activeRef ? this.embeddingModels.findIndex((m) => m.hf_repo === activeRef) : -1;
+        const defaultIdx = activeIdx >= 0 ? activeIdx : 0;
         this.selectedEmbedding = this.embeddingModels[defaultIdx];
 
         this.renderSectionHeading(container, MESSAGES.WIZARD_EMBEDDING_RECOMMENDED);

--- a/tests/components/model-card.test.ts
+++ b/tests/components/model-card.test.ts
@@ -89,6 +89,18 @@ describe("renderModelCard", () => {
             expect(label?.getAttribute("title")).toBeNull();
         });
 
+        it("does not paint a hosted model with no key as Installed (shared)", () => {
+            const c = container();
+            const card = renderModelCard(
+                c,
+                makeEntry({ installed: true, source: "frontier", key_status: "missing_key", downloads: 100 }),
+                {},
+            ) as unknown as MockElement;
+            const label = card.find("lilbee-model-card-status-label");
+            expect(label?.textContent).not.toBe(MESSAGES.LABEL_INSTALLED);
+            expect(label?.getAttribute("title")).toBeNull();
+        });
+
         it("renders an active dot+label when isActive is true", () => {
             const c = container();
             const card = renderModelCard(c, makeEntry({ installed: true }), {

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -1550,6 +1550,72 @@ describe("SetupWizard", () => {
             expect(controller.signal.aborted).toBe(true);
             expect(closeSpy).toHaveBeenCalled();
         });
+
+        it("pre-selects the server's active chat model over a larger installed one", async () => {
+            const entries = [
+                makeEntry({
+                    hf_repo: "Qwen/Qwen3-4B-GGUF",
+                    display_name: "Qwen3 4B",
+                    installed: true,
+                    min_ram_gb: 8,
+                }),
+                makeEntry({
+                    hf_repo: "janhq/Jan-v3.5-4B-gguf/Jan-v3.5-4B-Q4_K_M.gguf",
+                    display_name: "Jan v3.5 4B",
+                    installed: true,
+                    min_ram_gb: 4,
+                }),
+            ];
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
+            plugin.api.listModels = vi.fn().mockResolvedValue({
+                chat: {
+                    active: "janhq/Jan-v3.5-4B-gguf/Jan-v3.5-4B-Q4_K_M.gguf",
+                    catalog: [],
+                    installed: [],
+                },
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = WIZARD_STEP.MODEL_PICKER;
+            (wizard as any).renderStep();
+            await tick();
+            await tick();
+
+            // recommendedIndex would pick Qwen3 (higher min_ram_gb), but the active model is Jan.
+            expect((wizard as any).selectedModel?.hf_repo).toBe("janhq/Jan-v3.5-4B-gguf/Jan-v3.5-4B-Q4_K_M.gguf");
+        });
+
+        it("falls back to recommendedIndex when listModels throws during chat load", async () => {
+            const entries = [makeEntry({ hf_repo: "bge/bge-small", display_name: "BGE Small", installed: true })];
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
+            plugin.api.listModels = vi.fn().mockRejectedValue(new Error("server down"));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = WIZARD_STEP.MODEL_PICKER;
+            (wizard as any).renderStep();
+            await tick();
+            await tick();
+
+            expect((wizard as any).selectedModel?.hf_repo).toBe("bge/bge-small");
+        });
+
+        it("falls back to first pick when listModels throws during embedding load", async () => {
+            const entries = [
+                makeEntry({ hf_repo: "bge/bge-small", display_name: "BGE Small", task: "embedding" }),
+                makeEntry({ hf_repo: "nomic/nomic-embed-text", display_name: "Nomic", task: "embedding" }),
+            ];
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
+            plugin.api.listModels = vi.fn().mockRejectedValue(new Error("server down"));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const statusEl = new MockElement("div") as unknown as HTMLElement;
+            await (wizard as any).loadEmbeddingModels(container, statusEl);
+            expect((wizard as any).selectedEmbedding?.hf_repo).toBe("bge/bge-small");
+        });
     });
 
     describe("Step 3: Sync", () => {
@@ -3187,6 +3253,29 @@ describe("SetupWizard", () => {
             expect((wizard as any).selectedEmbedding?.name).toBe("nomic-embed-text");
             expect((wizard as any).embeddingModels.length).toBe(2);
         });
+
+        it("loadEmbeddingModels pre-selects the server's active embedding model", async () => {
+            const entries = [
+                makeEntry({ hf_repo: "bge/bge-small", display_name: "BGE Small", task: "embedding" }),
+                makeEntry({
+                    hf_repo: "nomic/nomic-embed-text-v1.5",
+                    display_name: "Nomic Embed v1.5",
+                    task: "embedding",
+                }),
+            ];
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
+            plugin.api.listModels = vi.fn().mockResolvedValue({
+                chat: { active: "", catalog: [], installed: [] },
+                embedding: { active: "nomic/nomic-embed-text-v1.5", catalog: [], installed: [] },
+            });
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const statusEl = new MockElement("div") as unknown as HTMLElement;
+            await (wizard as any).loadEmbeddingModels(container, statusEl);
+            expect((wizard as any).selectedEmbedding?.hf_repo).toBe("nomic/nomic-embed-text-v1.5");
+        });
     });
 
     describe("back from step 2", () => {
@@ -4079,6 +4168,55 @@ describe("SetupWizard", () => {
             const { el } = await openPicksStep(splitCatalog(featured, wider));
 
             expect(renderedRepos(el)).toEqual(["f/0", "f/1", "f/huge"]);
+        });
+    });
+
+    describe("recommendation skips hosted rows", () => {
+        it("never recommends a frontier model with no key over a native installed model", () => {
+            const native = makeEntry({
+                hf_repo: "janhq/Jan-v3.5-4B-gguf/Jan-v3.5-4B-Q4_K_M.gguf",
+                display_name: "Jan v3.5 4B",
+                installed: true,
+                source: "native",
+                min_ram_gb: 6,
+            });
+            const gemini = makeEntry({
+                hf_repo: "gemini-2.0-flash-001",
+                display_name: "Gemini 2.0 Flash 001",
+                installed: true,
+                source: "frontier",
+                min_ram_gb: 0,
+                key_status: "missing_key",
+            });
+            const models = [gemini, native];
+
+            const idx = recommendedIndex(models, 32);
+
+            expect(models[idx].hf_repo).toBe("janhq/Jan-v3.5-4B-gguf/Jan-v3.5-4B-Q4_K_M.gguf");
+        });
+
+        it("picks the native installed model when a hosted row is the only installed one", () => {
+            const native = makeEntry({
+                hf_repo: "Qwen/Qwen3-4B-GGUF",
+                display_name: "Qwen3 4B",
+                installed: false,
+                source: "native",
+                min_ram_gb: 6,
+            });
+            const gemini = makeEntry({
+                hf_repo: "gemini-2.0-flash-001",
+                display_name: "Gemini 2.0 Flash 001",
+                installed: true,
+                source: "frontier",
+                min_ram_gb: 0,
+                key_status: "missing_key",
+            });
+            const models = [native, gemini];
+
+            const idx = recommendedIndex(models, 32);
+
+            // The hosted model must not be recommended; fall back to the largest native that fits.
+            expect(models[idx].source).toBe("native");
         });
     });
 


### PR DESCRIPTION
## Problem

The setup wizard's chat and embedding pickers can recommend a hosted provider the user never chose, or switch an indexed vault's embedding model.

- The chat picker's `bestInstalledFitIndex` prefers any installed model by size, including hosted frontier rows that report `installed: true` with 0 GB RAM. A Gemini row with no API key gets recommended over a native GGUF.
- The embedding picker hardcodes a `nomic-embed-text` name match that drifts from the server's featured list, so it falls back to whatever sorts first by downloads and switches the vault's embedding model on Use