### PR TITLE
Don't crash-restart a server that exits cleanly on take-over

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -660,6 +660,20 @@ export default class LilbeePlugin extends Plugin {
         return entry?.displayName ?? "another vault";
     }
 
+    /** If another vault owns the shared root, show "serving <vault>" and return true. */
+    private refreshLockedByOtherStatus(): boolean {
+        const registry = this.vaultRegistry;
+        if (!registry) return false;
+        const owner = readScopeOwner(registry.sharedRoot);
+        if (owner === null) return false;
+        const ourDataDir = registry.resolveDataDir(this.vaultId);
+        if (owner.dataDir === ourDataDir) return false;
+        const ownerName = this.lookupVaultNameByDataDir(owner.dataDir);
+        this.updateStatusBar(MESSAGES.STATUS_LOCKED_BY_OTHER(ownerName), DOT_STATE.MUTED);
+        this.setStatusClass("lilbee-status-error");
+        return true;
+    }
+
     /**
      * Gate run before a first-time managed binary download. When the binary is
      * already present we start straight away; otherwise we ask for consent and
@@ -1310,6 +1324,10 @@ export default class LilbeePlugin extends Plugin {
                 this.setStatusClass("lilbee-status-starting");
                 break;
             case SERVER_STATE.ERROR:
+                // A clean exit while another vault holds the shared root is a
+                // take-over, not a crash. Show "serving <vault>" instead of
+                // "error" so the loser knows who won without a restart loop.
+                if (this.refreshLockedByOtherStatus()) return;
                 this.updateStatusBar(MESSAGES.STATUS_ERROR, DOT_STATE.ERROR);
                 this.setStatusClass("lilbee-status-error");
                 break;
@@ -2025,6 +2043,9 @@ export default class LilbeePlugin extends Plugin {
         // Don't paint a red pill. External mode reports errors normally —
         // it points at a server the user already runs.
         if (this.settings.serverMode === SERVER_MODE.MANAGED && !this.serverEverReady) return;
+        // Another vault holds the shared root: the server was asked to exit,
+        // not down. Show who won and skip the "missing token" notice.
+        if (this.refreshLockedByOtherStatus()) return;
         if (this.serverUnreachable) return;
         this.serverUnreachable = true;
         this.updateStatusBar(MESSAGES.STATUS_ERROR, DOT_STATE.ERROR);

--- a/src/server-manager.ts
+++ b/src/server-manager.ts
@@ -401,7 +401,9 @@ export class ServerManager {
             // and main.ts surfaces that as STATUS_LOCKED_BY_OTHER.
             const exitedCleanly = code === 0 || signal === "SIGTERM";
             if (exitedCleanly) {
-                this.journal(`server pid ${child.pid} exited (${describeExit(code, signal)}): another vault took over the shared root`);
+                this.journal(
+                    `server pid ${child.pid} exited (${describeExit(code, signal)}): another vault took over the shared root`,
+                );
                 this.setState(SERVER_STATE.ERROR);
                 return;
             }

--- a/src/server-manager.ts
+++ b/src/server-manager.ts
@@ -395,6 +395,16 @@ export class ServerManager {
                 this.setState(SERVER_STATE.ERROR);
                 return;
             }
+            // A clean exit (code 0 or SIGTERM) while we still wanted the server
+            // running means another vault asked it to stop via a take-over. Not
+            // a crash: do not restart. The scope sidecar now names the winner,
+            // and main.ts surfaces that as STATUS_LOCKED_BY_OTHER.
+            const exitedCleanly = code === 0 || signal === "SIGTERM";
+            if (exitedCleanly) {
+                this.journal(`server pid ${child.pid} exited (${describeExit(code, signal)}): another vault took over the shared root`);
+                this.setState(SERVER_STATE.ERROR);
+                return;
+            }
             this.pushOutputLine(`server exited (${describeExit(code, signal)})`);
             this.journal(`server pid ${child.pid} exited (${describeExit(code, signal)})`);
             this.snapshotCrashOutput();

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -6624,6 +6624,24 @@ describe("LilbeePlugin", () => {
             expect(plugin.statusBarEl?.classList.contains("lilbee-status-error")).toBe(true);
         });
 
+        it("handleServerStateChange error shows STATUS_LOCKED_BY_OTHER when another vault owns the root", async () => {
+            const sm = await import("../src/server-manager");
+            vi.mocked(sm.readScopeOwner).mockReturnValue({
+                dataDir: "/shared/vaults/other",
+                pid: 999,
+            });
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const stateChange = mockServerOpts?.onStateChange;
+            stateChange("error");
+
+            expect(plugin.statusBarEl?.textContent).toContain("serving");
+            expect(plugin.statusBarEl?.textContent).not.toContain("error");
+        });
+
         it("handleServerStateChange ready re-renders an open lilbee Settings tab (ydt)", async () => {
             const { LilbeeSettingTab } = await import("../src/settings");
             const plugin = await createPlugin({ serverMode: "managed" });

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -6653,6 +6653,15 @@ describe("LilbeePlugin", () => {
             expect((plugin as any).refreshLockedByOtherStatus()).toBe(false);
         });
 
+        it("refreshLockedByOtherStatus returns false without a registry", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            (plugin as any).vaultRegistry = null;
+            expect((plugin as any).refreshLockedByOtherStatus()).toBe(false);
+        });
+
         it("refreshLockedByOtherStatus returns false when we own the root", async () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -6643,6 +6643,9 @@ describe("LilbeePlugin", () => {
         });
 
         it("refreshLockedByOtherStatus returns false when no foreign owner", async () => {
+            const sm = await import("../src/server-manager");
+            vi.mocked(sm.readScopeOwner).mockReturnValue(null);
+
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
             await flush();
@@ -6671,7 +6674,8 @@ describe("LilbeePlugin", () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
             await flush();
-            // Force the server-unreachable path.
+            // Make the health probe fail so it reaches the locked-by-other check.
+            plugin.api.health = vi.fn().mockResolvedValue({ isOk: () => false, isErr: () => true });
             (plugin as any).serverEverReady = true;
             (plugin as any).healthFailureStreak = 1;
             await (plugin as any).probeServerHealth();

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -6642,6 +6642,44 @@ describe("LilbeePlugin", () => {
             expect(plugin.statusBarEl?.textContent).not.toContain("error");
         });
 
+        it("refreshLockedByOtherStatus returns false when no foreign owner", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            expect((plugin as any).refreshLockedByOtherStatus()).toBe(false);
+        });
+
+        it("refreshLockedByOtherStatus returns false when we own the root", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const sm = await import("../src/server-manager");
+            const ourDataDir = (plugin as any).vaultRegistry.resolveDataDir((plugin as any).vaultId);
+            vi.mocked(sm.readScopeOwner).mockReturnValue({ dataDir: ourDataDir, pid: 1 });
+
+            expect((plugin as any).refreshLockedByOtherStatus()).toBe(false);
+        });
+
+        it("health probe shows STATUS_LOCKED_BY_OTHER and skips token notice", async () => {
+            const sm = await import("../src/server-manager");
+            vi.mocked(sm.readScopeOwner).mockReturnValue({
+                dataDir: "/shared/vaults/other",
+                pid: 999,
+            });
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+            // Force the server-unreachable path.
+            (plugin as any).serverEverReady = true;
+            (plugin as any).healthFailureStreak = 1;
+            await (plugin as any).probeServerHealth();
+
+            expect(plugin.statusBarEl?.textContent).toContain("serving");
+            expect(Notice.instances.some((n) => n.message.includes("session token"))).toBe(false);
+        });
+
         it("handleServerStateChange ready re-renders an open lilbee Settings tab (ydt)", async () => {
             const { LilbeeSettingTab } = await import("../src/settings");
             const plugin = await createPlugin({ serverMode: "managed" });

--- a/tests/server-manager.test.ts
+++ b/tests/server-manager.test.ts
@@ -842,6 +842,26 @@ describe("ServerManager", () => {
             expect(mgr.state).toBe("ready");
         });
 
+        it("a clean exit (SIGTERM) is a take-over, not a crash: no restart", async () => {
+            const mgr = await startFresh();
+            child()._emit("exit", null, "SIGTERM");
+            expect(mgr.state).toBe("error");
+            expect(mgr.lastOutput).toContain("another vault took over");
+            // No crash snapshot, no restart scheduled.
+            expect(appendFileSyncSpy).not.toHaveBeenCalled();
+            await vi.advanceTimersByTimeAsync(3000);
+            expect(spawnSpy).toHaveBeenCalledTimes(1); // no restart
+        });
+
+        it("a clean exit (code 0) is a take-over, not a crash: no restart", async () => {
+            const mgr = await startFresh();
+            child()._emit("exit", 0, null);
+            expect(mgr.state).toBe("error");
+            expect(mgr.lastOutput).toContain("another vault took over");
+            await vi.advanceTimersByTimeAsync(3000);
+            expect(spawnSpy).toHaveBeenCalledTimes(1); // no restart
+        });
+
         it("a signal exit is described by its signal", async () => {
             const mgr = await startFresh();
             child()._emit("exit", null, "SIGSEGV");

--- a/tests/server-manager.test.ts
+++ b/tests/server-manager.test.ts
@@ -843,10 +843,11 @@ describe("ServerManager", () => {
         });
 
         it("a clean exit (SIGTERM) is a take-over, not a crash: no restart", async () => {
-            const mgr = await startFresh();
+            const journal: string[] = [];
+            const mgr = await startFresh({ onJournal: (m) => journal.push(m) });
             child()._emit("exit", null, "SIGTERM");
             expect(mgr.state).toBe("error");
-            expect(mgr.lastOutput).toContain("another vault took over");
+            expect(journal.join("\n")).toContain("another vault took over");
             // No crash snapshot, no restart scheduled.
             expect(appendFileSyncSpy).not.toHaveBeenCalled();
             await vi.advanceTimersByTimeAsync(3000);
@@ -854,10 +855,11 @@ describe("ServerManager", () => {
         });
 
         it("a clean exit (code 0) is a take-over, not a crash: no restart", async () => {
-            const mgr = await startFresh();
+            const journal: string[] = [];
+            const mgr = await startFresh({ onJournal: (m) => journal.push(m) });
             child()._emit("exit", 0, null);
             expect(mgr.state).toBe("error");
-            expect(mgr.lastOutput).toContain("another vault took over");
+            expect(journal.join("\n")).toContain("another vault took over");
             await vi.advanceTimersByTimeAsync(3000);
             expect(spawnSpy).toHaveBeenCalledTimes(1); // no restart
         });


### PR DESCRIPTION
## Problem

When another vault takes the shared root, the losing server exits with SIGTERM (code 143). The supervisor counts this as a crash and restarts into a ScopeHeldError loop, showing "error" and a missing-token notice. #285

## Solution

A clean exit (code 0 or SIGTERM) while the server is still desired is a take-over, not a crash: set ERROR without scheduling a crash restart. main.ts shows STATUS_LOCKED_BY_OTHER when the scope sidecar names a different owner, and skips the missing-token notice in the health probe.

## Notes

Related: #284, #286.