### PR TITLE
Hide worker-pool rows until server reports their keys

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2158,29 +2158,46 @@ export class LilbeeSettingTab extends PluginSettingTab {
     }
 
     private rowsWorkerPool(): RowSpec[] {
+        // Each row waits for the server to report its own key: the server rejects
+        // PATCH for unknown keys, so a row the server does not know would only
+        // error. The visible predicate hides it until the key arrives.
         return [
-            this.numberRow(
-                {
-                    key: "worker_pool_call_timeout_s",
-                    name: MESSAGES.LABEL_WORKER_POOL_CALL_TIMEOUT,
-                    desc: MESSAGES.DESC_WORKER_POOL_CALL_TIMEOUT,
-                },
-                { integer: false, min: 0 },
+            this.visibleRow(
+                this.numberRow(
+                    {
+                        key: "worker_pool_call_timeout_s",
+                        name: MESSAGES.LABEL_WORKER_POOL_CALL_TIMEOUT,
+                        desc: MESSAGES.DESC_WORKER_POOL_CALL_TIMEOUT,
+                    },
+                    { integer: false, min: 0 },
+                ),
+                "worker_pool_call_timeout_s",
             ),
-            this.toggleRow({
-                key: "worker_pool_eager_start",
-                name: MESSAGES.LABEL_WORKER_POOL_EAGER_START,
-                desc: MESSAGES.DESC_WORKER_POOL_EAGER_START,
-            }),
-            this.numberRow(
-                {
-                    key: "worker_pool_max_idle_s",
-                    name: MESSAGES.LABEL_WORKER_POOL_MAX_IDLE,
-                    desc: MESSAGES.DESC_WORKER_POOL_MAX_IDLE,
-                },
-                { integer: false, min: 0 },
+            this.visibleRow(
+                this.toggleRow({
+                    key: "worker_pool_eager_start",
+                    name: MESSAGES.LABEL_WORKER_POOL_EAGER_START,
+                    desc: MESSAGES.DESC_WORKER_POOL_EAGER_START,
+                }),
+                "worker_pool_eager_start",
+            ),
+            this.visibleRow(
+                this.numberRow(
+                    {
+                        key: "worker_pool_max_idle_s",
+                        name: MESSAGES.LABEL_WORKER_POOL_MAX_IDLE,
+                        desc: MESSAGES.DESC_WORKER_POOL_MAX_IDLE,
+                    },
+                    { integer: false, min: 0 },
+                ),
+                "worker_pool_max_idle_s",
             ),
         ];
+    }
+
+    /** A row whose visibility tracks whether the server reports *key*. */
+    private visibleRow(row: RowSpec, key: string): RowSpec {
+        return { ...row, visible: () => this.serverReports(key) };
     }
 
     private renderWorkerPoolSettings(containerEl: HTMLElement): void {


### PR DESCRIPTION
## Problem

The worker-pool timeout rows write keys the server rejects with 400 "Unknown or read-only setting". On Obsidian 1.13+, the old hideUntilServerReports mechanism is a no-op and the rows were always visible. #289

## Solution

Each worker-pool row now has a visible predicate so it stays hidden until the server reports its key via GET /api/config. New visibleRow() helper wraps a RowSpec with a visible: () => serverReports(key) predicate.

## Notes

Related: #289.