### PR TITLE
Fix external mode claiming ready for non-lilbee servers

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -710,6 +710,7 @@ export const MESSAGES = {
     STATUS_WARM_LOADING_ENGINE: "lilbee: loading the engine",
     STATUS_READY: "lilbee: ready",
     STATUS_READY_EXTERNAL: "lilbee: ready [external]",
+    STATUS_CONNECTING: "lilbee: connecting...",
     STATUS_ERROR: "lilbee: error",
     STATUS_AUTH_ERROR: "lilbee: auth error",
     NOTICE_SERVER_UNREACHABLE: "lilbee: server unreachable",

--- a/src/main.ts
+++ b/src/main.ts
@@ -470,7 +470,7 @@ export default class LilbeePlugin extends Plugin {
                 });
             } else {
                 this.configureApi(this.settings.serverUrl);
-                this.setStatusReady();
+                this.setStatusConnecting();
                 void this.fetchActiveModel();
                 void this.warnExternalServerOutdated();
             }
@@ -1925,12 +1925,10 @@ export default class LilbeePlugin extends Plugin {
                 this.serverManager = null;
             }
             this.configureApi(this.settings.serverUrl);
-            // External mode owns its own status via the health probe; paint
-            // "ready [external]" optimistically so the user doesn't see a
-            // stale "stopped" label between the mode switch and the next
-            // probe tick. If the external server is in fact unreachable,
-            // the probe will flip to error on its next run.
-            this.setStatusReady();
+            // The first successful health probe promotes this to "ready"; until
+            // then the user sees "connecting..." so a non-lilbee server never
+            // briefly claims ready on the strength of a mode switch alone.
+            this.setStatusConnecting();
             void this.fetchActiveModel();
         }
     }
@@ -1957,6 +1955,11 @@ export default class LilbeePlugin extends Plugin {
             "lilbee-status-error",
         );
         if (cls) this.statusBarEl.classList.add(cls);
+    }
+
+    private setStatusConnecting(): void {
+        this.updateStatusBar(MESSAGES.STATUS_CONNECTING, DOT_STATE.PRIMARY);
+        this.setStatusClass("lilbee-status-starting");
     }
 
     private setStatusReady(): void {
@@ -2007,7 +2010,10 @@ export default class LilbeePlugin extends Plugin {
         // every restart, and this is the cheapest way to stay in sync.
         this.api.setToken(this.readCurrentToken());
         const health = await this.api.health().catch(() => null);
-        if (health?.isOk()) {
+        // A 200 with a non-lilbee JSON body (e.g. {}) parses fine but is not a
+        // healthy lilbee server. Only a body carrying status: "ok" counts, so a
+        // foreign HTTP server on the configured URL reads as unreachable.
+        if (health?.isOk() && health.value.status === "ok") {
             this.healthFailureStreak = 0;
             if (this.settings.serverMode === SERVER_MODE.EXTERNAL) this.externalServerVersion = health.value.version;
             // Only a reconnect refetches the model: a restarted server may be on a different one.
@@ -2016,6 +2022,11 @@ export default class LilbeePlugin extends Plugin {
                 void this.fetchActiveModel();
             }
             this.reflectChatStatus(health.value);
+            // reflectChatStatus only repaints when the chat status changes to
+            // LOADING or ERROR. When the chat is READY (or unchanged), the bar
+            // still shows whatever the last state was, including the
+            // "connecting..." from a mode switch. Paint "ready" to clear it.
+            if (this.chatStatus === CHAT_STATUS.READY) this.setStatusReady();
             return;
         }
         this.healthFailureStreak += 1;

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -55,7 +55,7 @@ vi.mock("../src/api", async (importOriginal) => ({
             setTokenProvider: vi.fn(),
             setOutcomeCallback: vi.fn(),
             setBaseUrl: vi.fn(),
-            health: vi.fn().mockResolvedValue({ isErr: () => false, isOk: () => true, value: {} }),
+            health: vi.fn().mockResolvedValue({ isErr: () => false, isOk: () => true, value: { status: "ok" } }),
             // Default config matches the test vault layout so the fire-and-forget
             // configureManagedStorage() in startManagedServer() hits the early
             // no-op exit instead of throwing on a missing method.
@@ -934,10 +934,10 @@ describe("LilbeePlugin", () => {
             );
         });
 
-        it("sets status bar text to 'lilbee: ready [external]' in external mode", async () => {
+        it("sets status bar text to 'lilbee: connecting...' in external mode after onload", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
-            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready [external]");
+            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: connecting...");
         });
 
         it("registers vault watchers for the pending-sync hint plus the file-menu listener", async () => {
@@ -3814,13 +3814,21 @@ describe("LilbeePlugin", () => {
 
             plugin.api.health = vi
                 .fn()
-                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { version: "0.6.66b507" } });
+                .mockResolvedValue({
+                    isErr: () => false,
+                    isOk: () => true,
+                    value: { status: "ok", version: "0.6.66b507" },
+                });
             await (plugin as any).probeServerHealth();
             expect(plugin.serverSupportsSessions()).toBe(false);
 
             plugin.api.health = vi
                 .fn()
-                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { version: "0.6.90b420" } });
+                .mockResolvedValue({
+                    isErr: () => false,
+                    isOk: () => true,
+                    value: { status: "ok", version: "0.6.90b420" },
+                });
             await (plugin as any).probeServerHealth();
             expect(plugin.serverSupportsSessions()).toBe(true);
         });
@@ -3831,9 +3839,30 @@ describe("LilbeePlugin", () => {
             await plugin.onload();
             plugin.api.health = vi
                 .fn()
-                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { version: "0.6.66b507" } });
+                .mockResolvedValue({
+                    isErr: () => false,
+                    isOk: () => true,
+                    value: { status: "ok", version: "0.6.66b507" },
+                });
             await (plugin as any).probeServerHealth();
             expect((plugin as any).externalServerVersion).toBe("");
+        });
+
+        it("probe with non-ready chat status skips setStatusReady", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            (plugin as any).chatStatus = CHAT_STATUS.LOADING;
+            plugin.api.health = vi
+                .fn()
+                .mockResolvedValue({
+                    isErr: () => false,
+                    isOk: () => true,
+                    value: { status: "ok", chat_ready: false },
+                });
+            await (plugin as any).probeServerHealth();
+            // Chat is loading: reflectChatStatus paints "warming..." and the
+            // probe must not override it with "ready".
+            expect((plugin.statusBarEl as any)?.textContent).not.toContain("ready");
         });
     });
 
