### PR TITLE
Operator surface: catalog, em dashes, settings search

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -686,6 +686,7 @@ export class LilbeeClient {
         installed?: boolean;
         limit?: number;
         offset?: number;
+        signal?: AbortSignal;
     }): Promise<Result<CatalogResponse, Error>> {
         const qs = new URLSearchParams();
         if (params?.task) qs.set("task", params.task);
@@ -697,7 +698,9 @@ export class LilbeeClient {
         if (params?.limit !== undefined) qs.set("limit", String(params.limit));
         if (params?.offset !== undefined) qs.set("offset", String(params.offset));
         const suffix = qs.toString() ? `?${qs}` : "";
-        return this.fetchResult<CatalogResponse>(`${this.baseUrl}/api/models/catalog${suffix}`);
+        return this.fetchResult<CatalogResponse>(`${this.baseUrl}/api/models/catalog${suffix}`, undefined, {
+            signal: params?.signal,
+        });
     }
 
     async installedModels(params?: { task?: ModelTask }): Promise<InstalledResponse> {

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -219,12 +219,12 @@ export const MESSAGES = {
     COMMAND_MODEL_PICKER_EMBED: "Pick embedding model",
     DESC_CHAT_MODE: "Search uses your documents and returns citations. Chat is a general assistant with no retrieval.",
     TOOLTIP_CHAT_MODE_NEEDS_EMBEDDING: "Configure an embedding model to enable Search.",
-    TOOLTIP_MODE_SEARCH: "Search your vault — finds relevant passages and answers with citations.",
-    TOOLTIP_MODE_CHAT: "Chat with the model directly — no vault retrieval.",
-    TOOLTIP_ROLE_CHAT: "Chat model — writes the answers.",
-    TOOLTIP_ROLE_EMBED: "Embedding model — indexes your notes so search can find them.",
-    TOOLTIP_ROLE_VISION: "Vision model — reads scanned or image-only PDFs. Optional.",
-    TOOLTIP_ROLE_RERANK: "Reranker — reorders search hits for sharper relevance. Optional.",
+    TOOLTIP_MODE_SEARCH: "Search your vault: finds relevant passages and answers with citations.",
+    TOOLTIP_MODE_CHAT: "Chat with the model directly: no vault retrieval.",
+    TOOLTIP_ROLE_CHAT: "Chat model: writes the answers.",
+    TOOLTIP_ROLE_EMBED: "Embedding model: indexes your notes so search can find them.",
+    TOOLTIP_ROLE_VISION: "Vision model: reads scanned or image-only PDFs. Optional.",
+    TOOLTIP_ROLE_RERANK: "Reranker: reorders search hits for sharper relevance. Optional.",
     LABEL_GEN_TEMPERATURE: "Creativity",
     LABEL_GEN_TOP_P: "Top P",
     LABEL_GEN_TOP_K: "Top K (sampling)",
@@ -291,7 +291,7 @@ export const MESSAGES = {
     LABEL_ADVANCED: "Advanced",
     LABEL_STORE_CONTENT_IN_VAULT: STORE_CONTENT_IN_VAULT_LABEL,
     DESC_STORE_CONTENT_IN_VAULT:
-        "Materialize crawled pages and imported files inside your vault so you can browse them in Obsidian. Disabled for external servers — their files live on the server machine, not your computer.",
+        "Materialize crawled pages and imported files inside your vault so you can browse them in Obsidian. Disabled for external servers: their files live on the server machine, not your computer.",
     NOTICE_STORAGE_REORGANIZING: "Reorganizing lilbee storage into your vault…",
     NOTICE_STORAGE_REORGANIZED: "Lilbee storage is now inside your vault.",
     NOTICE_STORAGE_REORGANIZE_FAILED: (reason: string | null, logPath: string | null, willRetry: boolean): string =>
@@ -317,7 +317,7 @@ export const MESSAGES = {
     STATUS_LOCKED_BY_OTHER: (vaultName: string): string => `lilbee: serving "${vaultName}"`,
     COMMAND_TAKE_OVER: "Take over the managed lilbee server",
     TOOLTIP_MODEL_INSTALLED_SHARED:
-        "Installed in the shared lilbee models directory — every vault on this computer can use it without re-downloading.",
+        "Installed in the shared lilbee models directory: every vault on this computer can use it without re-downloading.",
     LABEL_SHARED_ROOT: "Shared lilbee directory",
     DESC_SHARED_ROOT: (resolved: string): string =>
         `Holds the lilbee binary, model cache, and one subfolder per vault. Leave blank to use the platform default (currently ${resolved}). Restart the plugin or Obsidian for changes to take effect.`,
@@ -349,7 +349,7 @@ export const MESSAGES = {
     LABEL_VISION_DISABLED: "(disabled)",
     LABEL_VISION_HOSTED_GROUP: "Hosted via LiteLLM",
     DESC_VISION_MODEL:
-        "Used to read scanned PDFs when OCR fails. Separate from the chat model — vision models run only on image-only documents.",
+        "Used to read scanned PDFs when OCR fails. Separate from the chat model: vision models run only on image-only documents.",
     NOTICE_VISION_UPDATED: "lilbee: vision model updated",
     NOTICE_FAILED_VISION: "lilbee: failed to update vision model",
     NOTICE_VISION_LOAD_FAILED: "lilbee: failed to load vision options",
@@ -386,7 +386,7 @@ export const MESSAGES = {
     LABEL_TASK_STATE_FAILED: "failed",
     LABEL_TASK_STATE_CANCELLED: "cancelled",
     LABEL_TASK_STATE_WAITING: "waiting on server",
-    STATUS_WAITING_ON_SERVER: "Already ingesting on the server — waiting for it to finish",
+    STATUS_WAITING_ON_SERVER: "Already ingesting on the server: waiting for it to finish",
     STATUS_TASKS_RUNNING_PLURAL: "{count} tasks running · {name} {pct}%",
     STATUS_TASK_RUNNING_SINGLE: "{name} {pct}%",
     // A job whose length cannot be known reads as stuck when it is labelled 0%,
@@ -411,7 +411,7 @@ export const MESSAGES = {
     LABEL_RIBBON_UPDATE_AVAILABLE: (version: string) =>
         `lilbee server ${version} is available. Open the update settings.`,
     LABEL_STATUSBAR_OPEN_SETTINGS: "Open lilbee settings",
-    ERROR_STREAM_IDLE: "server stopped sending events — check that lilbee is running",
+    ERROR_STREAM_IDLE: "server stopped sending events: check that lilbee is running",
     LABEL_OUR_PICKS: "Our picks",
     LABEL_SECTION_INSTALLED: "Installed",
     LABEL_SECTION_CHAT: "Chat",
@@ -556,7 +556,7 @@ export const MESSAGES = {
     DESC_SERVER_URL_HELP: "Address of the lilbee HTTP server",
     LABEL_MANUAL_TOKEN: "Session token",
     DESC_MANUAL_TOKEN:
-        "Paste the server's session token (required for remote servers). When the lilbee server runs on this machine the plugin discovers the token automatically — leave this blank.",
+        "Paste the server's session token (required for remote servers). When the lilbee server runs on this machine the plugin discovers the token automatically: leave this blank.",
     DESC_SWITCH_MANAGED: "Stop using an external server and start the built-in one",
     DESC_MODELS_HELP: "Browse the catalog for available models. Requires the lilbee server.",
     DESC_REFRESH_MODELS: "Fetch available models from the server",
@@ -718,7 +718,7 @@ export const MESSAGES = {
     STATUS_ADDING: "lilbee: adding {label}...",
     STATUS_NOTHING_NEW: "lilbee: nothing new to add",
     STATUS_ADD_CANCELLED: "lilbee: add cancelled",
-    STATUS_SYNCED: "lilbee: synced — {summary}",
+    STATUS_SYNCED: "lilbee: synced: {summary}",
     STATUS_SYNC_CANCELLED: "lilbee: sync cancelled",
     STATUS_SYNC_FAILED: "lilbee: sync failed",
     STATUS_SYNC_PILL: (n: number) => `⟳ ${n}`,
@@ -800,11 +800,11 @@ export const MESSAGES = {
     ERROR_COULD_NOT_CONNECT_EXT: "Could not connect. Check the URL and make sure the server is running.",
     ERROR_DOWNLOAD_FAILED: "Download failed. Please try again or pick a different model.",
     ERROR_INDEXING_FAILED: "Indexing failed. You can retry from the settings tab.",
-    ERROR_CRAWL_FAILED: "lilbee: crawl failed — {msg}",
-    ERROR_CRAWL_ERROR: "lilbee: crawl error — {msg}",
+    ERROR_CRAWL_FAILED: "lilbee: crawl failed: {msg}",
+    ERROR_CRAWL_ERROR: "lilbee: crawl error: {msg}",
     ERROR_CRAWLER_SETUP_FAILED:
         "Crawler setup failed: {error}. Run 'make crawl-setup' in the lilbee repo or 'lilbee setup crawler' to retry.",
-    ERROR_CRAWLER_SETUP_FAILED_SHORT: "Chromium setup failed — see setup task",
+    ERROR_CRAWLER_SETUP_FAILED_SHORT: "Chromium setup failed: see setup task",
     ERROR_CRAWLER_SETUP_INCOMPLETE: "The server stopped the Chromium download before it finished.",
     ERROR_SERVER_UNREACHABLE: "Could not connect to lilbee server. Is it running?",
     ERROR_STREAM: (msg: string) => `lilbee: ${msg}`,
@@ -818,23 +818,23 @@ export const MESSAGES = {
         retryAfterSeconds !== null
             ? `lilbee is busy with another request. Try again in ${retryAfterSeconds} seconds.`
             : `lilbee is busy with another request. Try again in a moment.`,
-    ERROR_ADD_FAILED_DETAIL: (msg: string) => `lilbee: add failed — ${msg}`,
+    ERROR_ADD_FAILED_DETAIL: (msg: string) => `lilbee: add failed: ${msg}`,
     NOTICE_ALREADY_INGESTING: (source: string) =>
-        `lilbee: server is already ingesting ${source} — waiting for it to finish`,
+        `lilbee: server is already ingesting ${source}, waiting for it to finish`,
 
-    NOTICE_NO_CHAT_MODEL: "lilbee: no chat model set — select one in settings",
+    NOTICE_NO_CHAT_MODEL: "lilbee: no chat model set: select one in settings",
     NOTICE_FLEET_WARMING: "lilbee: the model is still loading, try again in a moment",
     NOTICE_FLEET_ERROR: (reason: string | null): string =>
         reason ? `lilbee: ${reason}` : "lilbee: the chat model failed to load. Pick another model in settings.",
     NOTICE_MODEL_ACTIVATED: (model: string) => `Now using ${model}`,
     NOTICE_PULL_CANCELLED: "lilbee: pull cancelled",
-    NOTICE_NO_TOKEN_MANAGED: "lilbee: managed server didn't produce a session token — try restarting the plugin",
+    NOTICE_NO_TOKEN_MANAGED: "lilbee: managed server didn't produce a session token: try restarting the plugin",
     NOTICE_NO_TOKEN_EXTERNAL:
-        "lilbee: no session token — run 'lilbee token' and paste it in Settings → Session token, or set LILBEE_DATA",
-    NOTICE_SESSION_TOKEN_INVALID: "lilbee: session token invalid — paste a new one in Settings → Session token",
+        "lilbee: no session token: run 'lilbee token' and paste it in Settings → Session token, or set LILBEE_DATA",
+    NOTICE_SESSION_TOKEN_INVALID: "lilbee: session token invalid: paste a new one in Settings → Session token",
     NOTICE_SESSION_TOKEN_INVALID_MANAGED:
-        "lilbee: managed server rejected its own token — restart the server from Settings → Switch to managed server, or open Status for logs",
-    NOTICE_QUEUE_FULL: "lilbee: too many tasks queued — wait for some to finish",
+        "lilbee: managed server rejected its own token: restart the server from Settings → Switch to managed server, or open Status for logs",
+    NOTICE_QUEUE_FULL: "lilbee: too many tasks queued: wait for some to finish",
     NOTICE_SYNC_IN_PROGRESS:
         "lilbee: a sync is already running or queued. Wait for it to finish, or cancel it in the Task Center.",
     LABEL_DATASET_FILTER: "lilbee dataset",
@@ -842,13 +842,13 @@ export const MESSAGES = {
     STATUS_DATASET_IMPORTING: "Re-embedding pages…",
     STATUS_DATASET_EMBEDDING: (file: string) => `Re-embedding ${file}…`,
     NOTICE_DATASET_EXPORTED: (path: string) => `lilbee: exported dataset to ${path}`,
-    ERROR_DATASET_EXPORT: (msg: string) => `lilbee: export failed — ${msg}`,
-    ERROR_DATASET_READ: (msg: string) => `lilbee: could not read dataset — ${msg}`,
+    ERROR_DATASET_EXPORT: (msg: string) => `lilbee: export failed: ${msg}`,
+    ERROR_DATASET_READ: (msg: string) => `lilbee: could not read dataset: ${msg}`,
     ERROR_DATASET_TOO_LARGE:
-        "lilbee: dataset exceeds the 10 MB upload limit — use `lilbee import` from the CLI for larger files",
+        "lilbee: dataset exceeds the 10 MB upload limit: use `lilbee import` from the CLI for larger files",
     NOTICE_DATASET_IMPORTED: (sources: number, pages: number, chunks: number, folder: string) =>
         `lilbee: imported ${sources} source(s) into "${folder}/" (${pages} page(s), ${chunks} chunk(s))`,
-    ERROR_DATASET_IMPORT: (msg: string) => `lilbee: import failed — ${msg}`,
+    ERROR_DATASET_IMPORT: (msg: string) => `lilbee: import failed: ${msg}`,
     NOTICE_MODEL_ACTIVATED_FULL: (model: string) => `lilbee: ${model} pulled and activated`,
     NOTICE_SET_MODEL: (type: string, model: string) => `${type} set to ${model}`,
     NOTICE_FAILED_SET_MODEL: (type: string) => `Failed to set ${type} model`,
@@ -859,7 +859,7 @@ export const MESSAGES = {
     NOTICE_FAILED_RESET: (field: string) => `lilbee: failed to reset ${field}`,
     NOTICE_SETTINGS_RESET: "lilbee: settings reset to defaults",
     NOTICE_FAILED_RESET_ALL: "lilbee: failed to reset settings",
-    NOTICE_REINDEX_REQUIRED: "lilbee: re-indexing required — starting sync...",
+    NOTICE_REINDEX_REQUIRED: "lilbee: re-indexing required: starting sync...",
     NOTICE_API_KEY_SAVED: "lilbee: API key saved",
     NOTICE_HF_TOKEN_SAVED: "lilbee: HuggingFace token saved",
     NOTICE_FAILED_HF_TOKEN: "lilbee: failed to save HuggingFace token",
@@ -875,7 +875,7 @@ export const MESSAGES = {
     NOTICE_SAVED: (path: string) => `Saved to ${path}`,
     NOTICE_REMOVED: (model: string) => `Deleted ${model}`,
     NOTICE_SYNC_SUMMARY: (summary: string) => `lilbee: ${summary}`,
-    NOTICE_CRAWL_DONE: (pages: number) => `lilbee: crawl done — ${pages} pages`,
+    NOTICE_CRAWL_DONE: (pages: number) => `lilbee: crawl done: ${pages} pages`,
     NOTICE_ENTER_URL: "lilbee: please enter a URL",
     NOTICE_DOWNLOAD_CANCELLED: "lilbee: download cancelled",
     NOTICE_INDEXING_CANCELLED: "lilbee: indexing cancelled",
@@ -980,7 +980,7 @@ export const MESSAGES = {
     LABEL_DRAFT_KIND_BAD_TITLE: "BAD TITLE",
     LABEL_DRAFT_PUBLISHED: "pub",
     LABEL_DRAFT_NEW: "new",
-    LABEL_DRAFT_FAITH_NA: "faith —",
+    LABEL_DRAFT_FAITH_NA: "faith",
     LABEL_DRAFT_FAITH: (score: number) => `faith ${score.toFixed(2)}`,
     LABEL_DRAFT_DRIFT: (pct: number) => `${pct}% drift`,
     LABEL_NO_DRAFTS: "No pending wiki drafts.",
@@ -1002,7 +1002,7 @@ export const MESSAGES = {
     LABEL_PREVIEW_CLOSE: "Close",
     LABEL_PREVIEW_SAVE_TO_VAULT: "Save to vault",
     LABEL_PREVIEW_OPEN_IN_VAULT: "Open in vault",
-    TOOLTIP_PREVIEW_SAVE_SOON: "Coming soon — available once the server supports vault storage.",
+    TOOLTIP_PREVIEW_SAVE_SOON: "Coming soon: available once the server supports vault storage.",
     ERROR_PREVIEW_INVALID_SOURCE: "Cannot preview: source reference is empty.",
     ERROR_PREVIEW_LOAD: (reason: string) => `Failed to load source: ${reason}`,
     ERROR_PREVIEW_UNSUPPORTED: (mime: string) =>
@@ -1103,7 +1103,7 @@ export const MESSAGES = {
     LABEL_WIKI_VAULT_FOLDER: "Wiki vault folder",
     DESC_WIKI_VAULT_FOLDER: "Folder in your vault where wiki pages are written",
     NOTICE_WIKI_SYNC: (written: number, removed: number) =>
-        `lilbee: wiki sync — ${written} written, ${removed} removed`,
+        `lilbee: wiki sync: ${written} written, ${removed} removed`,
 
     // Search mode
     LABEL_SEARCH_ALL: "All",
@@ -1111,7 +1111,7 @@ export const MESSAGES = {
     LABEL_SEARCH_RAW: "Raw",
 
     // Wiki tasks/notices
-    NOTICE_WIKI_LINT_DONE: (issues: number) => `lilbee: lint complete — ${issues} issues found`,
+    NOTICE_WIKI_LINT_DONE: (issues: number) => `lilbee: lint complete: ${issues} issues found`,
     NOTICE_WIKI_UPDATE_DONE: (count: number) => `lilbee: wiki updated, ${count} pages`,
     NOTICE_WIKI_PRUNE_DONE: (archived: number) => `lilbee: pruned ${archived} pages`,
     NOTICE_WIKI_PRUNE_CONFIRM: "This will archive wiki pages with broken citations. Continue?",
@@ -1137,7 +1137,7 @@ export const MESSAGES = {
     WIZARD_STEP_CHOOSE_SERVER: "Choose where lilbee runs (this machine, or an existing server)",
     WIZARD_STEP_CHOOSE_MODEL: "Choose an AI model that fits the host's RAM",
     WIZARD_STEP_INDEX: "Index your vault so you can search and chat",
-    WIZARD_LOCAL_ONLY_MANAGED: "Managed mode runs on this machine — your notes never leave your laptop.",
+    WIZARD_LOCAL_ONLY_MANAGED: "Managed mode runs on this machine: your notes never leave your laptop.",
     WIZARD_LOCAL_ONLY_EXTERNAL:
         "External mode talks to your existing lilbee server. Your notes stay on whichever host runs it.",
     WIZARD_MODEL_HELP:
@@ -1180,7 +1180,7 @@ export const MESSAGES = {
     WIZARD_WIKI_PRO_ANSWERS: "Chat and search can reference wiki pages for more coherent answers",
     WIZARD_WIKI_CONS_HEADING: "Worth knowing",
     WIZARD_WIKI_CON_TOKENS: "Each page run uses LLM compute / API tokens",
-    WIZARD_WIKI_CON_ACCURACY: "Small models can hallucinate — always verify against source",
+    WIZARD_WIKI_CON_ACCURACY: "Small models can hallucinate: always verify against source",
     WIZARD_WIKI_CON_SEARCH: "Search may prioritise wiki chunks over raw ones if you include both",
     WIZARD_WIKI_CON_COMPLEXITY: "Adds a second index shape to maintain alongside raw embeddings",
     WIZARD_WIKI_ENABLE: "Enable wiki (on-demand generation)",
@@ -1265,7 +1265,7 @@ export const MESSAGES = {
     PLACEMENT_ROLE_VRAM: (size: string): string => `~${size}`,
     PLACEMENT_TIP_ROLE_VRAM: (role: WorkerRole): string => `Estimated memory the ${roleNoun(role)} model needs`,
     PLACEMENT_UTIL: (pct: number): string => `${pct}%`,
-    PLACEMENT_UTIL_NA: "—",
+    PLACEMENT_UTIL_NA: "N/A",
     PLACEMENT_METER_UTIL: "util",
     PLACEMENT_METER_VRAM: "vram",
     PLACEMENT_HINT_SPLIT: "split",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1102,8 +1102,7 @@ export const MESSAGES = {
         "Write wiki pages as files in your vault so they appear in graph view, search, and backlinks",
     LABEL_WIKI_VAULT_FOLDER: "Wiki vault folder",
     DESC_WIKI_VAULT_FOLDER: "Folder in your vault where wiki pages are written",
-    NOTICE_WIKI_SYNC: (written: number, removed: number) =>
-        `lilbee: wiki sync: ${written} written, ${removed} removed`,
+    NOTICE_WIKI_SYNC: (written: number, removed: number) => `lilbee: wiki sync: ${written} written, ${removed} removed`,
 
     // Search mode
     LABEL_SEARCH_ALL: "All",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -980,7 +980,7 @@ export const MESSAGES = {
     LABEL_DRAFT_KIND_BAD_TITLE: "BAD TITLE",
     LABEL_DRAFT_PUBLISHED: "pub",
     LABEL_DRAFT_NEW: "new",
-    LABEL_DRAFT_FAITH_NA: "faith",
+    LABEL_DRAFT_FAITH_NA: "faith unavailable",
     LABEL_DRAFT_FAITH: (score: number) => `faith ${score.toFixed(2)}`,
     LABEL_DRAFT_DRIFT: (pct: number) => `${pct}% drift`,
     LABEL_NO_DRAFTS: "No pending wiki drafts.",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1278,7 +1278,7 @@ export default class LilbeePlugin extends Plugin {
         const output = this.serverManager?.lastOutput;
         if (output) console.error(`[lilbee] server output:\n${output}`);
         const outputTail = output ? `\n${output.split("\n").slice(-5).join("\n")}` : "";
-        const notice = new Notice(`lilbee: ${label} — ${detail}${outputTail}`, NOTICE_ERROR_DURATION_MS);
+        const notice = new Notice(`lilbee: ${label}: ${detail}${outputTail}`, NOTICE_ERROR_DURATION_MS);
         if (this.serverManager !== null) this.attachExportLink(notice);
         this.updateStatusBar(MESSAGES.STATUS_ERROR, DOT_STATE.ERROR);
         this.setStatusClass(null);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -834,7 +834,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             // Rows hidden by capability (server does not report the key) must stay
             // hidden even when the search box is cleared: clearing the box makes
             // matches() true for every row, which would otherwise reveal them.
-            if (item.hasAttribute("data-lilbee-hidden-by-capability")) {
+            if (item.getAttribute("data-lilbee-hidden-by-capability") !== null) {
                 (item as HTMLElement).style.display = "none";
                 continue;
             }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2679,7 +2679,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         const localInstalled = catalogEntries.filter((e) => !HOSTED_SOURCES.has(e.source) && isInstalled(e));
         for (const e of localInstalled) opts.push([e.hf_repo, e.display_name]);
         for (const [ref, label] of hostedOptions(catalogEntries)) {
-            opts.push([ref, `${label} — ${MESSAGES.LABEL_RERANKER_HOSTED_GROUP}`]);
+            opts.push([ref, `${label} [${MESSAGES.LABEL_RERANKER_HOSTED_GROUP}]`]);
         }
         return opts;
     }
@@ -2830,7 +2830,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
         );
         for (const e of localInstalled) opts.push([e.hf_repo, e.display_name]);
         for (const [ref, label] of hostedOptions(catalogEntries)) {
-            opts.push([ref, `${label} — ${MESSAGES.LABEL_VISION_HOSTED_GROUP}`]);
+            opts.push([ref, `${label} [${MESSAGES.LABEL_VISION_HOSTED_GROUP}]`]);
         }
         return opts;
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -559,6 +559,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
     /** Detected agent CLIs; null until the first probe lands or after it fails. */
     private agentDetections: AgentClientDetection[] | null = null;
     private agentBodyEl: HTMLElement | null = null;
+    private settingsFilterQuery = "";
     /** Last server config; the definitions read it to decide which rows the connected server supports. */
     private serverConfig: ConfigResponse | null = null;
     /** Capabilities the connected server reports; null until the first probe lands. */
@@ -697,6 +698,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
     render(): void {
         const { containerEl } = this;
         containerEl.empty();
+        this.settingsFilterQuery = "";
         this.serverConfigInputs.clear();
         this.serverConfigToggles.clear();
         this.serverConfigTextAreas.clear();
@@ -709,6 +711,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             attr: { type: "text" },
         });
         filterInput.addEventListener("input", () => {
+            this.settingsFilterQuery = filterInput.value;
             this.filterSettings(containerEl, filterInput.value);
         });
         this.renderBugFeedback(containerEl);
@@ -819,7 +822,10 @@ export class LilbeeSettingTab extends PluginSettingTab {
         if (!crawling && this.crawlingContainerEl) this.crawlingContainerEl.hide();
         if (!wiki && this.wikiContainerEl) this.wikiContainerEl.hide();
         // The offer belongs inside a visible Crawling section, never on its own.
-        if (crawling && !crawlingBrowser && this.crawlerBrowserSetupEl) this.crawlerBrowserSetupEl.show();
+        if (crawling && !crawlingBrowser && this.crawlerBrowserSetupEl) {
+            this.crawlerBrowserSetupEl.removeAttribute("data-lilbee-hidden-by-capability");
+            this.crawlerBrowserSetupEl.show();
+        }
     }
 
     private filterSettings(containerEl: HTMLElement, query: string): void {
@@ -835,10 +841,11 @@ export class LilbeeSettingTab extends PluginSettingTab {
             // hidden even when the search box is cleared: clearing the box makes
             // matches() true for every row, which would otherwise reveal them.
             if (item.getAttribute("data-lilbee-hidden-by-capability") !== null) {
-                (item as HTMLElement).style.display = "none";
+                (item as HTMLElement).hide();
                 continue;
             }
-            (item as HTMLElement).style.display = matches(item) ? "" : "none";
+            if (matches(item)) (item as HTMLElement).show();
+            else (item as HTMLElement).hide();
         }
 
         const wrappers = containerEl.querySelectorAll(
@@ -849,7 +856,8 @@ export class LilbeeSettingTab extends PluginSettingTab {
         for (const wrapper of Array.from(wrappers)) {
             const items = Array.from(wrapper.querySelectorAll(".setting-item"));
             const anyVisible = items.some((i) => (i as HTMLElement).style.display !== "none");
-            (wrapper as HTMLElement).style.display = anyVisible || !term ? "" : "none";
+            if (anyVisible || !term) (wrapper as HTMLElement).show();
+            else (wrapper as HTMLElement).hide();
             if (term && anyVisible && wrapper.tagName === "DETAILS") {
                 wrapper.setAttribute("open", "");
             }
@@ -1949,20 +1957,26 @@ export class LilbeeSettingTab extends PluginSettingTab {
     /** Show or hide a row the plugin owns. On 1.13 the row's visible predicate owns it and this is a no-op. */
     private setRowVisible(el: HTMLElement | null, visible: boolean): void {
         if (!el || this.usesDefinitions()) return;
-        if (visible) el.show();
-        else el.hide();
+        if (visible) {
+            el.show();
+            el.removeAttribute("data-lilbee-hidden-by-capability");
+        } else {
+            el.hide();
+            el.setAttribute("data-lilbee-hidden-by-capability", "true");
+        }
     }
 
     /** Pre-1.13 hides the row until the server reports the key; 1.13 uses the row's visible predicate. */
     private hideUntilServerReports(el: HTMLElement, key: string): void {
         if (this.usesDefinitions()) return;
         el.hide();
+        el.setAttribute("data-lilbee-hidden-by-capability", "true");
         this.serverConfigHideableEls.set(key, el);
     }
 
-    /** Fails open: settings search skips a hidden row, and the config that would unhide it loads late. */
+    /** True only when the loaded server config reports the key. */
     private serverReports(key: string): boolean {
-        return this.serverConfig === null || this.serverConfig[key] !== undefined;
+        return this.serverConfig !== null && this.serverConfig[key] !== undefined;
     }
 
     /** True until a capability probe says the connected server lacks the feature. */
@@ -1983,6 +1997,8 @@ export class LilbeeSettingTab extends PluginSettingTab {
                 settingEl.setAttribute("data-lilbee-hidden-by-capability", "true");
             }
         }
+        if (this.usesDefinitions()) return;
+        this.filterSettings(this.containerEl, this.settingsFilterQuery);
     }
 
     private applyChatModeFromConfig(cfg: ConfigResponse): void {
@@ -3095,6 +3111,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             this.refreshVisibility();
             return;
         }
+        this.crawlerBrowserSetupEl?.setAttribute("data-lilbee-hidden-by-capability", "true");
         this.crawlerBrowserSetupEl?.hide();
     }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -831,6 +831,13 @@ export class LilbeeSettingTab extends PluginSettingTab {
         };
 
         for (const item of Array.from(containerEl.querySelectorAll(".setting-item"))) {
+            // Rows hidden by capability (server does not report the key) must stay
+            // hidden even when the search box is cleared: clearing the box makes
+            // matches() true for every row, which would otherwise reveal them.
+            if (item.hasAttribute("data-lilbee-hidden-by-capability")) {
+                (item as HTMLElement).style.display = "none";
+                continue;
+            }
             (item as HTMLElement).style.display = matches(item) ? "" : "none";
         }
 
@@ -1970,6 +1977,10 @@ export class LilbeeSettingTab extends PluginSettingTab {
         for (const [key, settingEl] of this.serverConfigHideableEls) {
             if (cfg[key] !== undefined) {
                 settingEl.show();
+                settingEl.removeAttribute("data-lilbee-hidden-by-capability");
+            } else {
+                settingEl.hide();
+                settingEl.setAttribute("data-lilbee-hidden-by-capability", "true");
             }
         }
     }

--- a/src/views/catalog-helpers.ts
+++ b/src/views/catalog-helpers.ts
@@ -122,29 +122,18 @@ export function tabIdToTask(tab: CatalogTab): ModelTask | null {
 const FOR_YOU_ROLE_ORDER: ModelTask[] = [MODEL_TASK.CHAT, MODEL_TASK.EMBEDDING, MODEL_TASK.VISION, MODEL_TASK.RERANK];
 
 /**
- * Comfortable fit first, then alphabetical.
- *
- * Only ever called on rows `forYouRail` has already kept, so the fit is either
- * `fits` or `tight` -- there is no rank here for a size that will not run or is
- * unknown, because such a row never reaches the sort.
- */
-function forYouSortKey(entry: CatalogEntry): [number, string] {
-    return [entry.fit === HARDWARE_FIT.FITS ? 0 : 1, entry.display_name.toLowerCase()];
-}
-
-/**
  * One runnable pick per role, in role order.
  *
  * Featured is not a curated list — the server resolves it from HuggingFace
  * trending at runtime, so a pick is only as safe as its hardware fit. A row
- * qualifies only when the engine supports its architecture and the machine can
- * hold it, which makes every card a one-click install rather than a coin flip.
- * Rows with no fit chip are excluded outright: an unknown size cannot be
- * promised.
+ * qualifies when the engine supports its architecture and it is not known to be
+ * unrunnable. Rows with no fit chip are kept (a failed memory probe must not
+ * empty the rail) but ranked behind rows whose fit is known, so a measurable
+ * "fits" still wins over an unknown.
  */
 export function forYouRail(entries: CatalogEntry[]): CatalogEntry[] {
     const runnable = entries.filter(
-        (e) => e.featured && e.compat === MODEL_COMPAT.SUPPORTED && e.fit != null && e.fit !== HARDWARE_FIT.WONT_RUN,
+        (e) => e.featured && e.compat === MODEL_COMPAT.SUPPORTED && e.fit !== HARDWARE_FIT.WONT_RUN,
     );
     const picks: CatalogEntry[] = [];
     for (const task of FOR_YOU_ROLE_ORDER) {
@@ -158,6 +147,17 @@ export function forYouRail(entries: CatalogEntry[]): CatalogEntry[] {
         if (best) picks.push(best);
     }
     return picks;
+}
+
+/** Fit rank: known fits first, then unknown (null), then tight. Lower sorts first. */
+function forYouSortKey(entry: CatalogEntry): [number, string] {
+    const rank =
+        entry.fit === HARDWARE_FIT.FITS
+            ? 0
+            : entry.fit === null || entry.fit === undefined
+              ? 1
+              : 2;
+    return [rank, entry.display_name.toLowerCase()];
 }
 
 export function yourCollectionRail(entries: CatalogEntry[]): CatalogEntry[] {

--- a/src/views/catalog-helpers.ts
+++ b/src/views/catalog-helpers.ts
@@ -151,12 +151,7 @@ export function forYouRail(entries: CatalogEntry[]): CatalogEntry[] {
 
 /** Fit rank: known fits first, then unknown (null), then tight. Lower sorts first. */
 function forYouSortKey(entry: CatalogEntry): [number, string] {
-    const rank =
-        entry.fit === HARDWARE_FIT.FITS
-            ? 0
-            : entry.fit === null || entry.fit === undefined
-              ? 1
-              : 2;
+    const rank = entry.fit === HARDWARE_FIT.FITS ? 0 : entry.fit === null || entry.fit === undefined ? 1 : 2;
     return [rank, entry.display_name.toLowerCase()];
 }
 

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -105,6 +105,8 @@ export class CatalogModal extends Modal {
     private hasMore = false;
     private isFetching = false;
     private fetchGeneration = 0;
+    private catalogController: AbortController | null = null;
+    private modalClosed = true;
     private entries: CatalogEntry[] = [];
     private resultsEl: HTMLElement | null = null;
     private viewMode: CatalogViewMode = CATALOG_VIEW_MODE.GRID;
@@ -152,6 +154,7 @@ export class CatalogModal extends Modal {
     }
 
     onOpen(): void {
+        this.modalClosed = false;
         const { contentEl } = this;
         contentEl.empty();
         contentEl.addClass("lilbee-catalog-modal");
@@ -327,7 +330,9 @@ export class CatalogModal extends Modal {
     }
 
     onClose(): void {
+        this.modalClosed = true;
         this.cancelDebouncedSearch();
+        this.catalogController?.abort();
         this.resultsEl?.removeEventListener("scroll", this.onScroll);
         this.bodyEl?.removeEventListener("focusin", this.onCardFocus);
         this.bodyEl?.removeEventListener("pointerover", this.onCardFocus);
@@ -421,6 +426,7 @@ export class CatalogModal extends Modal {
 
     private resetAndFetch(): void {
         this.fetchGeneration++;
+        this.catalogController?.abort();
         this.offset = 0;
         this.clearResults();
         void this.fetchPage();
@@ -464,22 +470,27 @@ export class CatalogModal extends Modal {
         // while this page was in flight) can be discarded instead of rendering
         // under the new filter.
         const generation = this.fetchGeneration;
+        const controller = new AbortController();
+        this.catalogController = controller;
 
         let superseded = false;
         try {
-            const result = await this.plugin.api.catalog(this.catalogParams(query));
-            if (result.isErr()) {
-                new Notice(noticeForResultError(result.error, MESSAGES.ERROR_LOAD_CATALOG));
-            } else if (generation !== this.fetchGeneration) {
-                // A filter/sort/size change superseded this request while it was in flight.
+            const result = await this.plugin.api.catalog({
+                ...this.catalogParams(query),
+                signal: controller.signal,
+            });
+            if (controller.signal.aborted || generation !== this.fetchGeneration) {
                 superseded = true;
+            } else if (result.isErr()) {
+                new Notice(noticeForResultError(result.error, MESSAGES.ERROR_LOAD_CATALOG));
             } else {
                 this.applyPage(result.value);
             }
         } finally {
             this.isFetching = false;
+            this.catalogController = null;
         }
-        if (superseded) await this.fetchPage();
+        if (superseded && !this.modalClosed) await this.fetchPage();
     }
 
     private renderResults(): void {

--- a/src/views/catalog-modal.ts
+++ b/src/views/catalog-modal.ts
@@ -104,6 +104,7 @@ export class CatalogModal extends Modal {
     private fetchedQuery = "";
     private hasMore = false;
     private isFetching = false;
+    private fetchGeneration = 0;
     private entries: CatalogEntry[] = [];
     private resultsEl: HTMLElement | null = null;
     private viewMode: CatalogViewMode = CATALOG_VIEW_MODE.GRID;
@@ -419,6 +420,7 @@ export class CatalogModal extends Modal {
     }
 
     private resetAndFetch(): void {
+        this.fetchGeneration++;
         this.offset = 0;
         this.clearResults();
         void this.fetchPage();
@@ -458,14 +460,18 @@ export class CatalogModal extends Modal {
             this.clearResults();
         }
         this.isFetching = true;
+        // Capture the request generation so a stale response (a filter changed
+        // while this page was in flight) can be discarded instead of rendering
+        // under the new filter.
+        const generation = this.fetchGeneration;
 
         let superseded = false;
         try {
             const result = await this.plugin.api.catalog(this.catalogParams(query));
             if (result.isErr()) {
                 new Notice(noticeForResultError(result.error, MESSAGES.ERROR_LOAD_CATALOG));
-            } else if (query !== this.filterSearch) {
-                // The term moved on while this page was in flight.
+            } else if (generation !== this.fetchGeneration) {
+                // A filter/sort/size change superseded this request while it was in flight.
                 superseded = true;
             } else {
                 this.applyPage(result.value);

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -771,7 +771,7 @@ export class ChatView extends ItemView {
         const hosted = entries.filter(isUsableHostedRow);
         const options = localInstalled.map((e) => ({ value: e.hf_repo, label: e.display_name }));
         for (const e of hosted) {
-            options.push({ value: e.hf_repo, label: `${e.display_name} — ${MESSAGES.LABEL_VISION_HOSTED_GROUP}` });
+            options.push({ value: e.hf_repo, label: `${e.display_name} [${MESSAGES.LABEL_VISION_HOSTED_GROUP}]` });
         }
         return options;
     }
@@ -1527,7 +1527,7 @@ export class ChatView extends ItemView {
         const folder = "lilbee";
         const path = `${folder}/${filename}`;
 
-        const lines = [`# ${MESSAGES.LABEL_CHAT_VIEW} — ${now.toLocaleDateString()}`, ""];
+        const lines = [`# ${MESSAGES.LABEL_CHAT_VIEW}: ${now.toLocaleDateString()}`, ""];
         for (const msg of this.history) {
             const label = msg.role === "user" ? "User" : "Assistant";
             lines.push(`**${label}**: ${msg.content}`, "");

--- a/src/views/task-center.ts
+++ b/src/views/task-center.ts
@@ -322,7 +322,7 @@ function statsLine(task: TaskEntry, state: TaskStatus): string {
         parts.push(formatRate(task.rateBps));
     }
     if (parts.length === 0 && task.detail) return task.detail;
-    return parts.join(" — ");
+    return parts.join(" · ");
 }
 
 function isWithinFlashWindow(task: TaskEntry): boolean {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -728,6 +728,15 @@ describe("pullModel()", () => {
             expect(url.searchParams.get("limit")).toBe("10");
             expect(url.searchParams.get("offset")).toBe("20");
         });
+
+        it("passes a caller signal through to the catalog request", async () => {
+            fetchMock.mockResolvedValue(jsonResponse({ total: 0, limit: 20, offset: 0, models: [], has_more: false }));
+            const controller = new AbortController();
+
+            await client.catalog({ signal: controller.signal });
+
+            expect((fetchMock.mock.calls[0]?.[1] as RequestInit).signal).toBe(controller.signal);
+        });
     });
 
     describe("installedModels()", () => {

--- a/tests/locales/en.test.ts
+++ b/tests/locales/en.test.ts
@@ -131,7 +131,7 @@ describe("MESSAGES", () => {
             expect(MESSAGES.DESC_GEMINI_API_KEY).toBe("For Gemini models via litellm");
             expect(MESSAGES.LABEL_MANUAL_TOKEN).toBe("Session token");
             expect(MESSAGES.DESC_MANUAL_TOKEN).toBe(
-                "Paste the server's session token (required for remote servers). When the lilbee server runs on this machine the plugin discovers the token automatically — leave this blank.",
+                "Paste the server's session token (required for remote servers). When the lilbee server runs on this machine the plugin discovers the token automatically: leave this blank.",
             );
             expect(MESSAGES.LABEL_WIKI_SECTION).toBe("Wiki (beta)");
             expect(MESSAGES.DESC_WIKI_ENABLE_TOGGLE).toBe(
@@ -251,12 +251,12 @@ describe("MESSAGES", () => {
         });
 
         it("NOTICE_CRAWL_DONE produces correct output", () => {
-            expect(MESSAGES.NOTICE_CRAWL_DONE(10)).toBe("lilbee: crawl done — 10 pages");
+            expect(MESSAGES.NOTICE_CRAWL_DONE(10)).toBe("lilbee: crawl done: 10 pages");
         });
 
         it("NOTICE_ALREADY_INGESTING produces correct output", () => {
             expect(MESSAGES.NOTICE_ALREADY_INGESTING("doc.pdf")).toBe(
-                "lilbee: server is already ingesting doc.pdf — waiting for it to finish",
+                "lilbee: server is already ingesting doc.pdf, waiting for it to finish",
             );
         });
 
@@ -282,7 +282,7 @@ describe("MESSAGES", () => {
         });
 
         it("NOTICE_CRAWL_DONE produces correct output", () => {
-            expect(MESSAGES.NOTICE_CRAWL_DONE(10)).toBe("lilbee: crawl done — 10 pages");
+            expect(MESSAGES.NOTICE_CRAWL_DONE(10)).toBe("lilbee: crawl done: 10 pages");
         });
 
         it("NOTICE_SYNC_SUMMARY produces correct output", () => {
@@ -309,8 +309,8 @@ describe("MESSAGES", () => {
         });
 
         it("NOTICE_WIKI_LINT_DONE produces correct output", () => {
-            expect(MESSAGES.NOTICE_WIKI_LINT_DONE(3)).toBe("lilbee: lint complete — 3 issues found");
-            expect(MESSAGES.NOTICE_WIKI_LINT_DONE(0)).toBe("lilbee: lint complete — 0 issues found");
+            expect(MESSAGES.NOTICE_WIKI_LINT_DONE(3)).toBe("lilbee: lint complete: 3 issues found");
+            expect(MESSAGES.NOTICE_WIKI_LINT_DONE(0)).toBe("lilbee: lint complete: 0 issues found");
         });
 
         it("NOTICE_WIKI_UPDATE_DONE produces correct output", () => {
@@ -346,8 +346,8 @@ describe("MESSAGES", () => {
         });
 
         it("NOTICE_WIKI_SYNC produces correct output", () => {
-            expect(MESSAGES.NOTICE_WIKI_SYNC(3, 1)).toBe("lilbee: wiki sync — 3 written, 1 removed");
-            expect(MESSAGES.NOTICE_WIKI_SYNC(0, 0)).toBe("lilbee: wiki sync — 0 written, 0 removed");
+            expect(MESSAGES.NOTICE_WIKI_SYNC(3, 1)).toBe("lilbee: wiki sync: 3 written, 1 removed");
+            expect(MESSAGES.NOTICE_WIKI_SYNC(0, 0)).toBe("lilbee: wiki sync: 0 written, 0 removed");
         });
     });
 

--- a/tests/locales/en.test.ts
+++ b/tests/locales/en.test.ts
@@ -1,9 +1,25 @@
 import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { MESSAGES, FILTERS, TASK_LABELS } from "../../src/locales/en";
 import { MODEL_TASK, NVIDIA_PROBE_STATUS, SERVER_VARIANT } from "../../src/types";
 import type { AmdProbe, GpuDetection, NvidiaProbe } from "../../src/types";
 
+function withoutComments(source: string): string {
+    return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+}
+
 describe("MESSAGES", () => {
+    it("keeps em dashes out of production copy while allowing comments to use them", () => {
+        const offenders = readdirSync("src", { recursive: true })
+            .filter((path) => path.endsWith(".ts"))
+            .map((path) => join("src", path))
+            .filter((path) => withoutComments(readFileSync(path, "utf8")).includes("—"))
+            .sort();
+
+        expect(offenders).toEqual([]);
+    });
+
     describe("BUTTON_ constants", () => {
         it("has all button labels", () => {
             expect(MESSAGES.BUTTON_SKIP_SETUP).toBe("Skip setup");

--- a/tests/settings-definitions.test.ts
+++ b/tests/settings-definitions.test.ts
@@ -442,12 +442,11 @@ describe("visibility predicates", () => {
         return items.find((item) => item.heading === heading);
     }
 
-    it("keeps a server-config row searchable before the config loads, then hides it if unsupported", () => {
+    it("hides a server-config row until the config reports support", () => {
         const tab = makeTab();
         const row = findRow(tab.getSettingDefinitions() as Definition[], MESSAGES.LABEL_FLASH_ATTENTION);
 
-        // The config has not loaded when a search runs, and search skips a hidden row.
-        expect(row?.visible?.()).toBe(true);
+        expect(row?.visible?.()).toBe(false);
 
         (tab as any).serverConfig = { something_else: true };
         expect(row?.visible?.()).toBe(false);

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -2,7 +2,7 @@ import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { App, Notice, Setting } from "obsidian";
 import { MockElement } from "./__mocks__/obsidian";
 import { LilbeeSettingTab, SEPARATOR_KEY } from "../src/settings";
-import type { CatalogEntry, CatalogResponse, InstalledModel, LilbeeSettings } from "../src/types";
+import type { CatalogEntry, CatalogResponse, ConfigResponse, InstalledModel, LilbeeSettings } from "../src/types";
 import {
     DEFAULT_SETTINGS,
     MEMORY_CONFIG_KEY,
@@ -4604,25 +4604,40 @@ describe("managed mode settings", () => {
             const tab = makeTab(plugin);
             tab.display();
 
-            const container = new MockElement("div") as any;
-            const section = container.createEl("details", { cls: "lilbee-settings-section" });
+            const hideable = (tab as unknown as { serverConfigHideableEls: Map<string, MockElement> })
+                .serverConfigHideableEls;
+            const item2 = hideable.get("worker_pool_call_timeout_s");
+            expect(item2).toBeDefined();
+            expect(item2?.getAttribute("data-lilbee-hidden-by-capability")).toBe("true");
 
-            const item1 = section.createDiv({ cls: "setting-item" });
-            const name1 = item1.createDiv({ cls: "setting-item-name" });
-            name1.textContent = "Server URL";
+            // Clearing the search must not reveal the producer-hidden row.
+            (tab as unknown as { filterSettings(container: HTMLElement, query: string): void }).filterSettings(
+                tab.containerEl,
+                "",
+            );
 
-            const item2 = section.createDiv({ cls: "setting-item" });
-            const name2 = item2.createDiv({ cls: "setting-item-name" });
-            name2.textContent = "Worker pool";
-            // Mark as hidden by capability (server does not report this key)
-            item2.setAttribute("data-lilbee-hidden-by-capability", "true");
-            item2.style.display = "none";
+            expect(item2?.style.display).toBe("none");
+        });
 
-            // Clear the search: item1 should show, item2 must stay hidden
-            (tab as any).filterSettings(container, "");
+        it("reapplies the active query when a hidden row becomes supported", () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            tab.display();
 
-            expect(item1.style.display).toBe("");
-            expect(item2.style.display).toBe("none");
+            const hideable = (tab as unknown as { serverConfigHideableEls: Map<string, MockElement> })
+                .serverConfigHideableEls;
+            const row = hideable.get("worker_pool_call_timeout_s")!;
+            const filter = tab.containerEl.find("lilbee-settings-filter")!;
+            filter.value = "does not match";
+            filter.trigger("input");
+            expect(row.style.display).toBe("none");
+
+            (tab as unknown as { applyHideableConfigFields(cfg: ConfigResponse): void }).applyHideableConfigFields({
+                worker_pool_call_timeout_s: 30,
+            });
+
+            expect(row.style.display).toBe("none");
         });
 
         it("di8: filterSettings hides non-matching top-level setting items", () => {

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -4598,6 +4598,33 @@ describe("managed mode settings", () => {
             expect(section.style.display).toBe("");
         });
 
+        it("filterSettings keeps capability-hidden rows hidden when query is cleared", () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            tab.display();
+
+            const container = new MockElement("div") as any;
+            const section = container.createEl("details", { cls: "lilbee-settings-section" });
+
+            const item1 = section.createDiv({ cls: "setting-item" });
+            const name1 = item1.createDiv({ cls: "setting-item-name" });
+            name1.textContent = "Server URL";
+
+            const item2 = section.createDiv({ cls: "setting-item" });
+            const name2 = item2.createDiv({ cls: "setting-item-name" });
+            name2.textContent = "Worker pool";
+            // Mark as hidden by capability (server does not report this key)
+            item2.setAttribute("data-lilbee-hidden-by-capability", "true");
+            item2.style.display = "none";
+
+            // Clear the search: item1 should show, item2 must stay hidden
+            (tab as any).filterSettings(container, "");
+
+            expect(item1.style.display).toBe("");
+            expect(item2.style.display).toBe("none");
+        });
+
         it("di8: filterSettings hides non-matching top-level setting items", () => {
             const plugin = makePlugin();
             mockChatPicker(plugin);

--- a/tests/views/catalog-helpers.test.ts
+++ b/tests/views/catalog-helpers.test.ts
@@ -319,11 +319,21 @@ describe("catalog-helpers", () => {
             expect(forYouRail(rows).map((r) => r.hf_repo)).toEqual(["f/ok"]);
         });
 
-        it("forYouRail excludes a row with no fit chip, since an unknown size cannot be promised", () => {
+        it("forYouRail keeps a null-fit row when no known-fit row exists", () => {
+            const rows = [
+                pick({ hf_repo: "f/nosize", task: "chat", fit: null }),
+                pick({ hf_repo: "f/ok", task: "embedding" }),
+            ];
+            // The null-fit chat row is kept (failed probe must not empty the rail).
+            expect(forYouRail(rows).map((r) => r.hf_repo)).toEqual(["f/nosize", "f/ok"]);
+        });
+
+        it("forYouRail ranks a known fit ahead of a null fit", () => {
             const rows = [
                 pick({ hf_repo: "f/nosize", task: "chat", fit: null }),
                 pick({ hf_repo: "f/ok", task: "chat" }),
             ];
+            // Both qualify, but the known-fit row ranks first.
             expect(forYouRail(rows).map((r) => r.hf_repo)).toEqual(["f/ok"]);
         });
 

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -2522,7 +2522,8 @@ describe("CatalogModal fetch generation", () => {
         let resolveFirst: (r: any) => void = () => {};
         const firstPromise = new Promise<any>((r) => { resolveFirst = r; });
         plugin.api.catalog.mockReturnValueOnce(firstPromise);
-        plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry()])));
+        // The recursive fetch after supersedence also returns empty.
+        plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([])));
 
         const modal = await openModal(plugin);
         // Start fetching the first page (in flight).
@@ -2534,6 +2535,7 @@ describe("CatalogModal fetch generation", () => {
 
         // Resolve the stale request.
         resolveFirst(ok(makeCatalogResponse([makeEntry({ hf_repo: "stale/repo", display_name: "Stale" })])));
+        await tick();
         await tick();
         await tick();
 

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -2520,7 +2520,9 @@ describe("CatalogModal fetch generation", () => {
         const plugin = makePlugin();
         // Defer the first catalog call so we can change the filter before it resolves.
         let resolveFirst: (r: any) => void = () => {};
-        const firstPromise = new Promise<any>((r) => { resolveFirst = r; });
+        const firstPromise = new Promise<any>((r) => {
+            resolveFirst = r;
+        });
         plugin.api.catalog.mockReturnValueOnce(firstPromise);
         // The recursive fetch after supersedence also returns empty.
         plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([])));

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -2514,3 +2514,32 @@ describe("CatalogModal", () => {
         });
     });
 });
+
+describe("CatalogModal fetch generation", () => {
+    it("discards a stale response when the filter changes mid-flight", async () => {
+        const plugin = makePlugin();
+        // Defer the first catalog call so we can change the filter before it resolves.
+        let resolveFirst: (r: any) => void = () => {};
+        const firstPromise = new Promise<any>((r) => { resolveFirst = r; });
+        plugin.api.catalog.mockReturnValueOnce(firstPromise);
+        plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([makeEntry()])));
+
+        const modal = await openModal(plugin);
+        // Start fetching the first page (in flight).
+        (modal as any).resetAndFetch();
+        expect((modal as any).isFetching).toBe(true);
+
+        // Change the filter mid-flight: increments fetchGeneration.
+        (modal as any).fetchGeneration++;
+
+        // Resolve the stale request.
+        resolveFirst(ok(makeCatalogResponse([makeEntry({ hf_repo: "stale/repo", display_name: "Stale" })])));
+        await tick();
+        await tick();
+
+        // The stale response is discarded; entries stay empty.
+        expect((modal as any).entries.length).toBe(0);
+        expect((modal as any).isFetching).toBe(false);
+        modal.close();
+    });
+});

--- a/tests/views/catalog-modal.test.ts
+++ b/tests/views/catalog-modal.test.ts
@@ -7,6 +7,7 @@ import { CATALOG_TAB, SSE_EVENT, TASK_TYPE } from "../../src/types";
 import type { CatalogEntry, CatalogResponse, CatalogTab } from "../../src/types";
 import { TaskQueue } from "../../src/task-queue";
 import { ok, err } from "../../src/result";
+import type { Result } from "../../src/result";
 import { MESSAGES } from "../../src/locales/en";
 
 let mockConfirmResult = true;
@@ -104,6 +105,14 @@ function findButtons(el: MockElement): MockElement[] {
 }
 
 const tick = () => new Promise((r) => setTimeout(r, 0));
+
+function deferred<T>() {
+    let settle!: (value: T) => void;
+    const promise = new Promise<T>((resolve) => {
+        settle = resolve;
+    });
+    return { promise, settle };
+}
 
 async function openModal(
     plugin: ReturnType<typeof makePlugin>,
@@ -846,14 +855,6 @@ describe("CatalogModal", () => {
             (modal as unknown as { resetAndFetch(): void }).resetAndFetch();
         }
 
-        function deferred<T>() {
-            let settle!: (value: T) => void;
-            const promise = new Promise<T>((resolve) => {
-                settle = resolve;
-            });
-            return { promise, settle };
-        }
-
         function calls(plugin: ReturnType<typeof makePlugin>): Record<string, unknown>[] {
             return plugin.api.catalog.mock.calls.map((c: unknown[]) => c[0] as Record<string, unknown>);
         }
@@ -1542,6 +1543,29 @@ describe("CatalogModal", () => {
             modal.close();
             // Reaching here without throwing is the assertion.
             expect(true).toBe(true);
+        });
+
+        it("aborts an in-flight catalog request on close without showing an error", async () => {
+            const plugin = makePlugin();
+            const modal = await openModal(plugin);
+            const pending = deferred<Result<CatalogResponse, Error>>();
+            plugin.api.catalog.mockClear();
+            plugin.api.catalog.mockReturnValueOnce(pending.promise);
+
+            const sortSelect = contentEl(modal).find("lilbee-catalog-filter-sort")! as unknown as {
+                value: string;
+                trigger(event: string): void;
+            };
+            sortSelect.value = "downloads";
+            sortSelect.trigger("change");
+            const request = plugin.api.catalog.mock.calls[0]?.[0] as { signal?: AbortSignal };
+            expect(request.signal).toBeDefined();
+
+            modal.close();
+            expect(request.signal?.aborted).toBe(true);
+            pending.settle(err(new Error("closed")));
+            await tick();
+            expect(Notice.instances).toHaveLength(0);
         });
     });
 
@@ -2516,34 +2540,43 @@ describe("CatalogModal", () => {
 });
 
 describe("CatalogModal fetch generation", () => {
-    it("discards a stale response when the filter changes mid-flight", async () => {
+    it("discards a stale error and fetches the replacement after a real filter change", async () => {
         const plugin = makePlugin();
-        // Defer the first catalog call so we can change the filter before it resolves.
-        let resolveFirst: (r: any) => void = () => {};
-        const firstPromise = new Promise<any>((r) => {
-            resolveFirst = r;
-        });
-        plugin.api.catalog.mockReturnValueOnce(firstPromise);
-        // The recursive fetch after supersedence also returns empty.
+        const first = deferred<Result<CatalogResponse, Error>>();
+        // The replacement request returns an empty current page.
         plugin.api.catalog.mockResolvedValue(ok(makeCatalogResponse([])));
 
         const modal = await openModal(plugin);
-        // Start fetching the first page (in flight).
-        (modal as any).resetAndFetch();
-        expect((modal as any).isFetching).toBe(true);
+        plugin.api.catalog.mockClear();
+        plugin.api.catalog.mockReturnValueOnce(first.promise);
 
-        // Change the filter mid-flight: increments fetchGeneration.
-        (modal as any).fetchGeneration++;
+        const sortSelect = contentEl(modal).find("lilbee-catalog-filter-sort")! as unknown as {
+            value: string;
+            trigger(event: string): void;
+        };
+        sortSelect.value = "downloads";
+        sortSelect.trigger("change");
+        const request = plugin.api.catalog.mock.calls[0]?.[0] as { signal?: AbortSignal };
+        expect(request.signal).toBeDefined();
 
-        // Resolve the stale request.
-        resolveFirst(ok(makeCatalogResponse([makeEntry({ hf_repo: "stale/repo", display_name: "Stale" })])));
+        const sizeSelect = contentEl(modal).find("lilbee-catalog-filter-size")! as unknown as {
+            value: string;
+            trigger(event: string): void;
+        };
+        sizeSelect.value = "small";
+        sizeSelect.trigger("change");
+
+        first.settle(err(new Error("stale")));
         await tick();
         await tick();
         await tick();
 
-        // The stale response is discarded; entries stay empty.
-        expect((modal as any).entries.length).toBe(0);
-        expect((modal as any).isFetching).toBe(false);
+        expect(request.signal?.aborted).toBe(true);
+        expect(plugin.api.catalog).toHaveBeenCalledTimes(2);
+        expect(plugin.api.catalog).toHaveBeenLastCalledWith(
+            expect.objectContaining({ size: "small", sort: "downloads" }),
+        );
+        expect(Notice.instances).toHaveLength(0);
         modal.close();
     });
 });

--- a/tests/views/draft-modal.test.ts
+++ b/tests/views/draft-modal.test.ts
@@ -133,7 +133,7 @@ describe("DraftModal", () => {
         expect(texts.some((t) => t === "PARSE")).toBe(true);
         expect(texts.some((t) => t === "34% drift")).toBe(true);
         expect(texts.some((t) => t === "faith 0.42")).toBe(true);
-        expect(texts.some((t) => t === "faith")).toBe(true);
+        expect(texts.some((t) => t === "faith unavailable")).toBe(true);
         expect(texts.some((t) => t === "pub")).toBe(true);
         expect(texts.some((t) => t === "new")).toBe(true);
     });

--- a/tests/views/draft-modal.test.ts
+++ b/tests/views/draft-modal.test.ts
@@ -133,7 +133,7 @@ describe("DraftModal", () => {
         expect(texts.some((t) => t === "PARSE")).toBe(true);
         expect(texts.some((t) => t === "34% drift")).toBe(true);
         expect(texts.some((t) => t === "faith 0.42")).toBe(true);
-        expect(texts.some((t) => t === "faith —")).toBe(true);
+        expect(texts.some((t) => t === "faith")).toBe(true);
         expect(texts.some((t) => t === "pub")).toBe(true);
         expect(texts.some((t) => t === "new")).toBe(true);
     });

--- a/tests/views/placement-view.test.ts
+++ b/tests/views/placement-view.test.ts
@@ -196,7 +196,7 @@ describe("PlacementView multi-GPU (auto)", () => {
 
     it("renders an empty utilization bar and free-memory text before any stats arrive", async () => {
         const { contentEl } = await openView(makePlugin(makeApi()));
-        expect(utilVal(contentEl, 0).textContent).toBe("—");
+        expect(utilVal(contentEl, 0).textContent).toBe("N/A");
         expect(vramVal(contentEl, 0).textContent).toBe("18.0 GB / 24.0 GB free");
     });
 
@@ -924,7 +924,7 @@ describe("PlacementView live usage bars", () => {
             { index: 0, utilization_pct: null, free_bytes: 1 * GB, total_bytes: 24 * GB },
         ]);
         expect(utilFill(contentEl, 0).style.width).toBe("0%");
-        expect(utilVal(contentEl, 0).textContent).toBe("—");
+        expect(utilVal(contentEl, 0).textContent).toBe("N/A");
         expect(vramVal(contentEl, 0).textContent).toBe("1.0 GB / 24.0 GB free");
     });
 
@@ -954,7 +954,7 @@ describe("PlacementView live usage bars", () => {
         (view as unknown as StatsApplier).applyStats([
             { index: 99, utilization_pct: 50, free_bytes: 0, total_bytes: 24 * GB },
         ]);
-        expect(utilVal(contentEl, 0).textContent).toBe("—");
+        expect(utilVal(contentEl, 0).textContent).toBe("N/A");
     });
 
     it("subscribes to the stats stream on open and applies streamed events", async () => {
@@ -980,7 +980,7 @@ describe("PlacementView live usage bars", () => {
         await view.onOpen();
         await flush();
         const contentEl = (view as unknown as { contentEl: MockElement }).contentEl;
-        expect(utilVal(contentEl, 0).textContent).toBe("—");
+        expect(utilVal(contentEl, 0).textContent).toBe("N/A");
         await view.onClose();
     });
 


### PR DESCRIPTION
## Problem

Stale catalog responses could render under a new filter, and a failed request stranded the current page. Clearing settings search revealed controls the server does not support. User-facing copy still carried em dashes, and the draft score could read as a measured value when none existed.

## Solution

- Superseded catalog requests abort on filter change and modal close, and stale errors stay silent while the current filter refetches
- Capability-hidden settings rows keep their marker and reapply the active search after config changes
- Em dashes swept from user-facing copy, with a test guarding production strings
- The draft label names the unavailable score plainly

## Notes

Closes #296
Closes #298
