### PR TITLE
Keep capability-hidden settings rows hidden when search cleared

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -834,7 +834,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             // Rows hidden by capability (server does not report the key) must stay
             // hidden even when the search box is cleared: clearing the box makes
             // matches() true for every row, which would otherwise reveal them.
-            if (item.hasAttribute("data-lilbee-hidden-by-capability")) {
+            if (item.getAttribute("data-lilbee-hidden-by-capability") !== null) {
                 (item as HTMLElement).style.display = "none";
                 continue;
             }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -831,6 +831,13 @@ export class LilbeeSettingTab extends PluginSettingTab {
         };
 
         for (const item of Array.from(containerEl.querySelectorAll(".setting-item"))) {
+            // Rows hidden by capability (server does not report the key) must stay
+            // hidden even when the search box is cleared: clearing the box makes
+            // matches() true for every row, which would otherwise reveal them.
+            if (item.hasAttribute("data-lilbee-hidden-by-capability")) {
+                (item as HTMLElement).style.display = "none";
+                continue;
+            }
             (item as HTMLElement).style.display = matches(item) ? "" : "none";
         }
 
@@ -1970,6 +1977,10 @@ export class LilbeeSettingTab extends PluginSettingTab {
         for (const [key, settingEl] of this.serverConfigHideableEls) {
             if (cfg[key] !== undefined) {
                 settingEl.show();
+                settingEl.removeAttribute("data-lilbee-hidden-by-capability");
+            } else {
+                settingEl.hide();
+                settingEl.setAttribute("data-lilbee-hidden-by-capability", "true");
             }
         }
     }

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -4598,6 +4598,33 @@ describe("managed mode settings", () => {
             expect(section.style.display).toBe("");
         });
 
+        it("filterSettings keeps capability-hidden rows hidden when query is cleared", () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            tab.display();
+
+            const container = new MockElement("div") as any;
+            const section = container.createEl("details", { cls: "lilbee-settings-section" });
+
+            const item1 = section.createDiv({ cls: "setting-item" });
+            const name1 = item1.createDiv({ cls: "setting-item-name" });
+            name1.textContent = "Server URL";
+
+            const item2 = section.createDiv({ cls: "setting-item" });
+            const name2 = item2.createDiv({ cls: "setting-item-name" });
+            name2.textContent = "Worker pool";
+            // Mark as hidden by capability (server does not report this key)
+            item2.setAttribute("data-lilbee-hidden-by-capability", "true");
+            item2.style.display = "none";
+
+            // Clear the search: item1 should show, item2 must stay hidden
+            (tab as any).filterSettings(container, "");
+
+            expect(item1.style.display).toBe("");
+            expect(item2.style.display).toBe("none");
+        });
+
         it("di8: filterSettings hides non-matching top-level setting items", () => {
             const plugin = makePlugin();
             mockChatPicker(plugin);


### PR DESCRIPTION
## Problem

Typing in the settings search box and then clearing it permanently reveals every server-backed control the running server does not support. filterSettings sets display = "" on all rows when the term is empty, including rows hidden because the server cannot accept them. #298

## Solution

applyHideableConfigFields now marks capability-hidden rows with a data attribute. filterSettings skips those rows when applying the search filter, so clearing the box does not reveal them.

## Notes

Single-file production change plus test.