### PR TITLE
Document removal notice prints count instead of file name

### DIFF
--- a/src/views/documents-modal.ts
+++ b/src/views/documents-modal.ts
@@ -84,8 +84,8 @@ export class DocumentsModal extends Modal {
         const confirmed = await confirm.result;
         if (!confirmed) return;
         try {
-            const result = await this.plugin.api.removeDocuments(names);
-            new Notice(MESSAGES.NOTICE_DELETED(result.removed));
+            await this.plugin.api.removeDocuments(names);
+            new Notice(MESSAGES.NOTICE_DELETED(names.length));
             this.resetAndFetch();
         } catch {
             new Notice(MESSAGES.ERROR_DELETE_DOCUMENTS);

--- a/tests/views/documents-modal.test.ts
+++ b/tests/views/documents-modal.test.ts
@@ -236,6 +236,32 @@ describe("DocumentsModal", () => {
         expect(Notice.instances.some((n) => n.message.includes("removed 1"))).toBe(true);
     });
 
+    it("notice prints the count, not the file name", async () => {
+        vi.useRealTimers();
+        const plugin = makePlugin();
+        plugin.api.listDocuments.mockResolvedValue(makeDocsResponse([makeDoc({ filename: "a.md" })]));
+        // Server returns a string in removed (the file name), not a number
+        plugin.api.removeDocuments.mockResolvedValue({ removed: "a.md", not_found: [] });
+        const app = new App();
+        const modal = new DocumentsModal(app as any, plugin as any);
+        modal.open();
+        await tick();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const checkbox = el.findAll("lilbee-documents-checkbox")[0];
+        (checkbox as any).checked = true;
+        checkbox.trigger("change");
+
+        const removeBtn = el.find("lilbee-documents-remove")!;
+        removeBtn.trigger("click");
+        await tick();
+        await tick();
+
+        // The notice must show the count (1), not the file name
+        expect(Notice.instances.some((n) => n.message.includes("removed 1"))).toBe(true);
+        expect(Notice.instances.some((n) => n.message.includes("a.md"))).toBe(false);
+    });
+
     it("confirms removal from the index and promises the files on disk survive", async () => {
         vi.useRealTimers();
         vi.mocked(ConfirmModal).mockClear();


### PR DESCRIPTION
## Problem

After removing documents, the notice reads the file name where the count belongs. The template receives the file name instead of the numeric count. #304

## Solution

Use names.length for the count shown in the notice instead of the server response.

## Notes

Single-file production change plus test.