### PR TITLE
Kill the managed server synchronously on plugin unload

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1739,8 +1739,8 @@ export default class LilbeePlugin extends Plugin {
         this.syncPillEl = null;
         this.taskQueue.dispose();
         if (this.serverManager) {
-            this.journal.lifecycle("plugin unloading; stopping the managed server");
-            void this.serverManager.stop();
+            this.journal.lifecycle("plugin unloading; killing the managed server before unload");
+            this.serverManager.killChildSync();
         }
     }
 

--- a/src/server-manager.ts
+++ b/src/server-manager.ts
@@ -726,6 +726,31 @@ export class ServerManager {
         this.journal(`server pid ${child.pid} exit observed after ${Date.now() - stopStartedAt}ms`);
     }
 
+    /**
+     * Synchronously signal the spawned child's process group to die and remove
+     * its port file. For use in synchronous teardown (onunload) only: it does
+     * not await the process exit. The OS reaps the child; the next plugin
+     * instance finds no stale port and no lock holder, so it spawns fresh.
+     */
+    killChildSync(): void {
+        this.desired = DESIRED.STOPPED;
+        if (this.restartTimer !== null) {
+            window.clearTimeout(this.restartTimer);
+            this.restartTimer = null;
+        }
+        this.stopAdoptedWatch();
+        const child = this.child;
+        this.child = null;
+        this.childExit = null;
+        this.adopted = false;
+        this._actualPort = null;
+        this.cleanupPortFile();
+        this.setState(SERVER_STATE.STOPPED);
+        if (child) {
+            this.signalGroup(child, "SIGKILL");
+        }
+    }
+
     /** Ask an adopted server to exit; report when it will not go. */
     private async stopAdopted(): Promise<void> {
         const gone = await askServerToExit(this.opts.dataDir, SERVER_MANAGER_CONFIG.STOP_GRACE_MS);

--- a/tests/main-shared.test.ts
+++ b/tests/main-shared.test.ts
@@ -642,12 +642,12 @@ describe("startManagedServer guards", () => {
 });
 
 describe("onunload", () => {
-    it("stops the managed server", async () => {
+    it("kills the managed server synchronously on unload", async () => {
         const plugin = await createPlugin();
-        const stop = vi.fn().mockResolvedValue(undefined);
-        (plugin as any).serverManager = { stop };
+        const killChildSync = vi.fn();
+        (plugin as any).serverManager = { killChildSync };
         plugin.onunload();
-        expect(stop).toHaveBeenCalled();
+        expect(killChildSync).toHaveBeenCalled();
     });
 });
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -226,6 +226,7 @@ vi.mock("../src/views/update-available-modal", () => ({
 const mockGatekeeperOpen = vi.fn();
 const mockServerStart = vi.fn().mockResolvedValue(undefined);
 const mockServerStop = vi.fn().mockResolvedValue(undefined);
+const mockServerKillChildSync = vi.fn();
 let mockServerOpts: any = null;
 
 vi.mock("../src/server-binary", () => ({
@@ -292,6 +293,7 @@ vi.mock("../src/server-manager", () => ({
         return {
             start: mockServerStart,
             stop: mockServerStop,
+            killChildSync: mockServerKillChildSync,
             restart: vi.fn(),
             get isAdopted() {
                 return mockIsAdopted;
@@ -7226,15 +7228,16 @@ describe("LilbeePlugin", () => {
     });
 
     describe("onunload with serverManager", () => {
-        it("calls serverManager.stop on unload", async () => {
+        it("calls serverManager.killChildSync on unload, not the async stop", async () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
             await flush();
 
-            mockServerStop.mockClear();
+            mockServerKillChildSync.mockClear();
             plugin.onunload();
 
-            expect(mockServerStop).toHaveBeenCalled();
+            expect(mockServerKillChildSync).toHaveBeenCalled();
+            expect(mockServerStop).not.toHaveBeenCalled();
         });
     });
 

--- a/tests/server-manager.test.ts
+++ b/tests/server-manager.test.ts
@@ -1243,6 +1243,73 @@ describe("ServerManager", () => {
         });
     });
 
+    // ── killChildSync ───────────────────────────────────────────────
+
+    describe("killChildSync", () => {
+        it("sends SIGKILL to the child and cleans up the port file, synchronously", async () => {
+            const mgr = await startFresh();
+            const c = child();
+            expect(mgr.state).toBe("ready");
+
+            mgr.killChildSync();
+
+            expect(c.kill).toHaveBeenCalledWith("SIGKILL");
+            expect(unlinkSyncSpy).toHaveBeenCalled();
+            expect(mgr.state).toBe("stopped");
+            expect(mgr.serverUrl).toBe("");
+        });
+
+        it("signals the process group when the group exists", async () => {
+            processKillSpy.mockImplementation(() => true);
+            const mgr = await startFresh();
+            const c = child();
+
+            mgr.killChildSync();
+
+            expect(processKillSpy).toHaveBeenCalledWith(-c.pid, "SIGKILL");
+        });
+
+        it("is a no-op when nothing is running", () => {
+            const mgr = new ServerManager(defaultOpts());
+            expect(() => mgr.killChildSync()).not.toThrow();
+            expect(mgr.state).toBe("stopped");
+        });
+
+        it("clears the restart timer so a queued restart does not fire after unload", async () => {
+            const mgr = await startFresh();
+            const c = child();
+            (mgr as any).restartTimer = 42;
+
+            mgr.killChildSync();
+
+            expect((mgr as any).restartTimer).toBeNull();
+            expect(c.kill).toHaveBeenCalledWith("SIGKILL");
+        });
+
+        it("cleans up an adopted server's state without killing anything", async () => {
+            readFileSyncSpy.mockImplementation(fileRouter("present"));
+            const mgr = new ServerManager(defaultOpts());
+            await mgr.start();
+            expect(mgr.isAdopted).toBe(true);
+
+            mgr.killChildSync();
+
+            expect(mgr.isAdopted).toBe(false);
+            expect(mgr.serverUrl).toBe("");
+            expect(unlinkSyncSpy).toHaveBeenCalled();
+        });
+
+        it("returns without awaiting — the child exit is not required to proceed", async () => {
+            const mgr = await startFresh();
+            const c = child();
+            // kill does NOT trigger an exit event; killChildSync still returns.
+            c.kill.mockImplementation(() => true);
+
+            expect(() => mgr.killChildSync()).not.toThrow();
+            expect(c.kill).toHaveBeenCalledWith("SIGKILL");
+        });
+    });
+
     // ── output capture ──────────────────────────────────────────────
 
     describe("output capture", () => {


### PR DESCRIPTION
## Problem

onunload fires async stop() without awaiting, so the managed server keeps running after the plugin unloads, holds the scope lock, and the new instance cannot spawn or adopt. #286

## Solution

Added killChildSync(): synchronously SIGKILLs the child process group, clears the restart timer, tears down the adopted watch, resets state, and cleans up the port file. No await. onunload now calls this instead of void stop().

## Notes

The async stop() is still used by restart() and uninstallServer() where awaiting the exit is correct.