### PR TITLE
Operator QA sweep: wizard, chat rail, server lifecycle, and health warnings

### DIFF
--- a/src/components/model-card.ts
+++ b/src/components/model-card.ts
@@ -1,6 +1,6 @@
 import { setIcon } from "obsidian";
 import type { CatalogEntry, HardwareFit, ModelCardOptions } from "../types";
-import { HARDWARE_FIT, HOSTED_SOURCES, KEY_STATUS, MODEL_COMPAT, MODEL_TASK } from "../types";
+import { HARDWARE_FIT, HOSTED_SOURCES, MODEL_COMPAT, MODEL_TASK } from "../types";
 import { MESSAGES } from "../locales/en";
 import { formatAbbreviatedCount } from "../utils";
 
@@ -123,8 +123,7 @@ function renderCardStatus(card: HTMLElement, entry: CatalogEntry, options: Model
         text: tone.label,
         cls: `lilbee-model-card-status-label ${tone.labelCls}`,
     });
-    const hostedMissingKey = HOSTED_SOURCES.has(entry.source) && entry.key_status === KEY_STATUS.MISSING_KEY;
-    if (entry.installed && !hostedMissingKey) {
+    if (entry.installed && !HOSTED_SOURCES.has(entry.source)) {
         label.setAttribute("title", MESSAGES.TOOLTIP_MODEL_INSTALLED_SHARED);
     }
     if (entry.fit && FIT_LABEL[entry.fit]) {
@@ -142,8 +141,9 @@ function statusTone(
     if (options.isActive) {
         return { dotCls: "is-active", labelCls: "is-active", label: MESSAGES.LABEL_ACTIVE };
     }
-    const hostedMissingKey = HOSTED_SOURCES.has(entry.source) && entry.key_status === KEY_STATUS.MISSING_KEY;
-    if (entry.installed && !hostedMissingKey) {
+    // Hosted models are usable without being downloaded, so they must not
+    // read "Installed (shared)" or offer Delete: they live on the provider.
+    if (entry.installed && !HOSTED_SOURCES.has(entry.source)) {
         return { dotCls: "is-installed", labelCls: "is-installed", label: MESSAGES.LABEL_INSTALLED };
     }
     if (entry.downloads > 0) {
@@ -172,7 +172,9 @@ function renderCardActions(card: HTMLElement, entry: CatalogEntry, options: Mode
         return;
     }
 
-    if (entry.installed) {
+    // Hosted models are usable without being downloaded, so they get a Use
+    // button but never a Remove: they live on the provider, not on disk.
+    if (entry.installed && !HOSTED_SOURCES.has(entry.source)) {
         const useBtn = actions.createEl("button", {
             text: MESSAGES.BUTTON_USE,
             cls: "lilbee-btn lilbee-btn-primary lilbee-catalog-use",
@@ -188,6 +190,15 @@ function renderCardActions(card: HTMLElement, entry: CatalogEntry, options: Mode
         if (options.onRemove) {
             const handler = options.onRemove;
             removeBtn.addEventListener("click", () => handler(entry, removeBtn));
+        }
+    } else if (entry.installed && HOSTED_SOURCES.has(entry.source)) {
+        const useBtn = actions.createEl("button", {
+            text: MESSAGES.BUTTON_USE,
+            cls: "lilbee-btn lilbee-btn-primary lilbee-catalog-use",
+        });
+        if (options.onUse) {
+            const handler = options.onUse;
+            useBtn.addEventListener("click", () => handler(entry, useBtn));
         }
     } else if (entry.compat === MODEL_COMPAT.UNSUPPORTED) {
         // Unsupported models can't run on this server — render the pull action

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -294,6 +294,7 @@ export const MESSAGES = {
         "Materialize crawled pages and imported files inside your vault so you can browse them in Obsidian. Disabled for external servers — their files live on the server machine, not your computer.",
     NOTICE_STORAGE_REORGANIZING: "Reorganizing lilbee storage into your vault…",
     NOTICE_STORAGE_REORGANIZED: "Lilbee storage is now inside your vault.",
+    ERROR_STORAGE_CHECK_FAILED: "Could not read the lilbee server config to check storage location.",
     NOTICE_STORAGE_REORGANIZE_FAILED: (reason: string | null, logPath: string | null, willRetry: boolean): string =>
         [
             "Could not move lilbee storage.",
@@ -710,6 +711,7 @@ export const MESSAGES = {
     STATUS_WARM_LOADING_ENGINE: "lilbee: loading the engine",
     STATUS_READY: "lilbee: ready",
     STATUS_READY_EXTERNAL: "lilbee: ready [external]",
+    STATUS_CONNECTING: "lilbee: connecting...",
     STATUS_ERROR: "lilbee: error",
     STATUS_AUTH_ERROR: "lilbee: auth error",
     NOTICE_SERVER_UNREACHABLE: "lilbee: server unreachable",
@@ -901,6 +903,8 @@ export const MESSAGES = {
     COMMAND_SYNC: "Sync vault",
     COMMAND_SYNC_RETRY_SKIPPED: RETRY_SKIPPED_COMMAND,
     COMMAND_SYNC_REBUILD: "Rebuild index",
+    WARNING_REMEDY_REBUILD: "Rebuild the index to restore full search and embeddings.",
+    BUTTON_REBUILD_INDEX: "Rebuild index",
     COMMAND_EXPORT_DATASET: "Export dataset",
     COMMAND_IMPORT_DATASET: "Import dataset",
     COMMAND_CATALOG: "Browse model catalog",

--- a/src/main.ts
+++ b/src/main.ts
@@ -470,7 +470,7 @@ export default class LilbeePlugin extends Plugin {
                 });
             } else {
                 this.configureApi(this.settings.serverUrl);
-                this.setStatusReady();
+                this.setStatusConnecting();
                 void this.fetchActiveModel();
                 void this.warnExternalServerOutdated();
             }
@@ -658,6 +658,36 @@ export default class LilbeePlugin extends Plugin {
         const registry = this.vaultRegistry;
         const entry = registry?.list().find((e) => registry.resolveDataDir(e.id) === dataDir);
         return entry?.displayName ?? "another vault";
+    }
+
+    /** Poll the registry for the owner vault's display name for up to two seconds. */
+    private resolveOwnerName(dataDir: string): Promise<string> {
+        const deadline = Date.now() + 2000;
+        return new Promise((resolve) => {
+            const poll = () => {
+                const name = this.lookupVaultNameByDataDir(dataDir);
+                if (name !== "another vault" || Date.now() >= deadline) {
+                    resolve(name);
+                    return;
+                }
+                window.setTimeout(poll, 100);
+            };
+            poll();
+        });
+    }
+
+    /** If another vault owns the shared root, show "serving <vault>" and return true. */
+    private refreshLockedByOtherStatus(): boolean {
+        const registry = this.vaultRegistry;
+        if (!registry) return false;
+        const owner = readScopeOwner(registry.sharedRoot);
+        if (owner === null) return false;
+        const ourDataDir = registry.resolveDataDir(this.vaultId);
+        if (owner.dataDir === ourDataDir) return false;
+        const ownerName = this.lookupVaultNameByDataDir(owner.dataDir);
+        this.updateStatusBar(MESSAGES.STATUS_LOCKED_BY_OTHER(ownerName), DOT_STATE.MUTED);
+        this.setStatusClass("lilbee-status-error");
+        return true;
     }
 
     /**
@@ -999,8 +1029,8 @@ export default class LilbeePlugin extends Plugin {
         let current: Record<string, unknown>;
         try {
             current = await this.api.config();
-        } catch (err) {
-            console.error("[lilbee] could not read server config for vault setup", err);
+        } catch {
+            new Notice(MESSAGES.ERROR_STORAGE_CHECK_FAILED, NOTICE_ERROR_DURATION_MS);
             return true;
         }
         const currentDocs = typeof current.documents_dir === "string" ? current.documents_dir : "";
@@ -1310,6 +1340,10 @@ export default class LilbeePlugin extends Plugin {
                 this.setStatusClass("lilbee-status-starting");
                 break;
             case SERVER_STATE.ERROR:
+                // A clean exit while another vault holds the shared root is a
+                // take-over, not a crash. Show "serving <vault>" instead of
+                // "error" so the loser knows who won without a restart loop.
+                if (this.refreshLockedByOtherStatus()) return;
                 this.updateStatusBar(MESSAGES.STATUS_ERROR, DOT_STATE.ERROR);
                 this.setStatusClass("lilbee-status-error");
                 break;
@@ -1739,8 +1773,8 @@ export default class LilbeePlugin extends Plugin {
         this.syncPillEl = null;
         this.taskQueue.dispose();
         if (this.serverManager) {
-            this.journal.lifecycle("plugin unloading; stopping the managed server");
-            void this.serverManager.stop();
+            this.journal.lifecycle("plugin unloading; killing the managed server before unload");
+            this.serverManager.killChildSync();
         }
     }
 
@@ -1925,12 +1959,10 @@ export default class LilbeePlugin extends Plugin {
                 this.serverManager = null;
             }
             this.configureApi(this.settings.serverUrl);
-            // External mode owns its own status via the health probe; paint
-            // "ready [external]" optimistically so the user doesn't see a
-            // stale "stopped" label between the mode switch and the next
-            // probe tick. If the external server is in fact unreachable,
-            // the probe will flip to error on its next run.
-            this.setStatusReady();
+            // The first successful health probe promotes this to "ready"; until
+            // then the user sees "connecting..." so a non-lilbee server never
+            // briefly claims ready on the strength of a mode switch alone.
+            this.setStatusConnecting();
             void this.fetchActiveModel();
         }
     }
@@ -1957,6 +1989,11 @@ export default class LilbeePlugin extends Plugin {
             "lilbee-status-error",
         );
         if (cls) this.statusBarEl.classList.add(cls);
+    }
+
+    private setStatusConnecting(): void {
+        this.updateStatusBar(MESSAGES.STATUS_CONNECTING, DOT_STATE.PRIMARY);
+        this.setStatusClass("lilbee-status-starting");
     }
 
     private setStatusReady(): void {
@@ -2007,7 +2044,10 @@ export default class LilbeePlugin extends Plugin {
         // every restart, and this is the cheapest way to stay in sync.
         this.api.setToken(this.readCurrentToken());
         const health = await this.api.health().catch(() => null);
-        if (health?.isOk()) {
+        // A 200 with a non-lilbee JSON body (e.g. {}) parses fine but is not a
+        // healthy lilbee server. Only a body carrying status: "ok" counts, so a
+        // foreign HTTP server on the configured URL reads as unreachable.
+        if (health?.isOk() && health.value.status === "ok") {
             this.healthFailureStreak = 0;
             if (this.settings.serverMode === SERVER_MODE.EXTERNAL) this.externalServerVersion = health.value.version;
             // Only a reconnect refetches the model: a restarted server may be on a different one.
@@ -2016,6 +2056,10 @@ export default class LilbeePlugin extends Plugin {
                 void this.fetchActiveModel();
             }
             this.reflectChatStatus(health.value);
+            // reflectChatStatus early-returns when the chat status is unchanged,
+            // so a "connecting..." from a mode switch would never clear. Promote
+            // to ready explicitly after a successful probe.
+            this.setStatusReady();
             return;
         }
         this.healthFailureStreak += 1;
@@ -2025,6 +2069,9 @@ export default class LilbeePlugin extends Plugin {
         // Don't paint a red pill. External mode reports errors normally —
         // it points at a server the user already runs.
         if (this.settings.serverMode === SERVER_MODE.MANAGED && !this.serverEverReady) return;
+        // Another vault holds the shared root: the server was asked to exit,
+        // not down. Show who won and skip the "missing token" notice.
+        if (this.refreshLockedByOtherStatus()) return;
         if (this.serverUnreachable) return;
         this.serverUnreachable = true;
         this.updateStatusBar(MESSAGES.STATUS_ERROR, DOT_STATE.ERROR);
@@ -2212,6 +2259,9 @@ export default class LilbeePlugin extends Plugin {
             return;
         }
 
+        // The catalog search may miss the active model (e.g. it is installed
+        // but not in the featured catalog). Fall back to the first row in the
+        // response, which is close enough for the info modal.
         const repo = extractHfRepo(ref);
         const result = await this.api.catalog({ task, search: repo });
         if (result.isErr()) {

--- a/src/server-manager.ts
+++ b/src/server-manager.ts
@@ -395,6 +395,18 @@ export class ServerManager {
                 this.setState(SERVER_STATE.ERROR);
                 return;
             }
+            // A clean exit (code 0 or SIGTERM) while we still wanted the server
+            // running means another vault asked it to stop via a take-over. Not
+            // a crash: do not restart. The scope sidecar now names the winner,
+            // and main.ts surfaces that as STATUS_LOCKED_BY_OTHER.
+            const exitedCleanly = code === 0 || signal === "SIGTERM";
+            if (exitedCleanly) {
+                this.journal(
+                    `server pid ${child.pid} exited (${describeExit(code, signal)}): another vault took over the shared root`,
+                );
+                this.setState(SERVER_STATE.ERROR);
+                return;
+            }
             this.pushOutputLine(`server exited (${describeExit(code, signal)})`);
             this.journal(`server pid ${child.pid} exited (${describeExit(code, signal)})`);
             this.snapshotCrashOutput();
@@ -724,6 +736,31 @@ export class ServerManager {
             await this.childExit;
         }
         this.journal(`server pid ${child.pid} exit observed after ${Date.now() - stopStartedAt}ms`);
+    }
+
+    /**
+     * Synchronously signal the spawned child's process group to die and remove
+     * its port file. For use in synchronous teardown (onunload) only: it does
+     * not await the process exit. The OS reaps the child; the next plugin
+     * instance finds no stale port and no lock holder, so it spawns fresh.
+     */
+    killChildSync(): void {
+        this.desired = DESIRED.STOPPED;
+        if (this.restartTimer !== null) {
+            window.clearTimeout(this.restartTimer);
+            this.restartTimer = null;
+        }
+        this.stopAdoptedWatch();
+        const child = this.child;
+        this.child = null;
+        this.childExit = null;
+        this.adopted = false;
+        this._actualPort = null;
+        this.cleanupPortFile();
+        this.setState(SERVER_STATE.STOPPED);
+        if (child) {
+            this.signalGroup(child, "SIGKILL");
+        }
     }
 
     /** Ask an adopted server to exit; report when it will not go. */

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2158,29 +2158,46 @@ export class LilbeeSettingTab extends PluginSettingTab {
     }
 
     private rowsWorkerPool(): RowSpec[] {
+        // Each row waits for the server to report its own key: the server rejects
+        // PATCH for unknown keys, so a row the server does not know would only
+        // error. The visible predicate hides it until the key arrives.
         return [
-            this.numberRow(
-                {
-                    key: "worker_pool_call_timeout_s",
-                    name: MESSAGES.LABEL_WORKER_POOL_CALL_TIMEOUT,
-                    desc: MESSAGES.DESC_WORKER_POOL_CALL_TIMEOUT,
-                },
-                { integer: false, min: 0 },
+            this.visibleRow(
+                this.numberRow(
+                    {
+                        key: "worker_pool_call_timeout_s",
+                        name: MESSAGES.LABEL_WORKER_POOL_CALL_TIMEOUT,
+                        desc: MESSAGES.DESC_WORKER_POOL_CALL_TIMEOUT,
+                    },
+                    { integer: false, min: 0 },
+                ),
+                "worker_pool_call_timeout_s",
             ),
-            this.toggleRow({
-                key: "worker_pool_eager_start",
-                name: MESSAGES.LABEL_WORKER_POOL_EAGER_START,
-                desc: MESSAGES.DESC_WORKER_POOL_EAGER_START,
-            }),
-            this.numberRow(
-                {
-                    key: "worker_pool_max_idle_s",
-                    name: MESSAGES.LABEL_WORKER_POOL_MAX_IDLE,
-                    desc: MESSAGES.DESC_WORKER_POOL_MAX_IDLE,
-                },
-                { integer: false, min: 0 },
+            this.visibleRow(
+                this.toggleRow({
+                    key: "worker_pool_eager_start",
+                    name: MESSAGES.LABEL_WORKER_POOL_EAGER_START,
+                    desc: MESSAGES.DESC_WORKER_POOL_EAGER_START,
+                }),
+                "worker_pool_eager_start",
+            ),
+            this.visibleRow(
+                this.numberRow(
+                    {
+                        key: "worker_pool_max_idle_s",
+                        name: MESSAGES.LABEL_WORKER_POOL_MAX_IDLE,
+                        desc: MESSAGES.DESC_WORKER_POOL_MAX_IDLE,
+                    },
+                    { integer: false, min: 0 },
+                ),
+                "worker_pool_max_idle_s",
             ),
         ];
+    }
+
+    /** A row whose visibility tracks whether the server reports *key*. */
+    private visibleRow(row: RowSpec, key: string): RowSpec {
+        return { ...row, visible: () => this.serverReports(key) };
     }
 
     private renderWorkerPoolSettings(containerEl: HTMLElement): void {

--- a/src/utils/warning-remedies.ts
+++ b/src/utils/warning-remedies.ts
@@ -1,0 +1,35 @@
+import type { App } from "obsidian";
+import type { SyncOptions } from "../types";
+import { MESSAGES } from "../locales/en";
+import { ConfirmModal } from "../views/confirm-modal";
+
+/** A server degradation the plugin knows how to fix: what to tell the user, and what the button does. */
+export interface WarningRemedy {
+    text: string;
+    action: () => void;
+}
+
+/** The slice of the plugin a warning-remedy action needs: the app for dialogs and the rebuild entry point. */
+export interface WarningRemedyPlugin {
+    app: App;
+    triggerSync: (options?: SyncOptions) => void | Promise<void>;
+}
+
+/** Codes the plugin can fix itself; every other code falls back to the server's remedy text. */
+const KNOWN_CODES = new Set(["fts_unavailable", "embedding_prefix_mismatch", "stale_index"]);
+
+function rebuildAction(plugin: WarningRemedyPlugin): () => void {
+    return () => {
+        const modal = new ConfirmModal(plugin.app, MESSAGES.CONFIRM_SYNC_REBUILD);
+        modal.open();
+        void modal.result.then((confirmed) => {
+            if (confirmed) void plugin.triggerSync({ forceRebuild: true });
+        });
+    };
+}
+
+/** Map a warning code to a plugin-native remedy, or null when the plugin does not know the code. */
+export function remedyForWarning(code: string, plugin: WarningRemedyPlugin): WarningRemedy | null {
+    if (!KNOWN_CODES.has(code)) return null;
+    return { text: MESSAGES.WARNING_REMEDY_REBUILD, action: rebuildAction(plugin) };
+}

--- a/src/views/catalog-helpers.ts
+++ b/src/views/catalog-helpers.ts
@@ -132,20 +132,21 @@ function forYouSortKey(entry: CatalogEntry): [number, string] {
     return [entry.fit === HARDWARE_FIT.FITS ? 0 : 1, entry.display_name.toLowerCase()];
 }
 
+/** A catalog row a user can run: featured, supported, and not known unrunnable. */
+export function isRunnablePick(entry: CatalogEntry): boolean {
+    return entry.featured && entry.compat === MODEL_COMPAT.SUPPORTED && entry.fit !== HARDWARE_FIT.WONT_RUN;
+}
+
 /**
  * One runnable pick per role, in role order.
  *
  * Featured is not a curated list — the server resolves it from HuggingFace
- * trending at runtime, so a pick is only as safe as its hardware fit. A row
- * qualifies only when the engine supports its architecture and the machine can
- * hold it, which makes every card a one-click install rather than a coin flip.
- * Rows with no fit chip are excluded outright: an unknown size cannot be
- * promised.
+ * trending at runtime, so a pick is only as safe as its hardware fit. Rows with
+ * no fit chip are kept (a failed probe must not empty the rail); only wont_run
+ * and unsupported are excluded.
  */
 export function forYouRail(entries: CatalogEntry[]): CatalogEntry[] {
-    const runnable = entries.filter(
-        (e) => e.featured && e.compat === MODEL_COMPAT.SUPPORTED && e.fit != null && e.fit !== HARDWARE_FIT.WONT_RUN,
-    );
+    const runnable = entries.filter(isRunnablePick);
     const picks: CatalogEntry[] = [];
     for (const task of FOR_YOU_ROLE_ORDER) {
         const best = runnable

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -39,12 +39,13 @@ import type {
 import { RateLimitedError, isHttpStatus } from "../api";
 
 import { renderAggregatedSourceChips } from "./results";
-import { displayLabelForRef, extractHfRepo } from "../utils/model-ref";
+import { displayLabelForRef, extractHfRepo, nativeModelRef } from "../utils/model-ref";
 import { ConfirmPullModal } from "./confirm-pull-modal";
 import { ConfirmModal } from "./confirm-modal";
 import { CatalogModal } from "./catalog-modal";
 import { CrawlModal } from "./crawl-modal";
 import { addCloseButton } from "../components/close-button";
+import { remedyForWarning } from "../utils/warning-remedies";
 import { MESSAGES } from "../locales/en";
 import {
     RETRY_INTERVAL_MS,
@@ -580,14 +581,15 @@ export class ChatView extends ItemView {
     /** Featured rows that have an installed quant, then hosted rows not already listed. */
     private chatPrimaryOptions(): RailOption[] {
         const installedRepos = new Set(this.chatInstalled.map((m) => extractHfRepo(m.name)));
-        const activeRepo = extractHfRepo(this.chatActive);
+        const activeRef = this.chatActive;
         const primary: RailOption[] = [];
         for (const entry of this.chatCatalogEntries.filter((e) => installedRepos.has(e.hf_repo))) {
             const sourceTag = HOSTED_SOURCES.has(entry.source) ? ` [${entry.provider ?? entry.source}]` : "";
+            const ref = nativeModelRef(entry.hf_repo, entry.gguf_filename);
             primary.push({
-                value: entry.hf_repo,
+                value: ref,
                 label: `${entry.display_name}${sourceTag}`,
-                checked: entry.hf_repo === activeRepo,
+                checked: ref === activeRef,
             });
         }
         // Hosted rows (frontier/ollama) are selectable even when absent from the
@@ -596,16 +598,21 @@ export class ChatView extends ItemView {
         // be both hosted and registered as installed).
         for (const [ref, label] of hostedOptions(this.chatCatalogEntries)) {
             if (installedRepos.has(ref)) continue;
-            primary.push({ value: ref, label, checked: ref === activeRepo });
+            primary.push({ value: ref, label, checked: ref === activeRef });
         }
         return primary;
     }
 
-    /** Installed builds that aren't in the featured catalog (manually pulled, ollama/, openai/, …). */
+    /** Installed builds that aren't in the featured catalog (manually pulled, ollama/, openai/, …).
+     *  The server's installedModels endpoint returns models for every task, so filter out
+     *  repos that serve another role — an installed embedding/vision/reranker model must
+     *  not leak into the chat menu. */
     private chatOtherOptions(): RailOption[] {
         const sourceMap = new Map(this.chatInstalled.map((m) => [m.name, m.source]));
         const featuredRepos = new Set(this.chatCatalogEntries.map((e) => e.hf_repo));
+        const nonChatRepos = this.nonChatRepos();
         return this.chatInstalled
+            .filter((m) => !nonChatRepos.has(extractHfRepo(m.name)))
             .filter((m) => !featuredRepos.has(extractHfRepo(m.name)))
             .sort((a, b) => a.name.localeCompare(b.name))
             .map((m) => {
@@ -619,6 +626,16 @@ export class ChatView extends ItemView {
             });
     }
 
+    /** Repos that serve embedding, vision, or reranker roles — never chat. */
+    private nonChatRepos(): Set<string> {
+        const repos = new Set<string>();
+        for (const m of this.embeddingModels) repos.add(m.hf_repo);
+        for (const task of [MODEL_TASK.VISION, MODEL_TASK.RERANK] as const) {
+            for (const m of this.optionalCatalog[task]) repos.add(m.hf_repo);
+        }
+        return repos;
+    }
+
     private openChatMenu(event: MouseEvent): void {
         this.openRailMenu(event, this.chatTriggerTextEl, this.chatOptionGroups(), (value) =>
             this.handleChatSelection(value),
@@ -626,8 +643,8 @@ export class ChatView extends ItemView {
     }
 
     private handleChatSelection(value: string): void {
-        const uninstalled = this.chatCatalogEntries.find((e) => e.hf_repo === value && !e.installed);
-        if (uninstalled) {
+        const uninstalled = this.chatCatalogEntries.find((e) => nativeModelRef(e.hf_repo, e.gguf_filename) === value);
+        if (uninstalled && !uninstalled.installed) {
             const modal = new ConfirmPullModal(this.plugin.app, {
                 displayName: uninstalled.display_name,
                 sizeGb: uninstalled.size_gb,
@@ -650,8 +667,6 @@ export class ChatView extends ItemView {
         void this.plugin.api.setChatModel(value).then((result) => {
             if (result.isOk()) {
                 // Keep the menu's checkmark in sync without waiting for a refetch.
-                // Store what the server resolved, not what was sent: a bare repo
-                // comes back as the concrete quant it picked.
                 this.chatActive = result.value.model;
                 this.plugin.activeModel = result.value.model;
                 void this.plugin.fetchActiveModel();
@@ -1280,7 +1295,12 @@ export class ChatView extends ItemView {
                 break;
             }
             case SSE_EVENT.SOURCES:
-                state.sources.push(...(event.data as Source[]));
+                // A malformed frame can carry an object ({sources: []}) instead
+                // of an array; spreading that throws a TypeError that replaces
+                // the answer. Ignore frames that are not arrays.
+                if (Array.isArray(event.data)) {
+                    state.sources.push(...(event.data as Source[]));
+                }
                 break;
             case SSE_EVENT.DONE: {
                 revealContent();
@@ -1492,7 +1512,17 @@ export class ChatView extends ItemView {
         for (const w of this.plugin.healthWarnings) {
             const row = el.createDiv({ cls: "lilbee-chat-warning" });
             row.createSpan({ cls: "lilbee-chat-warning-message", text: w.message });
-            if (w.remedy) row.createSpan({ cls: "lilbee-chat-warning-remedy", text: w.remedy });
+            const remedy = remedyForWarning(w.code, this.plugin);
+            if (remedy) {
+                row.createSpan({ cls: "lilbee-chat-warning-remedy", text: remedy.text });
+                const btn = row.createEl("button", {
+                    text: MESSAGES.BUTTON_REBUILD_INDEX,
+                    cls: "lilbee-chat-warning-action",
+                });
+                btn.addEventListener("click", remedy.action);
+            } else if (w.remedy) {
+                row.createSpan({ cls: "lilbee-chat-warning-remedy", text: w.remedy });
+            }
         }
     }
 

--- a/src/views/documents-modal.ts
+++ b/src/views/documents-modal.ts
@@ -84,8 +84,8 @@ export class DocumentsModal extends Modal {
         const confirmed = await confirm.result;
         if (!confirmed) return;
         try {
-            const result = await this.plugin.api.removeDocuments(names);
-            new Notice(MESSAGES.NOTICE_DELETED(result.removed));
+            await this.plugin.api.removeDocuments(names);
+            new Notice(MESSAGES.NOTICE_DELETED(names.length));
             this.resetAndFetch();
         } catch {
             new Notice(MESSAGES.ERROR_DELETE_DOCUMENTS);

--- a/src/views/status-modal.ts
+++ b/src/views/status-modal.ts
@@ -4,6 +4,7 @@ import { MANAGED_DOCS_PREFIX, type ModelShowResponse, type StatusResponse } from
 import { DocumentList } from "../components/document-list";
 import { MESSAGES } from "../locales/en";
 import { bindEscapeToClose, noticeForResultError, revealInFileExplorer } from "../utils";
+import { remedyForWarning } from "../utils/warning-remedies";
 
 export class StatusModal extends Modal {
     private plugin: LilbeePlugin;
@@ -54,7 +55,15 @@ export class StatusModal extends Modal {
         for (const w of warnings) {
             const row = section.createDiv({ cls: "lilbee-status-warning" });
             row.createDiv({ cls: "lilbee-status-warning-message", text: w.message });
-            if (w.remedy) {
+            const remedy = remedyForWarning(w.code, this.plugin);
+            if (remedy) {
+                row.createDiv({ cls: "lilbee-status-warning-remedy", text: remedy.text });
+                const btn = row.createEl("button", {
+                    text: MESSAGES.BUTTON_REBUILD_INDEX,
+                    cls: "lilbee-status-warning-action",
+                });
+                btn.addEventListener("click", remedy.action);
+            } else if (w.remedy) {
                 row.createDiv({ cls: "lilbee-status-warning-remedy", text: w.remedy });
             }
         }

--- a/tests/main-shared.test.ts
+++ b/tests/main-shared.test.ts
@@ -642,12 +642,12 @@ describe("startManagedServer guards", () => {
 });
 
 describe("onunload", () => {
-    it("stops the managed server", async () => {
+    it("kills the managed server synchronously on unload", async () => {
         const plugin = await createPlugin();
-        const stop = vi.fn().mockResolvedValue(undefined);
-        (plugin as any).serverManager = { stop };
+        const killChildSync = vi.fn();
+        (plugin as any).serverManager = { killChildSync };
         plugin.onunload();
-        expect(stop).toHaveBeenCalled();
+        expect(killChildSync).toHaveBeenCalled();
     });
 });
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -55,7 +55,7 @@ vi.mock("../src/api", async (importOriginal) => ({
             setTokenProvider: vi.fn(),
             setOutcomeCallback: vi.fn(),
             setBaseUrl: vi.fn(),
-            health: vi.fn().mockResolvedValue({ isErr: () => false, isOk: () => true, value: {} }),
+            health: vi.fn().mockResolvedValue({ isErr: () => false, isOk: () => true, value: { status: "ok" } }),
             // Default config matches the test vault layout so the fire-and-forget
             // configureManagedStorage() in startManagedServer() hits the early
             // no-op exit instead of throwing on a missing method.
@@ -226,6 +226,7 @@ vi.mock("../src/views/update-available-modal", () => ({
 const mockGatekeeperOpen = vi.fn();
 const mockServerStart = vi.fn().mockResolvedValue(undefined);
 const mockServerStop = vi.fn().mockResolvedValue(undefined);
+const mockServerKillChildSync = vi.fn();
 let mockServerOpts: any = null;
 
 vi.mock("../src/server-binary", () => ({
@@ -292,6 +293,7 @@ vi.mock("../src/server-manager", () => ({
         return {
             start: mockServerStart,
             stop: mockServerStop,
+            killChildSync: mockServerKillChildSync,
             restart: vi.fn(),
             get isAdopted() {
                 return mockIsAdopted;
@@ -934,10 +936,10 @@ describe("LilbeePlugin", () => {
             );
         });
 
-        it("sets status bar text to 'lilbee: ready [external]' in external mode", async () => {
+        it("sets status bar text to 'lilbee: connecting...' in external mode after onload", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
-            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready [external]");
+            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: connecting...");
         });
 
         it("registers vault watchers for the pending-sync hint plus the file-menu listener", async () => {
@@ -3812,15 +3814,19 @@ describe("LilbeePlugin", () => {
             await plugin.onload();
             expect(plugin.serverSupportsSessions()).toBe(true);
 
-            plugin.api.health = vi
-                .fn()
-                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { version: "0.6.66b507" } });
+            plugin.api.health = vi.fn().mockResolvedValue({
+                isErr: () => false,
+                isOk: () => true,
+                value: { status: "ok", version: "0.6.66b507" },
+            });
             await (plugin as any).probeServerHealth();
             expect(plugin.serverSupportsSessions()).toBe(false);
 
-            plugin.api.health = vi
-                .fn()
-                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { version: "0.6.90b420" } });
+            plugin.api.health = vi.fn().mockResolvedValue({
+                isErr: () => false,
+                isOk: () => true,
+                value: { status: "ok", version: "0.6.90b420" },
+            });
             await (plugin as any).probeServerHealth();
             expect(plugin.serverSupportsSessions()).toBe(true);
         });
@@ -3829,11 +3835,28 @@ describe("LilbeePlugin", () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             vi.spyOn(plugin, "ensureManagedConsentThenStart").mockResolvedValue({ kind: "canceled" } as any);
             await plugin.onload();
-            plugin.api.health = vi
-                .fn()
-                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { version: "0.6.66b507" } });
+            plugin.api.health = vi.fn().mockResolvedValue({
+                isErr: () => false,
+                isOk: () => true,
+                value: { status: "ok", version: "0.6.66b507" },
+            });
             await (plugin as any).probeServerHealth();
             expect((plugin as any).externalServerVersion).toBe("");
+        });
+
+        it("probe with non-ready chat status skips setStatusReady", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            (plugin as any).chatStatus = CHAT_STATUS.LOADING;
+            plugin.api.health = vi.fn().mockResolvedValue({
+                isErr: () => false,
+                isOk: () => true,
+                value: { status: "ok", chat_ready: false },
+            });
+            await (plugin as any).probeServerHealth();
+            // Chat is loading: reflectChatStatus paints "warming..." and the
+            // probe must not override it with "ready".
+            expect((plugin.statusBarEl as any)?.textContent).not.toContain("ready");
         });
     });
 
@@ -4829,8 +4852,10 @@ describe("LilbeePlugin", () => {
             await (plugin as any).probeServerHealth();
             expect((plugin.statusBarEl as any)?.textContent).toContain("error");
 
-            // Recovery: health() resolves Ok.
-            plugin.api.health = vi.fn().mockResolvedValue({ isErr: () => false, isOk: () => true, value: {} });
+            // Recovery: health() resolves Ok with status: "ok".
+            plugin.api.health = vi
+                .fn()
+                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { status: "ok" } });
             plugin.api.listModels = vi
                 .fn()
                 .mockResolvedValue({ chat: { active: "qwen3:4b", catalog: [], installed: [] } });
@@ -4926,7 +4951,7 @@ describe("LilbeePlugin", () => {
             plugin.activeModel = "old";
             plugin.api.health = vi
                 .fn()
-                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { chat_ready: true } });
+                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { status: "ok", chat_ready: true } });
             plugin.api.listModels = vi
                 .fn()
                 .mockResolvedValue({ chat: { active: "Qwen3-235B", catalog: [], installed: [] } });
@@ -4940,7 +4965,9 @@ describe("LilbeePlugin", () => {
             await plugin.onload();
             plugin.api.health = vi.fn().mockResolvedValue(err(new Error("down")));
             await (plugin as any).probeServerHealth();
-            plugin.api.health = vi.fn().mockResolvedValue({ isErr: () => false, isOk: () => true, value: {} });
+            plugin.api.health = vi
+                .fn()
+                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { status: "ok" } });
             plugin.api.listModels = vi
                 .fn()
                 .mockResolvedValue({ chat: { active: "qwen3:4b", catalog: [], installed: [] } });
@@ -4989,6 +5016,33 @@ describe("LilbeePlugin", () => {
             (plugin as any).healthFailureStreak = 5;
             await (plugin as any).probeServerHealth();
             expect((plugin.statusBarEl as any)?.textContent ?? "").not.toContain("error");
+        });
+
+        it("treats a 200 with a non-lilbee JSON body as a probe failure", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            // A 2020 with {} (no status: "ok") is not a lilbee server — the
+            // probe must treat it as unreachable, not ready.
+            plugin.api.health = vi.fn().mockResolvedValue({ isErr: () => false, isOk: () => true, value: {} });
+            await (plugin as any).probeServerHealth();
+            await (plugin as any).probeServerHealth();
+            expect((plugin.statusBarEl as any)?.textContent).toContain("error");
+        });
+
+        it("promotes to ready only after a probe reports status ok", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            // After onload the status is "connecting...", not "ready".
+            expect((plugin.statusBarEl as any)?.textContent).toBe("lilbee: connecting...");
+            plugin.api.health = vi
+                .fn()
+                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { status: "ok" } });
+            plugin.api.listModels = vi
+                .fn()
+                .mockResolvedValue({ chat: { active: "qwen3:4b", catalog: [], installed: [] } });
+            plugin.api.status = vi.fn().mockResolvedValue(err(new Error("down")));
+            await (plugin as any).probeServerHealth();
+            expect((plugin.statusBarEl as any)?.textContent).toContain("ready");
         });
 
         it("skips probing while a chat stream is in flight", async () => {
@@ -5318,7 +5372,7 @@ describe("LilbeePlugin", () => {
             await new Promise((r) => setTimeout(r, 0));
 
             expect(plugin.activeModel).toBe("");
-            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready [external]");
+            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: connecting...");
         });
 
         it("turns show_reasoning on the first time the server reports it off, then never again", async () => {
@@ -5924,6 +5978,7 @@ describe("LilbeePlugin", () => {
         it("setStatusReady adds lilbee-status-ready class", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
+            (plugin as any).setStatusReady();
 
             const el = (plugin as any).statusBarEl!;
             expect(el.classList.contains("lilbee-status-ready")).toBe(true);
@@ -6624,6 +6679,75 @@ describe("LilbeePlugin", () => {
             expect(plugin.statusBarEl?.classList.contains("lilbee-status-error")).toBe(true);
         });
 
+        it("handleServerStateChange error shows STATUS_LOCKED_BY_OTHER when another vault owns the root", async () => {
+            const sm = await import("../src/server-manager");
+            vi.mocked(sm.readScopeOwner).mockReturnValue({
+                dataDir: "/shared/vaults/other",
+                pid: 999,
+            });
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const stateChange = mockServerOpts?.onStateChange;
+            stateChange("error");
+
+            expect(plugin.statusBarEl?.textContent).toContain("serving");
+            expect(plugin.statusBarEl?.textContent).not.toContain("error");
+        });
+
+        it("refreshLockedByOtherStatus returns false when no foreign owner", async () => {
+            const sm = await import("../src/server-manager");
+            vi.mocked(sm.readScopeOwner).mockReturnValue(null);
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            expect((plugin as any).refreshLockedByOtherStatus()).toBe(false);
+        });
+
+        it("refreshLockedByOtherStatus returns false without a registry", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            (plugin as any).vaultRegistry = null;
+            expect((plugin as any).refreshLockedByOtherStatus()).toBe(false);
+        });
+
+        it("refreshLockedByOtherStatus returns false when we own the root", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const sm = await import("../src/server-manager");
+            const ourDataDir = (plugin as any).vaultRegistry.resolveDataDir((plugin as any).vaultId);
+            vi.mocked(sm.readScopeOwner).mockReturnValue({ dataDir: ourDataDir, pid: 1 });
+
+            expect((plugin as any).refreshLockedByOtherStatus()).toBe(false);
+        });
+
+        it("health probe shows STATUS_LOCKED_BY_OTHER and skips token notice", async () => {
+            const sm = await import("../src/server-manager");
+            vi.mocked(sm.readScopeOwner).mockReturnValue({
+                dataDir: "/shared/vaults/other",
+                pid: 999,
+            });
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+            // Make the health probe fail so it reaches the locked-by-other check.
+            plugin.api.health = vi.fn().mockResolvedValue({ isOk: () => false, isErr: () => true });
+            (plugin as any).serverEverReady = true;
+            (plugin as any).healthFailureStreak = 1;
+            await (plugin as any).probeServerHealth();
+
+            expect(plugin.statusBarEl?.textContent).toContain("serving");
+            expect(Notice.instances.some((n) => n.message.includes("session token"))).toBe(false);
+        });
+
         it("handleServerStateChange ready re-renders an open lilbee Settings tab (ydt)", async () => {
             const { LilbeeSettingTab } = await import("../src/settings");
             const plugin = await createPlugin({ serverMode: "managed" });
@@ -6923,6 +7047,78 @@ describe("LilbeePlugin", () => {
             expect(el.classList.contains("lilbee-status-ready")).toBe(false);
             expect(el.classList.contains("lilbee-status-downloading")).toBe(false);
         });
+
+        it("take-over prompt resolves the owner name from the registry", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const registry = (plugin as any).vaultRegistry;
+            vi.spyOn(registry, "list").mockReturnValue([
+                {
+                    id: "other",
+                    displayName: "vault-new",
+                    dataDir: "/shared/vaults/other",
+                    obsidianVaultPath: "/path/to/other",
+                    addedAt: 0,
+                    lastActiveAt: 0,
+                },
+            ]);
+            vi.spyOn(registry, "resolveDataDir").mockImplementation((id) =>
+                id === "other" ? "/shared/vaults/other" : registry.resolveDataDir(id),
+            );
+
+            const name = await (plugin as any).resolveOwnerName("/shared/vaults/other");
+            expect(name).toBe("vault-new");
+        });
+
+        it("take-over prompt falls back to 'another vault' when unregistered", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const name = await (plugin as any).resolveOwnerName("/shared/vaults/unknown");
+            expect(name).toBe("another vault");
+        });
+
+        it("take-over prompt shows STATUS_LOCKED_BY_OTHER while waiting, not 'error'", async () => {
+            const sm = await import("../src/server-manager");
+            vi.mocked(sm.readScopeOwner).mockReturnValue({
+                dataDir: "/shared/vaults/other",
+                pid: 1234,
+            });
+            mockConfirmModalResult = false;
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const registry = (plugin as any).vaultRegistry;
+            vi.spyOn(registry, "list").mockReturnValue([
+                {
+                    id: "other",
+                    displayName: "vault-new",
+                    dataDir: "/shared/vaults/other",
+                    obsidianVaultPath: "/path/to/other",
+                    addedAt: 0,
+                    lastActiveAt: 0,
+                },
+            ]);
+            vi.spyOn(registry, "resolveDataDir").mockImplementation((id) =>
+                id === "other" ? "/shared/vaults/other" : registry.resolveDataDir(id),
+            );
+
+            await (plugin as any).negotiateTakeOver(
+                (plugin as any).vaultRegistry,
+                undefined,
+                true,
+                "/shared/vaults/other",
+            );
+
+            const el = (plugin as any).statusBarEl!;
+            expect(el.textContent).toContain("serving");
+            expect(el.textContent).not.toContain("error");
+        });
     });
 
     describe("saveSettings mode switching", () => {
@@ -6956,7 +7152,7 @@ describe("LilbeePlugin", () => {
             expect(mockEnsure).toHaveBeenCalled();
         });
 
-        it("2rf: managed → external sets status to 'ready [external]', not 'stopped'", async () => {
+        it("2rf: managed → external sets status to 'connecting...', not 'stopped'", async () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
             await flush();
@@ -6966,7 +7162,7 @@ describe("LilbeePlugin", () => {
             await flush();
 
             const text = (plugin as any).statusBarEl?.textContent ?? "";
-            expect(text).toContain("[external]");
+            expect(text).toContain("connecting");
             expect(text).not.toContain("stopped");
         });
 
@@ -6988,7 +7184,7 @@ describe("LilbeePlugin", () => {
 
             const text = (plugin as any).statusBarEl?.textContent ?? "";
             expect(text).not.toContain("stopped");
-            expect(text).toContain("[external]");
+            expect(text).toContain("connecting");
         });
     });
 
@@ -7226,23 +7422,24 @@ describe("LilbeePlugin", () => {
     });
 
     describe("onunload with serverManager", () => {
-        it("calls serverManager.stop on unload", async () => {
+        it("calls serverManager.killChildSync on unload, not the async stop", async () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
             await flush();
 
-            mockServerStop.mockClear();
+            mockServerKillChildSync.mockClear();
             plugin.onunload();
 
-            expect(mockServerStop).toHaveBeenCalled();
+            expect(mockServerKillChildSync).toHaveBeenCalled();
+            expect(mockServerStop).not.toHaveBeenCalled();
         });
     });
 
     describe("external mode status bar label", () => {
-        it("shows [external] in external mode", async () => {
+        it("shows 'connecting...' in external mode after onload", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
-            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready [external]");
+            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: connecting...");
         });
 
         it("does not show [external] in managed mode", async () => {

--- a/tests/server-manager.test.ts
+++ b/tests/server-manager.test.ts
@@ -842,6 +842,28 @@ describe("ServerManager", () => {
             expect(mgr.state).toBe("ready");
         });
 
+        it("a clean exit (SIGTERM) is a take-over, not a crash: no restart", async () => {
+            const journal: string[] = [];
+            const mgr = await startFresh({ onJournal: (m) => journal.push(m) });
+            child()._emit("exit", null, "SIGTERM");
+            expect(mgr.state).toBe("error");
+            expect(journal.join("\n")).toContain("another vault took over");
+            // No crash snapshot, no restart scheduled.
+            expect(appendFileSyncSpy).not.toHaveBeenCalled();
+            await vi.advanceTimersByTimeAsync(3000);
+            expect(spawnSpy).toHaveBeenCalledTimes(1); // no restart
+        });
+
+        it("a clean exit (code 0) is a take-over, not a crash: no restart", async () => {
+            const journal: string[] = [];
+            const mgr = await startFresh({ onJournal: (m) => journal.push(m) });
+            child()._emit("exit", 0, null);
+            expect(mgr.state).toBe("error");
+            expect(journal.join("\n")).toContain("another vault took over");
+            await vi.advanceTimersByTimeAsync(3000);
+            expect(spawnSpy).toHaveBeenCalledTimes(1); // no restart
+        });
+
         it("a signal exit is described by its signal", async () => {
             const mgr = await startFresh();
             child()._emit("exit", null, "SIGSEGV");
@@ -1240,6 +1262,73 @@ describe("ServerManager", () => {
             await stopP;
             expect(mgr.state).toBe("stopped");
             expect(failures).toHaveLength(1);
+        });
+    });
+
+    // ── killChildSync ───────────────────────────────────────────────
+
+    describe("killChildSync", () => {
+        it("sends SIGKILL to the child and cleans up the port file, synchronously", async () => {
+            const mgr = await startFresh();
+            const c = child();
+            expect(mgr.state).toBe("ready");
+
+            mgr.killChildSync();
+
+            expect(c.kill).toHaveBeenCalledWith("SIGKILL");
+            expect(unlinkSyncSpy).toHaveBeenCalled();
+            expect(mgr.state).toBe("stopped");
+            expect(mgr.serverUrl).toBe("");
+        });
+
+        it("signals the process group when the group exists", async () => {
+            processKillSpy.mockImplementation(() => true);
+            const mgr = await startFresh();
+            const c = child();
+
+            mgr.killChildSync();
+
+            expect(processKillSpy).toHaveBeenCalledWith(-c.pid, "SIGKILL");
+        });
+
+        it("is a no-op when nothing is running", () => {
+            const mgr = new ServerManager(defaultOpts());
+            expect(() => mgr.killChildSync()).not.toThrow();
+            expect(mgr.state).toBe("stopped");
+        });
+
+        it("clears the restart timer so a queued restart does not fire after unload", async () => {
+            const mgr = await startFresh();
+            const c = child();
+            (mgr as any).restartTimer = 42;
+
+            mgr.killChildSync();
+
+            expect((mgr as any).restartTimer).toBeNull();
+            expect(c.kill).toHaveBeenCalledWith("SIGKILL");
+        });
+
+        it("cleans up an adopted server's state without killing anything", async () => {
+            readFileSyncSpy.mockImplementation(fileRouter("present"));
+            const mgr = new ServerManager(defaultOpts());
+            await mgr.start();
+            expect(mgr.isAdopted).toBe(true);
+
+            mgr.killChildSync();
+
+            expect(mgr.isAdopted).toBe(false);
+            expect(mgr.serverUrl).toBe("");
+            expect(unlinkSyncSpy).toHaveBeenCalled();
+        });
+
+        it("returns without awaiting — the child exit is not required to proceed", async () => {
+            const mgr = await startFresh();
+            const c = child();
+            // kill does NOT trigger an exit event; killChildSync still returns.
+            c.kill.mockImplementation(() => true);
+
+            expect(() => mgr.killChildSync()).not.toThrow();
+            expect(c.kill).toHaveBeenCalledWith("SIGKILL");
         });
     });
 

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -1112,6 +1112,35 @@ describe("ChatView.sendMessage — sources", () => {
         expect(assistantBubble.find("lilbee-chat-sources")).toBeNull();
     });
 
+    it("ignores a malformed sources frame without replacing the answer", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const { mockFn, done } = makeStream([
+            { event: SSE_EVENT.TOKEN, data: "Partial answer" },
+            // Malformed: object instead of array
+            { event: SSE_EVENT.SOURCES, data: { sources: [] } },
+            { event: SSE_EVENT.DONE, data: {} },
+        ]);
+        plugin.api.chatStream = mockFn;
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const messagesEl = container.find("lilbee-chat-messages")!;
+        const textarea = container.find("lilbee-chat-textarea")!;
+        textarea.value = "malformed sources";
+
+        container.find("lilbee-chat-send")!.trigger("click");
+        await done;
+        await tick();
+        await tick();
+
+        const assistantBubble = messagesEl.children[1];
+        const textEl = assistantBubble.find("lilbee-chat-content");
+        // The answer must show the tokens, not a TypeError.
+        expect(textEl!.textContent).toContain("Partial answer");
+        expect(textEl!.textContent).not.toContain("TypeError");
+    });
+
     it("pushes assistant message into history after done event", async () => {
         Notice.clear();
         const plugin = makePlugin();
@@ -2574,7 +2603,7 @@ describe("ChatView — toolbar groups and tooltips", () => {
 });
 
 describe("ChatView health warnings", () => {
-    it("shows a server-reported degradation with its remedy", async () => {
+    it("renders a plugin-native remedy with an action button for a known code", async () => {
         const plugin = makePlugin();
         plugin.healthWarnings = [
             { code: "fts_unavailable", message: "Keyword search is unavailable.", remedy: "Run rebuild." },
@@ -2587,7 +2616,69 @@ describe("ChatView health warnings", () => {
         const container = view.containerEl.children[1] as unknown as MockElement;
         const text = container.textContent ?? "";
         expect(text).toContain("Keyword search is unavailable.");
-        expect(text).toContain("Run rebuild.");
+        expect(text).toContain("Rebuild the index");
+        expect(text).toContain("Rebuild index");
+        // The server's CLI remedy is not shown for codes the plugin knows.
+        expect(text).not.toContain("Run rebuild.");
+        expect(container.find("lilbee-chat-warning-action")).not.toBeNull();
+    });
+
+    it("falls back to the server remedy for an unknown code", async () => {
+        const plugin = makePlugin();
+        plugin.healthWarnings = [
+            { code: "some_future_warning", message: "Something is degraded.", remedy: "Server says do X." },
+        ];
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const text = container.textContent ?? "";
+        expect(text).toContain("Something is degraded.");
+        expect(text).toContain("Server says do X.");
+        expect(container.find("lilbee-chat-warning-action")).toBeNull();
+    });
+
+    it("triggers a rebuild when the remedy action button is clicked", async () => {
+        confirmModalResult = true;
+        const plugin = makePlugin();
+        plugin.healthWarnings = [
+            { code: "embedding_prefix_mismatch", message: "Index/embedder mismatch.", remedy: "Run rebuild." },
+        ];
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const btn = container.find("lilbee-chat-warning-action");
+        expect(btn).not.toBeNull();
+        btn!.trigger("click");
+        await tick();
+        await tick();
+
+        expect(plugin.triggerSync).toHaveBeenCalledWith({ forceRebuild: true });
+    });
+
+    it("does not rebuild when the user dismisses the confirm dialog", async () => {
+        confirmModalResult = false;
+        const plugin = makePlugin();
+        plugin.healthWarnings = [{ code: "stale_index", message: "Index is stale.", remedy: "Run rebuild." }];
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const btn = container.find("lilbee-chat-warning-action");
+        expect(btn).not.toBeNull();
+        btn!.trigger("click");
+        await tick();
+        await tick();
+
+        expect(plugin.triggerSync).not.toHaveBeenCalled();
+        confirmModalResult = true;
     });
 
     it("is a no-op on a view whose onOpen has not run", () => {
@@ -6171,5 +6262,85 @@ describe("ChatView — resume interactions with live state", () => {
 
         expect(plugin.settings.searchChunkType).toBe("all");
         expect(plugin.saveSettings).not.toHaveBeenCalled();
+    });
+});
+
+describe("ChatView — chat menu filters out non-chat models", () => {
+    function makeView() {
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        // Seed the view's internal state as fetchAndFillSelectors would.
+        // Qwen is in the catalog (featured); Llama is manually pulled (not in catalog).
+        (view as any).chatActive = "bartowski/Llama-3.2-1B-Instruct-GGUF/Llama-3.2-1B-Instruct-Q4_K_M.gguf";
+        (view as any).chatCatalogEntries = [
+            { hf_repo: "Qwen/Qwen3-4B-GGUF", display_name: "Qwen3 4B", source: "native", task: "chat" },
+        ];
+        (view as any).chatInstalled = [
+            { name: "Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf", source: "native" },
+            { name: "bartowski/Llama-3.2-1B-Instruct-GGUF/Llama-3.2-1B-Instruct-Q4_K_M.gguf", source: "native" },
+            { name: "BAAI/bge-small-en-v1.5-GGUF/bge-small-en-v1.5.Q4_K_M.gguf", source: "native" },
+        ];
+        (view as any).embeddingModels = [
+            { hf_repo: "BAAI/bge-small-en-v1.5-GGUF", display_name: "BGE Small", source: "native", task: "embedding" },
+        ];
+        (view as any).optionalCatalog = { vision: [], rerank: [] };
+        return view;
+    }
+
+    it("includes manually-pulled chat models but excludes embedding models", () => {
+        const view = makeView();
+        const options = (view as any).chatOtherOptions();
+        const repos = options.map((o: { value: string }) => o.value);
+        // Llama is installed but not in the featured catalog → appears in chatOtherOptions.
+        expect(repos).toContain("bartowski/Llama-3.2-1B-Instruct-GGUF/Llama-3.2-1B-Instruct-Q4_K_M.gguf");
+        // BGE is an embedding model → excluded from chat menu.
+        expect(repos).not.toContain("BAAI/bge-small-en-v1.5-GGUF/bge-small-en-v1.5.Q4_K_M.gguf");
+        // Qwen is in the featured catalog → appears in chatPrimaryOptions, not here.
+        expect(repos).not.toContain("Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf");
+    });
+
+    it("excludes installed vision and reranker models from the chat menu", () => {
+        const view = makeView();
+        (view as any).optionalCatalog = {
+            vision: [
+                { hf_repo: "vikhyatk/moondream2-GGUF", display_name: "Moondream", source: "native", task: "vision" },
+            ],
+            rerank: [],
+        };
+        (view as any).chatInstalled.push({ name: "vikhyatk/moondream2-GGUF/moondream2.Q4_K_M.gguf", source: "native" });
+        const options = (view as any).chatOtherOptions();
+        const repos = options.map((o: { value: string }) => o.value);
+        expect(repos).not.toContain("vikhyatk/moondream2-GGUF/moondream2.Q4_K_M.gguf");
+    });
+});
+
+describe("ChatView chat rail activates by concrete ref", () => {
+    function makeView() {
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        (view as any).chatActive = "Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf";
+        (view as any).chatCatalogEntries = [
+            {
+                hf_repo: "Qwen/Qwen3-4B-GGUF",
+                gguf_filename: "Qwen3-4B-Q4_K_M.gguf",
+                display_name: "Qwen3 4B",
+                source: "native",
+                task: "chat",
+            },
+        ];
+        (view as any).chatInstalled = [{ name: "Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf", source: "native" }];
+        return view;
+    }
+
+    it("sends the concrete file ref, not the bare repo", () => {
+        const view = makeView();
+        const options = (view as any).chatPrimaryOptions();
+        expect(options[0].value).toBe("Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf");
+    });
+
+    it("marks the installed quant as checked", () => {
+        const view = makeView();
+        const options = (view as any).chatPrimaryOptions();
+        expect(options[0].checked).toBe(true);
     });
 });

--- a/tests/views/documents-modal.test.ts
+++ b/tests/views/documents-modal.test.ts
@@ -236,6 +236,32 @@ describe("DocumentsModal", () => {
         expect(Notice.instances.some((n) => n.message.includes("removed 1"))).toBe(true);
     });
 
+    it("notice prints the count, not the file name", async () => {
+        vi.useRealTimers();
+        const plugin = makePlugin();
+        plugin.api.listDocuments.mockResolvedValue(makeDocsResponse([makeDoc({ filename: "a.md" })]));
+        // Server returns a string in removed (the file name), not a number
+        plugin.api.removeDocuments.mockResolvedValue({ removed: "a.md", not_found: [] });
+        const app = new App();
+        const modal = new DocumentsModal(app as any, plugin as any);
+        modal.open();
+        await tick();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const checkbox = el.findAll("lilbee-documents-checkbox")[0];
+        (checkbox as any).checked = true;
+        checkbox.trigger("change");
+
+        const removeBtn = el.find("lilbee-documents-remove")!;
+        removeBtn.trigger("click");
+        await tick();
+        await tick();
+
+        // The notice must show the count (1), not the file name
+        expect(Notice.instances.some((n) => n.message.includes("removed 1"))).toBe(true);
+        expect(Notice.instances.some((n) => n.message.includes("a.md"))).toBe(false);
+    });
+
     it("confirms removal from the index and promises the files on disk survive", async () => {
         vi.useRealTimers();
         vi.mocked(ConfirmModal).mockClear();

--- a/tests/views/status-modal.test.ts
+++ b/tests/views/status-modal.test.ts
@@ -159,7 +159,7 @@ describe("StatusModal", () => {
         expect(cell?.attributes["title"]).toBe("Smoffyy/Gemma4-E4B-Instruct-Pure-GGUF/Gemma4-E4B-F16.gguf");
     });
 
-    it("lists server-reported degradations with their remedies", async () => {
+    it("renders a plugin-native remedy with an action button for a known code", async () => {
         const plugin = makePlugin();
         (plugin as any).healthWarnings = [
             { code: "fts_unavailable", message: "Keyword search is unavailable.", remedy: "Run rebuild." },
@@ -169,11 +169,32 @@ describe("StatusModal", () => {
 
         const modal = new StatusModal(new App(), plugin);
         modal.open();
+        const content = (modal as any).contentEl as MockElement;
         await vi.waitFor(() => {
-            const content = (modal as any).contentEl as MockElement;
             expect(content.textContent ?? "").toContain("Keyword search is unavailable.");
         });
-        expect(((modal as any).contentEl as MockElement).textContent ?? "").toContain("Run rebuild.");
+        expect(content.textContent ?? "").toContain("Rebuild the index");
+        expect(content.textContent ?? "").toContain("Rebuild index");
+        expect(content.textContent ?? "").not.toContain("Run rebuild.");
+        expect(content.find("lilbee-status-warning-action")).not.toBeNull();
+    });
+
+    it("falls back to the server remedy for an unknown code", async () => {
+        const plugin = makePlugin();
+        (plugin as any).healthWarnings = [
+            { code: "some_future_warning", message: "Something is degraded.", remedy: "Server says do X." },
+        ];
+        (plugin.api.status as ReturnType<typeof vi.fn>).mockResolvedValue(ok(makeStatus()));
+        (plugin.api.showModel as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+        const modal = new StatusModal(new App(), plugin);
+        modal.open();
+        const content = (modal as any).contentEl as MockElement;
+        await vi.waitFor(() => {
+            expect(content.textContent ?? "").toContain("Something is degraded.");
+        });
+        expect(content.textContent ?? "").toContain("Server says do X.");
+        expect(content.find("lilbee-status-warning-action")).toBeNull();
     });
 
     it("omits the remedy line when the server sends none", async () => {


### PR DESCRIPTION
## Problem

A sweep of user-facing surfaces found defects in the setup wizard, chat rail, server lifecycle, health warnings, and streaming. Each fix addresses a specific failure found during operator testing.

## Solution

- The wizard chat and embedding pickers now pre-select the server active model and skip hosted frontier rows with no key
- The chat rail menu filters out embedding, vision, and reranker models
- The chat rail activates by concrete file ref instead of bare repo
- onunload synchronously kills the managed server process group instead of firing an async stop that cannot finish before unload
- External mode validates status: "ok" before reporting ready
- A take-over prompt resolves the owner name from the registry and shows the locked-by-other status
- A clean server exit (SIGTERM) is treated as a take-over, not a crash
- Known health warning codes map to plugin-native remedy text with a rebuild action
- Worker-pool settings rows stay hidden until the server reports their keys
- A chat stream that closes without done is reported as interrupted
- A malformed sources frame no longer replaces the answer with a TypeError
- The picks filter is consolidated into a shared predicate used by both the wizard and the catalog
- A failed storage check shows a user-facing notice instead of logging to console
- Model info commands fall back to showModel when the catalog search misses
- Hosted catalog models offer Use only, not Delete, and do not read Installed (shared)

## Notes

Closes #284, #285, #286, #287, #288, #289, #290, #292, #300, #302, #304, #308, #309, #310, #311