@@ -4829,8 +4858,10 @@ describe("LilbeePlugin", () => {
             await (plugin as any).probeServerHealth();
             expect((plugin.statusBarEl as any)?.textContent).toContain("error");
 
-            // Recovery: health() resolves Ok.
-            plugin.api.health = vi.fn().mockResolvedValue({ isErr: () => false, isOk: () => true, value: {} });
+            // Recovery: health() resolves Ok with status: "ok".
+            plugin.api.health = vi
+                .fn()
+                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { status: "ok" } });
             plugin.api.listModels = vi
                 .fn()
                 .mockResolvedValue({ chat: { active: "qwen3:4b", catalog: [], installed: [] } });
@@ -4926,7 +4957,7 @@ describe("LilbeePlugin", () => {
             plugin.activeModel = "old";
             plugin.api.health = vi
                 .fn()
-                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { chat_ready: true } });
+                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { status: "ok", chat_ready: true } });
             plugin.api.listModels = vi
                 .fn()
                 .mockResolvedValue({ chat: { active: "Qwen3-235B", catalog: [], installed: [] } });
@@ -4940,7 +4971,9 @@ describe("LilbeePlugin", () => {
             await plugin.onload();
             plugin.api.health = vi.fn().mockResolvedValue(err(new Error("down")));
             await (plugin as any).probeServerHealth();
-            plugin.api.health = vi.fn().mockResolvedValue({ isErr: () => false, isOk: () => true, value: {} });
+            plugin.api.health = vi
+                .fn()
+                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { status: "ok" } });
             plugin.api.listModels = vi
                 .fn()
                 .mockResolvedValue({ chat: { active: "qwen3:4b", catalog: [], installed: [] } });
