### PR TITLE
Discard stale catalog responses when filter changes mid-flight

### DIFF
--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -104,6 +104,7 @@ export class CatalogModal extends Modal {
     private fetchedQuery = "";
     private hasMore = false;
     private isFetching = false;
+    private fetchGeneration = 0;
     private entries: CatalogEntry[] = [];
     private resultsEl: HTMLElement | null = null;
     private viewMode: CatalogViewMode = CATALOG_VIEW_MODE.GRID;
@@ -419,6 +420,7 @@ export class CatalogModal extends Modal {
     }
 
     private resetAndFetch(): void {
+        this.fetchGeneration++;
         this.offset = 0;
         this.clearResults();
         void this.fetchPage();
@@ -458,14 +460,18 @@ export class CatalogModal extends Modal {
             this.clearResults();
         }
         this.isFetching = true;
+        // Capture the request generation so a stale response (a filter changed
+        // while this page was in flight) can be discarded instead of rendering
+        // under the new filter.
+        const generation = this.fetchGeneration;
 
         let superseded = false;
         try {
             const result = await this.plugin.api.catalog(this.catalogParams(query));
             if (result.isErr()) {
                 new Notice(noticeForResultError(result.error, MESSAGES.ERROR_LOAD_CATALOG));
-            } else if (query !== this.filterSearch) {
-                // The term moved on while this page was in flight.
+            } else if (generation !== this.fetchGeneration) {
+                // A filter/sort/size change superseded this request while it was in flight.
                 superseded = true;
             } else {
                 this.applyPage(result.value);

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -2522,7 +2522,8 @@ describe("CatalogModal fetch generation", () => {
         let resolveFirst: (r: any) => void = () => {};
         const firstPromise = new Promise<any>((r) => { resolveFirst = r; });
         plugin.api.catalog.mockReturnValueOnce(firstPromise);
-        plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry()])));
+        // The recursive fetch after supersedence also returns empty.
+        plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([])));
 
         const modal = await openModal(plugin);
         // Start fetching the first page (in flight).
@@ -2534,6 +2535,7 @@ describe("CatalogModal fetch generation", () => {
 
         // Resolve the stale request.
         resolveFirst(ok(makeCatalogResponse([makeEntry({ hf_repo: "stale/repo", display_name: "Stale" })])));
+        await tick();
         await tick();
         await tick();
 

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -2520,7 +2520,9 @@ describe("CatalogModal fetch generation", () => {
         const plugin = makePlugin();
         // Defer the first catalog call so we can change the filter before it resolves.
         let resolveFirst: (r: any) => void = () => {};
-        const firstPromise = new Promise<any>((r) => { resolveFirst = r; });
+        const firstPromise = new Promise<any>((r) => {
+            resolveFirst = r;
+        });
         plugin.api.catalog.mockReturnValueOnce(firstPromise);
         // The recursive fetch after supersedence also returns empty.
         plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([])));

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -2514,3 +2514,32 @@ describe("CatalogModal", () => {
         });
     });
 });
+
+describe("CatalogModal fetch generation", () => {
+    it("discards a stale response when the filter changes mid-flight", async () => {
+        const plugin = makePlugin();
+        // Defer the first catalog call so we can change the filter before it resolves.
+        let resolveFirst: (r: any) => void = () => {};
+        const firstPromise = new Promise<any>((r) => { resolveFirst = r; });
+        plugin.api.catalog.mockReturnValueOnce(firstPromise);
+        plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry()])));
+
+        const modal = await openModal(plugin);
+        // Start fetching the first page (in flight).
+        (modal as any).resetAndFetch();
+        expect((modal as any).isFetching).toBe(true);
+
+        // Change the filter mid-flight: increments fetchGeneration.
+        (modal as any).fetchGeneration++;
+
+        // Resolve the stale request.
+        resolveFirst(ok(makeCatalogResponse([makeEntry({ hf_repo: "stale/repo", display_name: "Stale" })])));
+        await tick();
+        await tick();
+
+        // The stale response is discarded; entries stay empty.
+        expect((modal as any).entries.length).toBe(0);
+        expect((modal as any).isFetching).toBe(false);
+        modal.close();
+    });
+});


### PR DESCRIPTION
## Problem

fetchPage returns early while isFetching is true, so a size, sort or task change made while a page is loading is never fetched. The in-flight response then lands and renders under the new filter. The existing guard keys on the search term only. #290

## Solution

fetchPage captures a request generation counter and discards the response if a filter, sort, or size change superseded the request while it was in flight.

## Notes

Single-file change, no API surface affected.