### PR TITLE
Filter non-chat models from the chat rail menu

### DIFF
--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -601,11 +601,16 @@ export class ChatView extends ItemView {
         return primary;
     }
 
-    /** Installed builds that aren't in the featured catalog (manually pulled, ollama/, openai/, …). */
+    /** Installed builds that aren't in the featured catalog (manually pulled, ollama/, openai/, …).
+     *  The server's installedModels endpoint returns models for every task, so filter out
+     *  repos that serve another role — an installed embedding/vision/reranker model must
+     *  not leak into the chat menu. */
     private chatOtherOptions(): RailOption[] {
         const sourceMap = new Map(this.chatInstalled.map((m) => [m.name, m.source]));
         const featuredRepos = new Set(this.chatCatalogEntries.map((e) => e.hf_repo));
+        const nonChatRepos = this.nonChatRepos();
         return this.chatInstalled
+            .filter((m) => !nonChatRepos.has(extractHfRepo(m.name)))
             .filter((m) => !featuredRepos.has(extractHfRepo(m.name)))
             .sort((a, b) => a.name.localeCompare(b.name))
             .map((m) => {
@@ -617,6 +622,16 @@ export class ChatView extends ItemView {
                     checked: m.name === this.chatActive,
                 };
             });
+    }
+
+    /** Repos that serve embedding, vision, or reranker roles — never chat. */
+    private nonChatRepos(): Set<string> {
+        const repos = new Set<string>();
+        for (const m of this.embeddingModels) repos.add(m.hf_repo);
+        for (const task of [MODEL_TASK.VISION, MODEL_TASK.RERANK] as const) {
+            for (const m of this.optionalCatalog[task]) repos.add(m.hf_repo);
+        }
+        return repos;
     }
 
     private openChatMenu(event: MouseEvent): void {

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -6211,7 +6211,9 @@ describe("ChatView — chat menu filters out non-chat models", () => {
     it("excludes installed vision and reranker models from the chat menu", () => {
         const view = makeView();
         (view as any).optionalCatalog = {
-            vision: [{ hf_repo: "vikhyatk/moondream2-GGUF", display_name: "Moondream", source: "native", task: "vision" }],
+            vision: [
+                { hf_repo: "vikhyatk/moondream2-GGUF", display_name: "Moondream", source: "native", task: "vision" },
+            ],
             rerank: [],
         };
         (view as any).chatInstalled.push({ name: "vikhyatk/moondream2-GGUF/moondream2.Q4_K_M.gguf", source: "native" });

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -6173,3 +6173,44 @@ describe("ChatView — resume interactions with live state", () => {
         expect(plugin.saveSettings).not.toHaveBeenCalled();
     });
 });
+
+describe("ChatView — chat menu filters out non-chat models", () => {
+    function makeView() {
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        // Seed the view's internal state as fetchAndFillSelectors would.
+        (view as any).chatActive = "Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf";
+        (view as any).chatCatalogEntries = [
+            { hf_repo: "Qwen/Qwen3-4B-GGUF", display_name: "Qwen3 4B", source: "native", task: "chat" },
+        ];
+        (view as any).chatInstalled = [
+            { name: "Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf", source: "native" },
+            { name: "BAAI/bge-small-en-v1.5-GGUF/bge-small-en-v1.5.Q4_K_M.gguf", source: "native" },
+        ];
+        (view as any).embeddingModels = [
+            { hf_repo: "BAAI/bge-small-en-v1.5-GGUF", display_name: "BGE Small", source: "native", task: "embedding" },
+        ];
+        (view as any).optionalCatalog = { vision: [], rerank: [] };
+        return view;
+    }
+
+    it("excludes installed embedding models from the chat menu", () => {
+        const view = makeView();
+        const options = (view as any).chatOtherOptions();
+        const repos = options.map((o: { value: string }) => o.value);
+        expect(repos).toContain("Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf");
+        expect(repos).not.toContain("BAAI/bge-small-en-v1.5-GGUF/bge-small-en-v1.5.Q4_K_M.gguf");
+    });
+
+    it("excludes installed vision and reranker models from the chat menu", () => {
+        const view = makeView();
+        (view as any).optionalCatalog = {
+            vision: [{ hf_repo: "vikhyatk/moondream2-GGUF", display_name: "Moondream", source: "native", task: "vision" }],
+            rerank: [],
+        };
+        (view as any).chatInstalled.push({ name: "vikhyatk/moondream2-GGUF/moondream2.Q4_K_M.gguf", source: "native" });
+        const options = (view as any).chatOtherOptions();
+        const repos = options.map((o: { value: string }) => o.value);
+        expect(repos).not.toContain("vikhyatk/moondream2-GGUF/moondream2.Q4_K_M.gguf");
+    });
+});

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -6179,12 +6179,14 @@ describe("ChatView — chat menu filters out non-chat models", () => {
         const plugin = makePlugin();
         const view = new ChatView(makeLeaf(), plugin);
         // Seed the view's internal state as fetchAndFillSelectors would.
-        (view as any).chatActive = "Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf";
+        // Qwen is in the catalog (featured); Llama is manually pulled (not in catalog).
+        (view as any).chatActive = "bartowski/Llama-3.2-1B-Instruct-GGUF/Llama-3.2-1B-Instruct-Q4_K_M.gguf";
         (view as any).chatCatalogEntries = [
             { hf_repo: "Qwen/Qwen3-4B-GGUF", display_name: "Qwen3 4B", source: "native", task: "chat" },
         ];
         (view as any).chatInstalled = [
             { name: "Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf", source: "native" },
+            { name: "bartowski/Llama-3.2-1B-Instruct-GGUF/Llama-3.2-1B-Instruct-Q4_K_M.gguf", source: "native" },
             { name: "BAAI/bge-small-en-v1.5-GGUF/bge-small-en-v1.5.Q4_K_M.gguf", source: "native" },
         ];
         (view as any).embeddingModels = [
@@ -6194,12 +6196,16 @@ describe("ChatView — chat menu filters out non-chat models", () => {
         return view;
     }
 
-    it("excludes installed embedding models from the chat menu", () => {
+    it("includes manually-pulled chat models but excludes embedding models", () => {
         const view = makeView();
         const options = (view as any).chatOtherOptions();
         const repos = options.map((o: { value: string }) => o.value);
-        expect(repos).toContain("Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf");
+        // Llama is installed but not in the featured catalog → appears in chatOtherOptions.
+        expect(repos).toContain("bartowski/Llama-3.2-1B-Instruct-GGUF/Llama-3.2-1B-Instruct-Q4_K_M.gguf");
+        // BGE is an embedding model → excluded from chat menu.
         expect(repos).not.toContain("BAAI/bge-small-en-v1.5-GGUF/bge-small-en-v1.5.Q4_K_M.gguf");
+        // Qwen is in the featured catalog → appears in chatPrimaryOptions, not here.
+        expect(repos).not.toContain("Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf");
     });
 
     it("excludes installed vision and reranker models from the chat menu", () => {


### PR DESCRIPTION
## Problem

The chat rail menu lists embedding, vision, and reranker models alongside chat models. The server installedModels endpoint returns models for every task, so non-chat models leak into the chat menu. #287

## Solution

chatOtherOptions now filters out repos that serve another role, using the embedding and optional-role catalogs already loaded by the view. A new nonChatRepos() builds the exclusion set from embeddingModels and optionalCatalog.

## Notes

Related: #288.