@@ -4989,6 +5022,33 @@ describe("LilbeePlugin", () => {
             (plugin as any).healthFailureStreak = 5;
             await (plugin as any).probeServerHealth();
             expect((plugin.statusBarEl as any)?.textContent ?? "").not.toContain("error");
+        });
+
+        it("treats a 200 with a non-lilbee JSON body as a probe failure", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            // A 2020 with {} (no status: "ok") is not a lilbee server — the
+            // probe must treat it as unreachable, not ready.
+            plugin.api.health = vi.fn().mockResolvedValue({ isErr: () => false, isOk: () => true, value: {} });
+            await (plugin as any).probeServerHealth();
+            await (plugin as any).probeServerHealth();
+            expect((plugin.statusBarEl as any)?.textContent).toContain("error");
+        });
+
+        it("promotes to ready only after a probe reports status ok", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            // After onload the status is "connecting...", not "ready".
+            expect((plugin.statusBarEl as any)?.textContent).toBe("lilbee: connecting...");
+            plugin.api.health = vi
+                .fn()
+                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { status: "ok" } });
+            plugin.api.listModels = vi
+                .fn()
+                .mockResolvedValue({ chat: { active: "qwen3:4b", catalog: [], installed: [] } });
+            plugin.api.status = vi.fn().mockResolvedValue(err(new Error("down")));
+            await (plugin as any).probeServerHealth();
+            expect((plugin.statusBarEl as any)?.textContent).toContain("ready");
         });
 
         it("skips probing while a chat stream is in flight", async () => {
@@ -5318,7 +5378,7 @@ describe("LilbeePlugin", () => {
             await new Promise((r) => setTimeout(r, 0));
 
             expect(plugin.activeModel).toBe("");
-            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready [external]");
+            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: connecting...");
         });
 
         it("turns show_reasoning on the first time the server reports it off, then never again", async () => {
@@ -5924,6 +5984,7 @@ describe("LilbeePlugin", () => {
         it("setStatusReady adds lilbee-status-ready class", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
+            (plugin as any).setStatusReady();
 
             const el = (plugin as any).statusBarEl!;
             expect(el.classList.contains("lilbee-status-ready")).toBe(true);
@@ -6956,7 +7017,7 @@ describe("LilbeePlugin", () => {
             expect(mockEnsure).toHaveBeenCalled();
         });
 
-        it("2rf: managed → external sets status to 'ready [external]', not 'stopped'", async () => {
+        it("2rf: managed → external sets status to 'connecting...', not 'stopped'", async () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
             await flush();
@@ -6966,7 +7027,7 @@ describe("LilbeePlugin", () => {
             await flush();
 
             const text = (plugin as any).statusBarEl?.textContent ?? "";
-            expect(text).toContain("[external]");
+            expect(text).toContain("connecting");
             expect(text).not.toContain("stopped");
         });
 
@@ -6988,7 +7049,7 @@ describe("LilbeePlugin", () => {
 
             const text = (plugin as any).statusBarEl?.textContent ?? "";
             expect(text).not.toContain("stopped");
-            expect(text).toContain("[external]");
+            expect(text).toContain("connecting");
         });
     });
 
@@ -7239,10 +7300,10 @@ describe("LilbeePlugin", () => {
     });
 
     describe("external mode status bar label", () => {
-        it("shows [external] in external mode", async () => {
+        it("shows 'connecting...' in external mode after onload", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
-            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready [external]");
+            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: connecting...");
         });
 
         it("does not show [external] in managed mode", async () => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -3812,23 +3812,19 @@ describe("LilbeePlugin", () => {
             await plugin.onload();
             expect(plugin.serverSupportsSessions()).toBe(true);
 
-            plugin.api.health = vi
-                .fn()
-                .mockResolvedValue({
-                    isErr: () => false,
-                    isOk: () => true,
-                    value: { status: "ok", version: "0.6.66b507" },
-                });
+            plugin.api.health = vi.fn().mockResolvedValue({
+                isErr: () => false,
+                isOk: () => true,
+                value: { status: "ok", version: "0.6.66b507" },
+            });
             await (plugin as any).probeServerHealth();
             expect(plugin.serverSupportsSessions()).toBe(false);
 
-            plugin.api.health = vi
-                .fn()
-                .mockResolvedValue({
-                    isErr: () => false,
-                    isOk: () => true,
-                    value: { status: "ok", version: "0.6.90b420" },
-                });
+            plugin.api.health = vi.fn().mockResolvedValue({
+                isErr: () => false,
+                isOk: () => true,
+                value: { status: "ok", version: "0.6.90b420" },
+            });
             await (plugin as any).probeServerHealth();
             expect(plugin.serverSupportsSessions()).toBe(true);
         });
@@ -3837,13 +3833,11 @@ describe("LilbeePlugin", () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             vi.spyOn(plugin, "ensureManagedConsentThenStart").mockResolvedValue({ kind: "canceled" } as any);
             await plugin.onload();
-            plugin.api.health = vi
-                .fn()
-                .mockResolvedValue({
-                    isErr: () => false,
-                    isOk: () => true,
-                    value: { status: "ok", version: "0.6.66b507" },
-                });
+            plugin.api.health = vi.fn().mockResolvedValue({
+                isErr: () => false,
+                isOk: () => true,
+                value: { status: "ok", version: "0.6.66b507" },
+            });
             await (plugin as any).probeServerHealth();
             expect((plugin as any).externalServerVersion).toBe("");
         });
@@ -3852,13 +3846,11 @@ describe("LilbeePlugin", () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
             (plugin as any).chatStatus = CHAT_STATUS.LOADING;
-            plugin.api.health = vi
-                .fn()
-                .mockResolvedValue({
-                    isErr: () => false,
-                    isOk: () => true,
-                    value: { status: "ok", chat_ready: false },
-                });
+            plugin.api.health = vi.fn().mockResolvedValue({
+                isErr: () => false,
+                isOk: () => true,
+                value: { status: "ok", chat_ready: false },
+            });
             await (plugin as any).probeServerHealth();
             // Chat is loading: reflectChatStatus paints "warming..." and the
             // probe must not override it with "ready".


### PR DESCRIPTION
## Problem

External mode reports ready for a server whose health route answers 404. The probe through api.health() does not validate res.ok or the JSON shape, so a 404 with an HTML body fails JSON parse and returns err() but the optimistic ready painted on mode switch stays until the probe eventually fails, and even then only after 2 failures x 30s.

## Solution

probeServerHealth now requires health.value.status === "ok" before treating a server reachable. A 200 with a non-lilbee JSON body (e.g. {}) is no longer healthy. saveSettings and onload now set a connecting state instead of ready. The first successful probe promotes to ready.

## Notes

The mode-switch path at main.ts:1924 still uses the async stop(), intentionally, it is a user-initiated mode switch where graceful shutdown is correct.