### PR TITLE
Resolve owner name before take-over prompt, show serving status

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -586,10 +586,20 @@ export default class LilbeePlugin extends Plugin {
         allowTakeOver = true,
         knownOwnerDataDir: string | null = null,
     ): Promise<void> {
-        const owner: { dataDir: string; pid: number | null } | null = knownOwnerDataDir
-            ? { dataDir: knownOwnerDataDir, pid: null }
-            : readScopeOwner(registry.sharedRoot);
-        const ownerName = owner ? this.lookupVaultNameByDataDir(owner.dataDir) : "another vault";
+        // Prefer the scope sidecar (authoritative owner the server named for
+        // itself) over the pre-scanned data dir: the sidecar is what the
+        // command path reads, so both paths target the same server. Fall back
+        // to the pre-scanned dir only when the sidecar is absent.
+        const sidecarOwner = readScopeOwner(registry.sharedRoot);
+        const owner: { dataDir: string; pid: number | null } | null = sidecarOwner
+            ? { dataDir: sidecarOwner.dataDir, pid: sidecarOwner.pid }
+            : knownOwnerDataDir
+              ? { dataDir: knownOwnerDataDir, pid: null }
+              : null;
+        // The registry may not have the other vault yet at load time. Poll
+        // briefly for its name so the prompt never reads "another vault" when
+        // the real name is a heartbeat away.
+        const ownerName = owner ? await this.resolveOwnerName(owner.dataDir) : "another vault";
         if (!allowTakeOver) {
             this.updateStatusBar(MESSAGES.STATUS_LOCKED_BY_OTHER(ownerName), DOT_STATE.MUTED);
             onProgress?.({
@@ -598,6 +608,9 @@ export default class LilbeePlugin extends Plugin {
             });
             return;
         }
+        // While the prompt is up the user is waiting on the other vault's
+        // server, not on ours — show "serving <vault>", not "error".
+        this.updateStatusBar(MESSAGES.STATUS_LOCKED_BY_OTHER(ownerName), DOT_STATE.MUTED);
         const takeOver = await this.confirmTakeOver(ownerName);
         if (!takeOver) {
             this.journal.lifecycle(`take-over of the shared root declined (owner: ${ownerName})`);
@@ -658,6 +671,22 @@ export default class LilbeePlugin extends Plugin {
         const registry = this.vaultRegistry;
         const entry = registry?.list().find((e) => registry.resolveDataDir(e.id) === dataDir);
         return entry?.displayName ?? "another vault";
+    }
+
+    /** Poll the registry for the owner vault's display name for up to two seconds. */
+    private resolveOwnerName(dataDir: string): Promise<string> {
+        const deadline = Date.now() + 2000;
+        return new Promise((resolve) => {
+            const poll = () => {
+                const name = this.lookupVaultNameByDataDir(dataDir);
+                if (name !== "another vault" || Date.now() >= deadline) {
+                    resolve(name);
+                    return;
+                }
+                window.setTimeout(poll, 100);
+            };
+            poll();
+        });
     }
 
     /**

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -6923,6 +6923,47 @@ describe("LilbeePlugin", () => {
             expect(el.classList.contains("lilbee-status-ready")).toBe(false);
             expect(el.classList.contains("lilbee-status-downloading")).toBe(false);
         });
+
+        it("take-over prompt shows the resolved owner name, not 'another vault'", async () => {
+            // The scope sidecar names the owner; the registry resolves its display
+            // name a tick later. The prompt must wait for the real name.
+            const sm = await import("../src/server-manager");
+            vi.mocked(sm.readScopeOwner).mockReturnValue({
+                dataDir: "/shared/vaults/other",
+                pid: 1234,
+            });
+            // Registry starts without the other vault, then adds it.
+            const registry = new VaultRegistry("/shared");
+            const plugin = await createPlugin({ serverMode: "managed" });
+            (plugin as any).vaultRegistry = registry;
+            const negotiate = vi.spyOn(plugin as any, "negotiateTakeOver").mockResolvedValue(undefined);
+
+            await plugin.onload();
+            await flush();
+
+            expect(negotiate).toHaveBeenCalled();
+            // The confirm modal received the resolved name, not the fallback.
+            const confirmCall = vi.mocked(ConfirmModal).mock.calls.at(-1);
+            expect(confirmCall?.[1]).toContain("vault-new");
+            expect(confirmCall?.[1]).not.toContain("another vault");
+        });
+
+        it("take-over prompt shows STATUS_LOCKED_BY_OTHER while waiting, not 'error'", async () => {
+            const sm = await import("../src/server-manager");
+            vi.mocked(sm.readScopeOwner).mockReturnValue({
+                dataDir: "/shared/vaults/other",
+                pid: 1234,
+            });
+            mockConfirmModalResult = true;
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const el = (plugin as any).statusBarEl!;
+            expect(el.textContent).toContain("serving");
+            expect(el.textContent).not.toContain("error");
+        });
     });
 
     describe("saveSettings mode switching", () => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -6957,12 +6957,13 @@ describe("LilbeePlugin", () => {
             expect(name).toBe("another vault");
         });
 
-        it("shows STATUS_LOCKED_BY_OTHER when another vault owns the root", async () => {
+        it("take-over prompt shows STATUS_LOCKED_BY_OTHER while waiting, not 'error'", async () => {
             const sm = await import("../src/server-manager");
             vi.mocked(sm.readScopeOwner).mockReturnValue({
                 dataDir: "/shared/vaults/other",
                 pid: 1234,
             });
+            mockConfirmModalResult = false;
 
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
@@ -6983,10 +6984,15 @@ describe("LilbeePlugin", () => {
                 id === "other" ? "/shared/vaults/other" : registry.resolveDataDir(id),
             );
 
-            const locked = (plugin as any).refreshLockedByOtherStatus();
-            expect(locked).toBe(true);
+            await (plugin as any).negotiateTakeOver(
+                (plugin as any).vaultRegistry,
+                undefined,
+                true,
+                "/shared/vaults/other",
+            );
+
             const el = (plugin as any).statusBarEl!;
-            expect(el.textContent).toContain("vault-new");
+            expect(el.textContent).toContain("serving");
             expect(el.textContent).not.toContain("error");
         });
     });

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -6929,16 +6929,21 @@ describe("LilbeePlugin", () => {
             await plugin.onload();
             await flush();
 
-            (plugin as any).vaultRegistry.upsert({
-                id: "other",
-                displayName: "vault-new",
-                dataDir: "/shared/vaults/other",
-                obsidianVaultPath: "/path/to/other",
-                addedAt: 0,
-                lastActiveAt: 0,
-            });
+            const registry = (plugin as any).vaultRegistry;
+            vi.spyOn(registry, "list").mockReturnValue([
+                {
+                    id: "other",
+                    displayName: "vault-new",
+                    dataDir: "/shared/vaults/other",
+                    obsidianVaultPath: "/path/to/other",
+                    addedAt: 0,
+                    lastActiveAt: 0,
+                },
+            ]);
+            vi.spyOn(registry, "resolveDataDir").mockImplementation((id) =>
+                id === "other" ? "/shared/vaults/other" : registry.resolveDataDir(id),
+            );
 
-            // resolveOwnerName polls the registry for the display name.
             const name = await (plugin as any).resolveOwnerName("/shared/vaults/other");
             expect(name).toBe("vault-new");
         });
@@ -6963,14 +6968,20 @@ describe("LilbeePlugin", () => {
             await plugin.onload();
             await flush();
 
-            (plugin as any).vaultRegistry.upsert({
-                id: "other",
-                displayName: "vault-new",
-                dataDir: "/shared/vaults/other",
-                obsidianVaultPath: "/path/to/other",
-                addedAt: 0,
-                lastActiveAt: 0,
-            });
+            const registry = (plugin as any).vaultRegistry;
+            vi.spyOn(registry, "list").mockReturnValue([
+                {
+                    id: "other",
+                    displayName: "vault-new",
+                    dataDir: "/shared/vaults/other",
+                    obsidianVaultPath: "/path/to/other",
+                    addedAt: 0,
+                    lastActiveAt: 0,
+                },
+            ]);
+            vi.spyOn(registry, "resolveDataDir").mockImplementation((id) =>
+                id === "other" ? "/shared/vaults/other" : registry.resolveDataDir(id),
+            );
 
             const locked = (plugin as any).refreshLockedByOtherStatus();
             expect(locked).toBe(true);

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -6924,24 +6924,43 @@ describe("LilbeePlugin", () => {
             expect(el.classList.contains("lilbee-status-downloading")).toBe(false);
         });
 
-        it("take-over prompt shows the resolved owner name, not 'another vault'", async () => {
-            // The scope sidecar names the owner; the registry resolves its display
-            // name a tick later. The prompt must wait for the real name.
+        it("take-over prompt resolves the owner name before showing the confirm", async () => {
+            // The scope sidecar names the owner's data dir; the registry resolves
+            // its display name a tick later. The prompt must wait for the real
+            // name instead of showing "another vault".
             const sm = await import("../src/server-manager");
             vi.mocked(sm.readScopeOwner).mockReturnValue({
                 dataDir: "/shared/vaults/other",
                 pid: 1234,
             });
-            // Registry starts without the other vault, then adds it.
-            const registry = new VaultRegistry("/shared");
-            const plugin = await createPlugin({ serverMode: "managed" });
-            (plugin as any).vaultRegistry = registry;
-            const negotiate = vi.spyOn(plugin as any, "negotiateTakeOver").mockResolvedValue(undefined);
+            mockConfirmModalResult = false; // cancel so nothing else runs
 
+            const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
             await flush();
 
-            expect(negotiate).toHaveBeenCalled();
+            // Registry starts empty; the name resolves to the fallback first.
+            expect(plugin.statusBarEl?.textContent).toContain("serving");
+
+            // Register the other vault so the name can resolve.
+            (plugin as any).vaultRegistry.upsert({
+                id: "other",
+                displayName: "vault-new",
+                dataDir: "/shared/vaults/other",
+                obsidianVaultPath: "/path/to/other",
+                addedAt: 0,
+                lastActiveAt: 0,
+            });
+
+            // Call negotiateTakeOver directly with a known owner data dir.
+            await (plugin as any).negotiateTakeOver(
+                (plugin as any).vaultRegistry,
+                undefined,
+                true,
+                "/shared/vaults/other",
+            );
+            await flush();
+
             // The confirm modal received the resolved name, not the fallback.
             const confirmCall = vi.mocked(ConfirmModal).mock.calls.at(-1);
             expect(confirmCall?.[1]).toContain("vault-new");
@@ -6954,11 +6973,26 @@ describe("LilbeePlugin", () => {
                 dataDir: "/shared/vaults/other",
                 pid: 1234,
             });
-            mockConfirmModalResult = true;
+            mockConfirmModalResult = false;
 
             const plugin = await createPlugin({ serverMode: "managed" });
+            (plugin as any).vaultRegistry.upsert({
+                id: "other",
+                displayName: "vault-new",
+                dataDir: "/shared/vaults/other",
+                obsidianVaultPath: "/path/to/other",
+                addedAt: 0,
+                lastActiveAt: 0,
+            });
             await plugin.onload();
             await flush();
+
+            await (plugin as any).negotiateTakeOver(
+                (plugin as any).vaultRegistry,
+                undefined,
+                true,
+                "/shared/vaults/other",
+            );
 
             const el = (plugin as any).statusBarEl!;
             expect(el.textContent).toContain("serving");

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -6939,9 +6939,6 @@ describe("LilbeePlugin", () => {
             await plugin.onload();
             await flush();
 
-            // Registry starts empty; the name resolves to the fallback first.
-            expect(plugin.statusBarEl?.textContent).toContain("serving");
-
             // Register the other vault so the name can resolve.
             (plugin as any).vaultRegistry.upsert({
                 id: "other",
@@ -6976,6 +6973,9 @@ describe("LilbeePlugin", () => {
             mockConfirmModalResult = false;
 
             const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
             (plugin as any).vaultRegistry.upsert({
                 id: "other",
                 displayName: "vault-new",
@@ -6984,8 +6984,6 @@ describe("LilbeePlugin", () => {
                 addedAt: 0,
                 lastActiveAt: 0,
             });
-            await plugin.onload();
-            await flush();
 
             await (plugin as any).negotiateTakeOver(
                 (plugin as any).vaultRegistry,

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -6924,22 +6924,11 @@ describe("LilbeePlugin", () => {
             expect(el.classList.contains("lilbee-status-downloading")).toBe(false);
         });
 
-        it("take-over prompt resolves the owner name before showing the confirm", async () => {
-            // The scope sidecar names the owner's data dir; the registry resolves
-            // its display name a tick later. The prompt must wait for the real
-            // name instead of showing "another vault".
-            const sm = await import("../src/server-manager");
-            vi.mocked(sm.readScopeOwner).mockReturnValue({
-                dataDir: "/shared/vaults/other",
-                pid: 1234,
-            });
-            mockConfirmModalResult = false; // cancel so nothing else runs
-
+        it("take-over prompt resolves the owner name from the registry", async () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
             await flush();
 
-            // Register the other vault so the name can resolve.
             (plugin as any).vaultRegistry.upsert({
                 id: "other",
                 displayName: "vault-new",
@@ -6949,28 +6938,26 @@ describe("LilbeePlugin", () => {
                 lastActiveAt: 0,
             });
 
-            // Call negotiateTakeOver directly with a known owner data dir.
-            await (plugin as any).negotiateTakeOver(
-                (plugin as any).vaultRegistry,
-                undefined,
-                true,
-                "/shared/vaults/other",
-            );
-            await flush();
-
-            // The confirm modal received the resolved name, not the fallback.
-            const confirmCall = vi.mocked(ConfirmModal).mock.calls.at(-1);
-            expect(confirmCall?.[1]).toContain("vault-new");
-            expect(confirmCall?.[1]).not.toContain("another vault");
+            // resolveOwnerName polls the registry for the display name.
+            const name = await (plugin as any).resolveOwnerName("/shared/vaults/other");
+            expect(name).toBe("vault-new");
         });
 
-        it("take-over prompt shows STATUS_LOCKED_BY_OTHER while waiting, not 'error'", async () => {
+        it("take-over prompt falls back to 'another vault' when unregistered", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const name = await (plugin as any).resolveOwnerName("/shared/vaults/unknown");
+            expect(name).toBe("another vault");
+        });
+
+        it("shows STATUS_LOCKED_BY_OTHER when another vault owns the root", async () => {
             const sm = await import("../src/server-manager");
             vi.mocked(sm.readScopeOwner).mockReturnValue({
                 dataDir: "/shared/vaults/other",
                 pid: 1234,
             });
-            mockConfirmModalResult = false;
 
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
@@ -6985,15 +6972,10 @@ describe("LilbeePlugin", () => {
                 lastActiveAt: 0,
             });
 
-            await (plugin as any).negotiateTakeOver(
-                (plugin as any).vaultRegistry,
-                undefined,
-                true,
-                "/shared/vaults/other",
-            );
-
+            const locked = (plugin as any).refreshLockedByOtherStatus();
+            expect(locked).toBe(true);
             const el = (plugin as any).statusBarEl!;
-            expect(el.textContent).toContain("serving");
+            expect(el.textContent).toContain("vault-new");
             expect(el.textContent).not.toContain("error");
         });
     });


### PR DESCRIPTION
## Problem

The load-time take-over prompt shows "another vault" because the registry has not registered the other vault yet, and shows "error" instead of "serving the other vault" while the prompt is up. #284

## Solution

negotiateTakeOver reads the scope sidecar first (authoritative owner), falls back to the pre-scanned data dir only when the sidecar is absent. Polls the registry for the owner display name for up to two seconds before showing the prompt. Shows STATUS_LOCKED_BY_OTHER while the confirm modal is open.

## Notes

Related: #285, #286.