### PR TITLE
Report chat streams that close without done as interrupted

### DIFF
--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -121,6 +121,8 @@ interface StreamState {
     /** Set at DONE/stop/error so a queued animation-frame plain-text repaint
      *  can't overwrite the final markdown render. */
     streamEnded: boolean;
+    /** True once a DONE event arrives. A stream that ends without one was truncated. */
+    sawDone: boolean;
     /** The turn's user bubble; compaction markers are inserted above it. */
     anchorEl: HTMLElement;
     /** The condensing card, held so progress can advance it and the outcome can settle it. */
@@ -1136,6 +1138,7 @@ export class ChatView extends ItemView {
             reasoningDetailsEl: null,
             answerStarted: false,
             streamEnded: false,
+            sawDone: false,
             anchorEl: userBubble,
             compaction: null,
             spinnerEl: spinner,
@@ -1215,6 +1218,12 @@ export class ChatView extends ItemView {
             }
         } finally {
             state.streamEnded = true;
+            // A stream that closes without DONE is a truncated answer: the
+            // connection dropped between the last token and the done frame.
+            // Surface it the same way a truncated frame is reported.
+            if (!state.sawDone && state.fullContent && !this.streamController?.signal.aborted) {
+                this.renderInlineError(assistantBubble, streamInterruptedMessage(this.plugin.settings.serverMode));
+            }
             this.sending = false;
             this.streamController = null;
             this.plugin.notifyChatEnd();
@@ -1285,6 +1294,7 @@ export class ChatView extends ItemView {
             case SSE_EVENT.DONE: {
                 revealContent();
                 state.streamEnded = true;
+                state.sawDone = true;
                 const rendered = state.fullContent;
                 // Banner and sources grow the bubble after the last token; render
                 // them inside one follow so the view ends pinned to the bottom.

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -676,6 +676,33 @@ describe("ChatView.sendMessage — token streaming", () => {
         const textEl = assistantBubble.find("lilbee-chat-content");
         expect(textEl!.textContent).toBe("Hello world");
     });
+
+    it("reports a stream that closes without done as interrupted", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        // Stream sends tokens but closes without a DONE event.
+        const { mockFn, done } = makeStream([
+            { event: SSE_EVENT.TOKEN, data: "Hello" },
+            { event: SSE_EVENT.TOKEN, data: " world" },
+        ]);
+        plugin.api.chatStream = mockFn;
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const messagesEl = container.find("lilbee-chat-messages")!;
+        const textarea = container.find("lilbee-chat-textarea")!;
+        textarea.value = "stream test";
+
+        container.find("lilbee-chat-send")!.trigger("click");
+        await done;
+        await tick();
+        await tick();
+
+        const assistantBubble = messagesEl.children[1];
+        const errorEl = assistantBubble.find("lilbee-chat-error");
+        // A stream that closes without done must surface an error, not end silently.
+        expect(errorEl).not.toBeNull();
+    });
 });
 
 describe("ChatView.sendMessage — reasoning tokens", () => {


### PR DESCRIPTION
## Problem

A chat stream that sends tokens and then closes without a done event ends silently. The assistant bubble shows partial content with no indication the answer is incomplete. #300

## Solution

Track a sawDone flag in the stream state. In the finally block, if the stream ended without done and there is content, render the same interrupted-stream error used for truncated frames.

## Notes

Single-file production change plus test.