### PR TITLE
Operator QA sweep: wizard, chat rail, server lifecycle, health warnings, streaming

### DIFF
--- a/src/components/model-card.ts
+++ b/src/components/model-card.ts
@@ -1,6 +1,6 @@
 import { setIcon } from "obsidian";
 import type { CatalogEntry, HardwareFit, ModelCardOptions } from "../types";
-import { HARDWARE_FIT, HOSTED_SOURCES, KEY_STATUS, MODEL_COMPAT, MODEL_TASK } from "../types";
+import { HARDWARE_FIT, HOSTED_SOURCES, MODEL_COMPAT, MODEL_TASK } from "../types";
 import { MESSAGES } from "../locales/en";
 import { formatAbbreviatedCount } from "../utils";
 
@@ -123,8 +123,7 @@ function renderCardStatus(card: HTMLElement, entry: CatalogEntry, options: Model
         text: tone.label,
         cls: `lilbee-model-card-status-label ${tone.labelCls}`,
     });
-    const hostedMissingKey = HOSTED_SOURCES.has(entry.source) && entry.key_status === KEY_STATUS.MISSING_KEY;
-    if (entry.installed && !hostedMissingKey) {
+    if (entry.installed && !HOSTED_SOURCES.has(entry.source)) {
         label.setAttribute("title", MESSAGES.TOOLTIP_MODEL_INSTALLED_SHARED);
     }
     if (entry.fit && FIT_LABEL[entry.fit]) {
@@ -142,8 +141,9 @@ function statusTone(
     if (options.isActive) {
         return { dotCls: "is-active", labelCls: "is-active", label: MESSAGES.LABEL_ACTIVE };
     }
-    const hostedMissingKey = HOSTED_SOURCES.has(entry.source) && entry.key_status === KEY_STATUS.MISSING_KEY;
-    if (entry.installed && !hostedMissingKey) {
+    // Hosted models are usable without being downloaded, so they must not
+    // read "Installed (shared)" or offer Delete: they live on the provider.
+    if (entry.installed && !HOSTED_SOURCES.has(entry.source)) {
         return { dotCls: "is-installed", labelCls: "is-installed", label: MESSAGES.LABEL_INSTALLED };
     }
     if (entry.downloads > 0) {
@@ -172,7 +172,9 @@ function renderCardActions(card: HTMLElement, entry: CatalogEntry, options: Mode
         return;
     }
 
-    if (entry.installed) {
+    // Hosted models are usable without being downloaded, so they get a Use
+    // button but never a Remove: they live on the provider, not on disk.
+    if (entry.installed && !HOSTED_SOURCES.has(entry.source)) {
         const useBtn = actions.createEl("button", {
             text: MESSAGES.BUTTON_USE,
             cls: "lilbee-btn lilbee-btn-primary lilbee-catalog-use",
@@ -188,6 +190,15 @@ function renderCardActions(card: HTMLElement, entry: CatalogEntry, options: Mode
         if (options.onRemove) {
             const handler = options.onRemove;
             removeBtn.addEventListener("click", () => handler(entry, removeBtn));
+        }
+    } else if (entry.installed && HOSTED_SOURCES.has(entry.source)) {
+        const useBtn = actions.createEl("button", {
+            text: MESSAGES.BUTTON_USE,
+            cls: "lilbee-btn lilbee-btn-primary lilbee-catalog-use",
+        });
+        if (options.onUse) {
+            const handler = options.onUse;
+            useBtn.addEventListener("click", () => handler(entry, useBtn));
         }
     } else if (entry.compat === MODEL_COMPAT.UNSUPPORTED) {
         // Unsupported models can't run on this server — render the pull action

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -316,6 +316,7 @@ export const MESSAGES = {
     CONFIRM_TAKE_OVER: (vaultName: string): string =>
         `lilbee is currently serving "${vaultName}". Switch it to this vault? The other vault will lose its lilbee connection until you reopen it.`,
     STATUS_LOCKED_BY_OTHER: (vaultName: string): string => `lilbee: serving "${vaultName}"`,
+    LABEL_UNKNOWN_VAULT: "another vault",
     COMMAND_TAKE_OVER: "Take over the managed lilbee server",
     TOOLTIP_MODEL_INSTALLED_SHARED:
         "Installed in the shared lilbee models directory — every vault on this computer can use it without re-downloading.",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -294,6 +294,7 @@ export const MESSAGES = {
         "Materialize crawled pages and imported files inside your vault so you can browse them in Obsidian. Disabled for external servers — their files live on the server machine, not your computer.",
     NOTICE_STORAGE_REORGANIZING: "Reorganizing lilbee storage into your vault…",
     NOTICE_STORAGE_REORGANIZED: "Lilbee storage is now inside your vault.",
+    ERROR_STORAGE_CHECK_FAILED: "Could not read the lilbee server config to check storage location.",
     NOTICE_STORAGE_REORGANIZE_FAILED: (reason: string | null, logPath: string | null, willRetry: boolean): string =>
         [
             "Could not move lilbee storage.",
@@ -710,6 +711,7 @@ export const MESSAGES = {
     STATUS_WARM_LOADING_ENGINE: "lilbee: loading the engine",
     STATUS_READY: "lilbee: ready",
     STATUS_READY_EXTERNAL: "lilbee: ready [external]",
+    STATUS_CONNECTING: "lilbee: connecting...",
     STATUS_ERROR: "lilbee: error",
     STATUS_AUTH_ERROR: "lilbee: auth error",
     NOTICE_SERVER_UNREACHABLE: "lilbee: server unreachable",
@@ -901,6 +903,8 @@ export const MESSAGES = {
     COMMAND_SYNC: "Sync vault",
     COMMAND_SYNC_RETRY_SKIPPED: RETRY_SKIPPED_COMMAND,
     COMMAND_SYNC_REBUILD: "Rebuild index",
+    WARNING_REMEDY_REBUILD: "Rebuild the index to restore full search and embeddings.",
+    BUTTON_REBUILD_INDEX: "Rebuild index",
     COMMAND_EXPORT_DATASET: "Export dataset",
     COMMAND_IMPORT_DATASET: "Import dataset",
     COMMAND_CATALOG: "Browse model catalog",

--- a/src/main.ts
+++ b/src/main.ts
@@ -369,6 +369,9 @@ export default class LilbeePlugin extends Plugin {
     private chatInFlight = 0;
     // Counts consecutive failed probes against HEALTH_FAILURE_STREAK_THRESHOLD.
     private healthFailureStreak = 0;
+    // True once a health probe has validated status "ok". External readiness
+    // belongs to the probe, never to a model-list response.
+    private healthValidated = false;
     // External-mode server version, cached from the health probe; managed mode
     // reads the recorded install version instead.
     private externalServerVersion = "";
@@ -589,7 +592,11 @@ export default class LilbeePlugin extends Plugin {
         const owner: { dataDir: string; pid: number | null } | null = knownOwnerDataDir
             ? { dataDir: knownOwnerDataDir, pid: null }
             : readScopeOwner(registry.sharedRoot);
-        const ownerName = owner ? this.lookupVaultNameByDataDir(owner.dataDir) : "another vault";
+        const ownerName = owner ? await this.resolveOwnerName(owner.dataDir) : MESSAGES.LABEL_UNKNOWN_VAULT;
+        if (owner) {
+            this.updateStatusBar(MESSAGES.STATUS_LOCKED_BY_OTHER(ownerName), DOT_STATE.MUTED);
+            this.setStatusClass("lilbee-status-muted");
+        }
         if (!allowTakeOver) {
             this.updateStatusBar(MESSAGES.STATUS_LOCKED_BY_OTHER(ownerName), DOT_STATE.MUTED);
             onProgress?.({
@@ -657,7 +664,7 @@ export default class LilbeePlugin extends Plugin {
     private lookupVaultNameByDataDir(dataDir: string): string {
         const registry = this.vaultRegistry;
         const entry = registry?.list().find((e) => registry.resolveDataDir(e.id) === dataDir);
-        return entry?.displayName ?? "another vault";
+        return entry?.displayName ?? MESSAGES.LABEL_UNKNOWN_VAULT;
     }
 
     /** Poll the registry for the owner vault's display name for up to two seconds. */
@@ -666,7 +673,7 @@ export default class LilbeePlugin extends Plugin {
         return new Promise((resolve) => {
             const poll = () => {
                 const name = this.lookupVaultNameByDataDir(dataDir);
-                if (name !== "another vault" || Date.now() >= deadline) {
+                if (name !== MESSAGES.LABEL_UNKNOWN_VAULT || Date.now() >= deadline) {
                     resolve(name);
                     return;
                 }
@@ -686,7 +693,7 @@ export default class LilbeePlugin extends Plugin {
         if (owner.dataDir === ourDataDir) return false;
         const ownerName = this.lookupVaultNameByDataDir(owner.dataDir);
         this.updateStatusBar(MESSAGES.STATUS_LOCKED_BY_OTHER(ownerName), DOT_STATE.MUTED);
-        this.setStatusClass("lilbee-status-error");
+        this.setStatusClass("lilbee-status-muted");
         return true;
     }
 
@@ -1987,6 +1994,7 @@ export default class LilbeePlugin extends Plugin {
             "lilbee-status-ready",
             "lilbee-status-adding",
             "lilbee-status-error",
+            "lilbee-status-muted",
         );
         if (cls) this.statusBarEl.classList.add(cls);
     }
@@ -2049,6 +2057,7 @@ export default class LilbeePlugin extends Plugin {
         // foreign HTTP server on the configured URL reads as unreachable.
         if (health?.isOk() && health.value.status === "ok") {
             this.healthFailureStreak = 0;
+            this.healthValidated = true;
             if (this.settings.serverMode === SERVER_MODE.EXTERNAL) this.externalServerVersion = health.value.version;
             // Only a reconnect refetches the model: a restarted server may be on a different one.
             if (this.serverUnreachable) {
@@ -2280,7 +2289,12 @@ export default class LilbeePlugin extends Plugin {
         try {
             const models = await this.api.listModels();
             this.activeModel = models.chat.active;
-            this.setStatusReady();
+            // Repaint the pill so a new model name shows without claiming
+            // ready: only a validated probe promotes to ready.
+            if (this.settings.serverMode === SERVER_MODE.EXTERNAL) {
+                if (this.healthValidated) this.setStatusReady();
+                else this.setStatusConnecting();
+            }
             await this.applyReasoningDefaultOnce();
         } catch {
             // Silently fail - will retry on next action

--- a/src/main.ts
+++ b/src/main.ts
@@ -470,7 +470,7 @@ export default class LilbeePlugin extends Plugin {
                 });
             } else {
                 this.configureApi(this.settings.serverUrl);
-                this.setStatusReady();
+                this.setStatusConnecting();
                 void this.fetchActiveModel();
                 void this.warnExternalServerOutdated();
             }
@@ -658,6 +658,36 @@ export default class LilbeePlugin extends Plugin {
         const registry = this.vaultRegistry;
         const entry = registry?.list().find((e) => registry.resolveDataDir(e.id) === dataDir);
         return entry?.displayName ?? "another vault";
+    }
+
+    /** Poll the registry for the owner vault's display name for up to two seconds. */
+    private resolveOwnerName(dataDir: string): Promise<string> {
+        const deadline = Date.now() + 2000;
+        return new Promise((resolve) => {
+            const poll = () => {
+                const name = this.lookupVaultNameByDataDir(dataDir);
+                if (name !== "another vault" || Date.now() >= deadline) {
+                    resolve(name);
+                    return;
+                }
+                window.setTimeout(poll, 100);
+            };
+            poll();
+        });
+    }
+
+    /** If another vault owns the shared root, show "serving <vault>" and return true. */
+    private refreshLockedByOtherStatus(): boolean {
+        const registry = this.vaultRegistry;
+        if (!registry) return false;
+        const owner = readScopeOwner(registry.sharedRoot);
+        if (owner === null) return false;
+        const ourDataDir = registry.resolveDataDir(this.vaultId);
+        if (owner.dataDir === ourDataDir) return false;
+        const ownerName = this.lookupVaultNameByDataDir(owner.dataDir);
+        this.updateStatusBar(MESSAGES.STATUS_LOCKED_BY_OTHER(ownerName), DOT_STATE.MUTED);
+        this.setStatusClass("lilbee-status-error");
+        return true;
     }
 
     /**
@@ -999,8 +1029,8 @@ export default class LilbeePlugin extends Plugin {
         let current: Record<string, unknown>;
         try {
             current = await this.api.config();
-        } catch (err) {
-            console.error("[lilbee] could not read server config for vault setup", err);
+        } catch {
+            new Notice(MESSAGES.ERROR_STORAGE_CHECK_FAILED, NOTICE_ERROR_DURATION_MS);
             return true;
         }
         const currentDocs = typeof current.documents_dir === "string" ? current.documents_dir : "";
@@ -1310,6 +1340,10 @@ export default class LilbeePlugin extends Plugin {
                 this.setStatusClass("lilbee-status-starting");
                 break;
             case SERVER_STATE.ERROR:
+                // A clean exit while another vault holds the shared root is a
+                // take-over, not a crash. Show "serving <vault>" instead of
+                // "error" so the loser knows who won without a restart loop.
+                if (this.refreshLockedByOtherStatus()) return;
                 this.updateStatusBar(MESSAGES.STATUS_ERROR, DOT_STATE.ERROR);
                 this.setStatusClass("lilbee-status-error");
                 break;
@@ -1739,8 +1773,8 @@ export default class LilbeePlugin extends Plugin {
         this.syncPillEl = null;
         this.taskQueue.dispose();
         if (this.serverManager) {
-            this.journal.lifecycle("plugin unloading; stopping the managed server");
-            void this.serverManager.stop();
+            this.journal.lifecycle("plugin unloading; killing the managed server before unload");
+            this.serverManager.killChildSync();
         }
     }
 
@@ -1925,12 +1959,10 @@ export default class LilbeePlugin extends Plugin {
                 this.serverManager = null;
             }
             this.configureApi(this.settings.serverUrl);
-            // External mode owns its own status via the health probe; paint
-            // "ready [external]" optimistically so the user doesn't see a
-            // stale "stopped" label between the mode switch and the next
-            // probe tick. If the external server is in fact unreachable,
-            // the probe will flip to error on its next run.
-            this.setStatusReady();
+            // The first successful health probe promotes this to "ready"; until
+            // then the user sees "connecting..." so a non-lilbee server never
+            // briefly claims ready on the strength of a mode switch alone.
+            this.setStatusConnecting();
             void this.fetchActiveModel();
         }
     }
@@ -1957,6 +1989,11 @@ export default class LilbeePlugin extends Plugin {
             "lilbee-status-error",
         );
         if (cls) this.statusBarEl.classList.add(cls);
+    }
+
+    private setStatusConnecting(): void {
+        this.updateStatusBar(MESSAGES.STATUS_CONNECTING, DOT_STATE.PRIMARY);
+        this.setStatusClass("lilbee-status-starting");
     }
 
     private setStatusReady(): void {
@@ -2007,7 +2044,10 @@ export default class LilbeePlugin extends Plugin {
         // every restart, and this is the cheapest way to stay in sync.
         this.api.setToken(this.readCurrentToken());
         const health = await this.api.health().catch(() => null);
-        if (health?.isOk()) {
+        // A 200 with a non-lilbee JSON body (e.g. {}) parses fine but is not a
+        // healthy lilbee server. Only a body carrying status: "ok" counts, so a
+        // foreign HTTP server on the configured URL reads as unreachable.
+        if (health?.isOk() && health.value.status === "ok") {
             this.healthFailureStreak = 0;
             if (this.settings.serverMode === SERVER_MODE.EXTERNAL) this.externalServerVersion = health.value.version;
             // Only a reconnect refetches the model: a restarted server may be on a different one.
@@ -2016,6 +2056,10 @@ export default class LilbeePlugin extends Plugin {
                 void this.fetchActiveModel();
             }
             this.reflectChatStatus(health.value);
+            // reflectChatStatus early-returns when the chat status is unchanged,
+            // so a "connecting..." from a mode switch would never clear. Promote
+            // to ready explicitly after a successful probe.
+            this.setStatusReady();
             return;
         }
         this.healthFailureStreak += 1;
@@ -2025,6 +2069,9 @@ export default class LilbeePlugin extends Plugin {
         // Don't paint a red pill. External mode reports errors normally —
         // it points at a server the user already runs.
         if (this.settings.serverMode === SERVER_MODE.MANAGED && !this.serverEverReady) return;
+        // Another vault holds the shared root: the server was asked to exit,
+        // not down. Show who won and skip the "missing token" notice.
+        if (this.refreshLockedByOtherStatus()) return;
         if (this.serverUnreachable) return;
         this.serverUnreachable = true;
         this.updateStatusBar(MESSAGES.STATUS_ERROR, DOT_STATE.ERROR);
@@ -2212,6 +2259,9 @@ export default class LilbeePlugin extends Plugin {
             return;
         }
 
+        // The catalog search may miss the active model (e.g. it is installed
+        // but not in the featured catalog). Fall back to the first row in the
+        // response, which is close enough for the info modal.
         const repo = extractHfRepo(ref);
         const result = await this.api.catalog({ task, search: repo });
         if (result.isErr()) {

--- a/src/server-manager.ts
+++ b/src/server-manager.ts
@@ -398,9 +398,12 @@ export class ServerManager {
             // A clean exit (code 0 or SIGTERM) while we still wanted the server
             // running means another vault asked it to stop via a take-over. Not
             // a crash: do not restart. The scope sidecar now names the winner,
-            // and main.ts surfaces that as STATUS_LOCKED_BY_OTHER.
+            // and main.ts surfaces that as STATUS_LOCKED_BY_OTHER. Without a
+            // foreign owner on record this is an ordinary clean shutdown, so it
+            // keeps the crash path instead of claiming a take-over.
             const exitedCleanly = code === 0 || signal === "SIGTERM";
-            if (exitedCleanly) {
+            const owner = exitedCleanly ? readScopeOwner(this.opts.sharedRoot) : null;
+            if (owner && owner.dataDir !== this.opts.dataDir) {
                 this.journal(
                     `server pid ${child.pid} exited (${describeExit(code, signal)}): another vault took over the shared root`,
                 );
@@ -750,6 +753,7 @@ export class ServerManager {
             window.clearTimeout(this.restartTimer);
             this.restartTimer = null;
         }
+        const wasAdopted = this.adopted;
         this.stopAdoptedWatch();
         const child = this.child;
         this.child = null;
@@ -759,7 +763,17 @@ export class ServerManager {
         this.cleanupPortFile();
         this.setState(SERVER_STATE.STOPPED);
         if (child) {
-            this.signalGroup(child, "SIGKILL");
+            if (process.platform === PLATFORM.WIN32) {
+                this.journal(`sent taskkill /f /t to pid ${child.pid}`);
+                void node.execFile("taskkill", ["/pid", String(child.pid), "/f", "/t"]).catch((err: unknown) => {
+                    this.opts.onShutdownFailure?.(err instanceof Error ? err : new Error(String(err)));
+                });
+                child.kill("SIGKILL");
+            } else {
+                this.signalGroup(child, "SIGKILL");
+            }
+        } else if (wasAdopted) {
+            void requestServerShutdown(this.opts.dataDir);
         }
     }
 

--- a/src/server-manager.ts
+++ b/src/server-manager.ts
@@ -395,6 +395,18 @@ export class ServerManager {
                 this.setState(SERVER_STATE.ERROR);
                 return;
             }
+            // A clean exit (code 0 or SIGTERM) while we still wanted the server
+            // running means another vault asked it to stop via a take-over. Not
+            // a crash: do not restart. The scope sidecar now names the winner,
+            // and main.ts surfaces that as STATUS_LOCKED_BY_OTHER.
+            const exitedCleanly = code === 0 || signal === "SIGTERM";
+            if (exitedCleanly) {
+                this.journal(
+                    `server pid ${child.pid} exited (${describeExit(code, signal)}): another vault took over the shared root`,
+                );
+                this.setState(SERVER_STATE.ERROR);
+                return;
+            }
             this.pushOutputLine(`server exited (${describeExit(code, signal)})`);
             this.journal(`server pid ${child.pid} exited (${describeExit(code, signal)})`);
             this.snapshotCrashOutput();
@@ -724,6 +736,31 @@ export class ServerManager {
             await this.childExit;
         }
         this.journal(`server pid ${child.pid} exit observed after ${Date.now() - stopStartedAt}ms`);
+    }
+
+    /**
+     * Synchronously signal the spawned child's process group to die and remove
+     * its port file. For use in synchronous teardown (onunload) only: it does
+     * not await the process exit. The OS reaps the child; the next plugin
+     * instance finds no stale port and no lock holder, so it spawns fresh.
+     */
+    killChildSync(): void {
+        this.desired = DESIRED.STOPPED;
+        if (this.restartTimer !== null) {
+            window.clearTimeout(this.restartTimer);
+            this.restartTimer = null;
+        }
+        this.stopAdoptedWatch();
+        const child = this.child;
+        this.child = null;
+        this.childExit = null;
+        this.adopted = false;
+        this._actualPort = null;
+        this.cleanupPortFile();
+        this.setState(SERVER_STATE.STOPPED);
+        if (child) {
+            this.signalGroup(child, "SIGKILL");
+        }
     }
 
     /** Ask an adopted server to exit; report when it will not go. */

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -2158,29 +2158,46 @@ export class LilbeeSettingTab extends PluginSettingTab {
     }
 
     private rowsWorkerPool(): RowSpec[] {
+        // Each row waits for the server to report its own key: the server rejects
+        // PATCH for unknown keys, so a row the server does not know would only
+        // error. The visible predicate hides it until the key arrives.
         return [
-            this.numberRow(
-                {
-                    key: "worker_pool_call_timeout_s",
-                    name: MESSAGES.LABEL_WORKER_POOL_CALL_TIMEOUT,
-                    desc: MESSAGES.DESC_WORKER_POOL_CALL_TIMEOUT,
-                },
-                { integer: false, min: 0 },
+            this.visibleRow(
+                this.numberRow(
+                    {
+                        key: "worker_pool_call_timeout_s",
+                        name: MESSAGES.LABEL_WORKER_POOL_CALL_TIMEOUT,
+                        desc: MESSAGES.DESC_WORKER_POOL_CALL_TIMEOUT,
+                    },
+                    { integer: false, min: 0 },
+                ),
+                "worker_pool_call_timeout_s",
             ),
-            this.toggleRow({
-                key: "worker_pool_eager_start",
-                name: MESSAGES.LABEL_WORKER_POOL_EAGER_START,
-                desc: MESSAGES.DESC_WORKER_POOL_EAGER_START,
-            }),
-            this.numberRow(
-                {
-                    key: "worker_pool_max_idle_s",
-                    name: MESSAGES.LABEL_WORKER_POOL_MAX_IDLE,
-                    desc: MESSAGES.DESC_WORKER_POOL_MAX_IDLE,
-                },
-                { integer: false, min: 0 },
+            this.visibleRow(
+                this.toggleRow({
+                    key: "worker_pool_eager_start",
+                    name: MESSAGES.LABEL_WORKER_POOL_EAGER_START,
+                    desc: MESSAGES.DESC_WORKER_POOL_EAGER_START,
+                }),
+                "worker_pool_eager_start",
+            ),
+            this.visibleRow(
+                this.numberRow(
+                    {
+                        key: "worker_pool_max_idle_s",
+                        name: MESSAGES.LABEL_WORKER_POOL_MAX_IDLE,
+                        desc: MESSAGES.DESC_WORKER_POOL_MAX_IDLE,
+                    },
+                    { integer: false, min: 0 },
+                ),
+                "worker_pool_max_idle_s",
             ),
         ];
+    }
+
+    /** A row whose visibility tracks whether the server reports *key*. */
+    private visibleRow(row: RowSpec, key: string): RowSpec {
+        return { ...row, visible: () => this.serverReports(key) };
     }
 
     private renderWorkerPoolSettings(containerEl: HTMLElement): void {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -559,6 +559,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
     /** Detected agent CLIs; null until the first probe lands or after it fails. */
     private agentDetections: AgentClientDetection[] | null = null;
     private agentBodyEl: HTMLElement | null = null;
+    private settingsFilterQuery = "";
     /** Last server config; the definitions read it to decide which rows the connected server supports. */
     private serverConfig: ConfigResponse | null = null;
     /** Capabilities the connected server reports; null until the first probe lands. */
@@ -697,6 +698,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
     render(): void {
         const { containerEl } = this;
         containerEl.empty();
+        this.settingsFilterQuery = "";
         this.serverConfigInputs.clear();
         this.serverConfigToggles.clear();
         this.serverConfigTextAreas.clear();
@@ -709,6 +711,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             attr: { type: "text" },
         });
         filterInput.addEventListener("input", () => {
+            this.settingsFilterQuery = filterInput.value;
             this.filterSettings(containerEl, filterInput.value);
         });
         this.renderBugFeedback(containerEl);
@@ -819,7 +822,10 @@ export class LilbeeSettingTab extends PluginSettingTab {
         if (!crawling && this.crawlingContainerEl) this.crawlingContainerEl.hide();
         if (!wiki && this.wikiContainerEl) this.wikiContainerEl.hide();
         // The offer belongs inside a visible Crawling section, never on its own.
-        if (crawling && !crawlingBrowser && this.crawlerBrowserSetupEl) this.crawlerBrowserSetupEl.show();
+        if (crawling && !crawlingBrowser && this.crawlerBrowserSetupEl) {
+            this.crawlerBrowserSetupEl.removeAttribute("data-lilbee-hidden-by-capability");
+            this.crawlerBrowserSetupEl.show();
+        }
     }
 
     private filterSettings(containerEl: HTMLElement, query: string): void {
@@ -831,7 +837,12 @@ export class LilbeeSettingTab extends PluginSettingTab {
         };
 
         for (const item of Array.from(containerEl.querySelectorAll(".setting-item"))) {
-            (item as HTMLElement).style.display = matches(item) ? "" : "none";
+            if (item.getAttribute("data-lilbee-hidden-by-capability") !== null) {
+                (item as HTMLElement).hide();
+                continue;
+            }
+            if (matches(item)) (item as HTMLElement).show();
+            else (item as HTMLElement).hide();
         }
 
         const wrappers = containerEl.querySelectorAll(
@@ -842,7 +853,8 @@ export class LilbeeSettingTab extends PluginSettingTab {
         for (const wrapper of Array.from(wrappers)) {
             const items = Array.from(wrapper.querySelectorAll(".setting-item"));
             const anyVisible = items.some((i) => (i as HTMLElement).style.display !== "none");
-            (wrapper as HTMLElement).style.display = anyVisible || !term ? "" : "none";
+            if (anyVisible || !term) (wrapper as HTMLElement).show();
+            else (wrapper as HTMLElement).hide();
             if (term && anyVisible && wrapper.tagName === "DETAILS") {
                 wrapper.setAttribute("open", "");
             }
@@ -1942,20 +1954,26 @@ export class LilbeeSettingTab extends PluginSettingTab {
     /** Show or hide a row the plugin owns. On 1.13 the row's visible predicate owns it and this is a no-op. */
     private setRowVisible(el: HTMLElement | null, visible: boolean): void {
         if (!el || this.usesDefinitions()) return;
-        if (visible) el.show();
-        else el.hide();
+        if (visible) {
+            el.show();
+            el.removeAttribute("data-lilbee-hidden-by-capability");
+        } else {
+            el.hide();
+            el.setAttribute("data-lilbee-hidden-by-capability", "true");
+        }
     }
 
     /** Pre-1.13 hides the row until the server reports the key; 1.13 uses the row's visible predicate. */
     private hideUntilServerReports(el: HTMLElement, key: string): void {
         if (this.usesDefinitions()) return;
         el.hide();
+        el.setAttribute("data-lilbee-hidden-by-capability", "true");
         this.serverConfigHideableEls.set(key, el);
     }
 
-    /** Fails open: settings search skips a hidden row, and the config that would unhide it loads late. */
+    /** True only when the loaded server config reports the key. */
     private serverReports(key: string): boolean {
-        return this.serverConfig === null || this.serverConfig[key] !== undefined;
+        return this.serverConfig !== null && this.serverConfig[key] !== undefined;
     }
 
     /** True until a capability probe says the connected server lacks the feature. */
@@ -1970,8 +1988,14 @@ export class LilbeeSettingTab extends PluginSettingTab {
         for (const [key, settingEl] of this.serverConfigHideableEls) {
             if (cfg[key] !== undefined) {
                 settingEl.show();
+                settingEl.removeAttribute("data-lilbee-hidden-by-capability");
+            } else {
+                settingEl.hide();
+                settingEl.setAttribute("data-lilbee-hidden-by-capability", "true");
             }
         }
+        if (this.usesDefinitions()) return;
+        this.filterSettings(this.containerEl, this.settingsFilterQuery);
     }
 
     private applyChatModeFromConfig(cfg: ConfigResponse): void {
@@ -3101,6 +3125,7 @@ export class LilbeeSettingTab extends PluginSettingTab {
             this.refreshVisibility();
             return;
         }
+        this.crawlerBrowserSetupEl?.setAttribute("data-lilbee-hidden-by-capability", "true");
         this.crawlerBrowserSetupEl?.hide();
     }
 

--- a/src/utils/warning-remedies.ts
+++ b/src/utils/warning-remedies.ts
@@ -1,0 +1,35 @@
+import type { App } from "obsidian";
+import type { SyncOptions } from "../types";
+import { MESSAGES } from "../locales/en";
+import { ConfirmModal } from "../views/confirm-modal";
+
+/** A server degradation the plugin knows how to fix: what to tell the user, and what the button does. */
+export interface WarningRemedy {
+    text: string;
+    action: () => void;
+}
+
+/** The slice of the plugin a warning-remedy action needs: the app for dialogs and the rebuild entry point. */
+export interface WarningRemedyPlugin {
+    app: App;
+    triggerSync: (options?: SyncOptions) => void | Promise<void>;
+}
+
+/** Codes the plugin can fix itself; every other code falls back to the server's remedy text. */
+const KNOWN_CODES = new Set(["fts_unavailable", "embedding_prefix_mismatch", "stale_index"]);
+
+function rebuildAction(plugin: WarningRemedyPlugin): () => void {
+    return () => {
+        const modal = new ConfirmModal(plugin.app, MESSAGES.CONFIRM_SYNC_REBUILD);
+        modal.open();
+        void modal.result.then((confirmed) => {
+            if (confirmed) void plugin.triggerSync({ forceRebuild: true });
+        });
+    };
+}
+
+/** Map a warning code to a plugin-native remedy, or null when the plugin does not know the code. */
+export function remedyForWarning(code: string, plugin: WarningRemedyPlugin): WarningRemedy | null {
+    if (!KNOWN_CODES.has(code)) return null;
+    return { text: MESSAGES.WARNING_REMEDY_REBUILD, action: rebuildAction(plugin) };
+}

--- a/src/views/catalog-helpers.ts
+++ b/src/views/catalog-helpers.ts
@@ -132,20 +132,21 @@ function forYouSortKey(entry: CatalogEntry): [number, string] {
     return [entry.fit === HARDWARE_FIT.FITS ? 0 : 1, entry.display_name.toLowerCase()];
 }
 
+/** A catalog row a user can run: featured, supported, and not known unrunnable. */
+export function isRunnablePick(entry: CatalogEntry): boolean {
+    return entry.featured && entry.compat === MODEL_COMPAT.SUPPORTED && entry.fit !== HARDWARE_FIT.WONT_RUN;
+}
+
 /**
  * One runnable pick per role, in role order.
  *
  * Featured is not a curated list — the server resolves it from HuggingFace
- * trending at runtime, so a pick is only as safe as its hardware fit. A row
- * qualifies only when the engine supports its architecture and the machine can
- * hold it, which makes every card a one-click install rather than a coin flip.
- * Rows with no fit chip are excluded outright: an unknown size cannot be
- * promised.
+ * trending at runtime, so a pick is only as safe as its hardware fit. Rows with
+ * no fit chip are kept (a failed probe must not empty the rail); only wont_run
+ * and unsupported are excluded.
  */
 export function forYouRail(entries: CatalogEntry[]): CatalogEntry[] {
-    const runnable = entries.filter(
-        (e) => e.featured && e.compat === MODEL_COMPAT.SUPPORTED && e.fit != null && e.fit !== HARDWARE_FIT.WONT_RUN,
-    );
+    const runnable = entries.filter(isRunnablePick);
     const picks: CatalogEntry[] = [];
     for (const task of FOR_YOU_ROLE_ORDER) {
         const best = runnable

--- a/src/views/catalog-helpers.ts
+++ b/src/views/catalog-helpers.ts
@@ -132,9 +132,12 @@ function forYouSortKey(entry: CatalogEntry): [number, string] {
     return [entry.fit === HARDWARE_FIT.FITS ? 0 : 1, entry.display_name.toLowerCase()];
 }
 
-/** A catalog row a user can run: featured, supported, and not known unrunnable. */
+/** A catalog row a user can run: featured, supported, not known unrunnable, and key-ready when hosted. */
 export function isRunnablePick(entry: CatalogEntry): boolean {
-    return entry.featured && entry.compat === MODEL_COMPAT.SUPPORTED && entry.fit !== HARDWARE_FIT.WONT_RUN;
+    if (!entry.featured || entry.compat !== MODEL_COMPAT.SUPPORTED || entry.fit === HARDWARE_FIT.WONT_RUN) {
+        return false;
+    }
+    return !HOSTED_SOURCES.has(entry.source) || isUsableHostedRow(entry);
 }
 
 /**

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -589,7 +589,7 @@ export class ChatView extends ItemView {
             primary.push({
                 value: ref,
                 label: `${entry.display_name}${sourceTag}`,
-                checked: ref === activeRef,
+                checked: false,
             });
         }
         // Hosted rows (frontier/ollama) are selectable even when absent from the
@@ -598,7 +598,16 @@ export class ChatView extends ItemView {
         // be both hosted and registered as installed).
         for (const [ref, label] of hostedOptions(this.chatCatalogEntries)) {
             if (installedRepos.has(ref)) continue;
-            primary.push({ value: ref, label, checked: ref === activeRef });
+            primary.push({ value: ref, label, checked: false });
+        }
+        // Exactly one checkmark: the concrete ref first, else the first quant of
+        // the reported repo (the server sometimes reports a bare repository).
+        const exact = primary.findIndex((o) => o.value === activeRef);
+        if (exact >= 0) {
+            primary[exact].checked = true;
+        } else {
+            const repoMatch = primary.findIndex((o) => extractHfRepo(o.value) === extractHfRepo(activeRef));
+            if (repoMatch >= 0) primary[repoMatch].checked = true;
         }
         return primary;
     }
@@ -632,6 +641,11 @@ export class ChatView extends ItemView {
         for (const m of this.embeddingModels) repos.add(m.hf_repo);
         for (const task of [MODEL_TASK.VISION, MODEL_TASK.RERANK] as const) {
             for (const m of this.optionalCatalog[task]) repos.add(m.hf_repo);
+        }
+        // A manually installed non-chat build can be absent from every catalog
+        // response; the server's active role refs still name it.
+        for (const ref of [this.activeEmbeddingModel, this.optionalActive.vision, this.optionalActive.rerank]) {
+            if (ref) repos.add(extractHfRepo(ref));
         }
         return repos;
     }
@@ -900,13 +914,14 @@ export class ChatView extends ItemView {
 
         this.plugin.taskQueue.complete(taskId);
 
-        const result = await this.plugin.api.setChatModel(entry.hf_repo);
+        const ref = nativeModelRef(entry.hf_repo, entry.gguf_filename);
+        const result = await this.plugin.api.setChatModel(ref);
         if (result.isErr()) {
             new Notice(
                 noticeForResultError(result.error, MESSAGES.ERROR_SET_MODEL.replace("{model}", entry.display_name)),
             );
         } else {
-            this.plugin.activeModel = entry.hf_repo;
+            this.plugin.activeModel = ref;
             new Notice(MESSAGES.NOTICE_MODEL_ACTIVATED_FULL(entry.display_name));
             this.plugin.refreshSettingsTab();
         }
@@ -1197,6 +1212,9 @@ export class ChatView extends ItemView {
                 { summary: this.summary, sessionId: this.sessionId },
             )) {
                 this.handleStreamEvent(event, textEl, assistantBubble, state, revealContent, scheduleRender);
+            }
+            if (!state.streamEnded && !this.streamController?.signal.aborted) {
+                this.renderInlineError(assistantBubble, streamInterruptedMessage(this.plugin.settings.serverMode));
             }
         } catch (err) {
             // Trust the signal over the error shape: an aborted fetch reaches

--- a/src/views/chat-view.ts
+++ b/src/views/chat-view.ts
@@ -39,12 +39,13 @@ import type {
 import { RateLimitedError, isHttpStatus } from "../api";
 
 import { renderAggregatedSourceChips } from "./results";
-import { displayLabelForRef, extractHfRepo } from "../utils/model-ref";
+import { displayLabelForRef, extractHfRepo, nativeModelRef } from "../utils/model-ref";
 import { ConfirmPullModal } from "./confirm-pull-modal";
 import { ConfirmModal } from "./confirm-modal";
 import { CatalogModal } from "./catalog-modal";
 import { CrawlModal } from "./crawl-modal";
 import { addCloseButton } from "../components/close-button";
+import { remedyForWarning } from "../utils/warning-remedies";
 import { MESSAGES } from "../locales/en";
 import {
     RETRY_INTERVAL_MS,
@@ -580,14 +581,15 @@ export class ChatView extends ItemView {
     /** Featured rows that have an installed quant, then hosted rows not already listed. */
     private chatPrimaryOptions(): RailOption[] {
         const installedRepos = new Set(this.chatInstalled.map((m) => extractHfRepo(m.name)));
-        const activeRepo = extractHfRepo(this.chatActive);
+        const activeRef = this.chatActive;
         const primary: RailOption[] = [];
         for (const entry of this.chatCatalogEntries.filter((e) => installedRepos.has(e.hf_repo))) {
             const sourceTag = HOSTED_SOURCES.has(entry.source) ? ` [${entry.provider ?? entry.source}]` : "";
+            const ref = nativeModelRef(entry.hf_repo, entry.gguf_filename);
             primary.push({
-                value: entry.hf_repo,
+                value: ref,
                 label: `${entry.display_name}${sourceTag}`,
-                checked: entry.hf_repo === activeRepo,
+                checked: ref === activeRef,
             });
         }
         // Hosted rows (frontier/ollama) are selectable even when absent from the
@@ -596,16 +598,21 @@ export class ChatView extends ItemView {
         // be both hosted and registered as installed).
         for (const [ref, label] of hostedOptions(this.chatCatalogEntries)) {
             if (installedRepos.has(ref)) continue;
-            primary.push({ value: ref, label, checked: ref === activeRepo });
+            primary.push({ value: ref, label, checked: ref === activeRef });
         }
         return primary;
     }
 
-    /** Installed builds that aren't in the featured catalog (manually pulled, ollama/, openai/, …). */
+    /** Installed builds that aren't in the featured catalog (manually pulled, ollama/, openai/, …).
+     *  The server's installedModels endpoint returns models for every task, so filter out
+     *  repos that serve another role — an installed embedding/vision/reranker model must
+     *  not leak into the chat menu. */
     private chatOtherOptions(): RailOption[] {
         const sourceMap = new Map(this.chatInstalled.map((m) => [m.name, m.source]));
         const featuredRepos = new Set(this.chatCatalogEntries.map((e) => e.hf_repo));
+        const nonChatRepos = this.nonChatRepos();
         return this.chatInstalled
+            .filter((m) => !nonChatRepos.has(extractHfRepo(m.name)))
             .filter((m) => !featuredRepos.has(extractHfRepo(m.name)))
             .sort((a, b) => a.name.localeCompare(b.name))
             .map((m) => {
@@ -619,6 +626,16 @@ export class ChatView extends ItemView {
             });
     }
 
+    /** Repos that serve embedding, vision, or reranker roles — never chat. */
+    private nonChatRepos(): Set<string> {
+        const repos = new Set<string>();
+        for (const m of this.embeddingModels) repos.add(m.hf_repo);
+        for (const task of [MODEL_TASK.VISION, MODEL_TASK.RERANK] as const) {
+            for (const m of this.optionalCatalog[task]) repos.add(m.hf_repo);
+        }
+        return repos;
+    }
+
     private openChatMenu(event: MouseEvent): void {
         this.openRailMenu(event, this.chatTriggerTextEl, this.chatOptionGroups(), (value) =>
             this.handleChatSelection(value),
@@ -626,8 +643,8 @@ export class ChatView extends ItemView {
     }
 
     private handleChatSelection(value: string): void {
-        const uninstalled = this.chatCatalogEntries.find((e) => e.hf_repo === value && !e.installed);
-        if (uninstalled) {
+        const uninstalled = this.chatCatalogEntries.find((e) => nativeModelRef(e.hf_repo, e.gguf_filename) === value);
+        if (uninstalled && !uninstalled.installed) {
             const modal = new ConfirmPullModal(this.plugin.app, {
                 displayName: uninstalled.display_name,
                 sizeGb: uninstalled.size_gb,
@@ -650,8 +667,6 @@ export class ChatView extends ItemView {
         void this.plugin.api.setChatModel(value).then((result) => {
             if (result.isOk()) {
                 // Keep the menu's checkmark in sync without waiting for a refetch.
-                // Store what the server resolved, not what was sent: a bare repo
-                // comes back as the concrete quant it picked.
                 this.chatActive = result.value.model;
                 this.plugin.activeModel = result.value.model;
                 void this.plugin.fetchActiveModel();
@@ -1280,7 +1295,12 @@ export class ChatView extends ItemView {
                 break;
             }
             case SSE_EVENT.SOURCES:
-                state.sources.push(...(event.data as Source[]));
+                // A malformed frame can carry an object ({sources: []}) instead
+                // of an array; spreading that throws a TypeError that replaces
+                // the answer. Ignore frames that are not arrays.
+                if (Array.isArray(event.data)) {
+                    state.sources.push(...(event.data as Source[]));
+                }
                 break;
             case SSE_EVENT.DONE: {
                 revealContent();
@@ -1492,7 +1512,17 @@ export class ChatView extends ItemView {
         for (const w of this.plugin.healthWarnings) {
             const row = el.createDiv({ cls: "lilbee-chat-warning" });
             row.createSpan({ cls: "lilbee-chat-warning-message", text: w.message });
-            if (w.remedy) row.createSpan({ cls: "lilbee-chat-warning-remedy", text: w.remedy });
+            const remedy = remedyForWarning(w.code, this.plugin);
+            if (remedy) {
+                row.createSpan({ cls: "lilbee-chat-warning-remedy", text: remedy.text });
+                const btn = row.createEl("button", {
+                    text: MESSAGES.BUTTON_REBUILD_INDEX,
+                    cls: "lilbee-chat-warning-action",
+                });
+                btn.addEventListener("click", remedy.action);
+            } else if (w.remedy) {
+                row.createSpan({ cls: "lilbee-chat-warning-remedy", text: w.remedy });
+            }
         }
     }
 

--- a/src/views/documents-modal.ts
+++ b/src/views/documents-modal.ts
@@ -84,8 +84,8 @@ export class DocumentsModal extends Modal {
         const confirmed = await confirm.result;
         if (!confirmed) return;
         try {
-            await this.plugin.api.removeDocuments(names);
-            new Notice(MESSAGES.NOTICE_DELETED(names.length));
+            const result = await this.plugin.api.removeDocuments(names);
+            new Notice(MESSAGES.NOTICE_DELETED(result.removed));
             this.resetAndFetch();
         } catch {
             new Notice(MESSAGES.ERROR_DELETE_DOCUMENTS);

--- a/src/views/documents-modal.ts
+++ b/src/views/documents-modal.ts
@@ -84,8 +84,8 @@ export class DocumentsModal extends Modal {
         const confirmed = await confirm.result;
         if (!confirmed) return;
         try {
-            const result = await this.plugin.api.removeDocuments(names);
-            new Notice(MESSAGES.NOTICE_DELETED(result.removed));
+            await this.plugin.api.removeDocuments(names);
+            new Notice(MESSAGES.NOTICE_DELETED(names.length));
             this.resetAndFetch();
         } catch {
             new Notice(MESSAGES.ERROR_DELETE_DOCUMENTS);

--- a/src/views/setup-wizard.ts
+++ b/src/views/setup-wizard.ts
@@ -795,7 +795,11 @@ export class SetupWizard extends Modal {
                 });
                 return;
             }
-            this.featuredModels = await this.replaceUnrunnablePicks(pickNativeChatModels(result.value.models));
+            this.featuredModels = await this.replaceUnrunnablePicks(
+                pickNativeChatModels(
+                    result.value.models.filter((m) => !HOSTED_SOURCES.has(m.source) || isUsableHostedRow(m)),
+                ),
+            );
         } catch (e) {
             this.featuredModels = [];
             this.selectedModel = null;
@@ -1064,8 +1068,11 @@ export class SetupWizard extends Modal {
             }
             // Trust the server's featured list — don't filter by source.
             // Mis-configured builds can stamp every featured embedding as
-            // source="litellm", which would leave the picker empty.
-            this.embeddingModels = result.value.models.slice(0, MAX_FEATURED_PICKS);
+            // source="litellm", which would leave the picker empty. Only
+            // hosted rows missing their key are excluded: they are not usable.
+            this.embeddingModels = result.value.models
+                .filter((m) => !HOSTED_SOURCES.has(m.source) || isUsableHostedRow(m))
+                .slice(0, MAX_FEATURED_PICKS);
         } catch (e) {
             this.embeddingModels = [];
             this.selectedEmbedding = null;

--- a/src/views/status-modal.ts
+++ b/src/views/status-modal.ts
@@ -4,6 +4,7 @@ import { MANAGED_DOCS_PREFIX, type ModelShowResponse, type StatusResponse } from
 import { DocumentList } from "../components/document-list";
 import { MESSAGES } from "../locales/en";
 import { bindEscapeToClose, noticeForResultError, revealInFileExplorer } from "../utils";
+import { remedyForWarning } from "../utils/warning-remedies";
 
 export class StatusModal extends Modal {
     private plugin: LilbeePlugin;
@@ -54,7 +55,15 @@ export class StatusModal extends Modal {
         for (const w of warnings) {
             const row = section.createDiv({ cls: "lilbee-status-warning" });
             row.createDiv({ cls: "lilbee-status-warning-message", text: w.message });
-            if (w.remedy) {
+            const remedy = remedyForWarning(w.code, this.plugin);
+            if (remedy) {
+                row.createDiv({ cls: "lilbee-status-warning-remedy", text: remedy.text });
+                const btn = row.createEl("button", {
+                    text: MESSAGES.BUTTON_REBUILD_INDEX,
+                    cls: "lilbee-status-warning-action",
+                });
+                btn.addEventListener("click", remedy.action);
+            } else if (w.remedy) {
                 row.createDiv({ cls: "lilbee-status-warning-remedy", text: w.remedy });
             }
         }

--- a/styles.css
+++ b/styles.css
@@ -669,6 +669,14 @@
     padding: 0 var(--size-4-2, 8px);
 }
 
+/* Locked by another vault is informational, not an error: muted like stopped. */
+.status-bar-item.lilbee-status-muted {
+    color: var(--text-muted);
+    background-color: transparent;
+    border-radius: var(--radius-s, 4px);
+    padding: 0 var(--size-4-2, 8px);
+}
+
 .status-bar-item.lilbee-status-adding {
     color: var(--text-on-accent);
     background-color: var(--interactive-accent);
@@ -5312,6 +5320,11 @@ button.lilbee-model-chip-select:focus-visible {
 .lilbee-chat-warning-remedy,
 .lilbee-status-warning-remedy {
     color: var(--text-muted);
+}
+.lilbee-chat-warning-action,
+.lilbee-status-warning-action {
+    align-self: flex-start;
+    margin-top: 4px;
 }
 .lilbee-status-warning {
     padding: 6px 0;

--- a/tests/components/model-card.test.ts
+++ b/tests/components/model-card.test.ts
@@ -312,6 +312,27 @@ describe("renderModelCard", () => {
             expect(card.find("lilbee-catalog-remove")).not.toBeNull();
         });
 
+        it("shows Use without Remove for an installed hosted entry", () => {
+            const c = container();
+            const entry = makeEntry({ installed: true, source: "frontier" });
+            const onUse = vi.fn();
+            const card = renderModelCard(c, entry, { showActions: true, onUse }) as unknown as MockElement;
+            const btn = card.find("lilbee-catalog-use")!;
+            expect(btn).not.toBeNull();
+            expect(card.find("lilbee-catalog-remove")).toBeNull();
+            btn.trigger("click");
+            expect(onUse).toHaveBeenCalledWith(entry, btn);
+        });
+
+        it("does not throw when hosted Use button clicked without onUse", () => {
+            const c = container();
+            const card = renderModelCard(c, makeEntry({ installed: true, source: "frontier" }), {
+                showActions: true,
+            }) as unknown as MockElement;
+            const btn = card.find("lilbee-catalog-use")!;
+            expect(() => btn.trigger("click")).not.toThrow();
+        });
+
         it("shows a disabled Active button when isActive is true", () => {
             const c = container();
             const card = renderModelCard(c, makeEntry({ installed: true }), {

--- a/tests/main-shared.test.ts
+++ b/tests/main-shared.test.ts
@@ -642,12 +642,12 @@ describe("startManagedServer guards", () => {
 });
 
 describe("onunload", () => {
-    it("stops the managed server", async () => {
+    it("kills the managed server synchronously on unload", async () => {
         const plugin = await createPlugin();
-        const stop = vi.fn().mockResolvedValue(undefined);
-        (plugin as any).serverManager = { stop };
+        const killChildSync = vi.fn();
+        (plugin as any).serverManager = { killChildSync };
         plugin.onunload();
-        expect(stop).toHaveBeenCalled();
+        expect(killChildSync).toHaveBeenCalled();
     });
 });
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -55,7 +55,7 @@ vi.mock("../src/api", async (importOriginal) => ({
             setTokenProvider: vi.fn(),
             setOutcomeCallback: vi.fn(),
             setBaseUrl: vi.fn(),
-            health: vi.fn().mockResolvedValue({ isErr: () => false, isOk: () => true, value: {} }),
+            health: vi.fn().mockResolvedValue({ isErr: () => false, isOk: () => true, value: { status: "ok" } }),
             // Default config matches the test vault layout so the fire-and-forget
             // configureManagedStorage() in startManagedServer() hits the early
             // no-op exit instead of throwing on a missing method.
@@ -226,6 +226,7 @@ vi.mock("../src/views/update-available-modal", () => ({
 const mockGatekeeperOpen = vi.fn();
 const mockServerStart = vi.fn().mockResolvedValue(undefined);
 const mockServerStop = vi.fn().mockResolvedValue(undefined);
+const mockServerKillChildSync = vi.fn();
 let mockServerOpts: any = null;
 
 vi.mock("../src/server-binary", () => ({
@@ -292,6 +293,7 @@ vi.mock("../src/server-manager", () => ({
         return {
             start: mockServerStart,
             stop: mockServerStop,
+            killChildSync: mockServerKillChildSync,
             restart: vi.fn(),
             get isAdopted() {
                 return mockIsAdopted;
@@ -934,10 +936,10 @@ describe("LilbeePlugin", () => {
             );
         });
 
-        it("sets status bar text to 'lilbee: ready [external]' in external mode", async () => {
+        it("sets status bar text to 'lilbee: connecting...' in external mode after onload", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
-            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready [external]");
+            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: connecting...");
         });
 
         it("registers vault watchers for the pending-sync hint plus the file-menu listener", async () => {
@@ -3812,15 +3814,19 @@ describe("LilbeePlugin", () => {
             await plugin.onload();
             expect(plugin.serverSupportsSessions()).toBe(true);
 
-            plugin.api.health = vi
-                .fn()
-                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { version: "0.6.66b507" } });
+            plugin.api.health = vi.fn().mockResolvedValue({
+                isErr: () => false,
+                isOk: () => true,
+                value: { status: "ok", version: "0.6.66b507" },
+            });
             await (plugin as any).probeServerHealth();
             expect(plugin.serverSupportsSessions()).toBe(false);
 
-            plugin.api.health = vi
-                .fn()
-                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { version: "0.6.90b420" } });
+            plugin.api.health = vi.fn().mockResolvedValue({
+                isErr: () => false,
+                isOk: () => true,
+                value: { status: "ok", version: "0.6.90b420" },
+            });
             await (plugin as any).probeServerHealth();
             expect(plugin.serverSupportsSessions()).toBe(true);
         });
@@ -3829,11 +3835,28 @@ describe("LilbeePlugin", () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             vi.spyOn(plugin, "ensureManagedConsentThenStart").mockResolvedValue({ kind: "canceled" } as any);
             await plugin.onload();
-            plugin.api.health = vi
-                .fn()
-                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { version: "0.6.66b507" } });
+            plugin.api.health = vi.fn().mockResolvedValue({
+                isErr: () => false,
+                isOk: () => true,
+                value: { status: "ok", version: "0.6.66b507" },
+            });
             await (plugin as any).probeServerHealth();
             expect((plugin as any).externalServerVersion).toBe("");
+        });
+
+        it("probe with non-ready chat status skips setStatusReady", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            (plugin as any).chatStatus = CHAT_STATUS.LOADING;
+            plugin.api.health = vi.fn().mockResolvedValue({
+                isErr: () => false,
+                isOk: () => true,
+                value: { status: "ok", chat_ready: false },
+            });
+            await (plugin as any).probeServerHealth();
+            // Chat is loading: reflectChatStatus paints "warming..." and the
+            // probe must not override it with "ready".
+            expect((plugin.statusBarEl as any)?.textContent).not.toContain("ready");
         });
     });
 
@@ -4829,8 +4852,10 @@ describe("LilbeePlugin", () => {
             await (plugin as any).probeServerHealth();
             expect((plugin.statusBarEl as any)?.textContent).toContain("error");
 
-            // Recovery: health() resolves Ok.
-            plugin.api.health = vi.fn().mockResolvedValue({ isErr: () => false, isOk: () => true, value: {} });
+            // Recovery: health() resolves Ok with status: "ok".
+            plugin.api.health = vi
+                .fn()
+                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { status: "ok" } });
             plugin.api.listModels = vi
                 .fn()
                 .mockResolvedValue({ chat: { active: "qwen3:4b", catalog: [], installed: [] } });
@@ -4926,7 +4951,7 @@ describe("LilbeePlugin", () => {
             plugin.activeModel = "old";
             plugin.api.health = vi
                 .fn()
-                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { chat_ready: true } });
+                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { status: "ok", chat_ready: true } });
             plugin.api.listModels = vi
                 .fn()
                 .mockResolvedValue({ chat: { active: "Qwen3-235B", catalog: [], installed: [] } });
@@ -4940,7 +4965,9 @@ describe("LilbeePlugin", () => {
             await plugin.onload();
             plugin.api.health = vi.fn().mockResolvedValue(err(new Error("down")));
             await (plugin as any).probeServerHealth();
-            plugin.api.health = vi.fn().mockResolvedValue({ isErr: () => false, isOk: () => true, value: {} });
+            plugin.api.health = vi
+                .fn()
+                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { status: "ok" } });
             plugin.api.listModels = vi
                 .fn()
                 .mockResolvedValue({ chat: { active: "qwen3:4b", catalog: [], installed: [] } });
@@ -4989,6 +5016,33 @@ describe("LilbeePlugin", () => {
             (plugin as any).healthFailureStreak = 5;
             await (plugin as any).probeServerHealth();
             expect((plugin.statusBarEl as any)?.textContent ?? "").not.toContain("error");
+        });
+
+        it("treats a 200 with a non-lilbee JSON body as a probe failure", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            // A 2020 with {} (no status: "ok") is not a lilbee server — the
+            // probe must treat it as unreachable, not ready.
+            plugin.api.health = vi.fn().mockResolvedValue({ isErr: () => false, isOk: () => true, value: {} });
+            await (plugin as any).probeServerHealth();
+            await (plugin as any).probeServerHealth();
+            expect((plugin.statusBarEl as any)?.textContent).toContain("error");
+        });
+
+        it("promotes to ready only after a probe reports status ok", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            // After onload the status is "connecting...", not "ready".
+            expect((plugin.statusBarEl as any)?.textContent).toBe("lilbee: connecting...");
+            plugin.api.health = vi
+                .fn()
+                .mockResolvedValue({ isErr: () => false, isOk: () => true, value: { status: "ok" } });
+            plugin.api.listModels = vi
+                .fn()
+                .mockResolvedValue({ chat: { active: "qwen3:4b", catalog: [], installed: [] } });
+            plugin.api.status = vi.fn().mockResolvedValue(err(new Error("down")));
+            await (plugin as any).probeServerHealth();
+            expect((plugin.statusBarEl as any)?.textContent).toContain("ready");
         });
 
         it("skips probing while a chat stream is in flight", async () => {
@@ -5318,7 +5372,7 @@ describe("LilbeePlugin", () => {
             await new Promise((r) => setTimeout(r, 0));
 
             expect(plugin.activeModel).toBe("");
-            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready [external]");
+            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: connecting...");
         });
 
         it("turns show_reasoning on the first time the server reports it off, then never again", async () => {
@@ -5924,6 +5978,7 @@ describe("LilbeePlugin", () => {
         it("setStatusReady adds lilbee-status-ready class", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
+            (plugin as any).setStatusReady();
 
             const el = (plugin as any).statusBarEl!;
             expect(el.classList.contains("lilbee-status-ready")).toBe(true);
@@ -6624,6 +6679,75 @@ describe("LilbeePlugin", () => {
             expect(plugin.statusBarEl?.classList.contains("lilbee-status-error")).toBe(true);
         });
 
+        it("handleServerStateChange error shows STATUS_LOCKED_BY_OTHER when another vault owns the root", async () => {
+            const sm = await import("../src/server-manager");
+            vi.mocked(sm.readScopeOwner).mockReturnValue({
+                dataDir: "/shared/vaults/other",
+                pid: 999,
+            });
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const stateChange = mockServerOpts?.onStateChange;
+            stateChange("error");
+
+            expect(plugin.statusBarEl?.textContent).toContain("serving");
+            expect(plugin.statusBarEl?.textContent).not.toContain("error");
+        });
+
+        it("refreshLockedByOtherStatus returns false when no foreign owner", async () => {
+            const sm = await import("../src/server-manager");
+            vi.mocked(sm.readScopeOwner).mockReturnValue(null);
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            expect((plugin as any).refreshLockedByOtherStatus()).toBe(false);
+        });
+
+        it("refreshLockedByOtherStatus returns false without a registry", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            (plugin as any).vaultRegistry = null;
+            expect((plugin as any).refreshLockedByOtherStatus()).toBe(false);
+        });
+
+        it("refreshLockedByOtherStatus returns false when we own the root", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const sm = await import("../src/server-manager");
+            const ourDataDir = (plugin as any).vaultRegistry.resolveDataDir((plugin as any).vaultId);
+            vi.mocked(sm.readScopeOwner).mockReturnValue({ dataDir: ourDataDir, pid: 1 });
+
+            expect((plugin as any).refreshLockedByOtherStatus()).toBe(false);
+        });
+
+        it("health probe shows STATUS_LOCKED_BY_OTHER and skips token notice", async () => {
+            const sm = await import("../src/server-manager");
+            vi.mocked(sm.readScopeOwner).mockReturnValue({
+                dataDir: "/shared/vaults/other",
+                pid: 999,
+            });
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+            // Make the health probe fail so it reaches the locked-by-other check.
+            plugin.api.health = vi.fn().mockResolvedValue({ isOk: () => false, isErr: () => true });
+            (plugin as any).serverEverReady = true;
+            (plugin as any).healthFailureStreak = 1;
+            await (plugin as any).probeServerHealth();
+
+            expect(plugin.statusBarEl?.textContent).toContain("serving");
+            expect(Notice.instances.some((n) => n.message.includes("session token"))).toBe(false);
+        });
+
         it("handleServerStateChange ready re-renders an open lilbee Settings tab (ydt)", async () => {
             const { LilbeeSettingTab } = await import("../src/settings");
             const plugin = await createPlugin({ serverMode: "managed" });
@@ -6923,6 +7047,78 @@ describe("LilbeePlugin", () => {
             expect(el.classList.contains("lilbee-status-ready")).toBe(false);
             expect(el.classList.contains("lilbee-status-downloading")).toBe(false);
         });
+
+        it("take-over prompt resolves the owner name from the registry", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const registry = (plugin as any).vaultRegistry;
+            vi.spyOn(registry, "list").mockReturnValue([
+                {
+                    id: "other",
+                    displayName: "vault-new",
+                    dataDir: "/shared/vaults/other",
+                    obsidianVaultPath: "/path/to/other",
+                    addedAt: 0,
+                    lastActiveAt: 0,
+                },
+            ]);
+            vi.spyOn(registry, "resolveDataDir").mockImplementation((id) =>
+                id === "other" ? "/shared/vaults/other" : registry.resolveDataDir(id),
+            );
+
+            const name = await (plugin as any).resolveOwnerName("/shared/vaults/other");
+            expect(name).toBe("vault-new");
+        });
+
+        it("take-over prompt falls back to 'another vault' when unregistered", async () => {
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const name = await (plugin as any).resolveOwnerName("/shared/vaults/unknown");
+            expect(name).toBe("another vault");
+        });
+
+        it("take-over prompt shows STATUS_LOCKED_BY_OTHER while waiting, not 'error'", async () => {
+            const sm = await import("../src/server-manager");
+            vi.mocked(sm.readScopeOwner).mockReturnValue({
+                dataDir: "/shared/vaults/other",
+                pid: 1234,
+            });
+            mockConfirmModalResult = false;
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const registry = (plugin as any).vaultRegistry;
+            vi.spyOn(registry, "list").mockReturnValue([
+                {
+                    id: "other",
+                    displayName: "vault-new",
+                    dataDir: "/shared/vaults/other",
+                    obsidianVaultPath: "/path/to/other",
+                    addedAt: 0,
+                    lastActiveAt: 0,
+                },
+            ]);
+            vi.spyOn(registry, "resolveDataDir").mockImplementation((id) =>
+                id === "other" ? "/shared/vaults/other" : registry.resolveDataDir(id),
+            );
+
+            await (plugin as any).negotiateTakeOver(
+                (plugin as any).vaultRegistry,
+                undefined,
+                true,
+                "/shared/vaults/other",
+            );
+
+            const el = (plugin as any).statusBarEl!;
+            expect(el.textContent).toContain("serving");
+            expect(el.textContent).not.toContain("error");
+        });
     });
 
     describe("saveSettings mode switching", () => {
@@ -6956,7 +7152,7 @@ describe("LilbeePlugin", () => {
             expect(mockEnsure).toHaveBeenCalled();
         });
 
-        it("2rf: managed → external sets status to 'ready [external]', not 'stopped'", async () => {
+        it("2rf: managed → external sets status to 'connecting...', not 'stopped'", async () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
             await flush();
@@ -6966,7 +7162,7 @@ describe("LilbeePlugin", () => {
             await flush();
 
             const text = (plugin as any).statusBarEl?.textContent ?? "";
-            expect(text).toContain("[external]");
+            expect(text).toContain("connecting");
             expect(text).not.toContain("stopped");
         });
 
@@ -6988,7 +7184,7 @@ describe("LilbeePlugin", () => {
 
             const text = (plugin as any).statusBarEl?.textContent ?? "";
             expect(text).not.toContain("stopped");
-            expect(text).toContain("[external]");
+            expect(text).toContain("connecting");
         });
     });
 
@@ -7226,23 +7422,24 @@ describe("LilbeePlugin", () => {
     });
 
     describe("onunload with serverManager", () => {
-        it("calls serverManager.stop on unload", async () => {
+        it("calls serverManager.killChildSync on unload, not the async stop", async () => {
             const plugin = await createPlugin({ serverMode: "managed" });
             await plugin.onload();
             await flush();
 
-            mockServerStop.mockClear();
+            mockServerKillChildSync.mockClear();
             plugin.onunload();
 
-            expect(mockServerStop).toHaveBeenCalled();
+            expect(mockServerKillChildSync).toHaveBeenCalled();
+            expect(mockServerStop).not.toHaveBeenCalled();
         });
     });
 
     describe("external mode status bar label", () => {
-        it("shows [external] in external mode", async () => {
+        it("shows 'connecting...' in external mode after onload", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
-            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready [external]");
+            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: connecting...");
         });
 
         it("does not show [external] in managed mode", async () => {

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -5045,6 +5045,20 @@ describe("LilbeePlugin", () => {
             expect((plugin.statusBarEl as any)?.textContent).toContain("ready");
         });
 
+        it("stays connecting when listModels succeeds but the health probe fails", async () => {
+            const plugin = await createPlugin({ serverMode: "external" });
+            await plugin.onload();
+            plugin.api.listModels = vi
+                .fn()
+                .mockResolvedValue({ chat: { active: "qwen3:4b", catalog: [], installed: [] } });
+            await plugin.fetchActiveModel();
+            expect(plugin.activeModel).toBe("qwen3:4b");
+            plugin.api.health = vi.fn().mockResolvedValue({ isErr: () => false, isOk: () => true, value: {} });
+            await (plugin as any).probeServerHealth();
+            expect((plugin.statusBarEl as any)?.textContent).toContain("connecting");
+            expect((plugin.statusBarEl as any)?.textContent).not.toContain("ready");
+        });
+
         it("skips probing while a chat stream is in flight", async () => {
             const plugin = await createPlugin({ serverMode: "external" });
             await plugin.onload();
@@ -5347,7 +5361,7 @@ describe("LilbeePlugin", () => {
     });
 
     describe("active model in status bar", () => {
-        it("fetchActiveModel sets activeModel and updates status bar", async () => {
+        it("fetchActiveModel sets activeModel without claiming ready before the health probe", async () => {
             const plugin = await createPlugin();
             await plugin.onload();
 
@@ -5359,7 +5373,8 @@ describe("LilbeePlugin", () => {
             await new Promise((r) => setTimeout(r, 0));
 
             expect(plugin.activeModel).toBe("qwen3:8b");
-            expect((plugin as any).statusBarEl?.textContent).toBe("lilbee: ready [external] (qwen3:8b)");
+            expect((plugin as any).statusBarEl?.textContent).toContain("connecting");
+            expect((plugin as any).statusBarEl?.textContent).not.toContain("ready");
         });
 
         it("fetchActiveModel silently fails on API error", async () => {
@@ -7079,6 +7094,45 @@ describe("LilbeePlugin", () => {
 
             const name = await (plugin as any).resolveOwnerName("/shared/vaults/unknown");
             expect(name).toBe("another vault");
+        });
+
+        it("take-over prompt waits for a lagging registry heartbeat instead of 'another vault'", async () => {
+            const sm = await import("../src/server-manager");
+            vi.mocked(sm.readScopeOwner).mockReturnValue({
+                dataDir: "/shared/vaults/other",
+                pid: 1234,
+            });
+            mockConfirmModalResult = false;
+
+            const plugin = await createPlugin({ serverMode: "managed" });
+            await plugin.onload();
+            await flush();
+
+            const entry = {
+                id: "other",
+                displayName: "vault-new",
+                dataDir: "/shared/vaults/other",
+                obsidianVaultPath: "/path/to/other",
+                addedAt: 0,
+                lastActiveAt: 0,
+            };
+            const registry = (plugin as any).vaultRegistry;
+            let calls = 0;
+            vi.spyOn(registry, "list").mockImplementation(() => (++calls === 1 ? [] : [entry]));
+            vi.spyOn(registry, "resolveDataDir").mockImplementation((id: string) =>
+                id === "other" ? "/shared/vaults/other" : "/shared/vaults/mine",
+            );
+
+            await (plugin as any).negotiateTakeOver(
+                (plugin as any).vaultRegistry,
+                undefined,
+                true,
+                "/shared/vaults/other",
+            );
+
+            const el = (plugin as any).statusBarEl!;
+            expect(el.textContent).toContain("vault-new");
+            expect(el.textContent).not.toContain("another vault");
         });
 
         it("take-over prompt shows STATUS_LOCKED_BY_OTHER while waiting, not 'error'", async () => {

--- a/tests/server-manager.test.ts
+++ b/tests/server-manager.test.ts
@@ -845,6 +845,12 @@ describe("ServerManager", () => {
         it("a clean exit (SIGTERM) is a take-over, not a crash: no restart", async () => {
             const journal: string[] = [];
             const mgr = await startFresh({ onJournal: (m) => journal.push(m) });
+            readFileSyncSpy.mockImplementation((p: unknown) => {
+                if (String(p).endsWith("server.scope.owner.json")) {
+                    return JSON.stringify({ data_dir: "/tmp/other", pid: 42 });
+                }
+                return fileRouter("absent")(p);
+            });
             child()._emit("exit", null, "SIGTERM");
             expect(mgr.state).toBe("error");
             expect(journal.join("\n")).toContain("another vault took over");
@@ -857,11 +863,26 @@ describe("ServerManager", () => {
         it("a clean exit (code 0) is a take-over, not a crash: no restart", async () => {
             const journal: string[] = [];
             const mgr = await startFresh({ onJournal: (m) => journal.push(m) });
+            readFileSyncSpy.mockImplementation((p: unknown) => {
+                if (String(p).endsWith("server.scope.owner.json")) {
+                    return JSON.stringify({ data_dir: "/tmp/other", pid: 42 });
+                }
+                return fileRouter("absent")(p);
+            });
             child()._emit("exit", 0, null);
             expect(mgr.state).toBe("error");
             expect(journal.join("\n")).toContain("another vault took over");
             await vi.advanceTimersByTimeAsync(3000);
             expect(spawnSpy).toHaveBeenCalledTimes(1); // no restart
+        });
+
+        it("a clean exit with no foreign owner keeps the crash path", async () => {
+            const mgr = await startFresh();
+            child()._emit("exit", 0, null);
+            expect(mgr.state).toBe("error");
+            expect(appendFileSyncSpy).toHaveBeenCalled();
+            await vi.advanceTimersByTimeAsync(3000);
+            expect(spawnSpy).toHaveBeenCalledTimes(2); // restarted as a crash
         });
 
         it("a signal exit is described by its signal", async () => {
@@ -1319,6 +1340,72 @@ describe("ServerManager", () => {
             expect(mgr.isAdopted).toBe(false);
             expect(mgr.serverUrl).toBe("");
             expect(unlinkSyncSpy).toHaveBeenCalled();
+        });
+
+        it("asks an adopted server to exit over its API on unload", async () => {
+            readFileSyncSpy.mockImplementation(fileRouter("present"));
+            const mgr = new ServerManager(defaultOpts());
+            await mgr.start();
+            expect(mgr.isAdopted).toBe(true);
+            fetchSpy.mockClear();
+
+            mgr.killChildSync();
+
+            expect(fetchSpy.mock.calls.some((call) => String(call[0]).endsWith("/api/shutdown"))).toBe(true);
+            expect(mgr.isAdopted).toBe(false);
+        });
+
+        it("reports a taskkill failure on Windows without throwing", async () => {
+            const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+            const failures: Error[] = [];
+            try {
+                const mgr = await startFresh({ onShutdownFailure: (e) => failures.push(e) });
+                const c = child();
+                vi.spyOn(node, "execFile").mockRejectedValueOnce(new Error("Access is denied."));
+
+                mgr.killChildSync();
+                await vi.advanceTimersByTimeAsync(0);
+
+                expect(failures).toHaveLength(1);
+                expect(c.kill).toHaveBeenCalledWith("SIGKILL");
+                expect(mgr.state).toBe("stopped");
+            } finally {
+                platformSpy.mockRestore();
+            }
+        });
+
+        it("wraps a non-Error taskkill rejection on Windows", async () => {
+            const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+            const failures: Error[] = [];
+            try {
+                const mgr = await startFresh({ onShutdownFailure: (e) => failures.push(e) });
+                vi.spyOn(node, "execFile").mockRejectedValueOnce("denied");
+
+                mgr.killChildSync();
+                await vi.advanceTimersByTimeAsync(0);
+
+                expect(failures).toHaveLength(1);
+                expect(failures[0]).toEqual(new Error("denied"));
+            } finally {
+                platformSpy.mockRestore();
+            }
+        });
+
+        it("uses taskkill on Windows for a synchronous unload", async () => {
+            const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+            const execSpy = vi.spyOn(node, "execFile");
+            try {
+                const mgr = await startFresh();
+                const c = child();
+
+                mgr.killChildSync();
+
+                expect(execSpy).toHaveBeenCalledWith("taskkill", ["/pid", String(c.pid), "/f", "/t"]);
+                expect(c.kill).toHaveBeenCalledWith("SIGKILL");
+                expect(processKillSpy).not.toHaveBeenCalled();
+            } finally {
+                platformSpy.mockRestore();
+            }
         });
 
         it("returns without awaiting — the child exit is not required to proceed", async () => {

--- a/tests/server-manager.test.ts
+++ b/tests/server-manager.test.ts
@@ -842,6 +842,28 @@ describe("ServerManager", () => {
             expect(mgr.state).toBe("ready");
         });
 
+        it("a clean exit (SIGTERM) is a take-over, not a crash: no restart", async () => {
+            const journal: string[] = [];
+            const mgr = await startFresh({ onJournal: (m) => journal.push(m) });
+            child()._emit("exit", null, "SIGTERM");
+            expect(mgr.state).toBe("error");
+            expect(journal.join("\n")).toContain("another vault took over");
+            // No crash snapshot, no restart scheduled.
+            expect(appendFileSyncSpy).not.toHaveBeenCalled();
+            await vi.advanceTimersByTimeAsync(3000);
+            expect(spawnSpy).toHaveBeenCalledTimes(1); // no restart
+        });
+
+        it("a clean exit (code 0) is a take-over, not a crash: no restart", async () => {
+            const journal: string[] = [];
+            const mgr = await startFresh({ onJournal: (m) => journal.push(m) });
+            child()._emit("exit", 0, null);
+            expect(mgr.state).toBe("error");
+            expect(journal.join("\n")).toContain("another vault took over");
+            await vi.advanceTimersByTimeAsync(3000);
+            expect(spawnSpy).toHaveBeenCalledTimes(1); // no restart
+        });
+
         it("a signal exit is described by its signal", async () => {
             const mgr = await startFresh();
             child()._emit("exit", null, "SIGSEGV");
@@ -1240,6 +1262,73 @@ describe("ServerManager", () => {
             await stopP;
             expect(mgr.state).toBe("stopped");
             expect(failures).toHaveLength(1);
+        });
+    });
+
+    // ── killChildSync ───────────────────────────────────────────────
+
+    describe("killChildSync", () => {
+        it("sends SIGKILL to the child and cleans up the port file, synchronously", async () => {
+            const mgr = await startFresh();
+            const c = child();
+            expect(mgr.state).toBe("ready");
+
+            mgr.killChildSync();
+
+            expect(c.kill).toHaveBeenCalledWith("SIGKILL");
+            expect(unlinkSyncSpy).toHaveBeenCalled();
+            expect(mgr.state).toBe("stopped");
+            expect(mgr.serverUrl).toBe("");
+        });
+
+        it("signals the process group when the group exists", async () => {
+            processKillSpy.mockImplementation(() => true);
+            const mgr = await startFresh();
+            const c = child();
+
+            mgr.killChildSync();
+
+            expect(processKillSpy).toHaveBeenCalledWith(-c.pid, "SIGKILL");
+        });
+
+        it("is a no-op when nothing is running", () => {
+            const mgr = new ServerManager(defaultOpts());
+            expect(() => mgr.killChildSync()).not.toThrow();
+            expect(mgr.state).toBe("stopped");
+        });
+
+        it("clears the restart timer so a queued restart does not fire after unload", async () => {
+            const mgr = await startFresh();
+            const c = child();
+            (mgr as any).restartTimer = 42;
+
+            mgr.killChildSync();
+
+            expect((mgr as any).restartTimer).toBeNull();
+            expect(c.kill).toHaveBeenCalledWith("SIGKILL");
+        });
+
+        it("cleans up an adopted server's state without killing anything", async () => {
+            readFileSyncSpy.mockImplementation(fileRouter("present"));
+            const mgr = new ServerManager(defaultOpts());
+            await mgr.start();
+            expect(mgr.isAdopted).toBe(true);
+
+            mgr.killChildSync();
+
+            expect(mgr.isAdopted).toBe(false);
+            expect(mgr.serverUrl).toBe("");
+            expect(unlinkSyncSpy).toHaveBeenCalled();
+        });
+
+        it("returns without awaiting — the child exit is not required to proceed", async () => {
+            const mgr = await startFresh();
+            const c = child();
+            // kill does NOT trigger an exit event; killChildSync still returns.
+            c.kill.mockImplementation(() => true);
+
+            expect(() => mgr.killChildSync()).not.toThrow();
+            expect(c.kill).toHaveBeenCalledWith("SIGKILL");
         });
     });
 

--- a/tests/settings-definitions.test.ts
+++ b/tests/settings-definitions.test.ts
@@ -442,17 +442,29 @@ describe("visibility predicates", () => {
         return items.find((item) => item.heading === heading);
     }
 
-    it("keeps a server-config row searchable before the config loads, then hides it if unsupported", () => {
+    it("hides a server-config row until the config reports support", () => {
         const tab = makeTab();
         const row = findRow(tab.getSettingDefinitions() as Definition[], MESSAGES.LABEL_FLASH_ATTENTION);
 
-        // The config has not loaded when a search runs, and search skips a hidden row.
-        expect(row?.visible?.()).toBe(true);
+        expect(row?.visible?.()).toBe(false);
 
         (tab as any).serverConfig = { something_else: true };
         expect(row?.visible?.()).toBe(false);
 
         (tab as any).serverConfig = { flash_attention: true };
+        expect(row?.visible?.()).toBe(true);
+    });
+
+    it("hides worker-pool rows until the server reports each key", () => {
+        const tab = makeTab();
+        const row = findRow(tab.getSettingDefinitions() as Definition[], MESSAGES.LABEL_WORKER_POOL_CALL_TIMEOUT);
+
+        expect(row?.visible?.()).toBe(false);
+
+        (tab as any).serverConfig = { worker_pool_eager_start: true };
+        expect(row?.visible?.()).toBe(false);
+
+        (tab as any).serverConfig = { worker_pool_call_timeout_s: 30 };
         expect(row?.visible?.()).toBe(true);
     });
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -2,7 +2,7 @@ import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
 import { App, Notice, Setting } from "obsidian";
 import { MockElement } from "./__mocks__/obsidian";
 import { LilbeeSettingTab, SEPARATOR_KEY } from "../src/settings";
-import type { CatalogEntry, CatalogResponse, InstalledModel, LilbeeSettings } from "../src/types";
+import type { CatalogEntry, CatalogResponse, ConfigResponse, InstalledModel, LilbeeSettings } from "../src/types";
 import {
     DEFAULT_SETTINGS,
     MEMORY_CONFIG_KEY,
@@ -7407,6 +7407,47 @@ describe("managed mode settings", () => {
             expect(hideable.get("worker_pool_call_timeout_s")?.style.display).toBe("");
             expect(hideable.get("worker_pool_eager_start")?.style.display).toBe("");
             expect(hideable.get("worker_pool_max_idle_s")?.style.display).toBe("");
+        });
+
+        it("marks producer-hidden rows so clearing the search keeps them hidden", () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            tab.display();
+
+            const hideable = (tab as unknown as { serverConfigHideableEls: Map<string, MockElement> })
+                .serverConfigHideableEls;
+            const item = hideable.get("worker_pool_call_timeout_s");
+            expect(item).toBeDefined();
+            expect(item?.getAttribute("data-lilbee-hidden-by-capability")).toBe("true");
+
+            (tab as unknown as { filterSettings(container: HTMLElement, query: string): void }).filterSettings(
+                tab.containerEl,
+                "",
+            );
+
+            expect(item?.style.display).toBe("none");
+        });
+
+        it("reapplies the active query when a hidden row becomes supported", () => {
+            const plugin = makePlugin();
+            mockChatPicker(plugin);
+            const tab = makeTab(plugin);
+            tab.display();
+
+            const hideable = (tab as unknown as { serverConfigHideableEls: Map<string, MockElement> })
+                .serverConfigHideableEls;
+            const row = hideable.get("worker_pool_call_timeout_s")!;
+            const filter = tab.containerEl.find("lilbee-settings-filter")!;
+            filter.value = "does not match";
+            filter.trigger("input");
+            expect(row.style.display).toBe("none");
+
+            (tab as unknown as { applyHideableConfigFields(cfg: ConfigResponse): void }).applyHideableConfigFields({
+                worker_pool_call_timeout_s: 30,
+            });
+
+            expect(row.style.display).toBe("none");
         });
 
         it("PATCHes worker_pool_call_timeout_s with a parsed float", async () => {

--- a/tests/views/catalog-helpers.test.ts
+++ b/tests/views/catalog-helpers.test.ts
@@ -327,6 +327,20 @@ describe("catalog-helpers", () => {
             expect(forYouRail(rows).map((r) => r.hf_repo)).toEqual(["f/ok"]);
         });
 
+        it("forYouRail excludes a hosted row missing its provider key", () => {
+            const rows = [
+                pick({
+                    hf_repo: "openai/gpt-5",
+                    task: "chat",
+                    source: "frontier",
+                    provider: "openai",
+                    key_status: "missing_key",
+                }),
+                pick({ hf_repo: "f/ok", task: "chat" }),
+            ];
+            expect(forYouRail(rows).map((r) => r.hf_repo)).toEqual(["f/ok"]);
+        });
+
         it("forYouRail ignores rows that are not featured", () => {
             const rows = [row({ hf_repo: "p/plain", compat: "supported", fit: "fits" })];
             expect(forYouRail(rows)).toEqual([]);

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -1112,6 +1112,35 @@ describe("ChatView.sendMessage — sources", () => {
         expect(assistantBubble.find("lilbee-chat-sources")).toBeNull();
     });
 
+    it("ignores a malformed sources frame without replacing the answer", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const { mockFn, done } = makeStream([
+            { event: SSE_EVENT.TOKEN, data: "Partial answer" },
+            // Malformed: object instead of array
+            { event: SSE_EVENT.SOURCES, data: { sources: [] } },
+            { event: SSE_EVENT.DONE, data: {} },
+        ]);
+        plugin.api.chatStream = mockFn;
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const messagesEl = container.find("lilbee-chat-messages")!;
+        const textarea = container.find("lilbee-chat-textarea")!;
+        textarea.value = "malformed sources";
+
+        container.find("lilbee-chat-send")!.trigger("click");
+        await done;
+        await tick();
+        await tick();
+
+        const assistantBubble = messagesEl.children[1];
+        const textEl = assistantBubble.find("lilbee-chat-content");
+        // The answer must show the tokens, not a TypeError.
+        expect(textEl!.textContent).toContain("Partial answer");
+        expect(textEl!.textContent).not.toContain("TypeError");
+    });
+
     it("pushes assistant message into history after done event", async () => {
         Notice.clear();
         const plugin = makePlugin();
@@ -2574,7 +2603,7 @@ describe("ChatView — toolbar groups and tooltips", () => {
 });
 
 describe("ChatView health warnings", () => {
-    it("shows a server-reported degradation with its remedy", async () => {
+    it("renders a plugin-native remedy with an action button for a known code", async () => {
         const plugin = makePlugin();
         plugin.healthWarnings = [
             { code: "fts_unavailable", message: "Keyword search is unavailable.", remedy: "Run rebuild." },
@@ -2587,7 +2616,69 @@ describe("ChatView health warnings", () => {
         const container = view.containerEl.children[1] as unknown as MockElement;
         const text = container.textContent ?? "";
         expect(text).toContain("Keyword search is unavailable.");
-        expect(text).toContain("Run rebuild.");
+        expect(text).toContain("Rebuild the index");
+        expect(text).toContain("Rebuild index");
+        // The server's CLI remedy is not shown for codes the plugin knows.
+        expect(text).not.toContain("Run rebuild.");
+        expect(container.find("lilbee-chat-warning-action")).not.toBeNull();
+    });
+
+    it("falls back to the server remedy for an unknown code", async () => {
+        const plugin = makePlugin();
+        plugin.healthWarnings = [
+            { code: "some_future_warning", message: "Something is degraded.", remedy: "Server says do X." },
+        ];
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const text = container.textContent ?? "";
+        expect(text).toContain("Something is degraded.");
+        expect(text).toContain("Server says do X.");
+        expect(container.find("lilbee-chat-warning-action")).toBeNull();
+    });
+
+    it("triggers a rebuild when the remedy action button is clicked", async () => {
+        confirmModalResult = true;
+        const plugin = makePlugin();
+        plugin.healthWarnings = [
+            { code: "embedding_prefix_mismatch", message: "Index/embedder mismatch.", remedy: "Run rebuild." },
+        ];
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const btn = container.find("lilbee-chat-warning-action");
+        expect(btn).not.toBeNull();
+        btn!.trigger("click");
+        await tick();
+        await tick();
+
+        expect(plugin.triggerSync).toHaveBeenCalledWith({ forceRebuild: true });
+    });
+
+    it("does not rebuild when the user dismisses the confirm dialog", async () => {
+        confirmModalResult = false;
+        const plugin = makePlugin();
+        plugin.healthWarnings = [{ code: "stale_index", message: "Index is stale.", remedy: "Run rebuild." }];
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        await tick();
+        await tick();
+
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const btn = container.find("lilbee-chat-warning-action");
+        expect(btn).not.toBeNull();
+        btn!.trigger("click");
+        await tick();
+        await tick();
+
+        expect(plugin.triggerSync).not.toHaveBeenCalled();
+        confirmModalResult = true;
     });
 
     it("is a no-op on a view whose onOpen has not run", () => {
@@ -6171,5 +6262,85 @@ describe("ChatView — resume interactions with live state", () => {
 
         expect(plugin.settings.searchChunkType).toBe("all");
         expect(plugin.saveSettings).not.toHaveBeenCalled();
+    });
+});
+
+describe("ChatView — chat menu filters out non-chat models", () => {
+    function makeView() {
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        // Seed the view's internal state as fetchAndFillSelectors would.
+        // Qwen is in the catalog (featured); Llama is manually pulled (not in catalog).
+        (view as any).chatActive = "bartowski/Llama-3.2-1B-Instruct-GGUF/Llama-3.2-1B-Instruct-Q4_K_M.gguf";
+        (view as any).chatCatalogEntries = [
+            { hf_repo: "Qwen/Qwen3-4B-GGUF", display_name: "Qwen3 4B", source: "native", task: "chat" },
+        ];
+        (view as any).chatInstalled = [
+            { name: "Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf", source: "native" },
+            { name: "bartowski/Llama-3.2-1B-Instruct-GGUF/Llama-3.2-1B-Instruct-Q4_K_M.gguf", source: "native" },
+            { name: "BAAI/bge-small-en-v1.5-GGUF/bge-small-en-v1.5.Q4_K_M.gguf", source: "native" },
+        ];
+        (view as any).embeddingModels = [
+            { hf_repo: "BAAI/bge-small-en-v1.5-GGUF", display_name: "BGE Small", source: "native", task: "embedding" },
+        ];
+        (view as any).optionalCatalog = { vision: [], rerank: [] };
+        return view;
+    }
+
+    it("includes manually-pulled chat models but excludes embedding models", () => {
+        const view = makeView();
+        const options = (view as any).chatOtherOptions();
+        const repos = options.map((o: { value: string }) => o.value);
+        // Llama is installed but not in the featured catalog → appears in chatOtherOptions.
+        expect(repos).toContain("bartowski/Llama-3.2-1B-Instruct-GGUF/Llama-3.2-1B-Instruct-Q4_K_M.gguf");
+        // BGE is an embedding model → excluded from chat menu.
+        expect(repos).not.toContain("BAAI/bge-small-en-v1.5-GGUF/bge-small-en-v1.5.Q4_K_M.gguf");
+        // Qwen is in the featured catalog → appears in chatPrimaryOptions, not here.
+        expect(repos).not.toContain("Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf");
+    });
+
+    it("excludes installed vision and reranker models from the chat menu", () => {
+        const view = makeView();
+        (view as any).optionalCatalog = {
+            vision: [
+                { hf_repo: "vikhyatk/moondream2-GGUF", display_name: "Moondream", source: "native", task: "vision" },
+            ],
+            rerank: [],
+        };
+        (view as any).chatInstalled.push({ name: "vikhyatk/moondream2-GGUF/moondream2.Q4_K_M.gguf", source: "native" });
+        const options = (view as any).chatOtherOptions();
+        const repos = options.map((o: { value: string }) => o.value);
+        expect(repos).not.toContain("vikhyatk/moondream2-GGUF/moondream2.Q4_K_M.gguf");
+    });
+});
+
+describe("ChatView chat rail activates by concrete ref", () => {
+    function makeView() {
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        (view as any).chatActive = "Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf";
+        (view as any).chatCatalogEntries = [
+            {
+                hf_repo: "Qwen/Qwen3-4B-GGUF",
+                gguf_filename: "Qwen3-4B-Q4_K_M.gguf",
+                display_name: "Qwen3 4B",
+                source: "native",
+                task: "chat",
+            },
+        ];
+        (view as any).chatInstalled = [{ name: "Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf", source: "native" }];
+        return view;
+    }
+
+    it("sends the concrete file ref, not the bare repo", () => {
+        const view = makeView();
+        const options = (view as any).chatPrimaryOptions();
+        expect(options[0].value).toBe("Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf");
+    });
+
+    it("marks the installed quant as checked", () => {
+        const view = makeView();
+        const options = (view as any).chatPrimaryOptions();
+        expect(options[0].checked).toBe(true);
     });
 });

--- a/tests/views/chat-view.test.ts
+++ b/tests/views/chat-view.test.ts
@@ -676,6 +676,27 @@ describe("ChatView.sendMessage — token streaming", () => {
         const textEl = assistantBubble.find("lilbee-chat-content");
         expect(textEl!.textContent).toBe("Hello world");
     });
+
+    it("reports an interrupted stream when tokens arrive without a done event", async () => {
+        Notice.clear();
+        const plugin = makePlugin();
+        const { mockFn, done } = makeStream([{ event: SSE_EVENT.TOKEN, data: "partial" }]);
+        plugin.api.chatStream = mockFn;
+        const view = new ChatView(makeLeaf(), plugin);
+        await view.onOpen();
+        const container = view.containerEl.children[1] as unknown as MockElement;
+        const messagesEl = container.find("lilbee-chat-messages")!;
+        const textarea = container.find("lilbee-chat-textarea")!;
+        textarea.value = "truncated?";
+
+        container.find("lilbee-chat-send")!.trigger("click");
+        await done;
+        await tick();
+
+        const assistantBubble = messagesEl.children[1];
+        expect(assistantBubble.find("lilbee-chat-error-text")).not.toBeNull();
+        expect(Notice.instances.length).toBeGreaterThan(0);
+    });
 });
 
 describe("ChatView.sendMessage — reasoning tokens", () => {
@@ -6342,5 +6363,38 @@ describe("ChatView chat rail activates by concrete ref", () => {
         const view = makeView();
         const options = (view as any).chatPrimaryOptions();
         expect(options[0].checked).toBe(true);
+    });
+
+    it("checks the first quant when the server reports a bare repository", () => {
+        const view = makeView();
+        (view as any).chatActive = "Qwen/Qwen3-4B-GGUF";
+        const options = (view as any).chatPrimaryOptions();
+        expect(options[0].checked).toBe(true);
+        expect(options.filter((o: { checked: boolean }) => o.checked)).toHaveLength(1);
+    });
+
+    it("activates the concrete file ref after pulling an uninstalled quant", async () => {
+        const plugin = makePlugin();
+        plugin.api.pullModel = vi.fn().mockImplementation(async function* () {});
+        plugin.api.setChatModel = vi.fn((m: string) => Promise.resolve(ok({ model: m, reindex_required: false })));
+        const view = new ChatView(makeLeaf(), plugin);
+        await (view as any).autoPullAndSet({
+            hf_repo: "Qwen/Qwen3-4B-GGUF",
+            gguf_filename: "Qwen3-4B-Q4_K_M.gguf",
+            display_name: "Qwen3 4B",
+        });
+        expect(plugin.api.setChatModel).toHaveBeenCalledWith("Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf");
+        expect(plugin.activeModel).toBe("Qwen/Qwen3-4B-GGUF/Qwen3-4B-Q4_K_M.gguf");
+    });
+
+    it("excludes an installed non-chat model missing from every catalog but active as embedding", () => {
+        const plugin = makePlugin();
+        const view = new ChatView(makeLeaf(), plugin);
+        (view as any).chatInstalled = [{ name: "org/mystery-embed.gguf", source: "native" }];
+        (view as any).embeddingModels = [];
+        (view as any).optionalCatalog = { vision: [], rerank: [] };
+        (view as any).activeEmbeddingModel = "org/mystery-embed.gguf";
+        const options = (view as any).chatOtherOptions();
+        expect(options.map((o: { value: string }) => o.value)).not.toContain("org/mystery-embed.gguf");
     });
 });

--- a/tests/views/documents-modal.test.ts
+++ b/tests/views/documents-modal.test.ts
@@ -236,30 +236,31 @@ describe("DocumentsModal", () => {
         expect(Notice.instances.some((n) => n.message.includes("removed 1"))).toBe(true);
     });
 
-    it("notice prints the count, not the file name", async () => {
+    it("notice prints the server removed count, not the selected count", async () => {
         vi.useRealTimers();
         const plugin = makePlugin();
-        plugin.api.listDocuments.mockResolvedValue(makeDocsResponse([makeDoc({ filename: "a.md" })]));
-        // Server returns a string in removed (the file name), not a number
-        plugin.api.removeDocuments.mockResolvedValue({ removed: "a.md", not_found: [] });
+        plugin.api.listDocuments.mockResolvedValue(
+            makeDocsResponse([makeDoc({ filename: "a.md" }), makeDoc({ filename: "b.md" })]),
+        );
+        plugin.api.removeDocuments.mockResolvedValue({ removed: 1, not_found: [] });
         const app = new App();
         const modal = new DocumentsModal(app as any, plugin as any);
         modal.open();
         await tick();
 
         const el = modal.contentEl as unknown as MockElement;
-        const checkbox = el.findAll("lilbee-documents-checkbox")[0];
-        (checkbox as any).checked = true;
-        checkbox.trigger("change");
+        for (const checkbox of el.findAll("lilbee-documents-checkbox")) {
+            (checkbox as unknown as { checked: boolean }).checked = true;
+            checkbox.trigger("change");
+        }
 
         const removeBtn = el.find("lilbee-documents-remove")!;
         removeBtn.trigger("click");
         await tick();
         await tick();
 
-        // The notice must show the count (1), not the file name
         expect(Notice.instances.some((n) => n.message.includes("removed 1"))).toBe(true);
-        expect(Notice.instances.some((n) => n.message.includes("a.md"))).toBe(false);
+        expect(Notice.instances.some((n) => n.message.includes("removed 2"))).toBe(false);
     });
 
     it("confirms removal from the index and promises the files on disk survive", async () => {

--- a/tests/views/documents-modal.test.ts
+++ b/tests/views/documents-modal.test.ts
@@ -236,6 +236,32 @@ describe("DocumentsModal", () => {
         expect(Notice.instances.some((n) => n.message.includes("removed 1"))).toBe(true);
     });
 
+    it("notice prints the count, not the file name", async () => {
+        vi.useRealTimers();
+        const plugin = makePlugin();
+        plugin.api.listDocuments.mockResolvedValue(makeDocsResponse([makeDoc({ filename: "a.md" })]));
+        // Server returns a string in removed (the file name), not a number
+        plugin.api.removeDocuments.mockResolvedValue({ removed: "a.md", not_found: [] });
+        const app = new App();
+        const modal = new DocumentsModal(app as any, plugin as any);
+        modal.open();
+        await tick();
+
+        const el = modal.contentEl as unknown as MockElement;
+        const checkbox = el.findAll("lilbee-documents-checkbox")[0];
+        (checkbox as any).checked = true;
+        checkbox.trigger("change");
+
+        const removeBtn = el.find("lilbee-documents-remove")!;
+        removeBtn.trigger("click");
+        await tick();
+        await tick();
+
+        // The notice must show the count (1), not the file name
+        expect(Notice.instances.some((n) => n.message.includes("removed 1"))).toBe(true);
+        expect(Notice.instances.some((n) => n.message.includes("a.md"))).toBe(false);
+    });
+
     it("confirms removal from the index and promises the files on disk survive", async () => {
         vi.useRealTimers();
         vi.mocked(ConfirmModal).mockClear();

--- a/tests/views/setup-wizard.test.ts
+++ b/tests/views/setup-wizard.test.ts
@@ -3156,6 +3156,29 @@ describe("SetupWizard", () => {
             expect((wizard as any).embeddingModels.length).toBe(1);
         });
 
+        it("loadEmbeddingModels excludes a hosted row missing its key", async () => {
+            const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
+            const entries = [
+                makeEntry({ hf_repo: "nomic-ai/nomic-embed-text-v1.5-GGUF", task: "embedding" }),
+                makeEntry({
+                    hf_repo: "openai/text-embedding-3-small",
+                    task: "embedding",
+                    source: "frontier",
+                    provider: "openai",
+                    key_status: "missing_key",
+                }),
+            ];
+            plugin.api.catalog = vi.fn().mockResolvedValue(ok(makeCatalogResponse(entries)));
+            const wizard = new SetupWizard(plugin.app as any, plugin as any);
+            wizard.open();
+            const container = new MockElement("div") as unknown as HTMLElement;
+            const statusEl = new MockElement("div") as unknown as HTMLElement;
+            await (wizard as any).loadEmbeddingModels(container, statusEl);
+            expect((wizard as any).embeddingModels.map((m: CatalogEntry) => m.hf_repo)).toEqual([
+                "nomic-ai/nomic-embed-text-v1.5-GGUF",
+            ]);
+        });
+
         it("loadEmbeddingModels retries after an isErr result", async () => {
             const plugin = makePlugin({ settings: { serverMode: "external", setupCompleted: true } });
             plugin.api.catalog = vi.fn().mockResolvedValue(err(new Error("gateway timeout")));
@@ -4122,6 +4145,22 @@ describe("SetupWizard", () => {
 
             // The user cannot use it without a key they have not set, so it is not offered in its place.
             expect(renderedRepos(el)).toEqual(["f/0", "org/Other-0-GGUF"]);
+        });
+
+        it("excludes a featured frontier row missing its key from the initial picks", async () => {
+            const featured = featuredRow(1).concat(
+                makeEntry({
+                    hf_repo: "openai/gpt-5",
+                    display_name: "GPT-5",
+                    source: "frontier",
+                    provider: "openai",
+                    key_status: "missing_key",
+                }),
+            );
+
+            const { el } = await openPicksStep(splitCatalog(featured, []));
+
+            expect(renderedRepos(el)).toEqual(["f/0"]);
         });
 
         it("substitutes a hosted model the user can already use", async () => {

--- a/tests/views/status-modal.test.ts
+++ b/tests/views/status-modal.test.ts
@@ -159,7 +159,7 @@ describe("StatusModal", () => {
         expect(cell?.attributes["title"]).toBe("Smoffyy/Gemma4-E4B-Instruct-Pure-GGUF/Gemma4-E4B-F16.gguf");
     });
 
-    it("lists server-reported degradations with their remedies", async () => {
+    it("renders a plugin-native remedy with an action button for a known code", async () => {
         const plugin = makePlugin();
         (plugin as any).healthWarnings = [
             { code: "fts_unavailable", message: "Keyword search is unavailable.", remedy: "Run rebuild." },
@@ -169,11 +169,32 @@ describe("StatusModal", () => {
 
         const modal = new StatusModal(new App(), plugin);
         modal.open();
+        const content = (modal as any).contentEl as MockElement;
         await vi.waitFor(() => {
-            const content = (modal as any).contentEl as MockElement;
             expect(content.textContent ?? "").toContain("Keyword search is unavailable.");
         });
-        expect(((modal as any).contentEl as MockElement).textContent ?? "").toContain("Run rebuild.");
+        expect(content.textContent ?? "").toContain("Rebuild the index");
+        expect(content.textContent ?? "").toContain("Rebuild index");
+        expect(content.textContent ?? "").not.toContain("Run rebuild.");
+        expect(content.find("lilbee-status-warning-action")).not.toBeNull();
+    });
+
+    it("falls back to the server remedy for an unknown code", async () => {
+        const plugin = makePlugin();
+        (plugin as any).healthWarnings = [
+            { code: "some_future_warning", message: "Something is degraded.", remedy: "Server says do X." },
+        ];
+        (plugin.api.status as ReturnType<typeof vi.fn>).mockResolvedValue(ok(makeStatus()));
+        (plugin.api.showModel as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+        const modal = new StatusModal(new App(), plugin);
+        modal.open();
+        const content = (modal as any).contentEl as MockElement;
+        await vi.waitFor(() => {
+            expect(content.textContent ?? "").toContain("Something is degraded.");
+        });
+        expect(content.textContent ?? "").toContain("Server says do X.");
+        expect(content.find("lilbee-status-warning-action")).toBeNull();
     });
 
     it("omits the remedy line when the server sends none", async () => {


### PR DESCRIPTION
## Problem

Operator testing found defects across the setup wizard, chat rail, server lifecycle, health warnings, and streaming: silent stream ends, premature ready status, an unwired take-over lookup, orphaned adopted servers, wrong-quant activation, visible-but-unsupported settings, and hosted rows offered without a provider key.

## Solution

- Streams that close without finishing report as interrupted
- External servers stay connecting until a health probe validates them
- The take-over prompt waits for the registry and shows the locked status
- Unload asks an adopted server to exit and terminates the full process tree on Windows
- Clean exits count as take-over only with a foreign owner on record
- Chat checks and activates the concrete file, and filters non-chat builds
- Worker-pool rows stay hidden until the server reports their keys
- Picks exclude hosted rows missing a key in the catalog and the wizard
- Removal notices use the server count, and locked state renders muted

## Notes

Closes #284
Closes #285
Closes #286
Closes #287
Closes #288
Closes #289
Closes #290
Closes #292
Closes #300
Closes #302
Closes #304
Closes #308
Closes #309
Closes #310
Closes #311
