### PR TITLE
Map known health warnings to plugin-native remedies with rebuild action

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -901,6 +901,8 @@ export const MESSAGES = {
     COMMAND_SYNC: "Sync vault",
     COMMAND_SYNC_RETRY_SKIPPED: RETRY_SKIPPED_COMMAND,
     COMMAND_SYNC_REBUILD: "Rebuild index",
+    WARNING_REMEDY_REBUILD: "Rebuild the index to restore full search and embeddings.",
+    BUTTON_REBUILD_INDEX: "Rebuild index",
     COMMAND_EXPORT_DATASET: "Export dataset",
     COMMAND_IMPORT_DATASET: "Import dataset",
     COMMAND_CATALOG: "Browse model catalog",

--- a/src/utils/warning-remedies.ts
+++ b/src/utils/warning-remedies.ts
@@ -1,0 +1,35 @@
+import type { App } from "obsidian";
+import type { SyncOptions } from "../types";
+import { MESSAGES } from "../locales/en";
+import { ConfirmModal } from "../views/confirm-modal";
+
+/** A server degradation the plugin knows how to fix: what to tell the user, and what the button does. */
+export interface WarningRemedy {
+    text: string;
+    action: () => void;
+}
+
+/** The slice of the plugin a warning-remedy action needs: the app for dialogs and the rebuild entry point. */
+export interface WarningRemedyPlugin {
+    app: App;
+    triggerSync: (options?: SyncOptions) => void | Promise<void>;
+}
+
+/** Codes the plugin can fix itself; every other code falls back to the server's remedy text. */
+const KNOWN_CODES = new Set(["fts_unavailable", "embedding_prefix_mismatch", "stale_index"]);
+
+function rebuildAction(plugin: WarningRemedyPlugin): () => void {
+    return () => {
+        const modal = new ConfirmModal(plugin.app, MESSAGES.CONFIRM_SYNC_REBUILD);
+        modal.open();
+        void modal.result.then((confirmed) => {
+            if (confirmed) void plugin.triggerSync({ forceRebuild: true });
+        });
+    };
+}
+
+/** Map a warning code to a plugin-native remedy, or null when the plugin does not know the code. */
+export function remedyForWarning(code: string, plugin: WarningRemedyPlugin): WarningRemedy | null {
+    if (!KNOWN_CODES.has(code)) return null;
+    return { text: MESSAGES.WARNING_REMEDY_REBUILD, action: rebuildAction(plugin) };
+}

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -45,6 +45,7 @@ import { ConfirmModal } from "./confirm-modal";
 import { CatalogModal } from "./catalog-modal";
 import { CrawlModal } from "./crawl-modal";
 import { addCloseButton } from "../components/close-button";
+import { remedyForWarning } from "../utils/warning-remedies";
 import { MESSAGES } from "../locales/en";
 import {
     RETRY_INTERVAL_MS,
@@ -1492,7 +1493,17 @@ export class ChatView extends ItemView {
         for (const w of this.plugin.healthWarnings) {
             const row = el.createDiv({ cls: "lilbee-chat-warning" });
             row.createSpan({ cls: "lilbee-chat-warning-message", text: w.message });
-            if (w.remedy) row.createSpan({ cls: "lilbee-chat-warning-remedy", text: w.remedy });
+            const remedy = remedyForWarning(w.code, this.plugin);
+            if (remedy) {
+                row.createSpan({ cls: "lilbee-chat-warning-remedy", text: remedy.text });
+                const btn = row.createEl("button", {
+                    text: MESSAGES.BUTTON_REBUILD_INDEX,
+                    cls: "lilbee-chat-warning-action",
+                });
+                btn.addEventListener("click", remedy.action);
+            } else if (w.remedy) {
+                row.createSpan({ cls: "lilbee-chat-warning-remedy", text: w.remedy });
+            }
         }
     }
 

--- a/src/views/status-modal.ts
+++ b/src/views/status-modal.ts
@@ -4,6 +4,7 @@ import { MANAGED_DOCS_PREFIX, type ModelShowResponse, type StatusResponse } from
 import { DocumentList } from "../components/document-list";
 import { MESSAGES } from "../locales/en";
 import { bindEscapeToClose, noticeForResultError, revealInFileExplorer } from "../utils";
+import { remedyForWarning } from "../utils/warning-remedies";
 
 export class StatusModal extends Modal {
     private plugin: LilbeePlugin;
@@ -54,7 +55,15 @@ export class StatusModal extends Modal {
         for (const w of warnings) {
             const row = section.createDiv({ cls: "lilbee-status-warning" });
             row.createDiv({ cls: "lilbee-status-warning-message", text: w.message });
-            if (w.remedy) {
+            const remedy = remedyForWarning(w.code, this.plugin);
+            if (remedy) {
+                row.createDiv({ cls: "lilbee-status-warning-remedy", text: remedy.text });
+                const btn = row.createEl("button", {
+                    text: MESSAGES.BUTTON_REBUILD_INDEX,
+                    cls: "lilbee-status-warning-action",
+                });
+                btn.addEventListener("click", remedy.action);
+            } else if (w.remedy) {
                 row.createDiv({ cls: "lilbee-status-warning-remedy", text: w.remedy });
             }
         }

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -2574,7 +2574,7 @@ describe("ChatView — toolbar groups and tooltips", () => {
 });
 
 describe("ChatView health warnings", () => {
-    it("shows a server-reported degradation with its remedy", async () => {
+    it("renders a plugin-native remedy with an action button for a known code", async () => {
         const plugin = makePlugin();
         plugin.healthWarnings = [
             { code: "fts_unavailable", message: "Keyword search is unavailable.", remedy: "Run rebuild." },
@@ -2587,7 +2587,69 @@ describe("ChatView health warnings", () => {
         const container = view.containerEl.children[1] as unknown as MockElement;
         const text = container.textContent ?? "";
         expect(text).toContain("Keyword search is unavailable.");
-        expect(text).toContain("Run rebuild.");
+        expect(text).toContain("Rebuild the index");
+        expect(text).toContain("Rebuild index");
+        // The server's CLI remedy is not shown for codes the plugin knows.
+        expect(text).not.toContain("Run rebuild.");
+        expect(container.find("lilbee-chat-warning-action")).not.toBeNull();
+    });
+
+    it("falls back to the server remedy for an unknown code", async () => {
+        const plugin = makePlugin();
+        plugin.healthWarnings = [
+            { code: "some_future_warning", message: "Something is degraded.", remedy: "Server says do X." },
+        ];
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const text = container.textContent ?? "";
+        expect(text).toContain("Something is degraded.");
+        expect(text).toContain("Server says do X.");
+        expect(container.find("lilbee-chat-warning-action")).toBeNull();
+    });
+
+    it("triggers a rebuild when the remedy action button is clicked", async () => {
+        confirmModalResult = true;
+        const plugin = makePlugin();
+        plugin.healthWarnings = [
+            { code: "embedding_prefix_mismatch", message: "Index/embedder mismatch.", remedy: "Run rebuild." },
+        ];
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const btn = container.find("lilbee-chat-warning-action");
+        expect(btn).not.toBeNull();
+        btn!.trigger("click");
+        await tick();
+        await tick();
+
+        expect(plugin.triggerSync).toHaveBeenCalledWith({ forceRebuild: true });
+    });
+
+    it("does not rebuild when the user dismisses the confirm dialog", async () => {
+        confirmModalResult = false;
+        const plugin = makePlugin();
+        plugin.healthWarnings = [{ code: "stale_index", message: "Index is stale.", remedy: "Run rebuild." }];
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const btn = container.find("lilbee-chat-warning-action");
+        expect(btn).not.toBeNull();
+        btn!.trigger("click");
+        await tick();
+        await tick();
+
+        expect(plugin.triggerSync).not.toHaveBeenCalled();
+        confirmModalResult = true;
     });
 
     it("is a no-op on a view whose onOpen has not run", () => {

--- a/tests/views/status-modal.test.ts
+++ b/tests/views/status-modal.test.ts
@@ -159,7 +159,7 @@ describe("StatusModal", () => {
         expect(cell?.attributes["title"]).toBe("Smoffyy/Gemma4-E4B-Instruct-Pure-GGUF/Gemma4-E4B-F16.gguf");
     });
 
-    it("lists server-reported degradations with their remedies", async () => {
+    it("renders a plugin-native remedy with an action button for a known code", async () => {
         const plugin = makePlugin();
         (plugin as any).healthWarnings = [
             { code: "fts_unavailable", message: "Keyword search is unavailable.", remedy: "Run rebuild." },
@@ -169,11 +169,32 @@ describe("StatusModal", () => {
 
         const modal = new StatusModal(new App(), plugin);
         modal.open();
+        const content = (modal as any).contentEl as MockElement;
         await vi.waitFor(() => {
-            const content = (modal as any).contentEl as MockElement;
             expect(content.textContent ?? "").toContain("Keyword search is unavailable.");
         });
-        expect(((modal as any).contentEl as MockElement).textContent ?? "").toContain("Run rebuild.");
+        expect(content.textContent ?? "").toContain("Rebuild the index");
+        expect(content.textContent ?? "").toContain("Rebuild index");
+        expect(content.textContent ?? "").not.toContain("Run rebuild.");
+        expect(content.find("lilbee-status-warning-action")).not.toBeNull();
+    });
+
+    it("falls back to the server remedy for an unknown code", async () => {
+        const plugin = makePlugin();
+        (plugin as any).healthWarnings = [
+            { code: "some_future_warning", message: "Something is degraded.", remedy: "Server says do X." },
+        ];
+        (plugin.api.status as ReturnType<typeof vi.fn>).mockResolvedValue(ok(makeStatus()));
+        (plugin.api.showModel as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+        const modal = new StatusModal(new App(), plugin);
+        modal.open();
+        const content = (modal as any).contentEl as MockElement;
+        await vi.waitFor(() => {
+            expect(content.textContent ?? "").toContain("Something is degraded.");
+        });
+        expect(content.textContent ?? "").toContain("Server says do X.");
+        expect(content.find("lilbee-status-warning-action")).toBeNull();
     });
 
     it("omits the remedy line when the server sends none", async () => {


### PR DESCRIPTION
## Problem

Health warning remedies tell plugin users to run a CLI command (e.g. "Run lilbee rebuild"). Plugin users have no lilbee CLI. The banner shows the server remedy verbatim. #287

## Solution

New module warning-remedies.ts maps known warning codes (fts_unavailable, embedding_prefix_mismatch, stale_index) to plugin-native remedy text and a rebuild action that runs the existing sync-rebuild flow. Both renderers (chat-view and status-modal) check the code map. Known codes render native text and button, unknown codes fall back to the server remedy.

## Notes

Reuses the existing sync-rebuild command and ConfirmModal, no new rebuild logic.