### PR TITLE
Chat rail activates by concrete file ref

### DIFF
--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -627,9 +627,7 @@ export class ChatView extends ItemView {
     }
 
     private handleChatSelection(value: string): void {
-        const uninstalled = this.chatCatalogEntries.find(
-            (e) => nativeModelRef(e.hf_repo, e.gguf_filename) === value,
-        );
+        const uninstalled = this.chatCatalogEntries.find((e) => nativeModelRef(e.hf_repo, e.gguf_filename) === value);
         if (uninstalled && !uninstalled.installed) {
             const modal = new ConfirmPullModal(this.plugin.app, {
                 displayName: uninstalled.display_name,

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -39,7 +39,7 @@ import type {
 import { RateLimitedError, isHttpStatus } from "../api";
 
 import { renderAggregatedSourceChips } from "./results";
-import { displayLabelForRef, extractHfRepo } from "../utils/model-ref";
+import { displayLabelForRef, extractHfRepo, nativeModelRef } from "../utils/model-ref";
 import { ConfirmPullModal } from "./confirm-pull-modal";
 import { ConfirmModal } from "./confirm-modal";
 import { CatalogModal } from "./catalog-modal";
@@ -580,14 +580,15 @@ export class ChatView extends ItemView {
     /** Featured rows that have an installed quant, then hosted rows not already listed. */
     private chatPrimaryOptions(): RailOption[] {
         const installedRepos = new Set(this.chatInstalled.map((m) => extractHfRepo(m.name)));
-        const activeRepo = extractHfRepo(this.chatActive);
+        const activeRef = this.chatActive;
         const primary: RailOption[] = [];
         for (const entry of this.chatCatalogEntries.filter((e) => installedRepos.has(e.hf_repo))) {
             const sourceTag = HOSTED_SOURCES.has(entry.source) ? ` [${entry.provider ?? entry.source}]` : "";
+            const ref = nativeModelRef(entry.hf_repo, entry.gguf_filename);
             primary.push({
-                value: entry.hf_repo,
+                value: ref,
                 label: `${entry.display_name}${sourceTag}`,
-                checked: entry.hf_repo === activeRepo,
+                checked: ref === activeRef,
             });
         }
         // Hosted rows (frontier/ollama) are selectable even when absent from the
@@ -596,7 +597,7 @@ export class ChatView extends ItemView {
         // be both hosted and registered as installed).
         for (const [ref, label] of hostedOptions(this.chatCatalogEntries)) {
             if (installedRepos.has(ref)) continue;
-            primary.push({ value: ref, label, checked: ref === activeRepo });
+            primary.push({ value: ref, label, checked: ref === activeRef });
         }
         return primary;
     }
@@ -626,8 +627,10 @@ export class ChatView extends ItemView {
     }
 
     private handleChatSelection(value: string): void {
-        const uninstalled = this.chatCatalogEntries.find((e) => e.hf_repo === value && !e.installed);
-        if (uninstalled) {
+        const uninstalled = this.chatCatalogEntries.find(
+            (e) => nativeModelRef(e.hf_repo, e.gguf_filename) === value,
+        );
+        if (uninstalled && !uninstalled.installed) {
             const modal = new ConfirmPullModal(this.plugin.app, {
                 displayName: uninstalled.display_name,
                 sizeGb: uninstalled.size_gb,
@@ -650,8 +653,6 @@ export class ChatView extends ItemView {
         void this.plugin.api.setChatModel(value).then((result) => {
             if (result.isOk()) {
                 // Keep the menu's checkmark in sync without waiting for a refetch.
-                // Store what the server resolved, not what was sent: a bare repo
-                // comes back as the concrete quant it picked.
                 this.chatActive = result.value.model;
                 this.plugin.activeModel = result.value.model;
                 void this.plugin.fetchActiveModel();

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -6188,9 +6188,7 @@ describe("ChatView chat rail activates by concrete ref", () => {
                 task: "chat",
             },
         ];
-        (view as any).chatInstalled = [
-            { name: "Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf", source: "native" },
-        ];
+        (view as any).chatInstalled = [{ name: "Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf", source: "native" }];
         return view;
     }
 

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -6173,3 +6173,36 @@ describe("ChatView — resume interactions with live state", () => {
         expect(plugin.saveSettings).not.toHaveBeenCalled();
     });
 });
+
+describe("ChatView chat rail activates by concrete ref", () => {
+    function makeView() {
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        (view as any).chatActive = "Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf";
+        (view as any).chatCatalogEntries = [
+            {
+                hf_repo: "Qwen/Qwen3-4B-GGUF",
+                gguf_filename: "Qwen3-4B-Q4_K_M.gguf",
+                display_name: "Qwen3 4B",
+                source: "native",
+                task: "chat",
+            },
+        ];
+        (view as any).chatInstalled = [
+            { name: "Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf", source: "native" },
+        ];
+        return view;
+    }
+
+    it("sends the concrete file ref, not the bare repo", () => {
+        const view = makeView();
+        const options = (view as any).chatPrimaryOptions();
+        expect(options[0].value).toBe("Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf");
+    });
+
+    it("marks the installed quant as checked", () => {
+        const view = makeView();
+        const options = (view as any).chatPrimaryOptions();
+        expect(options[0].checked).toBe(true);
+    });
+});


### PR DESCRIPTION
## Problem

The chat rail activates models by bare hf_repo while the catalog sends the concrete file ref. When two quants of the same repo are installed, the rail choice is decided by the server alphabetical tiebreak, not by the user. #292

## Solution

chatPrimaryOptions now uses nativeModelRef to build the concrete file ref, matching what the catalog already does. handleChatSelection finds entries by concrete ref match.

## Notes

Single-file production change. The server accepts the concrete ref (verified live).