### PR TITLE
Show Use and continue for installed embedding model in wizard

### DIFF
--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -1086,6 +1086,7 @@ export class SetupWizard extends Modal {
         const activeIdx = activeRef ? this.embeddingModels.findIndex((m) => m.hf_repo === activeRef) : -1;
         const defaultIdx = activeIdx >= 0 ? activeIdx : 0;
         this.selectedEmbedding = this.embeddingModels[defaultIdx];
+        if (this.primaryBtn) this.setPrimaryActionLabel(this.primaryBtn, this.selectedEmbedding);
 
         this.renderSectionHeading(container, MESSAGES.WIZARD_EMBEDDING_RECOMMENDED);
         const grid = container.createDiv({ cls: "lilbee-catalog-grid" });
@@ -1101,6 +1102,7 @@ export class SetupWizard extends Modal {
 
     private selectEmbedding(grid: HTMLElement, model: EmbeddingModel): void {
         this.selectedEmbedding = model;
+        if (this.primaryBtn) this.setPrimaryActionLabel(this.primaryBtn, model);
         for (const child of Array.from(grid.children)) {
             const el = child as HTMLElement;
             if (el.dataset.repo === model.hf_repo) {

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -2792,7 +2792,29 @@ describe("SetupWizard", () => {
             expect(texts.some((t) => t.includes("Index your vault"))).toBe(true);
         });
 
-        it("download & continue with installed model sets embedding and advances to sync step", async () => {
+        it("shows Use & continue for an installed embedding model", async () => {
+            const entries = [
+                makeEntry({
+                    hf_repo: "nomic-ai/nomic-embed-text-v1.5-GGUF",
+                    display_name: "nomic-embed-text",
+                    task: "embedding",
+                    installed: true,
+                }),
+            ];
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            (wizard as any).step = 3;
+            (wizard as any).renderStep();
+            await tick();
+
+            const el = wizard.contentEl as unknown as MockElement;
+            const primaryBtn = findButtons(el).find((b) => b.textContent === "Use & continue");
+            expect(primaryBtn).not.toBeNull();
+        });
+
+        it("installed model click sets embedding and advances to sync step", async () => {
             const entries = [
                 makeEntry({
                     hf_repo: "nomic-ai/nomic-embed-text-v1.5-GGUF",
@@ -2816,7 +2838,7 @@ describe("SetupWizard", () => {
 
             const el = wizard.contentEl as unknown as MockElement;
             findButtons(el)
-                .find((b) => b.textContent === "Download & continue")!
+                .find((b) => b.textContent === "Use & continue")!
                 .trigger("click");
             await tick();
 


### PR DESCRIPTION
## Problem

The Embed step primary button reads "Download & continue" even when the selected embedding model is installed. It should read "Use & continue" for installed models, matching the behavior on the Model step. #302

## Solution

selectEmbedding now calls setPrimaryActionLabel to update the button text based on the selected model installed state. The initial label is also set when the picker loads.

## Notes

Single-file production change plus tests.